### PR TITLE
feat(fork-ext): Phase 1 — config hot-reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,9 +230,29 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -383,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +459,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -744,6 +800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1272,6 +1337,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1436,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1491,13 +1596,17 @@ name = "mempal"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "bimap",
+ "blake3",
  "clap",
  "jieba-rs",
  "model2vec-rs",
+ "notify",
  "ort",
+ "regex",
  "reqwest",
  "rmcp",
  "rusqlite",
@@ -1543,6 +1652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1641,6 +1751,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,7 +1828,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1713,7 +1850,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2104,7 +2241,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2266,7 +2403,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2286,7 +2423,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2352,6 +2489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,7 +2544,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2514,7 +2660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2896,7 +3042,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -3107,6 +3253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,7 +3378,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3290,6 +3446,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3588,7 +3753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,17 @@ rest = ["dep:axum", "dep:tower", "dep:tower-http", "model2vec"]
 
 [dependencies]
 anyhow = "1"
+arc-swap = "1"
 async-trait = "0.1"
 axum = { version = "0.8", optional = true }
 bimap = "0.6"
+blake3 = "1"
 clap = { version = "4", features = ["derive"] }
 jieba-rs = "0.8"
 model2vec-rs = { version = "0.1", optional = true }
+notify = "8"
 ort = { version = "2.0.0-rc.9", optional = true }
+regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rmcp = { version = "1.3.0", features = ["server", "macros", "schemars", "transport-async-rw", "transport-io"] }
 rusqlite = { version = "0.37", features = ["bundled"] }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,18 +1,27 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use serde::Deserialize;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
 const DEFAULT_EMBED_BACKEND: &str = "model2vec";
+const DEFAULT_HOT_RELOAD_DEBOUNCE_MS: u64 = 250;
+const DEFAULT_HOT_RELOAD_POLL_FALLBACK_SECS: u64 = 5;
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub db_path: String,
+    #[serde(alias = "embedder")]
     pub embed: EmbedConfig,
+    pub privacy: PrivacyConfig,
+    pub config_hot_reload: ConfigHotReloadConfig,
+    pub search: SearchConfig,
+    pub ingest_gating: IngestGatingConfig,
 }
 
 impl Default for Config {
@@ -20,6 +29,10 @@ impl Default for Config {
         Self {
             db_path: DEFAULT_DB_PATH.to_string(),
             embed: EmbedConfig::default(),
+            privacy: PrivacyConfig::default(),
+            config_hot_reload: ConfigHotReloadConfig::default(),
+            search: SearchConfig::default(),
+            ingest_gating: IngestGatingConfig::default(),
         }
     }
 }
@@ -31,23 +44,95 @@ impl Config {
 
     pub fn load_from(path: &Path) -> Result<Self, ConfigError> {
         match fs::read_to_string(path) {
-            Ok(contents) => Ok(toml::from_str(&contents)?),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Ok(contents) => Self::parse(&contents),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let config = Self::default();
+                config.validate()?;
+                Ok(config)
+            }
             Err(source) => Err(ConfigError::Read {
                 path: path.to_path_buf(),
                 source,
             }),
         }
     }
