### PR TITLE
fix: CSA design review absorption — blockers, schema rebase, cross-spec

### DIFF
--- a/specs/fork-ext/p10-folder-claudemd-hotpatch.spec.md
+++ b/specs/fork-ext/p10-folder-claudemd-hotpatch.spec.md
@@ -26,7 +26,7 @@ status: optional
   2. 对每个路径，沿目录向上找第一个含 CLAUDE.md（或 AGENTS.md / GEMINI.md，按配置）的目录 `<D>`
   3. 先把 `<D>` 标准化为**绝对路径**（`std::fs::canonicalize(<D>)?`；解析符号链接、消除 `..` / `.` 段），再对标准化结果计算稳定 hash（SHA-256 截前 12 字符）作为 suggestion 文件名：`~/.mempal/hotpatch/CLAUDE-<hash>.md`。**未规范化直接 hash 相对路径是禁止的**——同一物理目录被不同 cwd 访问会产生不同 hash，污染建议池并让 `mempal hotpatch apply --dir <D>` 找不到对应 suggestion。若 `canonicalize` 失败（路径不存在 / 权限不足）→ fail-fast 并在 daemon log warn，**不**回退为相对路径 hash
   4. 生成 suggestion 行（可选 AAAK signal 辅助）：`- <importance_stars 星> <topic>: <一句话摘要 (≤ 80 字符)> [drawer:<id[:8]>]`
