### PR TITLE
chore: add commit gates (justfile + lefthook)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,81 @@
+# Justfile for mempal
+# Single-crate Rust project. Adapted from ../cli-sub-agent/justfile.
+# AI AGENT: Do NOT modify this file or use `git commit -n`/`--no-verify` to
+# bypass pre-commit. Fix the actual code.
+
+set shell := ["bash", "-c"]
+set tempdir := "."
+set dotenv-load := true
+
+_repo_root := `git rev-parse --show-toplevel`
+export MISE_TRUSTED_CONFIG_PATHS := _repo_root
+
+# Default recipe
+default: pre-commit
+
+# Full pre-commit gate (fmt, clippy, test).
+pre-commit:
+    just fmt
+    just clippy
+    just test
+
+# Format code and auto-stage modified .rs files.
+fmt:
+    cargo fmt --all
+    git diff --name-only | grep '\.rs$' | xargs -r git add
+
+# Clippy for the whole crate (strict).
+clippy:
+    cargo clippy --all-features --all-targets -- -D warnings
+
+# All tests (default features + `rest`; `onnx` intentionally excluded — the
+# bundled onnxruntime C++ libs reference `__isoc23_strtoull`, which mold on
+# this host fails to resolve. `just test-onnx` is an opt-in for runs where
+# that toolchain is fixed.)
+test:
+    cargo test --features rest
+
+# Tests matching a pattern.
+# Usage: just test-f name
+test-f pattern:
+    cargo test --features rest {{pattern}}
+
+# ONNX feature test (opt-in; may fail due to mold linker `__isoc23_strtoull`).
+test-onnx:
+    cargo test --features onnx
+
+# Build release binary.
+build:
+    cargo build --release --all-features
+
+# Bump patch version (requires cargo-edit).
+bump-patch:
+    cargo set-version --bump patch
+
+# Install git hooks via lefthook.
+install-hooks:
+    @git config --unset core.hooksPath 2>/dev/null || true
+    lefthook install
+    @echo "Lefthook hooks installed."
+
+# Reviewed push: run csa review first, then push + create PR.
+# Usage: just push-reviewed [base=main]
+push-reviewed base="main":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Pre-push review: csa review --sa-mode false --range {{base}}...HEAD ==="
+    csa review --sa-mode false --range "{{base}}...HEAD"
+    echo "=== Review passed. Pushing... ==="
+    git push -u origin HEAD
+    echo "=== Creating or reusing PR targeting {{base}}... ==="
+    set +e
+    CREATE_OUTPUT="$(gh pr create --base "{{base}}" 2>&1)"
+    CREATE_RC=$?
+    set -e
+    if [ "${CREATE_RC}" -ne 0 ]; then
+        if ! printf '%s\n' "${CREATE_OUTPUT}" | grep -Eiq 'already exists|a pull request already exists'; then
+            echo "ERROR: gh pr create failed: ${CREATE_OUTPUT}"
+            exit 1
+        fi
+        echo "PR already exists. Continuing."
+    fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+# Lefthook — git hooks manager
+# Install: just install-hooks  (or: lefthook install)
+# Docs: https://github.com/evilmartians/lefthook
+
+pre-commit:
+  commands:
+    branch-protection:
+      run: scripts/hooks/branch-protection.sh
+    quality-gates:
+      run: just pre-commit

--- a/scripts/hooks/branch-protection.sh
+++ b/scripts/hooks/branch-protection.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Branch protection: blocks commits on protected branches.
+set -euo pipefail
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0
+[ -z "$branch" ] && exit 0  # detached HEAD
+
+PROTECTED="main dev master"
+
+for pb in $PROTECTED; do
+  if [ "$branch" = "$pb" ]; then
+    echo ""
+    echo "BLOCKED: Cannot commit directly to '$branch'."
+    echo ""
+    echo "Create a feature branch first:"
+    echo "  git checkout -b feat/<description>"
+    echo "  git checkout -b fix/<description>"
+    echo ""
+    echo "Branch naming: feat/ fix/ refactor/ chore/ docs/ test/"
+    echo ""
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- Add `justfile` with fmt/clippy/test/pre-commit/install-hooks recipes (adapted from `../cli-sub-agent/justfile`, single-crate simplified).
- Add `lefthook.yml` wiring pre-commit to branch-protection + `just pre-commit`.
- Add `scripts/hooks/branch-protection.sh` — blocks direct commits to main/dev/master.

## Rationale
Upcoming fork-ext P8 chain (Phase 0-5) will be implemented by csa-codex with gemini-cli review. Need mechanical commit gates in place first so quality issues fail-fast per commit rather than accumulating.

## Notes
- `just test` uses `--features rest` (skips `onnx`) because the bundled onnxruntime C++ libs reference `__isoc23_strtoull`, which mold on this host cannot resolve. Pre-existing env issue, unrelated to mempal. `just test-onnx` is opt-in.
- `just clippy` keeps `--all-features` (type-check only, no linker step).
- 156 tests pass with `--features rest`.

## Test plan
- [x] `just fmt` + `just clippy` exit 0
- [x] `just test` → 156 tests pass
- [x] pre-commit hook fires on `git commit` (verified on this commit)
- [ ] Subsequent code PRs (Phase 0+) must pass `just pre-commit`

Generated with Claude Code