### PR TITLE
fix(fork-ext): absorb 7 deferred risks + add p8-config-hot-reload

### DIFF
--- a/specs/fork-ext/p10-cli-dashboard.spec.md
+++ b/specs/fork-ext/p10-cli-dashboard.spec.md
@@ -28,7 +28,7 @@ estimate: 1.5d
 - 输出默认 ANSI-colored text；`--format json` 切 JSON lines（ndjson）；`--no-color` 禁色
 - `mempal tail`：
   - 默认展示最近 20 条（按 `added_at DESC`——codebase 既有列名是 `added_at`，见 `src/core/db.rs`；本 spec 全文其他 `added_at` 字样均指此列；未来若 P9 novelty 的 `updated_at` 列存在则 `--sort-by updated_at` 可选）
-  - `--follow` 每 2s 轮询 `SELECT ... WHERE id > ?last_seen_id ORDER BY id ASC`，append 新行；**用 ULID id 而非 timestamp 做游标**，规避同毫秒内多条 insert 被漏读的竞态（ULID 是 monotonically increasing，timestamp 会 tie）
+  - `--follow` 走 fs-watch + 250ms debounce 路径（详见下方 Decisions 里 "fs event 只作 wake-up 触发" 段）；fallback 无 inotify 时每 2s poll `SELECT ... WHERE id > ?last_seen_id ORDER BY id ASC`，append 新行；**用 ULID id 而非 timestamp 做游标**，规避同毫秒内多条 insert 被漏读的竞态（ULID 是 monotonically increasing，timestamp 会 tie）
   - 每行格式 `<timestamp> <flag>  <wing>/<room>  <drawer_id[:8]>  <preview(120 chars)>`
   - `--wing` / `--room` / `--since "7d"` 精细过滤（`--since` 仍走 `added_at`，仅 follow 游标用 id）
   - SIGINT 优雅退出
@@ -61,6 +61,13 @@ estimate: 1.5d
 - 所有 CLI 子命令只读 palace.db（`SELECT` only），绝不写入
 - 子命令若 palace.db 不存在 → 友好错误："run mempal init first"
 - `mempal tail --follow` 默认用 `inotify` / `fsevents` 监听 db **所在目录**（非单文件 `palace.db`）+ 按文件名过滤 `palace.db*` 模式，捕获 `palace.db` / `palace.db-wal` / `palace.db-shm` 三种事件；理由：WAL 模式（`p8-pending-message-store.spec.md`）下写入先落到 `-wal` 文件，主 db 文件 mtime 只在 checkpoint 时更新，单文件 watch 会漏事件；此外 SQLite 原子保存可能 rename 导致 inode 变——watch 目录更鲁棒。不可用时 fallback poll（2s interval）
+- **fs event 只作 wake-up 触发，不跟踪事件详情**（CSA debate 2026-04-20 R6 design）：
+  - tail --follow 维护 `last_seen_id: Option<Ulid>`（启动时 = 已显示的最后一条 drawer ulid）
+  - fs event 到达 → 进入 **250ms debounce 窗口**（`tokio::time::sleep(Duration::from_millis(250))`），窗口内所有后续 fs event 被直接丢弃（不再 reset 窗口避免无限推迟）
+  - 窗口结束 → 跑一次 `SELECT id, wing, room, added_at, content FROM drawers WHERE id > ? ORDER BY id ASC` (`?` = last_seen_id) → 打印新行 → 更新 last_seen_id
+  - 这个设计把 fs 事件的精确性从关键路径上移除——即使 ipmfs 漏报或重复发 event，SELECT 语句基于 db 真值；事件只是"该去查一次 db 了"的唤醒信号
+  - 优势：写高峰期一连串 fs 事件只触发一次 SELECT，避免 CPU 烧；ANSI 光标刷屏节奏稳定；无需区分 inotify 事件类型
+  - fallback poll 间隔保持 2s（inotify 不可用时的兜底）
 - **不**启动 daemon / service；每次子命令独立进程、独立退出
 
 ## Boundaries
@@ -128,6 +135,19 @@ Scenario: mempal tail --follow 响应新增 drawer
   When 主进程 `mempal_ingest` 新增一条 drawer
   Then follow 进程 5s 内 stdout 新增一行对应该 drawer
   And follow 进程仍在运行
+
+Scenario: tail --follow 在写入高峰下只触发一次 SELECT 而非每事件一次
+  Test:
+    Filter: test_tail_follow_coalesces_event_storm
+    Level: integration
+    Test Double: recording_sqlite
+    Targets: crates/mempal-cli/src/observability/tail.rs
+  Given `mempal tail --follow` 启动，启动后记录 `SELECT ... FROM drawers WHERE id > ?` 的调用次数（通过 SQLite 打点或 sqlite_trace）
+  When 在 200ms 内往 db 连续 ingest 20 条 drawer（触发 ~20 次 fs event）
+  Then 250ms debounce 窗口结束后发生 **1 次** 或 **2 次** SELECT（不是 20 次）
+  And 20 条 drawer 都被打印到 stdout
+  And 所有行按 ULID 升序排列（无重复、无遗漏）
+  And 总 CPU 时间显著低于每事件一次 SELECT 的基线（作为观察指标，不 assert 具体值）
 
 Scenario: mempal timeline 按天分组
   Test:

--- a/specs/fork-ext/p10-project-vector-isolation.spec.md
+++ b/specs/fork-ext/p10-project-vector-isolation.spec.md
@@ -38,6 +38,19 @@ estimate: 1d
 - 现有 drawer 的 backfill：
   - migration 时自动把所有 `project_id` 设为 NULL（兼容）
   - 提供 `mempal project migrate --project <id> [--wing <W>]` 子命令把指定 wing 下 drawer 的 `project_id` 批量 UPDATE
+  - **Batched UPDATE 避免长锁**（CSA debate 2026-04-20 R7 validated）：一次性 `UPDATE drawers SET project_id = ? WHERE ...` 对十万行大库会拿 SQLite 写锁数分钟，阻塞 daemon ingest 和 MCP search。改用**分批循环**：
+    ```sql
+    BEGIN IMMEDIATE;
+    UPDATE drawers SET project_id = ? WHERE id IN (
+      SELECT id FROM drawers WHERE project_id IS NULL AND wing = ? LIMIT 1000
+    );
+    COMMIT;
+    ```
+    循环直到 `changes() == 0`，每批 commit 后让出锁 ~10ms 让其它 writer 插入
+    - `BEGIN IMMEDIATE` fail-fast：若此时有其它 writer 持锁，立刻返回 `SQLITE_BUSY` 而非等待，migrate 子命令可选重试 backoff（500ms / 1s / 2s）或输出进度让用户看到"暂时让路"
+    - 并发 ingest 可能在 migrate 期间继续插入 `project_id IS NULL` 的新行——LIMIT loop 会在后续批次把它们也捕获，最终收敛（`changes() == 0` 时结束）
+    - 同步更新 `drawer_vectors` 表的 `project_id` 冗余列时，采用同样分批策略（对每个已 UPDATE 的 drawer id）
+  - `mempal project migrate` 子命令 stdout 逐批打印进度 `"batch 3: 1000 drawers updated, 42000 remaining"`，让用户能判断是否卡住
 - `project_id` 不参与 AAAK signal 提取（project 是元数据轴，非内容轴）
 - `mempal status` 加 "project breakdown" 行：`drawers per project: {proj-A:42, proj-B:18, NULL:7}`
 - `mempal tail` / `mempal timeline`（P10 CLI）支持 `--project <id>` 过滤