-  5. append 到 suggestion 文件（去重：若同 drawer_id 已存在，skip）
+  5. append 到 suggestion 文件（去重：若同 drawer_id 已存在，skip）。**必须 `flock`** 该 suggestion 文件（排他锁）再读、再 append、再 unlock——CSA design review 2026-04-20 识别的并发写问题：daemon 可能并行跑多个 worker（每个处理队列里一条消息），若同一目录下连续 hit 多个 drawer、触发多个 worker 同时 append 同一 `CLAUDE-<hash>.md` 文件，POSIX 文件系统下无锁 append 在 Linux 上未必原子（依赖 page cache 行为），更不用说 dedup 需要先 read 再 skip——read-then-append 的组合必须在锁内完成才能保证"同 drawer_id 不重复"的不变量
 - Suggestion 文件结构：
   ```md
   # mempal hotpatch suggestions for <dir-path>

--- a/specs/fork-ext/p10-project-vector-isolation.spec.md
+++ b/specs/fork-ext/p10-project-vector-isolation.spec.md
@@ -42,6 +42,11 @@ estimate: 1d
 - `mempal status` 加 "project breakdown" 行：`drawers per project: {proj-A:42, proj-B:18, NULL:7}`
 - `mempal tail` / `mempal timeline`（P10 CLI）支持 `--project <id>` 过滤
 - 严格 project 隔离是**默认关闭**的（保持 P0-P9 语义），用户显式开才生效
+- **Tunnel resolver 豁免**（CSA design review 2026-04-20 识别的交互）：upstream `specs/p10-explicit-tunnels.spec.md`（未 fork-ext，是 upstream 提出的 wing-to-wing 链接 schema）的 tunnel-follow 路径**必须豁免** project hard-filter——tunnels 的存在本身就是"跨 wing / 跨 project 的显式桥"，如果 tunnel 的 target drawer 属于另一 project，严格过滤会把 follow 变成 404。具体实现：
+  - `mempal_tunnels follow <tunnel_id>` / `mempal_search tunnel_hints` 解析目标 drawer 时，走 **bypass 版** `drawers::get_by_id()` 不带 `project_id` 筛选
+  - Tunnel row 存储时必须保存 target drawer 的 `project_id`（若有），让调用方看清"这个 tunnel 把我引向另一 project"
+  - Tunnel-resolved 的结果 DTO 明确标 `source: "tunnel_cross_project"`（与正常搜索结果的 `source: "project" | "global"` 并列），让 agent 知道命中是"故意越界"
+  - 这是 **唯一** 允许绕过 project filter 的读路径；ingest / direct search / KG query 全部尊重 project filter
 
 ## Boundaries
 

--- a/specs/fork-ext/p10-project-vector-isolation.spec.md
+++ b/specs/fork-ext/p10-project-vector-isolation.spec.md
@@ -14,7 +14,7 @@ estimate: 1d
 
 ## Decisions
 
-- schema v7 → v8 新 migration：
+- schema v9 → v10 新 migration：
   - `drawers` 表加 `project_id TEXT`（默认 NULL 兼容既有 drawer）
   - 索引 `CREATE INDEX idx_drawers_project_id ON drawers(project_id)`
   - `drawer_vectors` 表加 `project_id TEXT`（冗余列，为了 sqlite-vec filter 能直接过）
@@ -46,7 +46,7 @@ estimate: 1d
 ## Boundaries
 
 ### Allowed
-- `crates/mempal-core/src/db/schema.rs`（v7 → v8 migration）
+- `crates/mempal-core/src/db/schema.rs`（v9 → v10 migration）
 - `crates/mempal-core/src/project.rs`（新建：project_id 解析工具）
 - `crates/mempal-core/src/config.rs`（`[project] id`、`[search] strict_project_isolation`）
 - `crates/mempal-core/src/lib.rs`（`pub mod project`）
@@ -80,9 +80,9 @@ estimate: 1d
 
 ## Completion Criteria
 
-Scenario: schema 迁移 v7 → v8 添加 project_id 列
+Scenario: schema 迁移 v9 → v10 添加 project_id 列
   Test:
-    Filter: test_migration_v7_to_v8_adds_project_id
+    Filter: test_migration_v9_to_v10_adds_project_id
     Level: integration
     Targets: crates/mempal-core/src/db/schema.rs
   Given palace.db schema_version == "7"

--- a/specs/fork-ext/p8-embed-qwen3-backend.spec.md
+++ b/specs/fork-ext/p8-embed-qwen3-backend.spec.md
@@ -6,9 +6,7 @@ estimate: 2d
 
 ## Intent
 
-增加 `OpenAiCompatibleEmbedder`：任何 OpenAI-style `/v1/embeddings` HTTP 后端都能作为 `Embedder` trait 的实现。**支持配置**（按推荐顺序）：(1) **LAN 自部署**（默认推荐，如 `http://gb10:18002/v1/` 跑 `Qwen/Qwen3-Embedding-8B` 4096d——mempal 存在的核心理由就是把 claude-mem 的所有好处在这档硬件上做到位）；(2) **localhost 监听端口**（用户自起 ollama / vllm / TEI 等本地 embedding server）。`model2vec-rs` 进程内 fallback 保留（offline / LAN 不可达时）。**URL / model 完全 config-driven**，不在代码里硬编码任何主机名。
-
-**非支持配置**：协议层面 `OpenAiCompatibleEmbedder` 也能把请求发给云端商业 API（OpenAI text-embedding-3-*、Cohere、Voyage AI、SiliconFlow 等）——**但这不是 mempal 支持的配置**。mempal 存在的价值主张之一就是**不让用户为嵌入再烧一份云端 quota**（与 claude-mem 等强依赖云端 LLM 的工具形成对照）。用户若自行把 `base_url` 指向云端，后果自负、且与文档/README/Release Notes 描述的项目边界不一致。如果想省 VRAM、不想架 LAN，请用 `model2vec` backend（offline，零 API 成本）。
+增加 `OpenAiCompatibleEmbedder`：任何 OpenAI-style `/v1/embeddings` HTTP 后端都能作为 `Embedder` trait 的实现。**推荐配置顺序**：(1) **LAN 自部署**（首选，如 `http://gb10:18002/v1/` 跑 `Qwen/Qwen3-Embedding-8B` 4096d——mempal 存在的核心价值主张就是把 claude-mem 的好特性搬到这档 LAN 硬件上、**消除云端 generative LLM 的 quota 花费**）；(2) **localhost 监听端口**（用户自起 ollama / vllm / TEI 等本地 embedding server）；(3) **云端商业 embedding API**（OpenAI text-embedding-3-*、Cohere、Voyage AI、SiliconFlow 等）——协议原生支持、可用作 LAN 不可达时的后备，成本比 generative chat 低约 100×，但**不是 mempal 的推荐主路径**：agent session 累积几千次 embedding 调用仍有显著成本，且与 "mempal = 零云端依赖的 claude-mem 替代" 的定位不一致。`model2vec-rs` 进程内 fallback 保留（offline / LAN 全断时的最后一档）。**URL / model 完全 config-driven**，不在代码里硬编码任何主机名。
 
 **失败语义**：
 - **Ingest 路径**：**固定 2 秒间隔** 无限重试（**不做指数退避**，用户明确偏好——压力可预测、故障恢复可观测），数据永不丢
@@ -24,7 +22,7 @@ estimate: 2d
 - Degraded 状态同时推给外部（脚本）+ agent（MCP response）：外部是异步告警（人类可稍后看），agent 是同步门控（立即暂停，保证系统一致性）
 
 **与 feedback 的对应**：
