### PR TITLE
fix(pre-code): address gemini strategic review findings

### DIFF
--- a/docs/plans/2026-04-20-fork-ext-p8-implementation.md
+++ b/docs/plans/2026-04-20-fork-ext-p8-implementation.md
@@ -18,6 +18,23 @@
 
 ---
 
+## D0. Upstream-Sync 摩擦最小化约束（写代码前必读）
+
+**来源**：gemini-cli 2026-04-20 tier-3-complex 策略审查（session `01KPP36SKKNQ5T3C5JEFR9VN61`）。用户目标：`claude-mem` 执行 `sync-upstream` 时尽可能少花 token，fork 与 upstream 共存**永久化**。
+
+以下三条是 fork-ext 所有源码落点的**硬约束**，任何 PR 提审前自查：
+
+- **R1 — `src/core/config.rs` 保持单文件**。不拆 `config/{mod,schema,hot_reload}.rs` 子目录。upstream 每加一个 `Config` 字段会落在 `config.rs`，子目录拆分让 "加字段" 放大成树重构级冲突。fork 的热重载逻辑单独放新文件 `src/core/hot_reload.rs`。
+- **R2 — `src/core/db.rs` 只改一行**。所有 fork-ext DDL 常量 (`FORK_EXT_V*_SCHEMA_SQL`)、迁移数组、runner / reader / setter 全部落在**新文件** `src/core/db_fork_ext.rs`。`db.rs` 仅加 `mod db_fork_ext;` 和 `Database::open` 里一行 `db_fork_ext::apply_fork_ext_migrations(&conn)?;`。理由：`db.rs` 是 upstream 高频变更区，每次 schema 升级必改，fork 的大段 SQL 常量插在中间会让每次 merge 都爆冲突。
+- **R3 — fork-only MCP handler 只追加到末尾**。`src/mcp/server.rs` / `src/mcp/tools.rs` 里新 handler / 新工具枚举项必须放在**文件/match arm 最底部**，禁插在既有 upstream handler 之间。upstream 新增工具通常加在自己顺序位，fork 放底部让 git 能自动 3-way-merge。
+
+pre-flight 自查 checklist：
+- [ ] `grep -rn "config/\(mod\|schema\|hot_reload\)\.rs" src/` 空 → R1 ✅
+- [ ] `git diff main -- src/core/db.rs` 只含 `mod db_fork_ext;` 和一行 `apply_fork_ext_migrations` 调用 → R2 ✅
+- [ ] fork 新增 MCP handler 全部 `git diff main -- src/mcp/` 显示在既有 handler 之后（尾部）→ R3 ✅
+
+---
+
 ## Key Decisions（开工前已定）
 
 ### D1. 实际代码结构 ≠ spec 路径
@@ -153,17 +170,21 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 
 ### File Structure
 
+> **Upstream-sync 摩擦约束**（gemini 2026-04-20 策略审查 R2）：fork-ext DDL 常量 / 迁移数组 / runner / reader / setter 全部落在**新文件 `src/core/db_fork_ext.rs`**，不内联到 `src/core/db.rs`。理由：`db.rs` 是 upstream 高频变更区（每次 schema 升级都要改），把 fork 的 `FORK_EXT_V*_SCHEMA_SQL` 大段 SQL 常量插在中间会让每次 merge 都炸。`db.rs` 只做一件事：`mod db_fork_ext;` + `Database::open` 里调 `apply_fork_ext_migrations` 一行。
+
 | 文件 | 动作 | 职责 |
 |------|------|------|
-| `src/core/db.rs` | modify | 新增 `FORK_EXT_SCHEMA_VERSION` 常量、`fork_ext_migrations()`、`read_fork_ext_version`、`set_fork_ext_version`、`apply_fork_ext_migrations`；`open()` 里调用一次 |
+| `src/core/db.rs` | modify（极小） | 顶部加 `mod db_fork_ext;`；`Database::open` 在 upstream `apply_migrations` 之后调 `db_fork_ext::apply_fork_ext_migrations(&conn)?;`——**仅此两行改动** |
+| `src/core/db_fork_ext.rs` (new) | create | `FORK_EXT_SCHEMA_VERSION` 常量、`Migration` struct、`fork_ext_migrations()` 返回数组（Phase 0 为空）、`read_fork_ext_version`、`set_fork_ext_version`、`apply_fork_ext_migrations`、`FORK_EXT_META_DDL`（`CREATE TABLE IF NOT EXISTS fork_ext_meta ...`）|
+| `src/core/mod.rs` | unchanged | `db_fork_ext` 是 `db` 的子模块，不用 re-export |
 | `tests/fork_ext_schema_axis.rs` (new) | create | 3 scenarios：fresh DB → ext_v=0，bootstrap → ext_v=0，独立于 user_version |
 
 ### Tasks
 
 - [ ] **T0.1** 写失败测试 `test_fork_ext_version_is_zero_on_fresh_db`（fresh DB → `apply_fork_ext_migrations` 跑完 → `fork_ext_version=0`，因为 Phase 0 只建表不注册业务 migration）