@@ -90,9 +103,9 @@ Scenario: schema 迁移 v9 → v10 添加 project_id 列
     Filter: test_migration_v9_to_v10_adds_project_id
     Level: integration
     Targets: crates/mempal-core/src/db/schema.rs
-  Given palace.db schema_version == "7"
+  Given palace.db schema_version == "9"
   When 启动 mempal
-  Then schema_version == "8"
+  Then schema_version == "10"
   And `drawers`, `drawer_vectors`, `triples` 三表均有 `project_id` 列
   And 存在索引 `idx_drawers_project_id`
   And 既有 drawer 的 `project_id` 全部为 NULL
@@ -198,6 +211,31 @@ Scenario: mempal project migrate 批量迁移既有 drawer
   Then 该 wing 的 20 条 drawer `project_id == "proj-A"`
   And 其他 wing 的 drawer 不变
   And `drawer_vectors` 同步更新
+
+Scenario: project migrate 用分批 UPDATE 不长时阻塞 ingest
+  Test:
+    Filter: test_project_migrate_batched_does_not_block_ingest
+    Level: integration
+    Targets: crates/mempal-cli/src/project_migrate.rs
+  Given palace.db 含 **5000** 条 `project_id IS NULL` 的 drawer（wing=code-memory）
+  And 后台开启一个轻量 writer 线程，每 50ms 往 wing=logs 写一条 drawer（与 migrate 目标 wing 不同，模拟并发 ingest）
+  When 执行 `mempal project migrate --project proj-A --wing code-memory`
+  Then 命令在合理时间内完成（例如 < 10s）
+  And 后台 writer 期间的每次 ingest latency p99 < 200ms（未被长锁阻塞到秒级）
+  And 命令结束时 wing=code-memory 全部 5000 条 `project_id == "proj-A"`
+  And stdout 至少打印了 5 条 batch progress 行（5000 / 1000 批 = 5 批）
+
+Scenario: project migrate 遇到繁忙写锁时 BEGIN IMMEDIATE fail-fast 并重试
+  Test:
+    Filter: test_project_migrate_begin_immediate_fails_fast
+    Level: integration
+    Targets: crates/mempal-cli/src/project_migrate.rs
+  Given 另一进程持有写锁（模拟长事务）1 秒
+  When 执行 `mempal project migrate --project proj-A --wing code-memory`
+  Then 第一批 `BEGIN IMMEDIATE` 立即（< 100ms）返回 `SQLITE_BUSY`
+  And migrate 输出 `"batch busy, retrying in 500ms"` 类提示
+  And 持锁进程释放后 migrate 成功完成
+  And 没有死锁、没有线程悬挂
 
 Scenario: mempal status 显示 project breakdown
   Test:

--- a/specs/fork-ext/p8-config-hot-reload.spec.md
+++ b/specs/fork-ext/p8-config-hot-reload.spec.md
@@ -1,0 +1,261 @@
+spec: task
+name: "P8: Config hot-reload — fs watch + atomic swap + request-scoped snapshot (zero restart for most fields)"
+tags: [feature, config, reload, observability]
+estimate: 1d
+---
+
+## Intent
+
+让修改 `~/.mempal/config.toml` 不需要重启 `mempal daemon` / MCP server / CLI 长进程。通过 **fs-watch（`notify` crate）+ 原子替换读取 + 请求级 `Arc<Config>` snapshot** 实现：
+
+- 告警阈值、告警脚本路径、路由关键词、privacy regex、gating 规则、novelty 阈值、preview 截断长度、dashboard debounce、ingest 锁超时、strict_project_isolation、progressive_disclosure 等字段**实时生效**
+- embedder 后端、SQLite path、MCP server 路径等**需重启**字段被显式 blacklist
+- 解析失败不 crash，保留上一版 `Arc<Config>` 继续服务，stderr 打印警告
+- `mempal_status` / `mempal status` 输出 `config_version`（blake3 hash）+ `loaded_at` 时间戳，agent 和人类都能看到当前生效版本
+
+**动机**：当前 mempal 改任何一个字段（比如调 gating threshold 或加一条 privacy pattern）都要重启 daemon / 让 Claude Code 重拉 MCP 子进程，开发反馈循环被拖长到分钟级。热重载把这个降到秒级——保存 config.toml → 下一个 MCP 请求自动看到新配置。
+
+**v3 判决依据**：用户 2026-04-20 明确要求"配置文件尽可能热重载，修改配置不需要重启服务 / claude code"。CSA debate 2026-04-20 tier-4-critical session 确认：`notify` crate 是唯一对 daemon / MCP stdio 两种运行模式都兼容的机制（SIGHUP 送不到 Claude Code spawn 的 stdio 子进程），`Arc<Config>` 请求级 snapshot 是 mid-flight 不一致的唯一正确解法。
+
+**Default on**：`[config_hot_reload] enabled = true`，纯读文件变更，无副作用，默认开。用户可显式 `enabled = false` 回退到 "config 一加载到进程结束不变" 的旧语义。
+
+## Decisions
+
+- 新建 `crates/mempal-core/src/config/hot_reload.rs`（原 `config.rs` 按模块拆分：`config/mod.rs` + `config/schema.rs` + `config/hot_reload.rs`）
+- 全局状态用 `Arc<ArcSwap<Config>>`（`arc-swap` crate，workspace-dep）包裹 Config，提供 `ConfigHandle::current() -> Arc<Config>` 获取当前快照
+- 加载流程：
+  1. 启动时 parse `config.toml` → `Config` → 存入 `ArcSwap::new(Arc::new(cfg))`
+  2. spawn `notify::RecommendedWatcher` watch **config.toml 所在目录**（单文件 watch 被 editor rename/atomic-save 击穿，与 P10 dashboard 同理）+ 按文件名过滤 `config.toml`
+  3. 收到 `Create` / `Modify` / `Rename` 事件 → **250ms debounce**（editor 写多段文件时合并）→ 重读文件 → parse
+  4. parse 成功 → `ArcSwap::store(Arc::new(new_cfg))` 原子替换；旧 `Arc` 被读者释放后自动回收
+  5. parse 失败 → 保留 `ArcSwap` 当前内容不变，stderr `warn!("config hot-reload: parse failed, keeping previous version: {err}")`
+  6. `config_version` = blake3 hash of `config.toml` 字节（hex 前 12 位），每次成功加载都更新 `ConfigHandle.version`
+  7. `loaded_at` = Unix epoch millis，每次成功加载更新
+- 请求级 snapshot：
+  - MCP server 每个 tool handler 在入口处 `let cfg = ConfigHandle::current();` 拿一个 `Arc<Config>` 快照，之后整个 request 用这个 cfg
+  - `ingest::pipeline::ingest` 同理：入口拿 snapshot，整个 pipeline（privacy scrub → gating → novelty → store）共用
+  - 这消除 mid-flight 不一致：一个 ingest 请求不会看到 "privacy.enabled=true 开始 scrub，中途被热重载成 false 跳过 scrub" 的断层
+  - `cfg.clone()` 是廉价的（`Arc::clone`）
+- 可热重载字段白名单（`#[hot_reload(allowed)]` attribute 或 runtime 检查 enum）：
+  - `[alerting]` 全部（threshold / script_path / cooldown_secs）
+  - `[privacy]` 全部（enabled / strip_tags / scrub_patterns）
+  - `[taxonomy]`（wing/room 路由关键词）
+  - `[ingest_gating.rules]`、`[ingest_gating.embedding_classifier.threshold]`、`[ingest_gating.embedding_classifier.prototypes]`（改 prototype 会触发 daemon "下一次重启时重新 embed"——参见 "受限热重载" 下方）
+  - `[ingest_gating.novelty]` 全部（enabled / duplicate_threshold / merge_threshold / wing_scope / top_k_candidates / max_merges_per_drawer / max_content_bytes_per_drawer）
+  - `[progressive_disclosure]` 全部（preview_bytes / enabled）
+  - `[search] strict_project_isolation`
+  - `[hooks.session_end]` 全部（extract_self_review / trailing_messages / min_length / wing）
+  - `[hooks] daemon_poll_interval_ms` / `daemon_claim_ttl_secs`（下一轮循环生效）
+  - `[cli_dashboard] tail_debounce_ms` / `tail_poll_fallback_secs`
+  - `[pending_messages] claim_ttl_secs` / `reclaim_interval_secs` / `retry_backoff_ms`
+  - `[project] id`（下一个请求生效；**不**触发 backfill UPDATE）
+- 受限热重载字段（变更被接受但实际生效需 daemon 重启或显式命令）：
+  - `[ingest_gating.embedding_classifier.prototypes]` 增删 prototype 后，daemon 下次重启才重新 pre-compute；hot-reload 只更新 `Arc<Config>` 内的 prototype 文本，但实际使用的 `prototype_vectors: Vec<Vec<f32>>` 需 daemon 重启；stderr `warn!("prototype change detected, effective after daemon restart")`
+- 重启硬需字段 blacklist（热重载检测到变更 → stderr 报 `error!("field X requires restart, change ignored in current session")` 并保持旧值）：
+  - `[embedder]` 全部（`backend`、`base_url`、`model`、`dim` 等）——切后端要 `mempal reindex`，不是热重载能解决
+  - `[database] path`
+  - `[mcp] server_name` / 子进程启动时 MCP SDK 已拿走的 ServerInfo
+  - `[cli] binary_path` / 编译期决定的路径
+- 可观测性：
+  - `ConfigHandle` 暴露 `.version() -> String`, `.loaded_at() -> SystemTime`
+  - `mempal_status` MCP 工具 response 多两个字段：`config_version: String`, `config_loaded_at_unix_ms: u64`
+  - `mempal status` CLI 输出 `"config: version=a1b2c3d4e5f6 loaded=2026-04-20 12:34:56"`
+  - daemon log 记录每次热重载成功 / 失败 / 忽略（restart-required 字段）事件
+- 错误处理：
+  - `ConfigError`（`thiserror`）区分 `ParseFailed` / `IoFailed` / `RestartRequired { field }`
+  - hot_reload 回路**永不 panic**——任何 parse / io 错误都 catch 下来，回到上一版
+  - `notify` crate 本身死掉（watcher thread panic）→ stderr warn + fallback 到每 5s poll `stat(config.toml)`（mtime + size 对比），保证降级可用
+- 原子性：
+  - 读侧用 `ArcSwap::load()` 原子读取（一次 load 返回一致的 Arc）
+  - 写侧 `ArcSwap::store()` 原子替换
+  - 文件侧：假设 editor 用 `rename(tmp → config.toml)` 原子保存（vim / emacs / 所有主流 editor 默认）；直接 open+truncate+write 的编辑方式会产生短暂 parse 失败，但我们的"保留上一版"策略会兜住
+- 线程模型：
+  - `notify::RecommendedWatcher` 在独立 tokio task（`tokio::task::spawn_blocking`，因为 notify 是同步 API）
+  - 事件通过 `tokio::sync::mpsc::channel(64)` 送到 debounce task（tokio::task::spawn）
+  - debounce task 调 `parse → ArcSwap::store`
+  - 不需要任何 Mutex——`ArcSwap` 内部用 seqlock，读侧 lock-free
+- 集成顺序依赖：
+  - 本 spec 需要在 `p8-embed-qwen3-backend.spec.md` 引入的"告警脚本路径热重载"字段存在时落地——本 spec 把它泛化为通用机制，`p8-embed-qwen3-backend` 的告警路径是第一个消费者
+  - `p9-judge-gating-local` / `p9-novelty-filter` / `p10-cli-dashboard` / `p10-project-vector-isolation` 的配置字段上线时直接声明"可热重载 / 需重启"属性，由本 spec 机制落实
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/config/hot_reload.rs`（新建）
+- `crates/mempal-core/src/config/mod.rs`（拆分旧 `config.rs`）
+- `crates/mempal-core/src/config/schema.rs`（拆分）
+- `crates/mempal-core/Cargo.toml`（添加 `arc-swap` + `notify` + `blake3`——workspace dep 可复用）
+- `crates/mempal-mcp/src/tools.rs`（`mempal_status` response schema 加 `config_version` / `config_loaded_at_unix_ms`）
+- `crates/mempal-mcp/src/server.rs`（tool handler 入口拿 `ConfigHandle::current()`）
+- `crates/mempal-ingest/src/pipeline.rs`（入口拿 snapshot）
+- `crates/mempal-cli/src/main.rs`（`mempal status` 打印 config 行）
+- `crates/mempal-cli/src/daemon.rs`（daemon 启动时初始化 ConfigHandle + watcher）
+- `tests/config_hot_reload.rs`（新建）
+
+### Forbidden
+- 不要用 SIGHUP（对 Claude Code spawn 的 stdio MCP 子进程送不到；`notify` 覆盖所有模式）
+- 不要用轮询作为主路径（`notify` 可用时延迟 < 500ms；poll 是 degraded fallback）
+- 不要让 parse 失败导致 daemon / MCP server 退出——保留上一版
+- 不要在 `ConfigHandle::current()` 内部加任何 blocking（热路径）
+- 不要对 embedder backend 字段做 "partial hot-reload"（重建 Embedder trait object）——这破坏 dim 不变式，必须整进程重启 + `mempal reindex`
+- 不要把热重载的"新配置"写回到 `ArcSwap` 之外的其他缓存（会产生多个真源）
+- 不要为每个字段单独起 notify watcher（单一 watcher + 整 Config 替换）
+- 不要在 parse 成功后立刻把 `Arc<Config>` 的字段 move 到 static——读者可能还持着旧 Arc
+- 不要让 Config 有 `Deserialize` 之外的 side-effect（比如"加载后自动 `fs::create_dir_all`"）——加载纯函数
+- 不要让 `mempal status` 为了读 config_version 去读文件（从 `ConfigHandle` 拿即可）
+- 不要暴露 "force reload" MCP 工具让 agent 主动触发重载（violates principle of least surprise；fs-watch 自动触发，用户编辑文件就是意图信号）
+- 不要修改 db schema
+
+## Out of Scope
+
+- Per-request config override（agent 在 MCP 请求里传"用这个 config 跑这次"——YAGNI，未来有需求再独立 spec）
+- 配置版本历史 / rollback（ArcSwap 只保留当前版；用户自己 git 管理 config.toml 历史）
+- 加密 config（凭证存 config.toml 已经是 "the config is in the user's home"——不是本项目责任）
+- 配置 schema 版本迁移（字段加减直接 config.toml 字面编辑；工具辅助是未来 `mempal config migrate` 独立 spec）
+- Web UI 编辑 config（纯 CLI / 编辑器）
+- 向 agent 暴露 "reload failed" 错误（agent 无行动权；人类看 stderr / log）
+- 热重载 `[logging]` 级别（大多数 tracing subscriber 初始化后不支持动态 level；独立 spec）
+- multi-config 文件 merge（单 `~/.mempal/config.toml` 够用）
+- `[embedder]` 的"下次重启生效"自动存储（变更被 warn 掉，用户自己重启）
+
+## Completion Criteria
+
+Scenario: 修改 privacy.scrub_patterns 后下一次 ingest 立即应用新 pattern
+  Test:
+    Filter: test_privacy_pattern_hot_reload_applies_on_next_ingest
+    Level: integration
+    Targets: crates/mempal-core/src/config/hot_reload.rs, crates/mempal-ingest/src/pipeline.rs
+  Given `mempal daemon --foreground` 运行，config.toml 含 `openai_key` pattern，不含 `custom_token` pattern
+  When 执行一次 ingest（含 custom_token 字串 `"CT-1234567890abcdef"`），verify content 原样（未被 scrub）
+  And 随后编辑 config.toml append 一条 `custom_token` pattern（正则 `CT-[a-f0-9]{16}`）并保存（atomic rename）
+  And 等待 1s（debounce + parse）
+  And 执行第二次 ingest 同样内容
+  Then 第一次 drawer.content 含原 `CT-1234567890abcdef` 字面（彼时未开启）
+  And 第二次 drawer.content 含 `[REDACTED:custom_token]`，不含原字面
+  And daemon log 含一行 "config hot-reload: version changed from ... to ..."
+
+Scenario: parse 失败时保留上一版继续服务
+  Test:
+    Filter: test_parse_failure_preserves_previous_config
+    Level: integration
+    Targets: crates/mempal-core/src/config/hot_reload.rs
+  Given daemon 运行，config.toml 合法、privacy.enabled=true
+  When 编辑 config.toml 故意写入**非法 TOML**（比如 `privacy.enabled = ***`）并保存
+  And 等 1s
+  Then daemon 不退出
+  And stderr 含 "config hot-reload: parse failed, keeping previous version" 或等价
+  And 此时执行 ingest 仍走 privacy scrub（old cfg 生效）
+  When 再把 config.toml 改回合法（保存）
+  And 等 1s
+  Then ingest 走新版 privacy 规则
+  And daemon 恢复日志中的 config_version 更新
+
+Scenario: 请求级 Arc<Config> snapshot 防 mid-flight 不一致
+  Test:
+    Filter: test_request_scoped_snapshot_prevents_mid_flight_mutation
+    Level: integration
+    Test Double: slow_embedder_fixture
+    Targets: crates/mempal-ingest/src/pipeline.rs, crates/mempal-core/src/config/hot_reload.rs
+  Given daemon 运行，`privacy.enabled = true` + 一个人工 slow_embedder（每次 embed 2s）
+  When 发起一次 ingest（含 `sk-abcdef1234567890abcdef1234567890abcd`）
+  And 在该 ingest 的 embed 阶段（pipeline 已经 scrub 过但还没 embed 完）**热替换 config 把 privacy.enabled 改为 false**
+  Then 该次 ingest 的 drawer.content 仍含 `[REDACTED:openai_key]`（因为 pipeline 入口已 snapshot 当时的 cfg）
+  And embedder 收到的输入是 scrubbed 版本
+  And 随后的下一次 ingest（新请求）走 disabled 版本（不 scrub）
+
+Scenario: embedder backend 变更触发 restart-required warning 但不 reload
+  Test:
+    Filter: test_embedder_backend_change_warns_and_ignores
+    Level: integration
+    Targets: crates/mempal-core/src/config/hot_reload.rs
+  Given daemon 运行，`[embedder] backend = "openai-compat"`、`base_url = "http://gb10:18002/v1/"`
+  When 编辑 config.toml 把 `base_url` 改成 `http://localhost:9000/v1/` 保存
+  And 等 1s
+  Then daemon stderr 含 `"embedder.base_url requires restart, change ignored"` 类 error 级日志
+  And 运行时 embedder 仍调旧 `http://gb10:18002/v1/`（通过一次 ingest + 抓网络请求 target 或 embedder mock 验证）
+  And `config_version` **未**更新（因为 blacklist 字段变更不触发版本号变——防止 `mempal_status` 误报生效）
+  And 编辑 config.toml 其它（非 blacklist）字段再保存 → `config_version` 正常更新
+
+Scenario: notify watcher 死掉后 fallback poll 仍能捕获变更
+  Test:
+    Filter: test_notify_watcher_crash_falls_back_to_poll
+    Level: integration
+    Test Double: notify_kill_fixture
+    Targets: crates/mempal-core/src/config/hot_reload.rs
+  Given daemon 运行，人工 kill `notify::Watcher` 后台 thread（模拟 crash）
+  When 编辑 config.toml 改 `privacy.enabled = false`（atomic rename 保存）
+  And 等 6s（超过 fallback poll 间隔 5s）
+  Then daemon 依然捕获变更，`config_version` 更新
+  And 新 ingest 生效新 cfg
+  And daemon log 含 `"notify watcher crashed, falling back to poll"` 类 warn
+
+Scenario: mempal status 输出 config_version 和 loaded_at
+  Test:
+    Filter: test_status_prints_config_version_and_loaded_at
+    Level: integration
+    Targets: crates/mempal-cli/src/main.rs
+  Given daemon 运行，config 已加载
+  When 运行 `mempal status`
+  Then stdout 含形如 `"config: version=<12-char-hex> loaded=<ISO-8601 timestamp>"` 的行
+  And version 长度 == 12
+  And timestamp 在最近 10 分钟内
+
+Scenario: mempal_status MCP 工具返回 config_version 字段
+  Test:
+    Filter: test_mcp_status_returns_config_version
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs, crates/mempal-mcp/src/server.rs
+  Given mempal MCP server 运行
+  When agent 调 `mempal_status({})`
+  Then response JSON 含 `config_version: String` 字段（12 hex chars）
+  And 含 `config_loaded_at_unix_ms: number` 字段
+  And 修改 config.toml + 等 1s 后再次调 → `config_version` 值不同、`config_loaded_at_unix_ms` 更大
+
+Scenario: 一秒内多次保存只触发一次 parse（debounce 生效）
+  Test:
+    Filter: test_rapid_edits_coalesced_by_debounce
+    Level: integration
+    Test Double: parse_counter
+    Targets: crates/mempal-core/src/config/hot_reload.rs
+  Given daemon 运行
+  When 在 500ms 内连续保存 config.toml 5 次（每次 atomic rename）
+  And 等 1s
+  Then parse 被调用次数 <= 2 次（允许 1 或 2，视 debounce 时序窗口）
+  And 最终 `config_version` 对应最后一次保存的内容
+  And 日志无重复 warn
+
+Scenario: enabled=false 时完全不启动 watcher
+  Test:
+    Filter: test_hot_reload_disabled_no_watcher
+    Level: integration
+    Targets: crates/mempal-core/src/config/hot_reload.rs
+  Given `[config_hot_reload] enabled = false`
+  When daemon 启动并运行
+  Then 进程无 inotify watcher fd（`ls /proc/<pid>/fd | xargs -I{} readlink /proc/<pid>/fd/{}` 不含 `anon_inode:inotify`）
+  And 编辑 config.toml 不影响运行中的 Config
+  And `mempal status` 的 `config_loaded_at` 等于 daemon 启动时间
+
+Scenario: 新 prototype 被热重载但实际 embedding 直到下次 daemon 重启才生效
+  Test:
+    Filter: test_prototype_hot_reload_deferred_to_restart
+    Level: integration
+    Targets: crates/mempal-core/src/config/hot_reload.rs, crates/mempal-ingest/src/gating/prototypes.rs
+  Given daemon 运行，gating.prototypes 含 3 个 prototype A/B/C
+  When 编辑 config.toml 加一个新 prototype D 保存
+  And 等 1s
+  Then `ConfigHandle::current().ingest_gating.embedding_classifier.prototypes` 已含 D
+  And daemon 仍用旧 `prototype_vectors` 数组（只 embed 过 A/B/C）做判决
+  And 日志含 "prototype change detected, effective after daemon restart"
+  When 重启 daemon
+  Then prototype D 被新 daemon 启动时 embed 并加入 `prototype_vectors`
+
+Scenario: MCP stdio 子进程（被 Claude Code spawn）也能热重载
+  Test:
+    Filter: test_mcp_stdio_child_hot_reloads
+    Level: integration
+    Targets: crates/mempal-mcp/src/server.rs, crates/mempal-core/src/config/hot_reload.rs
+  Given Claude Code 把 mempal MCP server 作为 stdio 子进程启动（`mempal mcp stdio` 或等价）
+  When 编辑 config.toml 改 `[search] strict_project_isolation = true` 保存
+  And 等 1s
+  Then 对该 stdio 子进程发 `mempal_status` 返回的 config_version 已更新
+  And 下一次 `mempal_search` 请求走 strict isolation 语义（通过 fixture 数据验证）