-- 符合 `feedback_no_llm_api_dependency.md`：**LAN 自部署 + localhost + model2vec offline** 是三档合规配置，覆盖从"有一张够大的 GPU"到"出差没网"的所有场景。云端 API 端点**不**是合规配置（见 Intent 中的"非支持配置"）；把 embedding 当作"轻量向量化所以云端随便调"是危险的滑坡，因为单次 agent session 的 embedding 调用量可达几千次，累积成本并非可忽略。
+- 符合 `feedback_no_llm_api_dependency.md`（"generative LLM 云端 API 禁令不含 embedding 云端服务"，embedding 成本 ≈ generative chat 的 1%）。本 spec 的立场：**LAN 自部署为默认首选**（与项目价值主张一致），云端 embedding API 作为**可配置的后备**（协议原生支持、用户显式指向时不阻塞），model2vec 进程内作**最后一档**（offline / 全部 HTTP 后端不可用时）。推荐顺序不是硬约束而是运维建议：单 agent session 的 embedding 调用会累积，即使按 $0.02/1M tokens 的低价也非完全可忽略。
 - 符合 `feedback_cli_over_web_ui.md`：无 UI，告警走脚本、状态走 MCP field
 
 ## Decisions

--- a/specs/fork-ext/p8-embed-qwen3-backend.spec.md
+++ b/specs/fork-ext/p8-embed-qwen3-backend.spec.md
@@ -6,11 +6,15 @@ estimate: 2d
 
 ## Intent
 
-增加 `OpenAiCompatibleEmbedder`：任何 OpenAI-style `/v1/embeddings` HTTP 后端都能作为 `Embedder` trait 的实现，涵盖三类部署——**LAN 自部署**（如 `http://gb10:18002/v1/`，默认推荐，`Qwen/Qwen3-Embedding-8B` 4096d）、**localhost 监听端口**（未来用户自起本地 embedding server）、**云端 API**（OpenAI text-embedding-3-*、Cohere、Voyage AI、SiliconFlow 等）。`model2vec-rs` 进程内 fallback 保留。**URL / model 完全 config-driven**，不在代码里硬编码任何主机名。
+增加 `OpenAiCompatibleEmbedder`：任何 OpenAI-style `/v1/embeddings` HTTP 后端都能作为 `Embedder` trait 的实现。**支持配置**（按推荐顺序）：(1) **LAN 自部署**（默认推荐，如 `http://gb10:18002/v1/` 跑 `Qwen/Qwen3-Embedding-8B` 4096d——mempal 存在的核心理由就是把 claude-mem 的所有好处在这档硬件上做到位）；(2) **localhost 监听端口**（用户自起 ollama / vllm / TEI 等本地 embedding server）。`model2vec-rs` 进程内 fallback 保留（offline / LAN 不可达时）。**URL / model 完全 config-driven**，不在代码里硬编码任何主机名。
+
+**非支持配置**：协议层面 `OpenAiCompatibleEmbedder` 也能把请求发给云端商业 API（OpenAI text-embedding-3-*、Cohere、Voyage AI、SiliconFlow 等）——**但这不是 mempal 支持的配置**。mempal 存在的价值主张之一就是**不让用户为嵌入再烧一份云端 quota**（与 claude-mem 等强依赖云端 LLM 的工具形成对照）。用户若自行把 `base_url` 指向云端，后果自负、且与文档/README/Release Notes 描述的项目边界不一致。如果想省 VRAM、不想架 LAN，请用 `model2vec` backend（offline，零 API 成本）。
 
 **失败语义**：
 - **Ingest 路径**：**固定 2 秒间隔** 无限重试（**不做指数退避**，用户明确偏好——压力可预测、故障恢复可观测），数据永不丢
 - **Search 路径**：5s deadline 后 fallback 到 BM25-only，不阻塞用户
+
+**与 `pending-message-store` 的协议**（CSA design review 2026-04-20 blocker 1 修复）：embedder ingest 重试循环**必须**在每次 sleep(2s) 前后调用 `store.refresh_heartbeat(msg_id, worker_id)`——这是 "2s 无限重试 + 数据永不丢" 与 "claim TTL + reclaim_stale" 能并存的唯一正确协议。heartbeat 活着的 claim 不会被 reclaim_stale 回滚；只有 worker 进程真正崩溃（heartbeat 静默 > `stale_secs`，默认 10s）才触发回滚。这消除了 CSA 识别的 "worker 永久持有 claim → TTL 到期 → 第二 worker 双派发" 的死锁路径。
 - **告警**：累计失败每 `alert_every_n_failures` 次（默认 100，**配置文件可配且热重载**）调用用户预配置的绝对路径脚本（e.g., Telegram / Slack / email 推送）
 - **Agent 通知**：当累计失败超过 `degrade_after_n_failures`（默认 10），mempal 进入 **degraded 状态**，对所有 MCP tool response 注入 `system_warnings` 字段并**拒绝**写入类 MCP 工具（`mempal_ingest` / `mempal_kg` add|invalidate / `mempal_tunnels` add|invalidate），强制 agent 暂停写入；读类正常。一次成功 embed 退出 degraded 并清零计数
 