-- [ ] **T0.2** 实现 `fork_ext_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)` 表创建 + `read_fork_ext_version` / `set_fork_ext_version` helpers（表不存在时视为 0，便于幂等首次 bootstrap）
-- [ ] **T0.3** 实现 `apply_fork_ext_migrations(conn)`：建 `fork_ext_meta`（IF NOT EXISTS）→ 读 `fork_ext_version` → 遍历 `fork_ext_migrations()` 数组跑未应用的 → 写回 `fork_ext_version`；Phase 0 里数组是**空的**，`fork_ext_version` 保持 0
-- [ ] **T0.4** 在 `Database::open` 里调 upstream `apply_migrations` 之后调用 `apply_fork_ext_migrations`
+- [ ] **T0.2** 在**新文件** `src/core/db_fork_ext.rs` 实现 `fork_ext_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)` 表创建 + `read_fork_ext_version` / `set_fork_ext_version` helpers（表不存在时视为 0，便于幂等首次 bootstrap）
+- [ ] **T0.3** 在 `db_fork_ext.rs` 实现 `apply_fork_ext_migrations(conn)`：建 `fork_ext_meta`（IF NOT EXISTS）→ 读 `fork_ext_version` → 遍历 `fork_ext_migrations()` 数组跑未应用的 → 写回 `fork_ext_version`；Phase 0 里数组是**空的**，`fork_ext_version` 保持 0
+- [ ] **T0.4** 在 `src/core/db.rs` 顶部加 `mod db_fork_ext;`；`Database::open` 在 upstream `apply_migrations` 之后一行调用 `db_fork_ext::apply_fork_ext_migrations(&conn)?;`
 - [ ] **T0.5** 写测试 `test_apply_fork_ext_migrations_idempotent`（调两次，`fork_ext_meta` 不重复建、`fork_ext_version` 不错误升）
 - [ ] **T0.6** 写测试 `test_upstream_user_version_unchanged_after_fork_ext_bootstrap`（`PRAGMA user_version` 仍 = 4）
 - [ ] **T0.7** `cargo clippy --all-targets --all-features -- -D warnings` + `cargo fmt`
@@ -192,23 +213,23 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 
 ### File Structure
 
+> **Upstream-sync 摩擦约束**（gemini 2026-04-20 策略审查 R1）：**不拆** `src/core/config.rs` 成 `config/{mod,schema,hot_reload}.rs` 子目录。理由：upstream 未来每加一个 `Config` 字段都会落在 `config.rs`，子目录拆分会把 "加字段" 放大成 "删除旧文件 + 创建新文件" 级的树结构冲突。保留单文件 + 独立 `hot_reload.rs` 是冲突最小的结构。
+
 | 文件 | 动作 | 职责 |
 |------|------|------|
-| `src/core/config.rs` | **重写 + 拆模块** | 从 2.1KB 扩充，拆为 `config/{mod,schema,hot_reload}.rs` |
-| `src/core/config/mod.rs` (new) | create | `pub use` + `ConfigHandle` 公开 API |
-| `src/core/config/schema.rs` (new) | create | `Config` struct + `serde::Deserialize` + 字段属性 `#[hot_reload]` / `#[restart_required]` |
-| `src/core/config/hot_reload.rs` (new) | create | `ArcSwap<Config>` + `notify::Watcher` + debounce 任务 + blake3 hash + fallback poll |
-| `src/core/mod.rs` | modify | `pub mod config;`（目录模式） |
+| `src/core/config.rs` | modify | **保持单文件**；`Config` struct 在此 + 字段属性 `#[hot_reload]` / `#[restart_required]` marker（宏或 attribute 常量表）；新增 `pub struct ConfigHandle` 对外 API |
+| `src/core/hot_reload.rs` (new) | create | `ArcSwap<Config>` + `notify::Watcher` + 250ms debounce 任务 + blake3 hash + fallback poll；不包含 `Config` schema 定义 |
+| `src/core/mod.rs` | modify | `pub mod hot_reload;`（`config` 已存在） |
 | `src/main.rs` | modify | 启动时 `ConfigHandle::bootstrap(path)`；`mempal status` 打印 `config: version=... loaded=...` |
 | `src/mcp/tools.rs` | modify | `StatusResponse` 加 `config_version: String`、`config_loaded_at_unix_ms: u64` |
-| `src/mcp/server.rs` | modify | 每个 handler 入口 `let cfg = ConfigHandle::current();` |
+| `src/mcp/server.rs` | modify | 每个 handler 入口 `let cfg = ConfigHandle::current();`；新 handler 追加**末尾**，禁插在既有 upstream handler 之间（R3） |
 | `Cargo.toml` | modify | 加 `arc-swap`, `notify`, `blake3` |
 | `tests/config_hot_reload.rs` (new) | create | 10 scenarios |
 
 ### Tasks
 
 - [ ] **T1.1** 加依赖 + `cargo check`（`arc-swap` / `notify` / `blake3`）
-- [ ] **T1.2** 拆 `src/core/config.rs` → `config/{mod,schema,hot_reload}.rs`（先**不动功能**，纯 move），`cargo test` 全绿
+- [ ] **T1.2** 在 `src/core/config.rs` 单文件内扩充 `Config` struct + `ConfigHandle` 公开 API（**不拆目录**——R1 约束），新建 `src/core/hot_reload.rs` 空骨架；`cargo test` 全绿
 - [ ] **T1.3** 写失败测试 `test_privacy_pattern_hot_reload_applies_on_next_ingest`（scenario §Completion Criteria 第 1 条）
 - [ ] **T1.4** 实现 `ArcSwap<Config>` + `ConfigHandle::current()`，T1.3 转绿
 - [ ] **T1.5** 实现 `notify::RecommendedWatcher` + 250ms debounce task
@@ -237,7 +258,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 | 文件 | 动作 | 职责 |
 |------|------|------|
 | `src/core/queue.rs` (new) | create | `PendingMessageStore` + `enqueue` / `claim_next` / `confirm` / `mark_failed` / `refresh_heartbeat` / `reclaim_stale` |