--- a/specs/fork-ext/p8-hook-passive-capture.spec.md
+++ b/specs/fork-ext/p8-hook-passive-capture.spec.md
@@ -25,6 +25,12 @@ estimate: 2d
   - `mempal hook <event-type>` — 从 stdin 读 JSON，enqueue 后退出（退出码永远 0 除非 db 不可达）
   - `mempal daemon [--foreground]` — 启动 worker；默认 detach 走 `daemonize` crate（或等价专用 daemonization 库）；**禁止**在 tokio 多线程 runtime 启动后手动 `fork`——libc `fork` 在多线程 tokio 进程中高概率引起子进程 mutex 死锁或未定义行为（POSIX async-signal-safety 限制）；daemonize 必须发生在 **tokio runtime 初始化之前**；setsid + pid 文件 `~/.mempal/daemon.pid` 仍保留，由 daemonize crate 内部处理
   - **实现约束**：`crates/mempal-cli/src/main.rs` 顶层**不可**使用 `#[tokio::main]`（该宏会在 `main` 进入前先 build 多线程 runtime，导致 daemonize 无法发生在 runtime-init 之前）。替代：`fn main() -> anyhow::Result<()>` + 在每个子命令 handler 内按需手动 `tokio::runtime::Builder::new_multi_thread().enable_all().build()?.block_on(async { ... })`；`daemon` handler 必须在调用 `daemonize()` **之后** 才构造 runtime