@@ -20,7 +24,7 @@ estimate: 2d
 - Degraded 状态同时推给外部（脚本）+ agent（MCP response）：外部是异步告警（人类可稍后看），agent 是同步门控（立即暂停，保证系统一致性）
 
 **与 feedback 的对应**：
-- 符合 `feedback_no_llm_api_dependency.md`：embedding API 不是 generative LLM API，轻量向量化，成本 100× 低于 chat 完成，同时 LAN 自部署 + 云端 API 都合规（embedding 专属例外）
+- 符合 `feedback_no_llm_api_dependency.md`：**LAN 自部署 + localhost + model2vec offline** 是三档合规配置，覆盖从"有一张够大的 GPU"到"出差没网"的所有场景。云端 API 端点**不**是合规配置（见 Intent 中的"非支持配置"）；把 embedding 当作"轻量向量化所以云端随便调"是危险的滑坡，因为单次 agent session 的 embedding 调用量可达几千次，累积成本并非可忽略。
 - 符合 `feedback_cli_over_web_ui.md`：无 UI，告警走脚本、状态走 MCP field
 
 ## Decisions

--- a/specs/fork-ext/p8-hook-passive-capture.spec.md
+++ b/specs/fork-ext/p8-hook-passive-capture.spec.md
@@ -63,7 +63,7 @@ estimate: 2d
     }
   }
   ```
-  非侵入式合并：读既有 JSON，merge `hooks` key，保留其他配置；若已有相同命令则跳过。
+  **非侵入式合并语义**（CSA design review 2026-04-20 识别的共存需求）：读既有 JSON，对每个 hook 事件（`PostToolUse` / `UserPromptSubmit` / `SessionEnd` 等）**追加到既有数组**，不覆盖；若既有条目的 `command` 字段已等于 `mempal hook <event>` 的命令则跳过，避免重复注入。**不能**把整个 `hooks.UserPromptSubmit` 数组替换掉——upstream `mempal cowork-install-hooks`（见根目录 `specs/p8-cowork-inbox-push.spec.md`）也往同一个数组注入 `mempal cowork-drain` 条目，必须共存（两条 hook 各自 fire，互不干扰）。实现上：`hooks.<event>` 是 `Vec<HookGroup>`，本命令的 merge 规则是 `existing.chain(new.filter(not already_present_by_command))`；**绝不**是赋值。
 - `--dry-run` 打印 diff 不写入
 - 配置项在 `[hooks]`：`enabled`, `capture` (Vec<String>), `wing`, `daemon_poll_interval_ms`, `daemon_claim_ttl_secs`
 - `enabled = false` 时 `mempal hook <event>` **仍然** enqueue（让用户可以先写 hook 配置，再翻开关）；`mempal daemon` 检查到 `enabled = false` 直接退出并打印 warning

--- a/specs/fork-ext/p8-pending-message-store.spec.md
+++ b/specs/fork-ext/p8-pending-message-store.spec.md
@@ -29,16 +29,19 @@ estimate: 2d
       next_attempt_at INTEGER NOT NULL, -- unix seconds; indexed
       last_error TEXT,                  -- latest error message
       created_at INTEGER NOT NULL,
+      heartbeat_at INTEGER,             -- unix seconds; worker refresh while processing (NULL if pending)
       CHECK (status IN ('pending','claimed','failed'))
   );
   CREATE INDEX idx_pending_next_attempt ON pending_messages(status, next_attempt_at);
+  CREATE INDEX idx_pending_heartbeat ON pending_messages(status, heartbeat_at) WHERE status='claimed';
   ```
 - 公共 API：
   - `enqueue(kind: &str, payload: &str) -> Result<String>` 返回新消息 ULID，写入时 `status='pending'`, `next_attempt_at=now`
   - `claim_next(worker_id: &str, claim_ttl_secs: i64) -> Result<Option<ClaimedMessage>>` 原子更新（SELECT + UPDATE in txn）一条 `status='pending' AND next_attempt_at <= now` 的消息，标为 `claimed`
   - `confirm(id: &str) -> Result<()>` 处理成功，DELETE 该行
   - `mark_failed(id: &str, error: &str) -> Result<()>` 处理失败，`retry_count += 1`，`next_attempt_at = now + backoff(retry_count)`，`status='pending'`（重新可领取）；超过 `max_retries` 时 `status='failed'` 永久保留供审计