-| `src/core/db.rs` | modify | 定义 `FORK_EXT_V1_SCHEMA_SQL` 常量（`pending_messages` 表 + indexes DDL）；往 `fork_ext_migrations()` 数组追加 `Migration { version: 1, sql: FORK_EXT_V1_SCHEMA_SQL }`——`fork_ext_meta` 表 / runner / reader / setter 已由 Phase 0 就位，T2 这里**不再碰 infra** |
+| `src/core/db_fork_ext.rs` | modify | 定义 `FORK_EXT_V1_SCHEMA_SQL` 常量（`pending_messages` 表 + indexes DDL）；往 `fork_ext_migrations()` 数组追加 `Migration { version: 1, sql: FORK_EXT_V1_SCHEMA_SQL }`——`fork_ext_meta` 表 / runner / reader / setter 已由 Phase 0 就位，T2 这里**不再碰 infra**；**`src/core/db.rs` 不变**（R2 约束） |
 | `src/core/mod.rs` | modify | `pub mod queue;` |
 | `Cargo.toml` | modify | 无新 dep（rusqlite 已有） |
 | `tests/queue_claim_confirm.rs` (new) | create | scenarios from spec §Completion Criteria |
@@ -245,7 +266,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 
 ### Tasks
 
-- [ ] **T2.1** 定义 `FORK_EXT_V1_SCHEMA_SQL` 常量（pending_messages DDL），往 `fork_ext_migrations()` 数组追加 `Migration { version: 1, sql: FORK_EXT_V1_SCHEMA_SQL }`——runner / reader / setter 已由 Phase 0 就位，本任务**不碰 `fork_ext_meta` 表结构**
+- [ ] **T2.1** 在 `src/core/db_fork_ext.rs` 定义 `FORK_EXT_V1_SCHEMA_SQL` 常量（pending_messages DDL），往 `fork_ext_migrations()` 数组追加 `Migration { version: 1, sql: FORK_EXT_V1_SCHEMA_SQL }`——runner / reader / setter 已由 Phase 0 就位，本任务**不碰 `fork_ext_meta` 表结构**，**也不碰 `src/core/db.rs`**（R2）
 - [ ] **T2.2** 写失败测试 `test_enqueue_claim_confirm_basic`
 - [ ] **T2.3** 写 v0→v1 migration（CREATE TABLE pending_messages + indexes）
 - [ ] **T2.4** 实现 `PendingMessageStore::enqueue` / `claim_next` / `confirm` / `mark_failed`
@@ -271,7 +292,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 |------|------|------|
 | `src/ingest/privacy.rs` (new) | create | `scrub(text, cfg) -> (String, ScrubStats)` + 默认 pattern 库 |
 | `src/ingest/mod.rs` | modify | pipeline 里 normalize 之后、chunk 之前调 privacy::scrub |
-| `src/core/config/schema.rs` | modify | 加 `PrivacyConfig` struct（`#[hot_reload]`） |
+| `src/core/config.rs` | modify | 加 `PrivacyConfig` struct（`#[hot_reload]`） |
 | `Cargo.toml` | modify | 加 `regex = "1"`（若 baseline 未依赖；如已在 sha2 / jieba 依赖链中可传递，verify first） |
 | `tests/privacy_scrubbing.rs` (new) | create | 9 scenarios from spec |
 
@@ -279,7 +300,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 
 - [ ] **T3.1** verify `regex` crate is available（`cargo tree | grep regex`）；如无则加到 `Cargo.toml`
 - [ ] **T3.2** 写失败测试 `test_privacy_disabled_preserves_content_byte_identical`
-- [ ] **T3.3** 实现 `PrivacyConfig` 在 `config/schema.rs` + 标记 hot-reload
+- [ ] **T3.3** 实现 `PrivacyConfig` 在 `src/core/config.rs`（单文件，R1）+ 标记 hot-reload
 - [ ] **T3.4** 实现 `privacy::scrub` + 默认 pattern 库
 - [ ] **T3.5** 挂到 ingest pipeline（**关键顺序**：normalize → scrub → chunk）
 - [ ] **T3.6** 跑新增 `test_scrub_catches_cross_chunk_secret`（CSA R1 新 scenario）确认 pre-chunk 时机正确
@@ -304,8 +325,8 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 | `src/embed/retry.rs` (new) | create | 2s 固定间隔 retry loop + heartbeat callback |
 | `src/embed/alerting.rs` (new) | create | 阈值告警 + 脚本执行（热重载脚本路径） |
 | `src/embed/mod.rs` | modify | 默认改为 `OpenAiCompatibleEmbedder`；`model2vec-rs` 保留为 offline fallback |
-| `src/core/config/schema.rs` | modify | 加 `EmbedderConfig`（restart-required）+ `AlertingConfig`（hot-reload） |
-| `src/core/db.rs` | modify | 定义 `FORK_EXT_V2_SCHEMA_SQL`（`reindex_progress` 表 DDL）；往 `fork_ext_migrations()` 追加 `Migration { version: 2, sql: FORK_EXT_V2_SCHEMA_SQL }` |
+| `src/core/config.rs` | modify | 加 `EmbedderConfig`（restart-required）+ `AlertingConfig`（hot-reload）；**R1 单文件约束** |
+| `src/core/db_fork_ext.rs` | modify | 定义 `FORK_EXT_V2_SCHEMA_SQL`（`reindex_progress` 表 DDL）；往 `fork_ext_migrations()` 追加 `Migration { version: 2, sql: FORK_EXT_V2_SCHEMA_SQL }`；**`src/core/db.rs` 不变**（R2） |
 | `src/core/reindex.rs` (new) | create | `ReindexProgressStore` CRUD（resume checkpoint） |
 | `src/main.rs` | modify | `mempal reindex --embedder <name> [--resume]` 子命令 |
 | `tests/openai_compat_embedder.rs` (new) | create | scenarios |