+  - **Fork-unsafe 资源集中约束**（CSA debate 2026-04-20 round-3 identified）：除 tokio runtime 之外，以下资源同样**禁止**在 `daemonize()` **之前**初始化——fork 后子进程继承这些资源会导致 mutex 死锁、fd 泄漏、WAL 文件句柄悬空、tracing worker 线程不在子进程存活：
+    - `rusqlite::Connection::open`（任何到 `palace.db` 的连接都必须在 daemonize 后建立；pid 文件写入也要等 daemonize 结束）
+    - `tracing_subscriber::fmt().with_writer(file_writer).init()`（含 `tracing-appender` 的异步 worker 线程）
+    - 任何 `std::thread::spawn` / `tokio::task::spawn`
+  - **封装建议**：新建 `crates/mempal-cli/src/daemon_bootstrap.rs` 内 `DaemonContext::bootstrap()`，语义为"parse CLI → read config → daemonize (含 `working_directory`, `pid_file`, `stdout`→log, `stderr`→log, `umask=0o027`) → 返回 `DaemonContext { cfg, runtime, db, tracing_guard }`"。此函数内部的调用顺序即标准启动序，**所有 daemon 子命令** 都应走该入口以避免重复失误
+  - **fd 0/1/2 必须重定向**：`daemonize` crate 默认 close 0/1/2，但某些 libc 实现会让后续 `open()` 复用这些 fd 导致数据错乱（比如新 SQLite 连接拿到 fd 1 后，panic 的 stderr 写到 SQLite 文件）。必须显式把 stdin 重定向到 `/dev/null`、stdout+stderr 重定向到 `~/.mempal/daemon.log`（或 config 指定路径）；`daemonize` crate 的 `.stdout(file)` / `.stderr(file)` 参数完成此事；fallback 手动 `dup2(fd_dev_null, 0)` / `dup2(fd_log, 1)` / `dup2(fd_log, 2)`
   - `mempal daemon stop` — 读 pid 文件发 SIGTERM
   - `mempal daemon status` — 看 pid 文件存活 + 读 `pending_messages` stats 报告
   - `mempal hook install --target <T> [--dry-run]` — 写对应工具的 settings 文件注入 hook 配置
