### PR TITLE
feat(fork-ext): Phase 0 — fork_ext_version schema axis foundation

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip] #[path = "db_fork_ext.rs"] mod db_fork_ext;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -102,6 +103,7 @@ impl Database {
 
         let conn = Connection::open(path)?;
         apply_migrations(&conn)?;
+        db_fork_ext::apply_fork_ext_migrations(&conn)?;
 
         Ok(Self {
             conn,

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -1,0 +1,85 @@
+use rusqlite::{Connection, OptionalExtension, params};
+
+pub(crate) const FORK_EXT_META_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS fork_ext_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"#;
+
+struct Migration {
+    version: u32,
+    up: fn(&Connection) -> rusqlite::Result<()>,
+}
+
+pub(crate) fn read_fork_ext_version(conn: &Connection) -> rusqlite::Result<u32> {
+    let table_exists = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='fork_ext_meta'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if table_exists == 0 {
+        return Ok(0);
+    }
+
+    let value = conn
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = 'fork_ext_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+
+    match value {
+        Some(value) => Ok(value.parse().map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?),
+        None => Ok(0),
+    }
+}
+
+pub(crate) fn set_fork_ext_version(conn: &Connection, v: u32) -> rusqlite::Result<()> {
+    conn.execute(
+        r#"
+        INSERT INTO fork_ext_meta (key, value)
+        VALUES ('fork_ext_version', ?1)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+        params![v.to_string()],
+    )?;
+    Ok(())
+}
+
+fn fork_ext_migrations() -> &'static [Migration] {
+    &[]
+}
+
+pub(crate) fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_META_DDL)?;
+
+    let current_version = read_fork_ext_version(conn)?;
+    for migration in fork_ext_migrations()
+        .iter()
+        .filter(|migration| migration.version > current_version)
+    {
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+
+        let result = (|| {
+            (migration.up)(conn)?;
+            set_fork_ext_version(conn, migration.version)?;
+            conn.execute_batch("COMMIT")?;
+            Ok(())
+        })();
+
+        if let Err(error) = result {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -1,0 +1,77 @@
+use mempal::core::db::Database;
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+#[path = "../src/core/db_fork_ext.rs"]
+mod db_fork_ext;
+
+fn new_test_db() -> (TempDir, std::path::PathBuf, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db_path, db)
+}
+
+fn current_schema_version() -> u32 {
+    let source = include_str!("../src/core/db.rs");
+    let version_line = source
+        .lines()
+        .find(|line| line.contains("const CURRENT_SCHEMA_VERSION"))
+        .expect("CURRENT_SCHEMA_VERSION line");
+    let version = version_line
+        .split('=')
+        .nth(1)
+        .expect("version assignment")
+        .trim()
+        .trim_end_matches(';');
+
+    version.parse().expect("CURRENT_SCHEMA_VERSION value")
+}
+
+#[test]
+fn test_fork_ext_version_is_zero_on_fresh_db() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
+
+    assert_eq!(version, 0);
+}
+
+#[test]
+fn test_fork_ext_migrations_idempotent() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("first apply");
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
+    assert_eq!(version, 0);
+}
+
+#[test]
+fn test_upstream_user_version_preserved_after_fork_ext_init() {
+    let (_tmp, db_path, _db) = new_test_db();
+    let conn = Connection::open(db_path).expect("open sqlite connection");
+
+    let user_version = conn
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .expect("read user_version");
+
+    assert_eq!(user_version, current_schema_version());
+}
+
+#[test]
+fn test_fork_ext_meta_table_exists_after_init() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='fork_ext_meta'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+
+    assert_eq!(exists, 1);
+}


### PR DESCRIPTION
## Summary
- add `src/core/db_fork_ext.rs` with `fork_ext_meta` bootstrap, version read/write helpers, and an empty Phase 0 migration runner
- integrate fork-ext migrations into `Database::open` immediately after upstream migrations with a 2-line `src/core/db.rs` diff
- add integration coverage for fresh-db version zero, idempotent apply, upstream `user_version` preservation, and meta-table creation

## Verification
- `cargo test --features rest --test fork_ext_schema_axis`
- `just pre-commit`
- `csa review --diff --allow-fallback`

## Notes
- `src/core/db.rs` remains a 2-line addition only
- `PRAGMA user_version` stays on the upstream axis; fork-owned state lives in `fork_ext_meta`
- local working tree still has a pre-existing unstaged `weave.lock` change that is unrelated to this PR