@@ -317,7 +338,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 - [ ] **T4.1** 加 `reqwest` client 适配（已在 deps）
 - [ ] **T4.2** 写失败测试 `test_openai_compat_embed_happy_path`（mock server）
 - [ ] **T4.3** 实现 `OpenAiCompatibleEmbedder`（`/v1/embeddings` POST + `Qwen/Qwen3-Embedding-8B` model name）
-- [ ] **T4.4** 定义 `FORK_EXT_V2_SCHEMA_SQL` + `fork_ext_migrations()` 追加 ext-v2 entry（`reindex_progress` 表 DDL）；写 migration 测试
+- [ ] **T4.4** 在 `src/core/db_fork_ext.rs` 定义 `FORK_EXT_V2_SCHEMA_SQL` + `fork_ext_migrations()` 追加 ext-v2 entry（`reindex_progress` 表 DDL）；写 migration 测试；**不碰 `db.rs`**（R2）
 - [ ] **T4.5** 实现 2s 固定重试 + 每轮调 heartbeat callback（从 queue store 注入）
 - [ ] **T4.6** 实现 degraded 状态 + MCP `system_warnings` 注入
 - [ ] **T4.7** 实现告警阈值 + 脚本执行 + 路径热重载（消费 Phase 1 机制）
@@ -346,7 +367,7 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 | `src/daemon_bootstrap.rs` (new) | create | `DaemonContext::bootstrap()`（daemonize → runtime → db → tracing） |
 | `src/hook_install.rs` (new) | create | `mempal hook install --target <claude-code\|gemini-cli\|codex>` |
 | `src/main.rs` | modify | 顶层**禁用** `#[tokio::main]`；手动 `block_on` per-handler |
-| `src/core/config/schema.rs` | modify | `HooksConfig` + `HooksSessionEndConfig` |
+| `src/core/config.rs` | modify | `HooksConfig` + `HooksSessionEndConfig` |
 | `Cargo.toml` | modify | 加 `daemonize = "0.5"`；`libc`, `nix` verify 已在 deps |
 | `tests/hook_enqueue.rs` (new) | create | hook payload envelope + enqueue scenarios |
 | `tests/daemon_lifecycle.rs` (new) | create | start/stop/SIGTERM/reclaim_stale/DaemonContext 启动序检查 |