@@ -76,6 +82,7 @@ estimate: 2d
 ### Allowed
 - `crates/mempal-cli/src/hook.rs`（新建：`mempal hook <event>` 实现）
 - `crates/mempal-cli/src/daemon.rs`（新建：`mempal daemon` worker loop）
+- `crates/mempal-cli/src/daemon_bootstrap.rs`（新建：`DaemonContext::bootstrap()` 统一启动序——daemonize → runtime → db → tracing）
 - `crates/mempal-cli/src/hook_install.rs`（新建：各 target 的 settings 文件 patching）
 - `crates/mempal-cli/src/main.rs`（注册新子命令）
 - `crates/mempal-cli/Cargo.toml`（添加 `nix`/`libc` 仅用于 fork/setsid、signal 处理；`serde_json` 已有）
@@ -255,3 +262,26 @@ Scenario: hook 子命令不污染 stdout
   When 执行 `mempal hook hook_post_tool` 并捕获 stdout + stderr
   Then stdout 长度 == 0
   And stderr 可含 info/warn 日志但不 panic
+
+Scenario: DaemonContext::bootstrap 严格按 daemonize → runtime → db → tracing 顺序初始化
+  Test:
+    Filter: test_daemon_context_bootstrap_ordering
+    Level: integration
+    Targets: crates/mempal-cli/src/daemon_bootstrap.rs
+  Given 待启动的 daemon handler，测试通过 `tracing` pattern 记录每个资源的 init 时间戳
+  When 调 `DaemonContext::bootstrap(cli_args)`
+  Then 记录中 daemonize 完成时间戳 < runtime 构造时间戳
+  And runtime 构造时间戳 < rusqlite::Connection::open 时间戳
+  And runtime 构造时间戳 < tracing_subscriber init 时间戳
+  And fd 1 (stdout) 和 fd 2 (stderr) 不再指向 tty，而是指向配置的 daemon.log 文件（`readlink /proc/self/fd/1` 返回 log 路径）
+  And fd 0 (stdin) 指向 `/dev/null`
+
+Scenario: 禁止 daemonize 前 open SQLite 连接（静态检查）
+  Test:
+    Filter: test_no_sqlite_before_daemonize
+    Level: static
+    Targets: crates/mempal-cli/src/daemon.rs, crates/mempal-cli/src/daemon_bootstrap.rs
+  Given daemon handler 源码
+  When 用 `grep` / `cargo clippy` 检测在 `daemonize(…)` 调用**之前**是否存在 `rusqlite::Connection::open` 或 `crate::core::db::Database::open` 调用
+  Then 检测器不报警
+  And daemon_bootstrap.rs 的 `bootstrap()` 函数内，`daemonize` 调用位于 `Database::open` 上方

--- a/specs/fork-ext/p8-privacy-scrubbing.spec.md
+++ b/specs/fork-ext/p8-privacy-scrubbing.spec.md
@@ -160,6 +160,20 @@ Scenario: 清洗不影响 drawer 计数和 vector 维度
   Then `drawer` 条数为 "5"（scrub 不触发丢弃）
   And 每条 `drawer_vectors` 维度一致（256d for potion-multilingual-128M）
 
+Scenario: 跨 chunk 边界的 secret 仍被 scrub（pre-chunk 顺序断言）
+  Test:
+    Filter: test_scrub_catches_cross_chunk_secret
+    Level: integration
+    Targets: crates/mempal-ingest/src/pipeline.rs, crates/mempal-ingest/src/privacy.rs
+  Given `enabled = true` 且默认 `openai_key` pattern 启用
+  And chunk 上限调小到 50 字节（测试夹具强制触发分块）
+  And ingest payload：`"long preamble of ~48 bytes then sk-abcdef1234567890abcdef1234567890abcd rest..."` — 关键 secret **恰好跨越 chunk 边界**（48 字节前缀 + sk-key）
+  When 走 `ingest::pipeline::ingest`
+  Then 所有产生的 chunk 文本均不含 `sk-abcdef1234567890abcdef1234567890abcd` 原字面
+  And 至少一个 chunk 含 `[REDACTED:openai_key]`
+  And `embedder` 收到的每个 chunk 输入也不含原 secret 字面
+  And `ScrubStats.pattern_matches["openai_key"]` >= 1
+
 Scenario: 无新增外部运行时依赖
   Test:
     Filter: test_no_new_runtime_dependencies_introduced

--- a/specs/fork-ext/p9-judge-gating-local.spec.md
+++ b/specs/fork-ext/p9-judge-gating-local.spec.md
@@ -40,7 +40,12 @@ estimate: 2d
 - 多条规则**短路求值**：第一个 match 决定结果（`continue` 例外，会继续下一条）
 - Tier 2 原型分类器：
   - 配置 `[ingest_gating.embedding_classifier] enabled = true, threshold = 0.35, prototypes = [...]`
-  - 启动时 `Prototype { label, embed_vec }` 预计算（embed 阻塞一次）存内存
+  - 启动时 `Prototype { label, embed_vec }` **同步预计算**（embed 阻塞一次）存内存；**fail-fast**——任一 prototype embed 失败即阻止 daemon 启动并打印清晰错误（见下）
+  - **架构约束**（CSA debate 2026-04-20 R3 validated）：gating 只在 `mempal daemon` 后台 worker 路径运行（**不**在 `mempal hook` fast-path 调用，hook 只负责 enqueue），daemon 启动延迟对 agent 和用户完全不可见；因此**同步**预计算比 lazy / 后台预热 + ready flag 更稳：
+    - 消除 "first-request-too-slow" 尾延迟
+    - 消除 ready flag 的同步原语复杂度（arc-swap / OnceCell）
+    - fail-fast 让 misconfigured embedder 在 daemon 启动时立刻暴露，而非延迟到第一条 ingest 才崩（更易排查）
+    - 2-3 秒的 daemon 启动开销可接受（daemon 启动后持续运行）
   - 判决：计算 candidate embedding → 对每个 prototype 求 cosine → 取 max
   - max >= threshold → `Keep { tier: 2, label }`
   - max < threshold → `Skip { tier: 2, reason: "below_threshold" }`
@@ -72,7 +77,7 @@ estimate: 2d
 - 不要让 gating 决策进入 AAAK signal 提取结果
 - 不要在 MCP 工具（`mempal_ingest` 或其他）里暴露 "force skip gating" 参数——用户想强制就调 config 临时关 gating
 - 不要做 Tier 2 threshold 自适应（user-tuned 值即可，YAGNI）