-  - `reclaim_stale(older_than_secs: i64) -> Result<u64>` 把 `claimed` 但 `claimed_at < now - older_than_secs` 的消息回滚到 `pending`（进程崩溃恢复）
+  - `refresh_heartbeat(id: &str, worker_id: &str) -> Result<()>` 把 `heartbeat_at` 更新到 now；**必须**在 worker 每次 embedder 重试循环、每次慢处理等耗时步骤之间调用（建议频率 2-5s），否则 `reclaim_stale` 会把消息视为崩溃回滚。Worker 如持续 "正在重试" 必须持续 heartbeat——这就是嵌入器 2s 固定间隔重试与队列 claim TTL 共存的唯一正确协议（见 `p8-embed-qwen3-backend.spec.md` Intent "与 pending-message-store 的协议")。
+  - `reclaim_stale(stale_secs: i64) -> Result<u64>` 把 `claimed` 但 `heartbeat_at IS NULL OR heartbeat_at < now - stale_secs` 的消息回滚到 `pending`（**仅在 heartbeat 静默超阈值时触发，不再用 `claimed_at`**；rationale：嵌入器 2s 固定重试下，worker 处理时长可能远超 claim TTL，用 heartbeat 判 "worker 是否还活着" 才是正确不变量——CSA tier-4 design review 2026-04-20 识别的 blocker 1 修复）
 - 指数退避公式：`backoff(n) = min(base_delay_secs * 2^n, max_delay_secs)`，默认 `base=5`, `max=3600`, `max_retries=10`
 - Claim atomicity：用单一 `UPDATE ... WHERE id = (SELECT id FROM ... ORDER BY next_attempt_at LIMIT 1) RETURNING *` 或等价 txn 保证无两 worker 抢同一消息
 - SQLite 必须在 WAL 模式（`PRAGMA journal_mode=WAL`）。**事实核查**：截至 P7，`crates/mempal-core/src/db.rs` 的 `Database::open` 仅设 `PRAGMA foreign_keys=ON`，**未**启用 WAL。本 spec 同时在 `Database::open` 初始化路径追加 `PRAGMA journal_mode=WAL` 和 `PRAGMA synchronous=NORMAL`（后者是 WAL 下的推荐性能档：崩溃保 WAL 不保最后一次 commit 到磁盘，写入并发显著提升）；不追加 WAL 就谈不上队列无锁竞争
@@ -129,16 +132,26 @@ Scenario: mark_failed 指数退避
   And `status == 'pending'`（可重新被 claim）
   And `last_error == "timeout"`
 
-Scenario: reclaim_stale 把崩溃 worker 的 claim 回滚
+Scenario: reclaim_stale 把 heartbeat 静默的 worker claim 回滚（崩溃恢复）
   Test:
-    Filter: test_reclaim_stale_rolls_back_expired_claims
+    Filter: test_reclaim_stale_rolls_back_on_heartbeat_silence
     Level: integration
     Targets: crates/mempal-core/src/queue.rs
-  Given 一条被 claim 的消息，`claimed_at = now - 120`
+  Given 一条被 claim 的消息，`heartbeat_at = now - 120`（worker 进程崩溃，heartbeat 静默）
   When 调 `store.reclaim_stale(60)`
   Then 返回值 == "1"
-  And 该行 `status == 'pending'` 且 `claimed_at IS NULL`
+  And 该行 `status == 'pending'` 且 `claimed_at IS NULL` 且 `heartbeat_at IS NULL`
   And 该行 `retry_count` 未变
+
+Scenario: reclaim_stale 不回滚正在 heartbeat 的 claim（嵌入器重试期间保护）
+  Test:
+    Filter: test_reclaim_stale_preserves_heartbeating_claim
+    Level: integration
+    Targets: crates/mempal-core/src/queue.rs
+  Given 一条被 claim 的消息，`claimed_at = now - 300`（claim 已 300s）但 `heartbeat_at = now - 3`（3s 前刚 heartbeat 过——embedder 还在重试中）
+  When 调 `store.reclaim_stale(60)`
+  Then 返回值 == "0"（不回滚）
+  And 该行 `status == 'claimed'` 不变
 
 Scenario: 超过 max_retries 后状态变为 failed 永久保留
   Test:

--- a/specs/fork-ext/p8-pending-message-store.spec.md
+++ b/specs/fork-ext/p8-pending-message-store.spec.md
@@ -15,7 +15,7 @@ estimate: 2d
 ## Decisions
 
 - 新建 `crates/mempal-core/src/queue.rs` 模块，暴露 `PendingMessageStore` struct