@@ -362,11 +383,16 @@ Cargo.toml 当前是**单 crate 结构**（`[dependencies]` 直接列，无 `[wo
 - [ ] **T5.6** 实现 `mempal daemon` worker loop + handler 映射
 - [ ] **T5.7** 实现 truncated envelope → marker drawer path（不走重试）
 - [ ] **T5.8** 实现 privacy scrub 对 envelope preview 生效（验证跨 spec 集成）
-- [ ] **T5.9** 实现 `mempal hook install --target claude-code`（**关键**：append-to-array，**不**覆盖 upstream cowork hook）
+- [ ] **T5.9** 实现 `mempal hook install --target claude-code`——**关键三点**（gemini 2026-04-20 Part 1 + Part 3 #3）：
+  - **本地优先**：若 `<cwd>/.claude/settings.json` 存在（无论是 regular file 还是 symlink），写入本地；否则 fallback 写 `~/.claude/settings.json`（原设计）。理由：upstream `215b62f` 已将本地 `.claude/settings.json` 作为 tracked blob commit 到仓库，本地优先会直接被 Claude Code pick up 且不被 global shadow
+  - **symlink 感知**：若目标是 symlink，`canonicalize()` 到真实文件再读写。尊重用户习惯（用户常用 `git config core.excludesfile ~/.gitignore_noai` + `.claude/settings.json` 软链到独立 tracked 仓库）
+  - **append-to-array**：`hooks.UserPromptSubmit` / `hooks.PostToolUse` 等是数组，**push** fork 的 entry，**不覆盖** upstream 的 `mempal cowork-drain` entry
 - [ ] **T5.10** 实现 install --dry-run / uninstall（可选，stretch）
 - [ ] **T5.11** integration test：daemon crash → reclaim_stale
 - [ ] **T5.12** integration test：SIGTERM 优雅退出
-- [ ] **T5.13** integration test：hook install 合并 existing settings 且与 `mempal cowork-install-hooks` 共存
+- [ ] **T5.13** integration test `test_hook_install_respects_project_local_settings`：在 repo 里有 `.claude/settings.json`（tracked）时，install 写本地不写全局
+- [ ] **T5.13b** integration test `test_hook_install_follows_symlink_target`：`.claude/settings.json` 是 symlink 到 `drafts/claude-settings.json`，install 编辑目标文件不破坏 symlink
+- [ ] **T5.13c** integration test `test_hook_install_coexists_with_upstream_cowork_entry`：已含 upstream `user-prompt-submit.sh` 的 UserPromptSubmit 数组，install 后既有 entry 保留 + fork entry 追加
 - [ ] **T5.14** clippy / fmt / PR
 
 **Done when**: `mempal hook hook_post_tool < payload.json` enqueue；`mempal daemon --foreground` 消费并写 drawer；`mempal hook install --target claude-code` 注入不覆盖。

--- a/specs/fork-ext/p10-project-vector-isolation.spec.md
+++ b/specs/fork-ext/p10-project-vector-isolation.spec.md
@@ -15,10 +15,39 @@ estimate: 1d
 ## Decisions
 
 - fork-ext `fork_ext_version` `4 → 5` 新 migration：
-  - `drawers` 表加 `project_id TEXT`（默认 NULL 兼容既有 drawer）
+  - `drawers` 表加 `project_id TEXT`（默认 NULL 兼容既有 drawer） —— 走 `ALTER TABLE ADD COLUMN`（regular table 支持）
   - 索引 `CREATE INDEX idx_drawers_project_id ON drawers(project_id)`
-  - `drawer_vectors` 表加 `project_id TEXT`（冗余列，为了 sqlite-vec filter 能直接过）
-  - `triples` 表加 `project_id TEXT`（未来 KG 隔离用，本 spec 不用）
+  - `drawer_vectors` 表加 `project_id TEXT` —— **不能用 `ALTER TABLE`**（gemini 2026-04-20 策略审查 Part 3 #1 critical finding）：sqlite-vec `vec0` 是 SQLite virtual table，**不支持 `ALTER TABLE ADD COLUMN`**（也不支持 `ALTER TABLE ADD` 任何形式的列修改，只支持 `RENAME`）。必须走 **DROP + CREATE + 全量 reinsert** 流程，且整个过程必须把既有向量数据**逐行读回内存再写回新表**，否则会静默丢失全部历史向量（导致 search 只剩 BM25 但不报错）。具体步骤见下条"vec0 recreate 迁移步骤"
+  - `triples` 表加 `project_id TEXT`（未来 KG 隔离用，本 spec 不用） —— regular table 走 `ALTER TABLE ADD COLUMN`
+- **vec0 recreate 迁移步骤**（保数据零丢失）：
+  ```
+  BEGIN IMMEDIATE;
+  -- 1. 把既有向量全量读出到一个临时 regular table（不是 vec0）
+  CREATE TEMP TABLE _drawer_vectors_backup (id TEXT PRIMARY KEY, embedding BLOB);
+  INSERT INTO _drawer_vectors_backup (id, embedding)
+    SELECT id, embedding FROM drawer_vectors;
+  -- 2. DROP 老 vec0 表
+  DROP TABLE drawer_vectors;
+  -- 3. 重建 vec0，声明 auxiliary column `+project_id TEXT`（vec0 语法要求 `+` 前缀声明非索引 metadata 列）
+  CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+    id TEXT PRIMARY KEY,
+    embedding FLOAT[{DIM}],  -- DIM 取迁移前 SELECT vec_length(embedding) FROM _drawer_vectors_backup LIMIT 1
+    +project_id TEXT
+  );
+  -- 4. 把 backup 灌回新表，project_id 填 NULL（后续用 `mempal project migrate` 显式 backfill）
+  INSERT INTO drawer_vectors (id, embedding, project_id)
+    SELECT id, embedding, NULL FROM _drawer_vectors_backup;
+  -- 5. 断言行数一致
+  -- （代码侧检查：SELECT COUNT(*) FROM drawer_vectors 必须等于迁移前 COUNT(*)；不等则 ROLLBACK）
+  DROP TABLE _drawer_vectors_backup;
+  COMMIT;
+  ```
+  **关键不变量**：
+  - 整个迁移包在单个 `BEGIN IMMEDIATE ... COMMIT` 里——失败 `ROLLBACK` 后 `drawer_vectors` 恢复到迁移前状态（SQLite DDL 本身也支持事务）
+  - 行数 before/after 必须相等，否则立即 `ROLLBACK` + 返回 `MigrationError::VectorLossDetected { expected, got }` + fork_ext_version 不 bump
+  - 迁移期间 daemon / MCP 必须 pause 所有 ingest / search 写入（`mempal status` 显示 `migrating=true`，写入类 MCP 返回 `system_warnings` 要求 agent 重试）。读路径（search）在迁移期间 BM25-only，vector 部分静默跳过且在 `system_warnings` 标记
+  - 如果迁移前 `drawer_vectors` 表不存在（fresh DB 或 lazy-create 未触发），跳过 backup 步骤，直接 step 3 CREATE（带 `+project_id`）
+  - lazy-create 路径（`db.rs` `ensure_vector_table`）在 fork_ext_version >= 5 之后 MUST 带 `+project_id TEXT` 声明；schema drift 检测见 "`test_lazy_create_after_v5_has_project_id_column`" 新 scenario
 - `project_id` 识别：
   - CLI: `mempal ingest ... --project <id>`；默认从 `git rev-parse --show-toplevel` basename 推断（`mempal-dev` → `"mempal"`），或配置 `[project] id = "..."`
   - MCP: `mempal_ingest` / `mempal_search` input schema 加可选 `project_id` 字段；`mempal_search` 额外加可选 `include_global: bool`（默认 `false`）；未提供 `project_id` 时从 `[project]` config 回退
@@ -109,6 +138,43 @@ Scenario: fork-ext 迁移 v4 → v5 添加 project_id 列
   And `drawers`, `drawer_vectors`, `triples` 三表均有 `project_id` 列
   And 存在索引 `idx_drawers_project_id`
   And 既有 drawer 的 `project_id` 全部为 NULL
+
+Scenario: v4 → v5 迁移时 drawer_vectors DROP+CREATE 全程保留向量（零丢失）
+  Test:
+    Filter: test_v4_to_v5_migration_preserves_vectors_during_recreation
+    Level: integration
+    Targets: crates/mempal-core/src/db.rs, crates/mempal-core/src/db_fork_ext.rs
+  Given palace.db `fork_ext_version == "4"` 且 `drawer_vectors` 含 50 条向量（由过往 `mempal ingest` 真实写入，非 mock）
+  And 迁移前记录 `before_count = SELECT COUNT(*) FROM drawer_vectors`
+  And 迁移前为每条向量取 `(id, vec_length(embedding), vec_to_raw(embedding))` 元组存到测试内存
+  When 启动 mempal（触发 v4 → v5 migration）
+  Then `fork_ext_version == "5"`
+  And `SELECT COUNT(*) FROM drawer_vectors == before_count`（必须等于 50，否则 MigrationError::VectorLossDetected）
+  And 随机抽 5 个 drawer id，每个的 `(vec_length, vec_to_raw)` 字节级匹配迁移前记录（verbatim 不能丢精度）
+  And 新表 schema 含 `+project_id TEXT` auxiliary column（`PRAGMA table_info(drawer_vectors)` 或等价 vec0 metadata 检查）
+  And 所有 project_id 为 NULL（未 backfill）
+  And 迁移失败/ROLLBACK 时（模拟：mid-migration 写入权限被撤销）`drawer_vectors` **完整恢复**到迁移前状态（`COUNT` / 内容全部相同），`fork_ext_version` **不** bump
+
+Scenario: fresh DB 或 drawer_vectors 未 lazy-create 时 v4 → v5 跳过 backup 步骤
+  Test:
+    Filter: test_v4_to_v5_migration_skips_backup_when_table_absent
+    Level: integration
+    Targets: crates/mempal-core/src/db_fork_ext.rs
+  Given palace.db `fork_ext_version == "4"` 且 `drawer_vectors` 表不存在（`SELECT * FROM sqlite_master WHERE name='drawer_vectors'` 为空，即还没任何 ingest 触发 lazy-create）
+  When 启动 mempal
+  Then 迁移**不**尝试 `CREATE TEMP TABLE _drawer_vectors_backup`（空表 SELECT 会正常 no-op，但 spec 明确这一路径不依赖表存在）
+  And `fork_ext_version == "5"`
+  And 后续首次 ingest 触发 `ensure_vector_table` 时创建的 vec0 表**必须**含 `+project_id TEXT`（见下条 scenario）
+
+Scenario: lazy-create 路径在 fork_ext_version ≥ 5 后带 project_id auxiliary column
+  Test:
+    Filter: test_lazy_create_after_v5_has_project_id_column
+    Level: integration
+    Targets: crates/mempal-core/src/db.rs (ensure_vector_table)
+  Given palace.db `fork_ext_version == "5"` 且 `drawer_vectors` 表未建（fresh 或迁移后仍 zero ingest）
+  When 执行 `mempal ingest any.md --project proj-X`（触发首次 lazy-create + insert）
+  Then `drawer_vectors` schema 中**必须**含 auxiliary column `+project_id TEXT`（否则后续 KNN filter 会 planner 错误或静默全表扫）
+  And `SELECT project_id FROM drawer_vectors WHERE id=?` 返回 `"proj-X"`
 
 Scenario: ingest 带 --project 时 project_id 被持久化
   Test:

--- a/specs/fork-ext/p8-embed-qwen3-backend.spec.md
+++ b/specs/fork-ext/p8-embed-qwen3-backend.spec.md
@@ -149,6 +149,10 @@ estimate: 2d
 - fork-ext `fork_ext_version` `1 → 2`：加 `reindex_progress` 表（fork-ext 独立版本轴；queue 先占 ext_v1）
 - reindex 也走固定 2s 重试策略
 - **reindex 失败不触发 degraded**（degraded 只针对常规 ingest / search 路径）——reindex 是一次性批处理
+- **reindex 运行中的并发读写协议**（gemini 2026-04-20 策略审查 Part 3 #2）：`reindex_progress.reindex_in_progress = true` 期间 dim 可能混用（一部分 drawer 是新 dim，一部分还是老 dim），若让 search / ingest 继续走向量路径会 crash（dim 不匹配）或静默返回错乱分数。必须：
+  - **search 路径**：跳过向量打分，fallback 到 BM25-only，`system_warnings` 明示 `"reindex_in_progress: search degraded to BM25 until completion"`。**禁止静默截断**——必须把 BM25 召回的全部 top-k 返回，否则 agent 会把"索引重建中"误判为"记忆不存在"（幻觉风险）
+  - **ingest 路径**：直接拒绝（`status = "rejected"` + `system_warnings`），提示调用方 reindex 完后重试。**不允许**用老 dim 或新 dim 写入"半新半旧"污染向量表
+  - **queue 路径**（若 hook / daemon 走 `PendingMessageStore`）：enqueue 照常，daemon 检测到 `reindex_in_progress` 暂停 claim，等 reindex 结束后一次处理——与 P8 queue spec 的 heartbeat 协议兼容（长等时 heartbeat 保活不被 reclaim）
 
 ### 默认值
 
@@ -411,6 +415,26 @@ Scenario: `mempal reindex` 全库 re-embed + resume
   And 再执行 `mempal reindex --embedder openai_compat --resume`
   Then 全 50 条 drawer 完成 re-embed，dim=4096
   And `fork_ext_version == "2"`
+
+Scenario: reindex 跑到一半时并发 search 走 BM25 fallback + ingest 要求重试
+  Test:
+    Filter: test_search_and_ingest_during_partial_reindex
+    Level: integration
+    Test Double: mock_http_server + paused_reindex_at_50_percent
+    Targets: crates/mempal-cli/src/reindex.rs, crates/mempal-search/src/hybrid.rs, crates/mempal-ingest/src/pipeline.rs
+  Given 100 条旧 drawer (dim=256)
+  And `reindex_progress` 表显示 `reindex_in_progress = true`，已完成 50/100 条（新 dim=4096），剩 50 条仍 dim=256
+  When **并发**执行 `mempal_search "foo"`（MCP 调用）
+  Then response 正常返回（不崩溃、不 timeout），`system_warnings` 含 `"reindex_in_progress: search degraded to BM25 until completion"`
+  And 向量打分部分**完全跳过**（否则 dim 混用会 crash 或返回错乱 score）——结果仅来自 BM25 + tunnel hints
+  And 返回结果集不静默截断（MUST 把 BM25 召回的全部 top-k 正常返回，否则 agent 会误判"记忆不存在"）
+  When **并发**执行 `mempal_ingest payload.md`
+  Then response 返回 `status = "rejected"` + `system_warnings` 含 `"reindex_in_progress: ingest paused, retry after completion"`
+  And payload **不**被写入 `drawers`（避免 dim 不匹配的"半新半旧"向量污染）
+  And `pending_messages`（若走 queue 路径）仍正常 enqueue，等 reindex 完成后 daemon 一次处理（协议兼容 P8 queue spec）
+  When reindex 完成（剩 50 条 re-embed 完，`reindex_in_progress = false`）
+  Then 后续 `mempal_search` 恢复向量 + BM25 混合检索，无 `system_warnings`
+  And 后续 `mempal_ingest` 恢复正常写入
 
 Scenario: 配置首次启动若缺 base_url/model 则 fail-fast
   Test:

--- a/specs/fork-ext/p8-hook-passive-capture.spec.md
+++ b/specs/fork-ext/p8-hook-passive-capture.spec.md
@@ -60,7 +60,7 @@ estimate: 2d
   - **不**处理 `hook_pre_tool`（仅 audit 无新信息，skip）
   - **truncated envelope**（`_truncated: true`）→ 直接落 warn 日志 + 产出 drawer（wing=`hooks-raw`，room=`truncated`），content 放 envelope JSON 原文；**必须经 `ingest::pipeline` 写入**（关键安全要求：pipeline 会在 chunking 前对整个 envelope JSON 文本跑 privacy scrub——含 `payload_preview` 字段——由 P8 `p8-privacy-scrubbing.spec.md` L24 保证。4KB preview + scrub 双重兜底把残留 secret 暴露面压到最小）；**不**尝试解析 `payload` 字段，立即 `confirm`（不走 `mark_failed` → 不进重试循环）
 - 所有 handler 都走完整 ingest 管道，自动应用 P8 privacy scrub；gating（P9）未到时自动禁用
-- `mempal hook install --target claude-code` 写入 `~/.claude/settings.json` 的 `hooks` key：
+- `mempal hook install --target claude-code` 写入 Claude Code 的 `settings.json` 的 `hooks` key：
   ```json
   {
     "hooks": {
@@ -69,7 +69,12 @@ estimate: 2d
     }
   }
   ```
-  **非侵入式合并语义**（CSA design review 2026-04-20 识别的共存需求）：读既有 JSON，对每个 hook 事件（`PostToolUse` / `UserPromptSubmit` / `SessionEnd` 等）**追加到既有数组**，不覆盖；若既有条目的 `command` 字段已等于 `mempal hook <event>` 的命令则跳过，避免重复注入。**不能**把整个 `hooks.UserPromptSubmit` 数组替换掉——upstream `mempal cowork-install-hooks`（见根目录 `specs/p8-cowork-inbox-push.spec.md`）也往同一个数组注入 `mempal cowork-drain` 条目，必须共存（两条 hook 各自 fire，互不干扰）。实现上：`hooks.<event>` 是 `Vec<HookGroup>`，本命令的 merge 规则是 `existing.chain(new.filter(not already_present_by_command))`；**绝不**是赋值。
+  **写入目标选择（本地优先 → symlink 感知 → 全局 fallback）**（gemini 2026-04-20 策略审查 Part 1 + Part 3 #3）：
+  1. 先看 `<cwd>/.claude/settings.json` 是否存在。存在就写本地（**MUST**）。理由：upstream `215b62f` 把 `.claude/settings.json` + `.claude/hooks/user-prompt-submit.sh` 作为 tracked blob commit 进仓库根目录用来自装 `cowork-drain`；Claude Code 对同路径文件**本地优先于全局**，若此时往 `~/.claude/settings.json` 全局写，在该仓库下运行 Claude Code 会完全读不到本 fork 注入的 hook（**silent shadow**，bug 发现代价极高）
+  2. 本地文件是 symlink 时 `canonicalize()` 到真实文件再读写，尊重用户 `git config core.excludesfile ~/.gitignore_noai` + 软链到独立 tracked 仓库的工作习惯（直接 `fs::write` 会把 symlink 变成 regular file，污染用户的独立跟踪仓库）
+  3. 本地不存在则 fallback 写 `~/.claude/settings.json` 全局（原 P8 设计，对非 fork 仓库的普通用户场景仍适用）
+  
+  **非侵入式合并语义**（CSA design review 2026-04-20 识别的共存需求）：读既有 JSON，对每个 hook 事件（`PostToolUse` / `UserPromptSubmit` / `SessionEnd` 等）**追加到既有数组**，不覆盖；若既有条目的 `command` 字段已等于 `mempal hook <event>` 的命令则跳过，避免重复注入。**不能**把整个 `hooks.UserPromptSubmit` 数组替换掉——upstream `mempal cowork-install-hooks`（见根目录 `specs/p8-cowork-inbox-push.spec.md`）也往同一个数组注入 `mempal cowork-drain` 条目（upstream commit `215b62f` 已把这个数组内容 commit 进 `.claude/settings.json`），必须共存（两条 hook 各自 fire，互不干扰）。实现上：`hooks.<event>` 是 `Vec<HookGroup>`，本命令的 merge 规则是 `existing.chain(new.filter(not already_present_by_command))`；**绝不**是赋值。
 - `--dry-run` 打印 diff 不写入
 - 配置项在 `[hooks]`：`enabled`, `capture` (Vec<String>), `wing`, `daemon_poll_interval_ms`, `daemon_claim_ttl_secs`
 - `enabled = false` 时 `mempal hook <event>` **仍然** enqueue（让用户可以先写 hook 配置，再翻开关）；`mempal daemon` 检查到 `enabled = false` 直接退出并打印 warning
@@ -97,7 +102,8 @@ estimate: 2d
 - 不要改 `drawers` / `drawer_vectors` schema（新表已在 P8 queue spec 中独立 bump）
 - 不要在 `mempal-mcp` / `mempal-api` / `mempal-search` 任何 crate 引用 `mempal-cli::hook` 模块
 - 不要强制 hook 注入 auth token 或 HMAC 验证——目标是 localhost 工具链协同，非外网
-- 不要覆盖用户已有的 `~/.claude/settings.json` 内容；只 merge `hooks` 子树
+- 不要覆盖用户已有的 `.claude/settings.json`（本地或全局）内容；只 merge `hooks` 子树
+- `.claude/settings.json` 是 symlink 时**不**允许 `fs::write` 写目标路径（会把软链变 regular file）——必须 `canonicalize()` 后写真实文件
 - 不要做 systemd timer / cron 自动启动 daemon——用户显式调 `mempal daemon`
 - 不要在 `mempal hook <event>` 里输出 stdout（只能 stderr），避免干扰 agent 的 stdout 管道
 
@@ -192,6 +198,45 @@ Scenario: hook install --dry-run 不写文件
   When 执行 `mempal hook install --target claude-code --dry-run`
   Then stdout 输出 diff 预览
   And `~/.claude/settings.json` 仍不存在
+
+Scenario: hook install 本地优先——repo 内有 .claude/settings.json 时写本地
+  Test:
+    Filter: test_hook_install_respects_project_local_settings
+    Level: integration
+    Test Double: tempfile_cwd_with_local_settings
+    Targets: crates/mempal-cli/src/hook_install.rs
+  Given 临时 cwd 含 `.claude/settings.json`（regular file，JSON 内容 `{ "theme": "dark" }`）
+  And 临时 HOME 无 `.claude/settings.json`
+  When 执行 `mempal hook install --target claude-code`
+  Then `<cwd>/.claude/settings.json` 被修改，`theme == "dark"` 保留，`hooks.PostToolUse` 新增 `mempal hook hook_post_tool`
+  And `~/.claude/settings.json` **仍不存在**（全局路径 MUST NOT 被触碰，避免把 fork-only 配置写进 user 全局污染别的 repo）
+
+Scenario: hook install symlink 感知——edit target 不破坏软链
+  Test:
+    Filter: test_hook_install_follows_symlink_target
+    Level: integration
+    Test Double: tempfile_cwd_with_symlinked_settings
+    Targets: crates/mempal-cli/src/hook_install.rs
+  Given 临时 cwd 下 `.claude/settings.json` 是 symlink，指向 `<some-other-dir>/claude-settings.json`（真实文件）
+  And 真实目标 JSON `{ "theme": "dark" }`
+  When 执行 `mempal hook install --target claude-code`
+  Then `<cwd>/.claude/settings.json` 仍是 symlink（MUST `fs::symlink_metadata` → `is_symlink() == true`）
+  And symlink `readlink` 目标路径不变
+  And **真实目标文件** `<some-other-dir>/claude-settings.json` 被写入，含原 `theme` + 新 `hooks.PostToolUse` entry
+  And `fs::write` 未被直接调用在 symlink 路径（实现必须 `canonicalize` 后再写）
+
+Scenario: hook install 与 upstream cowork-drain entry 共存
+  Test:
+    Filter: test_hook_install_coexists_with_upstream_cowork_entry
+    Level: integration
+    Test Double: tempfile_cwd_with_upstream_committed_settings
+    Targets: crates/mempal-cli/src/hook_install.rs
+  Given 临时 cwd 下 `.claude/settings.json` 已含 upstream 注入的 `hooks.UserPromptSubmit = [{ "hooks": [{ "type": "command", "command": ".claude/hooks/user-prompt-submit.sh" }] }]`（来自 `mempal cowork-install-hooks`，upstream commit `215b62f`）
+  When 执行 `mempal hook install --target claude-code`
+  Then `hooks.UserPromptSubmit` 数组 **长度 = 2**（原 upstream entry 保留 + fork 新 entry 追加）
+  And 其中**必须**有一条 `command` 匹配 `.claude/hooks/user-prompt-submit.sh`（upstream 保留）
+  And 其中**必须**有另一条 `command == "mempal hook hook_user_prompt"`（fork 追加）
+  And 第二次执行同命令 **不再追加**（idempotent by command-string 匹配）
 
 Scenario: daemon status 报告运行状态和队列 stats
   Test:


### PR DESCRIPTION
## Summary

Absorb all 6 gemini tier-3-complex findings (session `01KPP36SKKNQ5T3C5JEFR9VN61`) before fork-ext P8 implementation begins. Covers three user concerns: (a) no duplicate upstream work, (b) minimize upstream-sync token cost, (c) data survives every fork migration.

## Commits

- `4f21500` plan: R1 keep `config.rs` single file, R2 extract `src/core/db_fork_ext.rs`, R3 append MCP handlers at bottom. Codified as D0 pre-flight constraints.
- `54f13f7` p8-hook: install local-first + symlink-aware + coexist with upstream `215b62f` cowork-drain entry. 3 new scenarios.
- `6f5647c` **CRITICAL** p10-vector-iso: sqlite-vec vec0 does NOT support ALTER TABLE ADD COLUMN. Explicit DROP+CREATE+reinsert with BEGIN IMMEDIATE + COUNT(*) invariant. 3 new scenarios prevent silent vector loss.
- `901ab6b` p8-embed-qwen3: search/ingest/queue protocol during mid-flight reindex (mixed dim state).

## Upstream overlap check

0 overlaps with upstream. fork_ext_meta axis stays clean. Only upstream-fork interaction: upstream 215b62f tracks local `.claude/settings.json` → fork's hook install must be local-aware (fixed in `54f13f7`).

## Test plan

- [ ] Docs-only PR (no source code touched).
- [ ] Next PR implements Phase 0 against these specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)