-- 不要在 prototypes 初始化失败时崩溃进程——若 embedder 对某个 prototype embed 失败，log warn 并 skip 该 prototype
+- 不要对 prototypes 初始化失败选择 silently-skip——CSA debate 2026-04-20 R3 反转早期设计：若 embedder 对任一 prototype embed 失败，daemon 启动 fail-fast 并退出码 != 0，stderr 打印 `"gating prototype init failed: label='{name}', reason='{err}'. Check [ingest_gating.embedding_classifier.prototypes] and the embedder backend at {base_url}."`。silently-skip 会造成 gating 语义漂移（哪些 label 被滤掉是不可观测的），不如启动崩溃让用户立刻发现配置错
 
 ## Out of Scope
 
@@ -179,13 +184,26 @@ Scenario: mempal gating stats 输出 kept/skipped 计数
 
 Scenario: schema 迁移 v7 → v8 创建 gating_audit 表
   Test:
-    Filter: test_migration_v5_to_v6_creates_gating_audit
+    Filter: test_migration_v7_to_v8_creates_gating_audit
     Level: integration
     Targets: crates/mempal-core/src/db/schema.rs
-  Given palace.db schema_version == "5"
+  Given palace.db schema_version == "7"
   When 启动 mempal
-  Then schema_version == "6"
+  Then schema_version == "8"
   And `gating_audit` 表存在
+
+Scenario: prototype 初始化失败时 daemon fail-fast 退出
+  Test:
+    Filter: test_prototype_init_failure_fails_fast
+    Level: integration
+    Test Double: failing_embedder
+    Targets: crates/mempal-ingest/src/gating/prototypes.rs, crates/mempal-cli/src/daemon.rs
+  Given `ingest_gating.enabled = true`，`embedding_classifier.enabled = true`，3 个 prototype 其中第 2 个 embed 时返回 `Err`
+  When 启动 `mempal daemon --foreground`
+  Then 进程在 10 秒内退出，退出码 != 0
+  And stderr 含 `"gating prototype init failed"` 字样
+  And stderr 含失败 prototype 的 label 名
+  And `~/.mempal/daemon.pid` 不存在（未注册）
 
 Scenario: gating 不影响 drawer 维度一致性
   Test:

--- a/specs/fork-ext/p9-novelty-filter.spec.md
+++ b/specs/fork-ext/p9-novelty-filter.spec.md
@@ -40,7 +40,16 @@ estimate: 1d
   - `updated_at = now()`
   - `merge_count` 列 +1（schema v9 新增）
   - **重新计算** embedding（合并后内容变化，旧 embedding 不再准确）：embed new `content`，UPDATE `drawer_vectors`
-  - FTS5 index 自动随 `drawers.content` UPDATE 触发同步（如现有 trigger 已覆盖）
+  - FTS5 index 显式 trigger 保证同步（CSA debate 2026-04-20 R4 validated），v8→v9 migration 中 `DROP TRIGGER IF EXISTS drawers_au_fts;` 再创建，保证幂等重入：
+    ```sql
+    DROP TRIGGER IF EXISTS drawers_au_fts;
+    CREATE TRIGGER drawers_au_fts AFTER UPDATE OF content ON drawers BEGIN
+      DELETE FROM drawers_fts WHERE rowid = old.id;
+      INSERT INTO drawers_fts(rowid, content) VALUES (new.id, new.content);
+    END;
+    ```
+    **为什么 DELETE-then-INSERT 而非 UPDATE**：DELETE-then-INSERT 是 SQLite 官方推荐给 FTS5 contentless / external-content 表的更新模式（索引结构保证一致性），直接 UPDATE contentless 行会让 FTS 内部 segment 与 base 表 rowid 映射漂移
+    **与 upstream 已有 trigger 的关系**：若 upstream 已注册同名 trigger（例如 P5 `p5-semantic-dedup.spec.md` 相关），`DROP ... IF EXISTS` 保证 migration 不因前置状态 fail；migration 每次 idempotent 可重入
   - **保留** drawer ID 不变（KG triples 引用稳定）
 - 去重触发后 write 到 `novelty_audit` 表（schema v9 新增）：`{ id, candidate_hash, decision, near_drawer_id, cosine, created_at }`，`mempal status` 汇总
 - 对 `mempal_ingest` MCP 工具调用方：返回 response metadata 含 `novelty_decision: "inserted" | "merged" | "dropped"`, `near_drawer_id`（如适用）；content 语义保持 raw，不影响字段形态
@@ -192,11 +201,24 @@ Scenario: schema 迁移 v8 → v9 加 merge_count 和 novelty_audit
     Filter: test_migration_v8_to_v9_schema
     Level: integration
     Targets: crates/mempal-core/src/db/schema.rs
-  Given palace.db schema_version == "6"
+  Given palace.db schema_version == "8"
   When 启动 mempal
-  Then schema_version == "7"
+  Then schema_version == "9"
   And `drawers` 表有 `merge_count` 列，默认值 0
   And `novelty_audit` 表存在
+  And trigger `drawers_au_fts` 存在（`SELECT name FROM sqlite_master WHERE type='trigger' AND name='drawers_au_fts'` 返回一行）
+
+Scenario: v8 → v9 migration 在存在同名旧 trigger 时幂等
+  Test:
+    Filter: test_migration_v8_to_v9_idempotent_trigger
+    Level: integration
+    Targets: crates/mempal-core/src/db/schema.rs
+  Given palace.db schema_version == "8"
+  And 在 migration 前人工 `CREATE TRIGGER drawers_au_fts AFTER UPDATE ON drawers BEGIN SELECT 1; END` 注册一个同名但不同逻辑的 trigger
+  When 启动 mempal
+  Then migration 成功（不返回 `SQLITE_ERROR` 或 `trigger drawers_au_fts already exists`）
+  And schema_version == "9"
+  And trigger `drawers_au_fts` 的 SQL 等于 spec Decisions 里给出的 DELETE-then-INSERT 版本（可通过 `SELECT sql FROM sqlite_master WHERE name='drawers_au_fts'` 断言）
 
 Scenario: merge 后 FTS5 搜索能命中新增内容
   Test:

--- a/specs/fork-ext/p9-session-self-review.spec.md
+++ b/specs/fork-ext/p9-session-self-review.spec.md
@@ -50,6 +50,7 @@ estimate: 1d
   - 这个段使用 sentinel `--- session_metadata ---` 作为 AAAK signal 提取器的可识别边界
   - **解析顺序必须从 content 末尾反向查找 sentinel**（`rfind("\n\n--- session_metadata ---\n")`），不是从头扫——assistant message 正文中偶发出现该字面量也不破坏 metadata 段；解析时要求 sentinel **后紧跟** 至少一个形如 `key: value\n` 的行，否则判为正文内容。合法 metadata 段必须出现在 content 的**最后一个**分隔块位置
   - sentinel 样例中的 `---` 数量（3 个短横线）刻意与 Markdown `hr` 区分——前后必有 `--- session_metadata ---` 带显式 tag，纯 `---` 分隔线不会被误识别