-- 新建 schema migration，引入 `pending_messages` 表（字段见下），bump `CURRENT_SCHEMA_VERSION` v4 → v5
+- 新建 schema migration，引入 `pending_messages` 表（字段见下），bump `CURRENT_SCHEMA_VERSION` v6 → v7
 - 表结构：
   ```sql
   CREATE TABLE pending_messages (
@@ -58,7 +58,7 @@ estimate: 2d
 ### Allowed
 - `crates/mempal-core/src/queue.rs`（新建）
 - `crates/mempal-core/src/lib.rs`（`pub mod queue` + re-export）
-- `crates/mempal-core/src/db/schema.rs` 或等价（migration v4 → v5 + `pending_messages` DDL）
+- `crates/mempal-core/src/db/schema.rs` 或等价（migration v6 → v7 + `pending_messages` DDL）
 - `crates/mempal-core/src/db.rs` 或 `db/mod.rs`（`Database::open` 追加 `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL`；启动时调 `reclaim_stale`）
 - `crates/mempal-core/Cargo.toml`（添加 `thiserror`、`ulid` workspace dep，若尚未有）
 - `crates/mempal-cli/src/main.rs`（`mempal status` 加队列 stats 行）
@@ -183,7 +183,7 @@ Scenario: 并发 enqueue 在 WAL 模式下不阻塞
   Then 队列中恰好有 "800" 条 pending
   And 整体耗时 < 5 秒（naive upper bound，表明无严重锁竞争）
 
-Scenario: schema 迁移 v4 → v5 创建 pending_messages 表
+Scenario: schema 迁移 v6 → v7 创建 pending_messages 表
   Test:
     Filter: test_migration_v4_to_v5_creates_pending_messages_table
     Level: integration

--- a/specs/fork-ext/p9-judge-gating-local.spec.md
+++ b/specs/fork-ext/p9-judge-gating-local.spec.md
@@ -48,7 +48,7 @@ estimate: 2d
 - 向量 dim 必须和 embedder 输出 dim 一致——由于 embedder 及其 dim 是 runtime 经 `config.toml` 配置，**编译期无从静态断言**；改为 prototypes 初始化阶段 runtime check：`assert_eq!(prototype_vector.len(), embedder.dim())`；不一致 fail-fast（`GatingError::DimMismatch`），拒绝进入 gating 路径并提示用户切后端后跑 `mempal reindex`
 - Gating stats：`GatingStats { tier1_kept, tier1_skipped, tier2_kept, tier2_skipped, unclassified }`，暴露到 `mempal status` 和新 CLI `mempal gating stats [--since <duration>]`
 - Gating 决策写入 `gating_audit` 表（`id`, `candidate_hash`, `decision`, `tier`, `label`, `created_at`, `retained_until` 默认 7d 滚动清理）供 `mempal gating stats` 查询
-- schema bump v5 → v6（新增 `gating_audit` 表）
+- schema bump v7 → v8（新增 `gating_audit` 表）
 - **禁止**任何 HTTP client 调用外部 LLM API——Tier 3 的 API backend 根本不实现；`GatingConfig` 解析时若见到 `[ingest_gating.llm_judge]` section 输出 warn 并忽略
 - 错误处理：`GatingError`（`thiserror`），embedder 失败时 `judge` 回退到 `Keep { tier: 0, label: "embedder_error" }`（fail-open，宁可多存也不丢）
 - judge 是 async（因为 embedder trait 是 async），在 ingest pipeline 中被 `.await` 调用
@@ -60,7 +60,7 @@ estimate: 2d
 - `crates/mempal-ingest/src/pipeline.rs`（插入 judge 调用点：privacy scrub 之后、chunking 之前）
 - `crates/mempal-ingest/src/lib.rs`（`pub mod gating`）
 - `crates/mempal-core/src/config.rs`（`GatingConfig` struct + `[ingest_gating]` parsing）
-- `crates/mempal-core/src/db/schema.rs`（v5 → v6 migration + `gating_audit` DDL）
+- `crates/mempal-core/src/db/schema.rs`（v7 → v8 migration + `gating_audit` DDL）
 - `crates/mempal-cli/src/main.rs`（`mempal gating stats` 子命令）
 - `tests/gating_rules.rs`, `tests/gating_prototypes.rs`, `tests/gating_integration.rs`（新建）
 
@@ -177,7 +177,7 @@ Scenario: mempal gating stats 输出 kept/skipped 计数
   Then stdout 含 `kept: 10` 和 `skipped: 20`
   And 按 tier 分解
 
-Scenario: schema 迁移 v5 → v6 创建 gating_audit 表
+Scenario: schema 迁移 v7 → v8 创建 gating_audit 表
   Test:
     Filter: test_migration_v5_to_v6_creates_gating_audit
     Level: integration

--- a/specs/fork-ext/p9-novelty-filter.spec.md
+++ b/specs/fork-ext/p9-novelty-filter.spec.md
@@ -38,13 +38,13 @@ estimate: 1d
   - 既有 drawer `content` 末尾追加分隔符 `\n---\nSUPPLEMENTARY ({timestamp}):\n` + candidate content
   - **硬上限防无界增长**：配置 `[novelty] max_merges_per_drawer`（默认 10）和 `max_content_bytes_per_drawer`（默认 65536 ≈ 64KB，LLM context 友好）；任一上限触发（`merge_count >= max_merges_per_drawer` 或 `len(merged_content) > max_content_bytes_per_drawer`）→ 该次去判决**降级为 Insert**（新建 drawer），不再继续往旧 drawer append；`novelty_audit` 写入 decision=`"insert_due_to_merge_cap"` 便于审计
   - `updated_at = now()`
-  - `merge_count` 列 +1（schema v7 新增）
+  - `merge_count` 列 +1（schema v9 新增）
   - **重新计算** embedding（合并后内容变化，旧 embedding 不再准确）：embed new `content`，UPDATE `drawer_vectors`
   - FTS5 index 自动随 `drawers.content` UPDATE 触发同步（如现有 trigger 已覆盖）
   - **保留** drawer ID 不变（KG triples 引用稳定）
-- 去重触发后 write 到 `novelty_audit` 表（schema v7 新增）：`{ id, candidate_hash, decision, near_drawer_id, cosine, created_at }`，`mempal status` 汇总
+- 去重触发后 write 到 `novelty_audit` 表（schema v9 新增）：`{ id, candidate_hash, decision, near_drawer_id, cosine, created_at }`，`mempal status` 汇总
 - 对 `mempal_ingest` MCP 工具调用方：返回 response metadata 含 `novelty_decision: "inserted" | "merged" | "dropped"`, `near_drawer_id`（如适用）；content 语义保持 raw，不影响字段形态
-- schema v6 → v7 bump：
+- schema v8 → v9 bump：
   - `drawers` 表加 `merge_count INTEGER NOT NULL DEFAULT 0` 和 `updated_at TEXT`（NULLABLE；仅 merge 发生时写入，未 merge 的 drawer 保持 NULL 以显式区分 added_at vs 后续变动）
   - 新建 `novelty_audit` 表
   - 注意：codebase 既有列名为 `added_at`（见 `src/core/db.rs`），**不是** `created_at`；novelty merge 场景新增的列名为 `updated_at` 以明确语义（last_merge_at 的意味），不重命名 `added_at`
@@ -59,7 +59,7 @@ estimate: 1d
 - `crates/mempal-ingest/src/pipeline.rs`（novelty filter 调用点：embedding 计算后、drawer 插入前）
 - `crates/mempal-ingest/src/lib.rs`（`pub mod novelty`）
 - `crates/mempal-core/src/config.rs`（`NoveltyConfig` struct）
-- `crates/mempal-core/src/db/schema.rs`（v6 → v7）
+- `crates/mempal-core/src/db/schema.rs`（v8 → v9）
 - `crates/mempal-mcp/src/tools.rs`（`IngestResponseDto` 加可选 `novelty_decision` / `near_drawer_id` 字段）
 - `crates/mempal-mcp/src/server.rs`（handler 传递 novelty 决策到 response）
 - `tests/novelty_filter.rs`（新建）
@@ -187,9 +187,9 @@ Scenario: embedder 错误时 fail-open 插入
   Then candidate 正常插入为新 drawer
   And stderr/log 含 warn
 
-Scenario: schema 迁移 v6 → v7 加 merge_count 和 novelty_audit
+Scenario: schema 迁移 v8 → v9 加 merge_count 和 novelty_audit
   Test:
-    Filter: test_migration_v6_to_v7_schema
+    Filter: test_migration_v8_to_v9_schema
     Level: integration
     Targets: crates/mempal-core/src/db/schema.rs
   Given palace.db schema_version == "6"

--- a/specs/fork-ext/p9-progressive-disclosure.spec.md
+++ b/specs/fork-ext/p9-progressive-disclosure.spec.md
@@ -35,8 +35,8 @@ estimate: 1d
   - input schema: `{ drawer_ids: Vec<String>, max_count: Option<u32> }`（默认 max 20）
   - output: `{ drawers: Vec<DrawerDto>, not_found: Vec<String> }`
   - 批量读取，超过 `max_count` 截断并返回 warn 字段
-- `SearchResultDto.content` 在 `progressive_disclosure = true` 时是 preview；为区分，**新增 bool 字段 `content_truncated: bool`**（只在 progressive 模式下可能为 true）
-- P7 的 5 个 AAAK signal 字段（`entities` / `topics` / `flags` / `emotions` / `importance_stars`）**基于完整 content 计算**，即使 progressive 模式下 `content` 被截断，signals 仍反映原文（在截断前调用 `aaak::signals::analyze(&full_content)`）
+- `SearchResultDto.content` 在 `progressive_disclosure = true` 时是 preview；为区分，**必填 bool 字段 `content_truncated: bool`**——在 progressive 模式下只要 `content.len() < original.len()` 就置 `true`，**非 optional、非 default-false-而不序列化**，客户端 DTO deserializer 必须看到它。CSA design review 2026-04-20 识别：若字段被遗漏或 default-elide，agent 看到 preview 却不知其为 preview，在决策引用时会把 "截断位置之后的证据" 当成 "不存在的证据"。同时 DTO 里也带 `original_content_bytes: usize` 让 agent 评估是否值得后续 `mempal_read_drawer`（很小的 drawer 可能不值得追一次）。
+- P7 的 5 个 AAAK signal 字段（`entities` / `topics` / `flags` / `emotions` / `importance_stars`）**基于完整 content 计算**，即使 progressive 模式下 `content` 被截断，signals 仍反映原文（在截断前调用 `aaak::signals::analyze(&full_content)`）。当 `content_truncated=true` 但某个 signal 指向 preview 中不可见的证据时，这是预期行为（不是 bug）——agent 可通过 `mempal_read_drawer(drawer_id)` 拉全文验证信号来源。
 - MCP ServerInfo.instructions 新增 workflow rule（编号 `10.` 续 9 条后）：
   ```
   RULE 10 (progressive disclosure): When progressive mode is active (server announces


### PR DESCRIPTION
## Summary

Absorb the 2026-04-20 CSA tier-4-critical design review of fork-ext draft specs (session `01KPNQCCSNDS9BN3VWACQHEZBC`). Four thematic commits.

## Commits

### `d0d6382` — fix(p8): reframe cloud-API + resolve queue×embedder deadlock
- `p8-embed-qwen3-backend`: cloud endpoints reframed (later softened in `43117dd`)
- `p8-embed-qwen3-backend` × `p8-pending-message-store`: add heartbeat protocol. Queue gains `heartbeat_at` column + `refresh_heartbeat()` API. `reclaim_stale` reconditions on heartbeat silence, not `claimed_at` age. Preserves "2s infinite retry, no data loss" user preference while fixing the double-dispatch deadlock CSA identified.

### `3b67bbf` — fix(schema): rebase fork-ext migrations to v7+
- v5 = upstream `p10-explicit-tunnels`
- v6 = upstream `p10-normalize-version`
- v7 = fork-ext p8-pending-message-store (queue)
- v8 = fork-ext p9-judge-gating-local (gating_audit)
- v9 = fork-ext p9-novelty-filter (novelty_audit + merge_count + updated_at)
- v10 = fork-ext p10-project-vector-isolation (project_id columns)

### `26d8da7` — fix(cross-spec): four interaction fixes
- `p8-hook-passive-capture`: `.claude/settings.json` merge must APPEND to hook arrays (coexist with upstream `mempal cowork-install-hooks`)
- `p10-project-vector-isolation`: carve out tunnel-resolver exemption from project filter; tunnel DTO tags `source: "tunnel_cross_project"`
- `p10-folder-claudemd-hotpatch`: mandate `flock` on shared `CLAUDE-<hash>.md` writes (concurrent daemon workers)
- `p9-progressive-disclosure`: `content_truncated` promoted to MUST-NOT-elide; add `original_content_bytes`

### `43117dd` — fix(p8-embed-qwen3): soften cloud-API to 'backup tier'
- Correction: project ban is on **generative** LLM APIs, not embedding APIs (per `feedback_no_llm_api_dependency.md`). Cloud embedding remains a supported (non-recommended) fallback tier.

## Deferred (per-spec top-risks, not blockers)
- Privacy regex cross-chunk (p8-privacy)
- daemonize × tokio startup timing (p8-hook)
- Gating prototype embed precompute blocking startup (p9-gating)
- FTS5 AFTER UPDATE trigger DDL (p9-novelty)
- `rfind` sentinel false-positive (p9-session-self-review)
- inotify debounce (p10-cli-dashboard)
- Bulk UPDATE lock-table (p10-vector-iso)

## Quality Gates
- [x] `cargo build --offline` — clean (no code changes, specs only)
- [x] No schema version collisions remaining across fork-ext + upstream
- [x] Cross-spec concerns traced to specific Decision blocks in each spec

CSA session archive: `~/.local/state/cli-sub-agent/.../sessions/01KPNQCCSNDS9BN3VWACQHEZBC/`