+
+    pub fn parse(contents: &str) -> Result<Self, ConfigError> {
+        let config: Self = toml::from_str(contents)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        for pattern in &self.privacy.scrub_patterns {
+            Regex::new(&pattern.pattern).map_err(|source| ConfigError::InvalidRegex {
+                name: pattern.name.clone(),
+                source,
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn scrub_content(&self, input: &str) -> String {
+        if !self.privacy.enabled {
+            return input.to_string();
+        }
+
+        self.privacy
+            .scrub_patterns
+            .iter()
+            .fold(input.to_string(), |content, pattern| {
+                match Regex::new(&pattern.pattern) {
+                    Ok(regex) => regex
+                        .replace_all(&content, format!("[REDACTED:{}]", pattern.name))
+                        .into_owned(),
+                    Err(_) => content,
+                }
+            })
+    }
+
+    pub fn effective_hash(&self) -> Result<String, ConfigError> {
+        let bytes = toml::to_string(self)
+            .map_err(|source| ConfigError::SerializeEffectiveConfig { source })?;
+        Ok(blake3::hash(bytes.as_bytes()).to_hex()[..12].to_string())
+    }
+
+    pub fn restart_required_fields_changed(&self, other: &Self) -> Vec<&'static str> {
+        let mut fields = Vec::new();
+        if self.db_path != other.db_path {
+            fields.push("database.path");
+        }
+        if self.embed.backend != other.embed.backend {
+            fields.push("embedder.backend");
+        }
+        if self.embed.base_url != other.embed.base_url {
+            fields.push("embedder.base_url");
+        }
+        if self.embed.model != other.embed.model {
+            fields.push("embedder.model");
+        }
+        if self.embed.api_model != other.embed.api_model {
+            fields.push("embedder.api_model");
+        }
+        fields
+    }
+
+    pub fn merge_runtime_allowed(&self, candidate: &Self) -> Self {
+        let mut effective = candidate.clone();
+        effective.db_path = self.db_path.clone();
+        effective.embed = self.embed.clone();
+        effective
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct EmbedConfig {
     pub backend: String,
     /// Model identifier (e.g., "minishlab/potion-multilingual-128M" for model2vec).
     pub model: Option<String>,
-    pub api_endpoint: Option<String>,
+    #[serde(alias = "api_endpoint")]
+    pub base_url: Option<String>,
     pub api_model: Option<String>,
 }
 
@@ -56,10 +141,60 @@ impl Default for EmbedConfig {
         Self {
             backend: DEFAULT_EMBED_BACKEND.to_string(),
             model: None,
-            api_endpoint: None,
+            base_url: None,
             api_model: None,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct PrivacyConfig {
+    pub enabled: bool,
+    pub scrub_patterns: Vec<ScrubPattern>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ScrubPattern {
+    pub name: String,
+    #[serde(alias = "regex")]
+    pub pattern: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ConfigHotReloadConfig {
+    pub enabled: bool,
+    pub debounce_ms: u64,
+    pub poll_fallback_secs: u64,
+}
+
+impl Default for ConfigHotReloadConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            debounce_ms: DEFAULT_HOT_RELOAD_DEBOUNCE_MS,
+            poll_fallback_secs: DEFAULT_HOT_RELOAD_POLL_FALLBACK_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct SearchConfig {
+    pub strict_project_isolation: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct IngestGatingConfig {
+    pub embedding_classifier: EmbeddingClassifierConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct EmbeddingClassifierConfig {
+    pub prototypes: Vec<String>,
 }
 
 #[derive(Debug, Error)]
@@ -72,11 +207,68 @@ pub enum ConfigError {
     },
     #[error("failed to parse config TOML")]
     Parse(#[from] toml::de::Error),
+    #[error("invalid privacy regex for pattern {name}")]
+    InvalidRegex {
+        name: String,
+        #[source]
+        source: regex::Error,
+    },
+    #[error("failed to serialize effective config")]
+    SerializeEffectiveConfig {
+        #[source]
+        source: toml::ser::Error,
+    },
 }
 
-fn default_config_path() -> PathBuf {
+pub fn default_config_path() -> PathBuf {
     env::var_os("HOME")
         .map(PathBuf::from)
         .map(|home| home.join(".mempal").join("config.toml"))
         .unwrap_or_else(|| PathBuf::from("~/.mempal/config.toml"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigSnapshotMeta {
+    pub version: String,
+    pub loaded_at_unix_ms: u64,
+}
+
+pub struct ConfigHandle;
+
+impl ConfigHandle {
+    pub fn bootstrap(path: impl AsRef<Path>) -> Result<(), ConfigError> {
+        super::hot_reload::global_hot_reload_state().bootstrap(path.as_ref())
+    }
+
+    pub fn current() -> Arc<Config> {
+        super::hot_reload::global_hot_reload_state().current()
+    }
+
+    pub fn snapshot_meta() -> ConfigSnapshotMeta {
+        super::hot_reload::global_hot_reload_state().snapshot_meta()
+    }
+
+    pub fn version() -> String {
+        Self::snapshot_meta().version
+    }
+
+    pub fn loaded_at_unix_ms() -> u64 {
+        Self::snapshot_meta().loaded_at_unix_ms
+    }
+
+    pub fn parse_attempts() -> usize {
+        super::hot_reload::global_hot_reload_state().parse_attempts()
+    }
+
+    pub fn recent_events() -> Vec<String> {
+        super::hot_reload::global_hot_reload_state().recent_events()
+    }
+
+    pub fn runtime_prototypes() -> Vec<String> {
+        super::hot_reload::global_hot_reload_state().runtime_prototypes()
+    }
+
+    pub fn simulate_notify_failure() {
+        super::hot_reload::global_hot_reload_state().simulate_notify_failure();
+    }
 }

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -1,0 +1,378 @@
+use std::collections::VecDeque;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use arc_swap::ArcSwap;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+
+use super::config::{Config, ConfigError, ConfigSnapshotMeta};
+
+const MAX_EVENT_LOG: usize = 64;
+
+#[derive(Debug)]
+struct ConfigSnapshot {
+    config: Arc<Config>,
+    version: String,
+    loaded_at_unix_ms: u64,
+}
+
+impl ConfigSnapshot {
+    fn from_config(config: Config) -> Result<Self, ConfigError> {
+        Ok(Self {
+            version: config.effective_hash()?,
+            loaded_at_unix_ms: now_unix_ms(),
+            config: Arc::new(config),
+        })
+    }
+}
+
+enum WatchMessage {
+    FileChanged,
+    NotifyFailed,
+    Stop,
+}
+
+struct RuntimeControl {
+    stop: Arc<AtomicBool>,
+    control_tx: mpsc::Sender<WatchMessage>,
+    coordinator: thread::JoinHandle<()>,
+    poller: thread::JoinHandle<()>,
+}
+
+impl RuntimeControl {
+    fn stop(self) {
+        self.stop.store(true, Ordering::SeqCst);
+        let _ = self.control_tx.send(WatchMessage::Stop);
+        let _ = self.coordinator.join();
+        let _ = self.poller.join();
+    }
+}
+
+pub struct HotReloadState {
+    snapshot: ArcSwap<ConfigSnapshot>,
+    runtime: Mutex<Option<RuntimeControl>>,
+    event_log: Mutex<VecDeque<String>>,
+    parse_attempts: AtomicUsize,
+    runtime_prototypes: ArcSwap<Vec<String>>,
+}
+
+impl HotReloadState {
+    fn new() -> Self {
+        let initial = Config::default();
+        let snapshot =
+            ConfigSnapshot::from_config(initial.clone()).expect("default config is valid");
+        Self {
+            snapshot: ArcSwap::from_pointee(snapshot),
+            runtime: Mutex::new(None),
+            event_log: Mutex::new(VecDeque::new()),
+            parse_attempts: AtomicUsize::new(0),
+            runtime_prototypes: ArcSwap::from_pointee(
+                initial.ingest_gating.embedding_classifier.prototypes,
+            ),
+        }
+    }
+
+    pub fn bootstrap(&self, path: &Path) -> Result<(), ConfigError> {
+        let config = Config::load_from(path)?;
+        let snapshot = ConfigSnapshot::from_config(config.clone())?;
+        self.snapshot.store(Arc::new(snapshot));
+        self.runtime_prototypes.store(Arc::new(
+            config.ingest_gating.embedding_classifier.prototypes.clone(),
+        ));
+        self.push_event(format!(
+            "config hot-reload: bootstrapped version {}",
+            self.snapshot_meta().version
+        ));
+
+        let mut runtime = self.runtime.lock().expect("runtime mutex poisoned");
+        if let Some(existing) = runtime.take() {
+            existing.stop();
+        }
+        if config.config_hot_reload.enabled {
+            *runtime = Some(self.start_runtime(
+                path.to_path_buf(),
+                config.config_hot_reload.debounce_ms,
+                config.config_hot_reload.poll_fallback_secs,
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn current(&self) -> Arc<Config> {
+        Arc::clone(&self.snapshot.load_full().config)
+    }
+
+    pub fn snapshot_meta(&self) -> ConfigSnapshotMeta {
+        let snapshot = self.snapshot.load_full();
+        ConfigSnapshotMeta {
+            version: snapshot.version.clone(),
+            loaded_at_unix_ms: snapshot.loaded_at_unix_ms,
+        }
+    }
+
+    pub fn parse_attempts(&self) -> usize {
+        self.parse_attempts.load(Ordering::SeqCst)
+    }
+
+    pub fn recent_events(&self) -> Vec<String> {
+        self.event_log
+            .lock()
+            .expect("event log mutex poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    pub fn runtime_prototypes(&self) -> Vec<String> {
+        (*self.runtime_prototypes.load_full()).clone()
+    }
+
+    pub fn simulate_notify_failure(&self) {
+        if let Some(runtime) = self
+            .runtime
+            .lock()
+            .expect("runtime mutex poisoned")
+            .as_ref()
+        {
+            let _ = runtime.control_tx.send(WatchMessage::NotifyFailed);
+        }
+    }
+
+    fn start_runtime(
+        &self,
+        path: PathBuf,
+        debounce_ms: u64,
+        poll_fallback_secs: u64,
+    ) -> RuntimeControl {
+        let stop = Arc::new(AtomicBool::new(false));
+        let fallback_poll_enabled = Arc::new(AtomicBool::new(false));
+        let (control_tx, control_rx) = mpsc::channel::<WatchMessage>();
+        let notify_tx = control_tx.clone();
+        let poll_tx = control_tx.clone();
+        let start_failure_tx = control_tx.clone();
+        let stop_for_coordinator = Arc::clone(&stop);
+        let stop_for_poller = Arc::clone(&stop);
+        let poll_toggle = Arc::clone(&fallback_poll_enabled);
+        let state = global_hot_reload_state_arc();
+        let watch_path = path.clone();
+        let poll_path = path;
+        let debounce = Duration::from_millis(debounce_ms.max(1));
+        let poll_interval = Duration::from_secs(poll_fallback_secs.max(1));
+        let (ready_tx, ready_rx) = mpsc::channel::<()>();
+
+        let coordinator = thread::spawn(move || {
+            let file_name = watch_path.file_name().map(OsStr::to_os_string);
+            let watch_dir = watch_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."));
+            let mut watcher = create_watcher(notify_tx, file_name.clone());
+
+            if let Some(active_watcher) = watcher.as_mut() {
+                if let Err(error) = active_watcher.watch(&watch_dir, RecursiveMode::NonRecursive) {
+                    state.push_event(format!(
+                        "config hot-reload: notify watch failed for {}: {error}",
+                        watch_dir.display()
+                    ));
+                    fallback_poll_enabled.store(true, Ordering::SeqCst);
+                    drop(watcher.take());
+                }
+            } else {
+                fallback_poll_enabled.store(true, Ordering::SeqCst);
+            }
+
+            let _ = ready_tx.send(());
+
+            if std::env::var_os("MEMPAL_TEST_NOTIFY_FAIL_AFTER_START").is_some() {
+                let _ = start_failure_tx.send(WatchMessage::NotifyFailed);
+            }
+
+            while let Ok(message) = control_rx.recv() {
+                match message {
+                    WatchMessage::Stop => break,
+                    WatchMessage::NotifyFailed => {
+                        drop(watcher.take());
+                        if !fallback_poll_enabled.swap(true, Ordering::SeqCst) {
+                            state.push_event(
+                                "config hot-reload: notify watcher crashed, falling back to poll"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    WatchMessage::FileChanged => {
+                        while let Ok(next) = control_rx.recv_timeout(debounce) {
+                            match next {
+                                WatchMessage::FileChanged => {}
+                                WatchMessage::NotifyFailed => {
+                                    drop(watcher.take());
+                                    if !fallback_poll_enabled.swap(true, Ordering::SeqCst) {
+                                        state.push_event("config hot-reload: notify watcher crashed, falling back to poll".to_string());
+                                    }
+                                }
+                                WatchMessage::Stop => return,
+                            }
+                        }
+                        if stop_for_coordinator.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        state.reload_from_disk(&watch_path);
+                    }
+                }
+            }
+        });
+
+        let poller = thread::spawn(move || {
+            let mut previous = file_signature(&poll_path);
+            while !stop_for_poller.load(Ordering::SeqCst) {
+                thread::sleep(poll_interval);
+                if !poll_toggle.load(Ordering::SeqCst) {
+                    previous = file_signature(&poll_path);
+                    continue;
+                }
+
+                let current = file_signature(&poll_path);
+                if current != previous {
+                    previous = current;
+                    let _ = poll_tx.send(WatchMessage::FileChanged);
+                }
+            }
+        });
+
+        let _ = ready_rx.recv_timeout(Duration::from_secs(1));
+
+        RuntimeControl {
+            stop,
+            control_tx,
+            coordinator,
+            poller,
+        }
+    }
+
+    fn reload_from_disk(&self, path: &Path) {
+        self.parse_attempts.fetch_add(1, Ordering::SeqCst);
+        let previous = self.snapshot.load_full();
+        let candidate = match Config::load_from(path) {
+            Ok(config) => config,
+            Err(error) => {
+                self.push_event(format!(
+                    "config hot-reload: parse failed, keeping previous version: {error}"
+                ));
+                return;
+            }
+        };
+
+        for field in previous.config.restart_required_fields_changed(&candidate) {
+            self.push_event(format!(
+                "config hot-reload: {field} requires restart, change ignored"
+            ));
+        }
+
+        if previous
+            .config
+            .ingest_gating
+            .embedding_classifier
+            .prototypes
+            != candidate.ingest_gating.embedding_classifier.prototypes
+        {
+            self.push_event(
+                "config hot-reload: prototype change detected, effective after daemon restart"
+                    .to_string(),
+            );
+        }
+
+        let effective = previous.config.merge_runtime_allowed(&candidate);
+        let next_version = match effective.effective_hash() {
+            Ok(version) => version,
+            Err(error) => {
+                self.push_event(format!(
+                    "config hot-reload: parse failed, keeping previous version: {error}"
+                ));
+                return;
+            }
+        };
+        if next_version == previous.version {
+            return;
+        }
+
+        let loaded_at_unix_ms = now_unix_ms();
+        self.snapshot.store(Arc::new(ConfigSnapshot {
+            config: Arc::new(effective),
+            version: next_version.clone(),
+            loaded_at_unix_ms,
+        }));
+        self.push_event(format!(
+            "config hot-reload: version changed from {} to {}",
+            previous.version, next_version
+        ));
+    }
+
+    fn push_event(&self, event: String) {
+        eprintln!("{event}");
+        let mut events = self.event_log.lock().expect("event log mutex poisoned");
+        if events.len() == MAX_EVENT_LOG {
+            let _ = events.pop_front();
+        }
+        events.push_back(event);
+    }
+}
+
+fn create_watcher(
+    tx: mpsc::Sender<WatchMessage>,
+    file_name: Option<OsString>,
+) -> Option<RecommendedWatcher> {
+    notify::recommended_watcher(move |result: notify::Result<Event>| match result {
+        Ok(event) if should_reload_event(&event, file_name.as_deref()) => {
+            let _ = tx.send(WatchMessage::FileChanged);
+        }
+        Ok(_) => {}
+        Err(_) => {
+            let _ = tx.send(WatchMessage::NotifyFailed);
+        }
+    })
+    .ok()
+}
+
+fn should_reload_event(event: &Event, file_name: Option<&OsStr>) -> bool {
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) | EventKind::Any
+    ) {
+        return false;
+    }
+
+    event.paths.iter().any(|path| match file_name {
+        Some(name) => path.file_name() == Some(name),
+        None => true,
+    })
+}
+
+fn file_signature(path: &Path) -> Option<(u64, u64)> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    let millis = modified.duration_since(UNIX_EPOCH).ok()?.as_millis() as u64;
+    Some((millis, metadata.len()))
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after unix epoch")
+        .as_millis() as u64
+}
+
+static HOT_RELOAD_STATE: OnceLock<Arc<HotReloadState>> = OnceLock::new();
+
+pub fn global_hot_reload_state() -> &'static HotReloadState {
+    HOT_RELOAD_STATE
+        .get_or_init(|| Arc::new(HotReloadState::new()))
+        .as_ref()
+}
+
+fn global_hot_reload_state_arc() -> Arc<HotReloadState> {
+    Arc::clone(HOT_RELOAD_STATE.get_or_init(|| Arc::new(HotReloadState::new())))
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod config;
 pub mod db;
+pub mod hot_reload;
 pub mod protocol;
 pub mod types;
 pub mod utils;

--- a/src/embed/factory.rs
+++ b/src/embed/factory.rs
@@ -45,7 +45,7 @@ impl EmbedderFactory for ConfiguredEmbedderFactory {
             "api" => Ok(Box::new(ApiEmbedder::new(
                 self.config
                     .embed
-                    .api_endpoint
+                    .base_url
                     .clone()
                     .unwrap_or_else(|| "http://localhost:11434/api/embeddings".to_string()),
                 self.config.embed.api_model.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 #[cfg(feature = "rest")]
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::core::{
-    config::Config,
+    config::{Config, ConfigHandle, default_config_path},
     db::Database,
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::TaxonomyEntry,
@@ -243,7 +243,9 @@ async fn run() -> Result<()> {
         _ => {}
     }
 
-    let config = Config::load().context("failed to load config")?;
+    let config_path = default_config_path();
+    ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
+    let config = ConfigHandle::current();
     let db = Database::open(&expand_home(&config.db_path)).context("failed to open database")?;
 
     match cli.command {
@@ -253,7 +255,7 @@ async fn run() -> Result<()> {
             wing,
             format,
             dry_run,
-        } => ingest_command(&db, &config, &dir, &wing, format, dry_run).await,
+        } => ingest_command(&db, config.as_ref(), &dir, &wing, format, dry_run).await,
         Commands::Search {
             query,
             wing,
@@ -263,7 +265,7 @@ async fn run() -> Result<()> {
         } => {
             search_command(
                 &db,
-                &config,
+                config.as_ref(),
                 &query,
                 wing.as_deref(),
                 room.as_deref(),
@@ -276,12 +278,12 @@ async fn run() -> Result<()> {
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
         Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
         Commands::Compress { text } => compress_command(&text),
-        Commands::Bench { command } => bench_command(&config, command).await,
-        Commands::Reindex => reindex_command(&db, &config).await,
+        Commands::Bench { command } => bench_command(config.as_ref(), command).await,
+        Commands::Reindex => reindex_command(&db, config.as_ref()).await,
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Tunnels => tunnels_command(&db),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
-        Commands::Serve { mcp } => serve_command(&config, mcp).await,
+        Commands::Serve { mcp } => serve_command(config.as_ref(), mcp).await,
         Commands::Status => status_command(&db),
         Commands::FactCheck {
             path,
@@ -953,6 +955,7 @@ fn fact_check_command(
 }
 
 fn status_command(db: &Database) -> Result<()> {
+    let cfg_meta = ConfigHandle::snapshot_meta();
     let schema_version = db
         .schema_version()
         .context("failed to read schema version")?;
@@ -978,6 +981,10 @@ fn status_command(db: &Database) -> Result<()> {
         println!("triples: {triple_count}");
     }
     println!("db_size_bytes: {db_size_bytes}");
+    println!(
+        "config: version={} loaded_unix_ms={}",
+        cfg_meta.version, cfg_meta.loaded_at_unix_ms
+    );
 
     let counts = db.scope_counts().context("failed to query scope counts")?;
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,3 +4,4 @@ mod server;
 mod tools;
 
 pub use server::MempalMcpServer;
+pub use tools::{IngestRequest, IngestResponse, StatusResponse};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use crate::core::{
+    config::ConfigHandle,
     db::Database,
     types::{Drawer, SourceType, Triple},
     utils::{build_drawer_id, build_triple_id, current_timestamp, source_file_or_synthetic},
@@ -73,7 +74,8 @@ impl MempalMcpServer {
         name = "mempal_status",
         description = "Return schema version, drawer counts, taxonomy counts, database size, scope breakdown, the AAAK format spec, and the memory protocol. Call once at session start if you haven't seen the protocol yet."
     )]
-    async fn mempal_status(&self) -> std::result::Result<Json<StatusResponse>, ErrorData> {
+    pub async fn mempal_status(&self) -> std::result::Result<Json<StatusResponse>, ErrorData> {
+        let cfg_meta = ConfigHandle::snapshot_meta();
         let db = self.open_db()?;
         let schema_version = db.schema_version().map_err(db_error)?;
         let drawer_count = db.drawer_count().map_err(db_error)?;
@@ -95,6 +97,8 @@ impl MempalMcpServer {
             drawer_count,
             taxonomy_count,
             db_size_bytes,
+            config_version: cfg_meta.version,
+            config_loaded_at_unix_ms: cfg_meta.loaded_at_unix_ms,
             scopes,
             aaak_spec: crate::aaak::generate_spec(),
             memory_protocol: crate::core::protocol::MEMORY_PROTOCOL.to_string(),
@@ -105,10 +109,11 @@ impl MempalMcpServer {
         name = "mempal_search",
         description = "Search persistent project memory via vector embedding with optional wing/room filters. PREFER THIS over grepping files or guessing from general knowledge when answering ANY project-specific question — past decisions, design rationale, implementation details, bug history, how a component works, why something was built a certain way, or any other project knowledge. Every result includes drawer_id and source_file for citation, plus structured AAAK-derived signals (`entities`, `topics`, `flags`, `emotions`, `importance_stars`) for filtering and ranking."
     )]
-    async fn mempal_search(
+    pub async fn mempal_search(
         &self,
         Parameters(request): Parameters<SearchRequest>,
     ) -> std::result::Result<Json<SearchResponse>, ErrorData> {
+        let _cfg = ConfigHandle::current();
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
         })?;
@@ -148,12 +153,14 @@ impl MempalMcpServer {
         name = "mempal_ingest",
         description = "Persist a decision, bug fix, or design insight to project memory. Call this when a decision is reached in conversation — include the rationale, not just the outcome. Wing is required; let mempal auto-route the room. Set dry_run=true to preview the drawer_id without writing."
     )]
-    async fn mempal_ingest(
+    pub async fn mempal_ingest(
         &self,
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        let cfg = ConfigHandle::current();
+        let scrubbed_content = cfg.scrub_content(&request.content);
         let room = request.room.as_deref();
-        let drawer_id = build_drawer_id(&request.wing, room, &request.content);
+        let drawer_id = build_drawer_id(&request.wing, room, &scrubbed_content);
 
         if request.dry_run.unwrap_or(false) {
             return Ok(Json(IngestResponse {
@@ -167,7 +174,7 @@ impl MempalMcpServer {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
         })?;
         let vector = embedder
-            .embed(&[request.content.as_str()])
+            .embed(&[scrubbed_content.as_str()])
             .await
             .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
             .into_iter()
@@ -193,13 +200,13 @@ impl MempalMcpServer {
         let lock_wait_ms = Some(lock_guard.wait_duration().as_millis() as u64);
 
         // Semantic dedup check: find most similar existing drawer
-        let duplicate_warning = check_semantic_duplicate(&db, &vector, &request.content);
+        let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);
 
         if !db.drawer_exists(&drawer_id).map_err(db_error)? {
             let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
             db.insert_drawer(&Drawer {
                 id: drawer_id.clone(),
-                content: request.content,
+                content: scrubbed_content,
                 wing: request.wing,
                 room: request.room,
                 source_file: Some(source_file),
@@ -226,10 +233,11 @@ impl MempalMcpServer {
         name = "mempal_delete",
         description = "Soft-delete a drawer by ID. The drawer is marked with a deleted_at timestamp and excluded from search results, but not physically removed. Use the CLI `mempal purge` to permanently remove soft-deleted drawers. Returns the drawer_id and whether it was found."
     )]
-    async fn mempal_delete(
+    pub async fn mempal_delete(
         &self,
         Parameters(request): Parameters<DeleteRequest>,
     ) -> std::result::Result<Json<DeleteResponse>, ErrorData> {
+        let _cfg = ConfigHandle::current();
         let db = self.open_db()?;
         let deleted = db
             .soft_delete_drawer(&request.drawer_id)
@@ -250,10 +258,11 @@ impl MempalMcpServer {
         name = "mempal_taxonomy",
         description = "List or edit wing/room taxonomy entries that drive query routing keywords."
     )]
-    async fn mempal_taxonomy(
+    pub async fn mempal_taxonomy(
         &self,
         Parameters(request): Parameters<TaxonomyRequest>,
     ) -> std::result::Result<Json<TaxonomyResponse>, ErrorData> {
+        let _cfg = ConfigHandle::current();
         let db = self.open_db()?;
         match request.action.as_str() {
             "list" => {
@@ -301,10 +310,11 @@ impl MempalMcpServer {
         name = "mempal_kg",
         description = "Knowledge graph: add, query, or invalidate triples (subject-predicate-object). Use 'add' to record structured relationships between entities. Use 'query' to find relationships by subject, predicate, or object. Use 'invalidate' to mark a triple as no longer valid."
     )]
-    async fn mempal_kg(
+    pub async fn mempal_kg(
         &self,
         Parameters(request): Parameters<KgRequest>,
     ) -> std::result::Result<Json<KgResponse>, ErrorData> {
+        let _cfg = ConfigHandle::current();
         let db = self.open_db()?;
         match request.action.as_str() {
             "add" => {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -118,6 +118,8 @@ pub struct StatusResponse {
     pub drawer_count: i64,
     pub taxonomy_count: i64,
     pub db_size_bytes: u64,
+    pub config_version: String,
+    pub config_loaded_at_unix_ms: u64,
     pub scopes: Vec<ScopeCount>,
     pub aaak_spec: String,
     pub memory_protocol: String,

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -1,0 +1,641 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct RecordingEmbedderFactory {
+    vector: Vec<f32>,
+    delay: Duration,
+    seen_inputs: Arc<Mutex<Vec<String>>>,
+    entered_tx: Arc<Mutex<Option<mpsc::Sender<()>>>>,
+}
+
+struct RecordingEmbedder {
+    vector: Vec<f32>,
+    delay: Duration,
+    seen_inputs: Arc<Mutex<Vec<String>>>,
+    entered_tx: Arc<Mutex<Option<mpsc::Sender<()>>>>,
+}
+
+#[async_trait]
+impl EmbedderFactory for RecordingEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(RecordingEmbedder {
+            vector: self.vector.clone(),
+            delay: self.delay,
+            seen_inputs: Arc::clone(&self.seen_inputs),
+            entered_tx: Arc::clone(&self.entered_tx),
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for RecordingEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        self.seen_inputs
+            .lock()
+            .expect("seen_inputs mutex poisoned")
+            .extend(texts.iter().map(|text| (*text).to_string()));
+        if let Some(tx) = self
+            .entered_tx
+            .lock()
+            .expect("entered_tx mutex poisoned")
+            .take()
+        {
+            let _ = tx.send(());
+        }
+        if !self.delay.is_zero() {
+            tokio::time::sleep(self.delay).await;
+        }
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "recording"
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    config_path: PathBuf,
+    db_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new(config_text: &str) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let config_path = mempal_home.join("config.toml");
+        write_config_atomic(&config_path, config_text);
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        Self {
+            _tmp: tmp,
+            config_path,
+            db_path,
+        }
+    }
+
+    fn server(&self, factory: Arc<dyn EmbedderFactory>) -> MempalMcpServer {
+        MempalMcpServer::new_with_factory(self.db_path.clone(), factory)
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+}
+
+fn write_config_atomic(path: &Path, content: &str) {
+    let tmp_path = path.with_extension("tmp");
+    fs::write(&tmp_path, content).expect("write temp config");
+    fs::rename(&tmp_path, path).expect("rename config atomically");
+}
+
+fn wait_until(timeout: Duration, step: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(step);
+    }
+    predicate()
+}
+
+fn wait_for_version_change(previous: &str) -> String {
+    let mut current = ConfigHandle::version();
+    let changed = wait_until(Duration::from_secs(3), Duration::from_millis(50), || {
+        current = ConfigHandle::version();
+        current != previous
+    });
+    assert!(changed, "config version did not change from {previous}");
+    current
+}
+
+fn recent_events() -> Vec<String> {
+    ConfigHandle::recent_events()
+}
+
+fn latest_event_contains(needle: &str) -> bool {
+    recent_events().iter().any(|event| event.contains(needle))
+}
+
+fn base_config(db_path: &Path) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embedder]
+backend = "api"
+base_url = "http://gb10:18002/v1/"
+api_model = "test-model"
+
+[privacy]
+enabled = true
+
+[[privacy.scrub_patterns]]
+name = "openai_key"
+pattern = "sk-[A-Za-z0-9]{{36}}"
+
+[config_hot_reload]
+enabled = true
+debounce_ms = 250
+poll_fallback_secs = 1
+
+[search]
+strict_project_isolation = false
+
+[ingest_gating.embedding_classifier]
+prototypes = ["A", "B", "C"]
+"#,
+        db_path.display()
+    )
+}
+
+fn config_with_custom_token(db_path: &Path) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embedder]
+backend = "api"
+base_url = "http://gb10:18002/v1/"
+api_model = "test-model"
+
+[privacy]
+enabled = true
+
+[[privacy.scrub_patterns]]
+name = "openai_key"
+pattern = "sk-[A-Za-z0-9]{{36}}"
+
+[[privacy.scrub_patterns]]
+name = "custom_token"
+pattern = "CT-[a-f0-9]{{16}}"
+
+[config_hot_reload]
+enabled = true
+debounce_ms = 250
+poll_fallback_secs = 1
+
+[search]
+strict_project_isolation = false
+
+[ingest_gating.embedding_classifier]
+prototypes = ["A", "B", "C"]
+"#,
+        db_path.display()
+    )
+}
+
+async fn ingest(server: &MempalMcpServer, content: &str) -> String {
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: content.to_string(),
+            wing: "mempal".to_string(),
+            room: Some("config-hot-reload".to_string()),
+            source: None,
+            dry_run: None,
+            importance: None,
+        }))
+        .await
+        .expect("ingest should succeed")
+        .0;
+    response.drawer_id
+}
+
+fn count_inotify_fds() -> usize {
+    let entries = fs::read_dir("/proc/self/fd").expect("read /proc/self/fd");
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| fs::read_link(entry.path()).ok())
+        .filter(|target| target.to_string_lossy().contains("anon_inode:inotify"))
+        .count()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_privacy_pattern_hot_reload_applies_on_next_ingest() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::ZERO,
+        seen_inputs: Arc::new(Mutex::new(Vec::new())),
+        entered_tx: Arc::new(Mutex::new(None)),
+    });
+    let server = env.server(factory);
+
+    let first_id = ingest(&server, "token CT-1234567890abcdef should stay").await;
+    let first = env
+        .db()
+        .get_drawer(&first_id)
+        .expect("get first drawer")
+        .expect("first drawer exists");
+    assert!(first.content.contains("CT-1234567890abcdef"));
+
+    let previous = ConfigHandle::version();
+    write_config_atomic(&env.config_path, &config_with_custom_token(&env.db_path));
+    wait_for_version_change(&previous);
+
+    let second_id = ingest(&server, "token CT-1234567890abcdef should redact").await;
+    let second = env
+        .db()
+        .get_drawer(&second_id)
+        .expect("get second drawer")
+        .expect("second drawer exists");
+    assert!(second.content.contains("[REDACTED:custom_token]"));
+    assert!(!second.content.contains("CT-1234567890abcdef"));
+    assert!(latest_event_contains(
+        "config hot-reload: version changed from"
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_parse_failure_preserves_previous_config() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_with_custom_token(&PathBuf::from(
+        "/tmp/placeholder",
+    )));
+    let config = config_with_custom_token(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::ZERO,
+        seen_inputs: Arc::new(Mutex::new(Vec::new())),
+        entered_tx: Arc::new(Mutex::new(None)),
+    });
+    let server = env.server(factory);
+
+    let stable_version = ConfigHandle::version();
+    write_config_atomic(
+        &env.config_path,
+        "privacy.enabled = ***\n[config_hot_reload]\nenabled = true\n",
+    );
+    std::thread::sleep(Duration::from_millis(500));
+    assert_eq!(ConfigHandle::version(), stable_version);
+    assert!(latest_event_contains(
+        "parse failed, keeping previous version"
+    ));
+
+    let drawer_id = ingest(&server, "bad CT-1234567890abcdef still scrubs").await;
+    let drawer = env
+        .db()
+        .get_drawer(&drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert!(drawer.content.contains("[REDACTED:custom_token]"));
+
+    let restored = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &restored);
+    wait_for_version_change(&stable_version);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_request_scoped_snapshot_prevents_mid_flight_mutation() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let seen_inputs = Arc::new(Mutex::new(Vec::new()));
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::from_millis(600),
+        seen_inputs: Arc::clone(&seen_inputs),
+        entered_tx: Arc::new(Mutex::new(Some(entered_tx))),
+    });
+    let server = env.server(factory);
+
+    let content = "sk-abcdef1234567890abcdef1234567890abcd should scrub";
+    let server_for_task = server.clone();
+    let first_task = tokio::spawn(async move { ingest(&server_for_task, content).await });
+    entered_rx.recv().expect("embedder entered");
+
+    let previous = ConfigHandle::version();
+    let disabled = base_config(&env.db_path).replace("enabled = true", "enabled = false");
+    write_config_atomic(&env.config_path, &disabled);
+    wait_for_version_change(&previous);
+
+    let first_id = first_task.await.expect("join first ingest");
+    let first = env
+        .db()
+        .get_drawer(&first_id)
+        .expect("get first drawer")
+        .expect("first drawer exists");
+    assert!(first.content.contains("[REDACTED:openai_key]"));
+
+    let second_id = ingest(&server, content).await;
+    let second = env
+        .db()
+        .get_drawer(&second_id)
+        .expect("get second drawer")
+        .expect("second drawer exists");
+    assert!(
+        second
+            .content
+            .contains("sk-abcdef1234567890abcdef1234567890abcd")
+    );
+
+    let seen = seen_inputs.lock().expect("seen mutex poisoned").clone();
+    assert!(seen[0].contains("[REDACTED:openai_key]"));
+    assert!(seen[1].contains("sk-abcdef1234567890abcdef1234567890abcd"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_embedder_backend_change_warns_and_ignores() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let stable_version = ConfigHandle::version();
+    let changed = config.replace("http://gb10:18002/v1/", "http://localhost:9000/v1/");
+    write_config_atomic(&env.config_path, &changed);
+    std::thread::sleep(Duration::from_millis(500));
+
+    assert_eq!(ConfigHandle::version(), stable_version);
+    assert_eq!(
+        ConfigHandle::current().embed.base_url.as_deref(),
+        Some("http://gb10:18002/v1/")
+    );
+    assert!(latest_event_contains(
+        "embedder.base_url requires restart, change ignored"
+    ));
+
+    let allowed = changed.replace(
+        "strict_project_isolation = false",
+        "strict_project_isolation = true",
+    );
+    write_config_atomic(&env.config_path, &allowed);
+    wait_for_version_change(&stable_version);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_notify_watcher_crash_falls_back_to_poll() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    ConfigHandle::simulate_notify_failure();
+    assert!(
+        wait_until(Duration::from_secs(1), Duration::from_millis(50), || {
+            latest_event_contains("notify watcher crashed, falling back to poll")
+        }),
+        "fallback poll log not observed"
+    );
+
+    let previous = ConfigHandle::version();
+    let disabled = config.replace("enabled = true", "enabled = false");
+    write_config_atomic(&env.config_path, &disabled);
+    wait_for_version_change(&previous);
+
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::ZERO,
+        seen_inputs: Arc::new(Mutex::new(Vec::new())),
+        entered_tx: Arc::new(Mutex::new(None)),
+    });
+    let server = env.server(factory);
+    let drawer_id = ingest(&server, "sk-abcdef1234567890abcdef1234567890abcd remains").await;
+    let drawer = env
+        .db()
+        .get_drawer(&drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert!(
+        drawer
+            .content
+            .contains("sk-abcdef1234567890abcdef1234567890abcd")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_prints_config_version_and_loaded_at() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let config = base_config(&db_path);
+    write_config_atomic(&mempal_home.join("config.toml"), &config);
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run mempal status");
+    assert!(output.status.success(), "status failed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    let line = stdout
+        .lines()
+        .find(|line| line.starts_with("config: version="))
+        .expect("config line present");
+    let version = line
+        .split("version=")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .expect("version token");
+    assert_eq!(version.len(), 12);
+
+    let loaded_ms = line
+        .split("loaded_unix_ms=")
+        .nth(1)
+        .and_then(|ms| ms.parse::<u64>().ok())
+        .expect("loaded_unix_ms token");
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_millis() as u64;
+    assert!(now_ms.saturating_sub(loaded_ms) < 600_000);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_status_returns_config_version() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::ZERO,
+        seen_inputs: Arc::new(Mutex::new(Vec::new())),
+        entered_tx: Arc::new(Mutex::new(None)),
+    });
+    let server = env.server(factory);
+
+    let first = server.mempal_status().await.expect("status").0;
+    assert_eq!(first.config_version.len(), 12);
+
+    let changed = config.replace(
+        "strict_project_isolation = false",
+        "strict_project_isolation = true",
+    );
+    write_config_atomic(&env.config_path, &changed);
+    wait_for_version_change(&first.config_version);
+
+    let second = server.mempal_status().await.expect("status").0;
+    assert_ne!(first.config_version, second.config_version);
+    assert!(second.config_loaded_at_unix_ms >= first.config_loaded_at_unix_ms);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_rapid_edits_coalesced_by_debounce() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let attempts_before = ConfigHandle::parse_attempts();
+    let previous = ConfigHandle::version();
+    for i in 0..5 {
+        let toggled = if i == 4 {
+            config.replace(
+                "strict_project_isolation = false",
+                "strict_project_isolation = true",
+            )
+        } else {
+            config.replace(
+                "api_model = \"test-model\"",
+                &format!("api_model = \"test-model-{i}\""),
+            )
+        };
+        write_config_atomic(&env.config_path, &toggled);
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    wait_for_version_change(&previous);
+
+    let attempts_after = ConfigHandle::parse_attempts();
+    assert!(
+        attempts_after.saturating_sub(attempts_before) <= 2,
+        "parse attempts delta too high: {}",
+        attempts_after.saturating_sub(attempts_before)
+    );
+    assert!(ConfigHandle::current().search.strict_project_isolation);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_hot_reload_disabled_no_watcher() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+
+    let disabled = format!(
+        r#"
+db_path = "{}"
+
+[embedder]
+backend = "api"
+base_url = "http://gb10:18002/v1/"
+api_model = "test-model"
+
+[privacy]
+enabled = true
+
+[config_hot_reload]
+enabled = false
+debounce_ms = 250
+poll_fallback_secs = 1
+
+[search]
+strict_project_isolation = false
+"#,
+        db_path.display()
+    );
+    let config_path = mempal_home.join("config.toml");
+    write_config_atomic(&config_path, &disabled);
+
+    let _before = count_inotify_fds();
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap disabled hot reload");
+    let after = count_inotify_fds();
+    assert_eq!(after, 0);
+
+    let version = ConfigHandle::version();
+    let loaded_at = ConfigHandle::loaded_at_unix_ms();
+    let changed = disabled.replace(
+        "strict_project_isolation = false",
+        "strict_project_isolation = true",
+    );
+    write_config_atomic(&config_path, &changed);
+    std::thread::sleep(Duration::from_millis(500));
+    assert_eq!(ConfigHandle::version(), version);
+    assert_eq!(ConfigHandle::loaded_at_unix_ms(), loaded_at);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_prototype_hot_reload_deferred_to_restart() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    assert_eq!(ConfigHandle::runtime_prototypes(), vec!["A", "B", "C"]);
+    let previous = ConfigHandle::version();
+    let changed = config.replace("[\"A\", \"B\", \"C\"]", "[\"A\", \"B\", \"C\", \"D\"]");
+    write_config_atomic(&env.config_path, &changed);
+    wait_for_version_change(&previous);
+
+    assert_eq!(
+        ConfigHandle::current()
+            .ingest_gating
+            .embedding_classifier
+            .prototypes,
+        vec!["A", "B", "C", "D"]
+    );
+    assert_eq!(ConfigHandle::runtime_prototypes(), vec!["A", "B", "C"]);
+    assert!(latest_event_contains(
+        "prototype change detected, effective after daemon restart"
+    ));
+
+    ConfigHandle::bootstrap(&env.config_path).expect("restart bootstrap");
+    assert_eq!(ConfigHandle::runtime_prototypes(), vec!["A", "B", "C", "D"]);
+}


### PR DESCRIPTION
## Summary
- add `ConfigHandle` + `src/core/hot_reload.rs` to keep a live `ArcSwap<Config>` backed by `notify` with debounce, effective-version hashing, parse-fail retention, and poll fallback
- extend config/status plumbing so CLI and MCP expose `config_version` / load time, while restart-required embedder/database fields stay ignored at runtime
- add `tests/config_hot_reload.rs` covering the Phase 1 hot-reload scenarios, including debounce, snapshot consistency, poll fallback, disabled mode, and prototype defer-to-restart behavior

## Validation
- `cargo test --test config_hot_reload`
- `cargo test --features rest`
- `just pre-commit`

## Notes
- `cargo run -- status` against the default `/home/obj/.mempal` could not be used as a live verification path in this environment because the target home-backed database directory is read-only (`Read-only file system`). The CLI output shape is covered by `test_status_prints_config_version_and_loaded_at` instead.