+  - **为何不改读 `.claude/sessions/<uuid>.jsonl` 取代此 sentinel 方案**（CSA debate 2026-04-20 R5 verdict: reject the switch）：把"session 真实文本"的获取从"hook payload 入参"改为"mempal 主动读 Claude Code 的内部文件"会把 mempal 耦合到 Claude Code 的未文档化 session 存储 schema，破坏跨 agent 兼容（Gemini CLI / Codex / 未来其他 agent 的 session 存储格式都不同）。正确路径是**要求 hook 脚本把 `messages` 数组打包进 hook payload**，mempal 只解析 payload 内存中的 `messages.iter().rfind(|m| m.role == "assistant")`——零磁盘 I/O，零 Claude Code 内部格式依赖。sentinel 方案的 `rfind` 假阳性风险由上面的 "sentinel + 后接 `key: value\n` 行" 双重校验消除
   - 本 spec **零 schema 迁移**；v8 被 `p10-project-vector-isolation.spec.md` 独占使用，本 spec 与其无 schema 冲突
 - MCP `mempal_search` 天然能召回 session-reviews wing 的 drawer（向量+FTS+RRF 不区分 wing）
 - 引入便利过滤器：未来 `mempal_search(wing_filter="session-reviews")` 可一键查 session reviews；本 spec 不实现 wing_filter，留给 P10 `p10-cli-dashboard.spec.md`
@@ -129,6 +130,17 @@ Scenario: trailing_messages=2 时拼接倒数 2 条 assistant 消息
   And messages 最后两条都是 assistant：`[..., {role:"assistant",content:"A"}, {role:"assistant",content:"B"}]`
   When 调 `session_review::extract`
   Then 返回的 content 含 "A" 和 "B" 之间有分隔符（如 `\n---\n`）
+
+Scenario: sentinel 在 assistant 正文中误出现时不触发 metadata 误解析
+  Test:
+    Filter: test_sentinel_false_positive_rejected_by_structure_check
+    Level: unit
+    Targets: crates/mempal-cli/src/session_review.rs
+  Given assistant message content 正文含字面字串 `"\n--- session_metadata ---\nthis is just an example in prose"`（后接非 `key: value` 格式的自由文本）
+  When 调用 session_review metadata 解析器
+  Then 解析器**不**把该 sentinel 视为 metadata 段起点（因为后接行不匹配 `^[a-z_]+: .+\n` 的 key:value 模式）
+  And 返回的 metadata 为空 `{}`（正文被视为纯 assistant message）
+  And drawer 被写入时该 sentinel 字面串保留在正文中，不被裁剪
 
 Scenario: linked_drawer_ids 写入 content 末尾 sentinel 段
   Test:

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "16b3e52a34600a0233fcb697562b95f7a07cd3e9"
+commit = "9089e767099b9c85b9fac7444908bb45316a6e94"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Docs-only spec absorption of the 7 deferred risks carried in `drafts/mempal/CLAUDE.md` since the 2026-04-20 round-1 CSA design review, plus a new `p8-config-hot-reload` spec so that modifying `config.toml` no longer requires restarting `mempal daemon` / MCP server / Claude Code.

Driven by a second CSA tier-4-critical debate session (`01KPNVMWSCD6HSGCWVRXCKSNMY`, gemini-3.1-pro × gpt-5.4, 3 rounds). Verdict: **3 accept / 3 modify / 1 reject**. Full transcript + details at `/home/obj/.local/state/cli-sub-agent/.../sessions/01KPNVMWSCD6HSGCWVRXCKSNMY/output/`.

## 7 Deferred Risks — Resolution

| # | Spec | Verdict | Resolution |
|---|------|---------|------------|
| R1 | p8-privacy-scrubbing | accept | normalization → scrub → chunking order pinned in a new cross-chunk scenario |
| R2 | p8-hook-passive-capture | modify | daemonize-first extended to rusqlite + tracing + fd 0/1/2; \`DaemonContext::bootstrap()\` helper introduced |
| R3 | p9-judge-gating-local | modify | **reversed**: synchronous pre-compute + fail-fast (gating runs in daemon, not fast-path) |
| R4 | p9-novelty-filter | accept | explicit DELETE-then-INSERT trigger DDL + idempotent \`DROP IF EXISTS\` migration |
| R5 | p9-session-self-review | **reject** | keep hook-payload sentinel approach; don't couple to \`.claude/sessions/*.jsonl\` (breaks cross-agent compat) |
| R6 | p10-cli-dashboard | modify | fs event = wake-up only; data via \`SELECT WHERE id > last_seen_id\`; 250ms debounce |
| R7 | p10-project-vector-isolation | accept | \`BEGIN IMMEDIATE\` + \`LIMIT 1000\` batched UPDATE loop |

Also fixes a set of stale \`schema_version == "5"/"6"/"7"/"8"\` string constants in scenario bodies that survived the earlier v7+ rebase (p9-gating, p9-novelty, p10-vector-iso).

## New Spec: p8-config-hot-reload

- **Mechanism**: \`notify\` crate fs-watch on \`~/.mempal/config.toml\` (directory-level, survives atomic rename saves). Works uniformly across \`mempal daemon\`, \`mempal mcp stdio\`, and the long-running MCP subprocess Claude Code spawns — SIGHUP would miss the stdio child case.
- **Atomicity**: \`ArcSwap<Config>\`. Every MCP tool handler and the ingest pipeline take an \`Arc<Config>\` snapshot at request entry, so a mid-flight reload cannot split a single ingest across two policy versions.
- **Safety**: parse failure keeps the previous \`Arc\`, logs \`warn!\` to stderr, never crashes. Lightweight 5s poll fallback if the notify watcher thread dies.
- **Scope**:
  - Hot-reloadable (whitelist): alerting, privacy, taxonomy, gating rules + classifier threshold, novelty thresholds, progressive disclosure, \`strict_project_isolation\`, hook session_end, ingest lock timeouts, CLI dashboard debounce
  - Restart-required (blacklist): \`[embedder]\` (backend / base_url / model / dim — needs \`mempal reindex\`), \`[database] path\`, MCP server_name. Detection → \`error!\` log, keeps old value, does not bump \`config_version\`.
  - Deferred hot-reload: \`[ingest_gating.embedding_classifier.prototypes]\` — text is swapped immediately, but the pre-computed \`prototype_vectors: Vec<Vec<f32>>\` only rebuild on next daemon restart (warned in logs).
- **Observability**: \`config_version = blake3(config.toml bytes)[:12]\` and \`loaded_at\` exposed via \`mempal_status\` MCP tool and \`mempal status\` CLI.

## Quality Gates

- [x] Docs-only — no crate code changes
- [x] Each resolution backed by a new or updated scenario
- [x] No upstream specs touched — all changes scoped to \`specs/fork-ext/\`
- [x] CSA debate transcript captured and cited

## Test plan

- [ ] Read through each modified spec's new scenarios for coherence
- [ ] Confirm \`p8-config-hot-reload\` whitelist matches each consumer spec's fields during implementation
- [ ] Use this batch as the reference for \`DaemonContext::bootstrap()\` signature + hot-reload \`ArcSwap\` wiring on next implementation cycle

Generated with Claude Code + csa debate.