### PR TITLE
feat(fork-ext): Phase 2 — pending-message-store queue

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -1,10 +1,35 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
-pub(crate) const FORK_EXT_META_DDL: &str = r#"
+pub const FORK_EXT_META_DDL: &str = r#"
 CREATE TABLE IF NOT EXISTS fork_ext_meta (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+"#;
+
+pub const FORK_EXT_V1_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS pending_messages (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    source_hash TEXT NOT NULL,
+    claim_token TEXT,
+    claimed_at INTEGER,
+    heartbeat_at INTEGER,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    retry_backoff_ms INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL CHECK(status IN ('pending', 'claimed', 'done', 'failed')),
+    payload TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_status_claimed_at
+    ON pending_messages(status, claimed_at);
+CREATE INDEX IF NOT EXISTS idx_pending_next_attempt
+    ON pending_messages(status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_pending_source_hash
+    ON pending_messages(source_hash);
 "#;
 
 struct Migration {
@@ -12,7 +37,7 @@ struct Migration {
     up: fn(&Connection) -> rusqlite::Result<()>,
 }
 
-pub(crate) fn read_fork_ext_version(conn: &Connection) -> rusqlite::Result<u32> {
+pub fn read_fork_ext_version(conn: &Connection) -> rusqlite::Result<u32> {
     let table_exists = conn.query_row(
         "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='fork_ext_meta'",
         [],
@@ -42,7 +67,7 @@ pub(crate) fn read_fork_ext_version(conn: &Connection) -> rusqlite::Result<u32> 
     }
 }
 
-pub(crate) fn set_fork_ext_version(conn: &Connection, v: u32) -> rusqlite::Result<()> {
+pub fn set_fork_ext_version(conn: &Connection, v: u32) -> rusqlite::Result<()> {
     conn.execute(
         r#"
         INSERT INTO fork_ext_meta (key, value)
@@ -55,10 +80,17 @@ pub(crate) fn set_fork_ext_version(conn: &Connection, v: u32) -> rusqlite::Resul
 }
 
 fn fork_ext_migrations() -> &'static [Migration] {
-    &[]
+    &[Migration {
+        version: 1,
+        up: apply_v1,
+    }]
 }
 
-pub(crate) fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {
+fn apply_v1(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V1_SCHEMA_SQL)
+}
+
+pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_META_DDL)?;
 
     let current_version = read_fork_ext_version(conn)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,5 +4,6 @@ pub mod config;
 pub mod db;
 pub mod hot_reload;
 pub mod protocol;
+pub mod queue;
 pub mod types;
 pub mod utils;

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1,0 +1,347 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use blake3::Hasher;
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use thiserror::Error;
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Error)]
+pub enum QueueError {
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("pending message not found: {0}")]
+    MessageNotFound(String),
+    #[error("retry count does not fit in u32 for message {id}")]
+    RetryCountOverflow { id: String },
+}
+
+pub type Result<T> = std::result::Result<T, QueueError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimedMessage {
+    pub id: String,
+    pub kind: String,
+    pub payload: String,
+    pub retry_count: u32,
+    pub claim_token: String,
+    pub source_hash: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueStats {
+    pub pending: u64,
+    pub claimed: u64,
+    pub failed: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueConfig {
+    pub base_delay_ms: i64,
+    pub max_delay_ms: i64,
+    pub max_retries: u32,
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            base_delay_ms: 5_000,
+            max_delay_ms: 3_600_000,
+            max_retries: 10,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingMessageStore {
+    db_path: PathBuf,
+    config: QueueConfig,
+}
+
+impl PendingMessageStore {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        Self::with_config(path, QueueConfig::default())
+    }
+
+    pub fn with_config(path: impl AsRef<Path>, config: QueueConfig) -> Result<Self> {
+        Ok(Self {
+            db_path: path.as_ref().to_path_buf(),
+            config,
+        })
+    }
+
+    pub fn enqueue(&self, kind: &str, payload: &str) -> Result<String> {
+        let id = next_id("msg");
+        let created_at = now_secs();
+        let source_hash = hash_source(kind, payload);
+
+        let conn = self.open_connection()?;
+        conn.execute(
+            r#"
+            INSERT INTO pending_messages (
+                id,
+                kind,
+                source_hash,
+                status,
+                payload,
+                created_at,
+                next_attempt_at
+            )
+            VALUES (?1, ?2, ?3, 'pending', ?4, ?5, ?5)
+            "#,
+            params![id, kind, source_hash, payload, created_at],
+        )?;
+
+        Ok(id)
+    }
+
+    pub fn claim_next(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+    ) -> Result<Option<ClaimedMessage>> {
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        reclaim_stale_tx(&tx, saturating_cutoff(now_secs(), claim_ttl_secs))?;
+
+        let now = now_secs();
+        let row = tx
+            .query_row(
+                r#"
+                SELECT id, kind, payload, retry_count, source_hash
+                FROM pending_messages
+                WHERE status = 'pending' AND next_attempt_at <= ?1
+                ORDER BY next_attempt_at ASC, created_at ASC, id ASC
+                LIMIT 1
+                "#,
+                [now],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, String>(4)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((id, kind, payload, retry_count_i64, source_hash)) = row else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let retry_count = u32::try_from(retry_count_i64)
+            .map_err(|_| QueueError::RetryCountOverflow { id: id.clone() })?;
+        let claim_token = format!("{worker_id}:{}", next_id("claim"));
+        let updated = tx.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'claimed',
+                claim_token = ?2,
+                claimed_at = ?3,
+                heartbeat_at = ?3
+            WHERE id = ?1 AND status = 'pending'
+            "#,
+            params![id, claim_token, now],
+        )?;
+        if updated == 0 {
+            tx.commit()?;
+            return Ok(None);
+        }
+
+        tx.commit()?;
+        Ok(Some(ClaimedMessage {
+            id,
+            kind,
+            payload,
+            retry_count,
+            claim_token,
+            source_hash,
+        }))
+    }
+
+    pub fn confirm(&self, id: &str) -> Result<()> {
+        let conn = self.open_connection()?;
+        let deleted = conn.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
+        if deleted == 0 {
+            return Err(QueueError::MessageNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    pub fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let current_retry = tx
+            .query_row(
+                "SELECT retry_count FROM pending_messages WHERE id = ?1",
+                [id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+            .ok_or_else(|| QueueError::MessageNotFound(id.to_string()))?;
+        let next_retry = current_retry.saturating_add(1);
+        let next_retry_u32 = u32::try_from(next_retry)
+            .map_err(|_| QueueError::RetryCountOverflow { id: id.to_string() })?;
+        let backoff_ms = self.compute_backoff_ms(next_retry_u32);
+        let next_attempt_at = now_secs().saturating_add(div_ceil(backoff_ms, 1_000));
+        let terminal = next_retry_u32 > self.config.max_retries;
+        let status = if terminal { "failed" } else { "pending" };
+
+        let updated = tx.execute(
+            r#"
+            UPDATE pending_messages
+            SET retry_count = ?2,
+                retry_backoff_ms = ?3,
+                next_attempt_at = ?4,
+                status = ?5,
+                claim_token = NULL,
+                claimed_at = NULL,
+                heartbeat_at = NULL,
+                last_error = ?6
+            WHERE id = ?1
+            "#,
+            params![id, next_retry, backoff_ms, next_attempt_at, status, error],
+        )?;
+        if updated == 0 {
+            return Err(QueueError::MessageNotFound(id.to_string()));
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn refresh_heartbeat(&self, id: &str, worker_id: &str) -> Result<()> {
+        let claim_prefix = format!("{worker_id}:");
+        let now = now_secs();
+        let conn = self.open_connection()?;
+        let updated = conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET heartbeat_at = ?2
+            WHERE id = ?1
+              AND status = 'claimed'
+              AND claim_token LIKE ?3
+            "#,
+            params![id, now, format!("{claim_prefix}%")],
+        )?;
+        if updated == 0 {
+            return Err(QueueError::MessageNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    pub fn reclaim_stale(&self, stale_secs: i64) -> Result<u64> {
+        let conn = self.open_connection()?;
+        let reclaimed = reclaim_stale_conn(&conn, saturating_cutoff(now_secs(), stale_secs))?;
+        Ok(reclaimed)
+    }
+
+    pub fn stats(&self) -> Result<QueueStats> {
+        let conn = self.open_connection()?;
+        let (pending, claimed, failed): (i64, i64, i64) = conn.query_row(
+            r#"
+            SELECT
+                COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'claimed' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0)
+            FROM pending_messages
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+
+        Ok(QueueStats {
+            pending: i64_to_u64(pending),
+            claimed: i64_to_u64(claimed),
+            failed: i64_to_u64(failed),
+        })
+    }
+
+    fn open_connection(&self) -> Result<Connection> {
+        Ok(Connection::open(&self.db_path)?)
+    }
+
+    fn compute_backoff_ms(&self, retry_count: u32) -> i64 {
+        let shift = retry_count.saturating_sub(1).min(30);
+        let multiplier = 1_i64 << shift;
+        self.config
+            .base_delay_ms
+            .saturating_mul(multiplier)
+            .min(self.config.max_delay_ms)
+    }
+}
+
+fn reclaim_stale_tx(conn: &rusqlite::Transaction<'_>, stale_cutoff: i64) -> rusqlite::Result<u64> {
+    let updated = conn.execute(
+        r#"
+        UPDATE pending_messages
+        SET status = 'pending',
+            claim_token = NULL,
+            claimed_at = NULL,
+            heartbeat_at = NULL
+        WHERE status = 'claimed'
+          AND (heartbeat_at IS NULL OR heartbeat_at < ?1)
+        "#,
+        [stale_cutoff],
+    )?;
+    Ok(updated as u64)
+}
+
+fn reclaim_stale_conn(conn: &Connection, stale_cutoff: i64) -> rusqlite::Result<u64> {
+    let updated = conn.execute(
+        r#"
+        UPDATE pending_messages
+        SET status = 'pending',
+            claim_token = NULL,
+            claimed_at = NULL,
+            heartbeat_at = NULL
+        WHERE status = 'claimed'
+          AND (heartbeat_at IS NULL OR heartbeat_at < ?1)
+        "#,
+        [stale_cutoff],
+    )?;
+    Ok(updated as u64)
+}
+
+fn hash_source(kind: &str, payload: &str) -> String {
+    let mut hasher = Hasher::new();
+    hasher.update(kind.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(payload.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn now_secs() -> i64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs() as i64,
+        Err(_) => 0,
+    }
+}
+
+fn next_id(prefix: &str) -> String {
+    let now_ms = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis(),
+        Err(_) => 0,
+    };
+    let counter = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{now_ms:016x}-{counter:016x}")
+}
+
+fn saturating_cutoff(now: i64, window_secs: i64) -> i64 {
+    now.saturating_sub(window_secs.max(0))
+}
+
+fn div_ceil(lhs: i64, rhs: i64) -> i64 {
+    if lhs <= 0 {
+        return 0;
+    }
+    ((lhs - 1) / rhs) + 1
+}
+
+fn i64_to_u64(value: i64) -> u64 {
+    if value <= 0 { 0 } else { value as u64 }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -959,6 +959,16 @@ fn status_command(db: &Database) -> Result<()> {
     let schema_version = db
         .schema_version()
         .context("failed to read schema version")?;
+    let fork_ext_version = db
+        .conn()
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = 'fork_ext_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(0);
     let drawer_count = db.drawer_count().context("failed to count drawers")?;
     let taxonomy_count = db.taxonomy_count().context("failed to count taxonomy")?;
     let db_size_bytes = db
@@ -970,6 +980,7 @@ fn status_command(db: &Database) -> Result<()> {
         .context("failed to count deleted drawers")?;
 
     println!("schema_version: {schema_version}");
+    println!("fork_ext_version: {fork_ext_version}");
     println!("drawer_count: {drawer_count}");
     if deleted_count > 0 {
         println!("deleted_drawers: {deleted_count} (use `mempal purge` to remove)");

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -469,6 +469,12 @@ async fn test_status_prints_config_version_and_loaded_at() {
         .expect("run mempal status");
     assert!(output.status.success(), "status failed: {output:?}");
     let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.trim() == "fork_ext_version: 1"),
+        "fork_ext_version line missing from status: {stdout}"
+    );
     let line = stdout
         .lines()
         .find(|line| line.starts_with("config: version="))

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_zero_on_fresh_db() {
+fn test_fork_ext_version_is_one_on_fresh_db_after_phase2() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 0);
+    assert_eq!(version, 1);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 0);
+    assert_eq!(version, 1);
 }
 
 #[test]

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -1,0 +1,227 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use mempal::core::db::Database;
+use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs() as i64
+}
+
+fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::new(&db_path).expect("create store");
+    (tmp, db_path, store)
+}
+
+#[test]
+fn test_fork_ext_migration_v0_to_v1_creates_pending_messages_table() {
+    let (_tmp, db_path, _store) = new_store();
+    let conn = Connection::open(db_path).expect("open sqlite");
+
+    let version = conn
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = 'fork_ext_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read fork_ext_version");
+    assert_eq!(version, "1");
+
+    let exists = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='pending_messages'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(exists, 1);
+
+    let index_exists = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_pending_next_attempt'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(index_exists, 1);
+}
+
+#[test]
+fn test_enqueue_claim_confirm_basic() {
+    let (_tmp, _db_path, store) = new_store();
+
+    let id = store
+        .enqueue("hook_event", r#"{"tool":"Bash"}"#)
+        .expect("enqueue");
+    let claimed = store
+        .claim_next("worker-1", 60)
+        .expect("claim")
+        .expect("message");
+
+    assert_eq!(claimed.id, id);
+    assert_eq!(claimed.kind, "hook_event");
+    assert_eq!(claimed.payload, r#"{"tool":"Bash"}"#);
+    assert_eq!(claimed.retry_count, 0);
+
+    store.confirm(&claimed.id).expect("confirm");
+    let stats = store.stats().expect("stats");
+    assert_eq!(stats.pending + stats.claimed + stats.failed, 0);
+}
+
+#[test]
+fn test_claim_is_exclusive() {
+    let (_tmp, _db_path, store) = new_store();
+    store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+
+    let first = store.claim_next("worker-a", 60).expect("first claim");
+    let second = store.claim_next("worker-b", 60).expect("second claim");
+
+    assert!(first.is_some());
+    assert!(second.is_none());
+}
+
+#[test]
+fn test_mark_failed_sets_backoff_next_attempt() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let claimed = store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+    assert_eq!(claimed.id, id);
+
+    let before = now_secs();
+    store.mark_failed(&id, "timeout").expect("mark failed");
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let (retry_count, retry_backoff_ms, next_attempt_at, status, last_error): (
+        i64,
+        i64,
+        i64,
+        String,
+        Option<String>,
+    ) = conn
+        .query_row(
+            "SELECT retry_count, retry_backoff_ms, next_attempt_at, status, last_error FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        )
+        .expect("read row");
+
+    assert_eq!(retry_count, 1);
+    assert!(retry_backoff_ms >= 5_000);
+    assert!(next_attempt_at >= before + 5);
+    assert!(next_attempt_at < before + 15);
+    assert_eq!(status, "pending");
+    assert_eq!(last_error.as_deref(), Some("timeout"));
+}
+
+#[test]
+fn test_max_retries_marks_failed_permanently() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            max_retries: 3,
+        },
+    )
+    .expect("store");
+
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    for worker in ["worker-a", "worker-b", "worker-c", "worker-d"] {
+        let claimed = store
+            .claim_next(worker, 60)
+            .expect("claim")
+            .expect("message");
+        assert_eq!(claimed.id, id);
+        store.mark_failed(&id, "timeout").expect("mark failed");
+    }
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    let status = conn
+        .query_row(
+            "SELECT status FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("query status");
+    assert_eq!(status, "failed");
+    assert!(
+        store
+            .claim_next("worker-z", 60)
+            .expect("claim after failed")
+            .is_none()
+    );
+}
+
+#[test]
+fn test_concurrent_claim_winner_takes_all() {
+    let (_tmp, _db_path, store) = new_store();
+    store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+
+    let shared = Arc::new(store);
+    let barrier = Arc::new(Barrier::new(3));
+    let store_a = Arc::clone(&shared);
+    let store_b = Arc::clone(&shared);
+    let barrier_a = Arc::clone(&barrier);
+    let barrier_b = Arc::clone(&barrier);
+
+    let handle_a = thread::spawn(move || {
+        barrier_a.wait();
+        store_a.claim_next("worker-a", 60).expect("claim a")
+    });
+    let handle_b = thread::spawn(move || {
+        barrier_b.wait();
+        store_b.claim_next("worker-b", 60).expect("claim b")
+    });
+    barrier.wait();
+
+    let a = handle_a.join().expect("join a");
+    let b = handle_b.join().expect("join b");
+    let winners = [a.is_some(), b.is_some()]
+        .into_iter()
+        .filter(|won| *won)
+        .count();
+    assert_eq!(winners, 1);
+}
+
+#[test]
+fn test_crash_recovery_reclaims_and_reissues_claim() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let _claimed = store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET heartbeat_at = ?2, claimed_at = ?2 WHERE id = ?1",
+        rusqlite::params![id, now_secs() - 120],
+    )
+    .expect("age heartbeat");
+
+    drop(conn);
+    let reclaimed = store.reclaim_stale(60).expect("reclaim");
+    assert_eq!(reclaimed, 1);
+
+    let reclaimed_msg = store
+        .claim_next("worker-b", 60)
+        .expect("claim again")
+        .expect("message");
+    assert_eq!(reclaimed_msg.id, id);
+}

--- a/tests/queue_heartbeat.rs
+++ b/tests/queue_heartbeat.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use mempal::core::db::Database;
+use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs() as i64
+}
+
+fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 5_000,
+            max_delay_ms: 60_000,
+            max_retries: 3,
+        },
+    )
+    .expect("create store");
+    (tmp, db_path, store)
+}
+
+#[test]
+fn test_refresh_heartbeat_updates_claimed_row() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store
+        .enqueue("hook_event", r#"{"tool":"Bash"}"#)
+        .expect("enqueue");
+    store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    store
+        .refresh_heartbeat(&id, "worker-a")
+        .expect("refresh heartbeat");
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let heartbeat_at = conn
+        .query_row(
+            "SELECT heartbeat_at FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .expect("query heartbeat");
+
+    assert!(heartbeat_at.unwrap_or_default() >= now_secs() - 5);
+}
+
+#[test]
+fn test_reclaim_stale_rolls_back_on_heartbeat_silence() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store
+        .enqueue("hook_event", r#"{"tool":"Bash"}"#)
+        .expect("enqueue");
+    store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET heartbeat_at = ?2, claimed_at = ?2 WHERE id = ?1",
+        rusqlite::params![id, now_secs() - 120],
+    )
+    .expect("age heartbeat");
+    drop(conn);
+
+    let reclaimed = store.reclaim_stale(60).expect("reclaim");
+    assert_eq!(reclaimed, 1);
+
+    let conn = Connection::open(db_path).expect("reopen sqlite");
+    let (status, claimed_at, heartbeat_at, retry_count): (String, Option<i64>, Option<i64>, i64) =
+        conn.query_row(
+            "SELECT status, claimed_at, heartbeat_at, retry_count FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("query reclaimed row");
+
+    assert_eq!(status, "pending");
+    assert!(claimed_at.is_none());
+    assert!(heartbeat_at.is_none());
+    assert_eq!(retry_count, 0);
+}
+
+#[test]
+fn test_reclaim_stale_preserves_heartbeating_claim() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store
+        .enqueue("hook_event", r#"{"tool":"Bash"}"#)
+        .expect("enqueue");
+    store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET claimed_at = ?2, heartbeat_at = ?3 WHERE id = ?1",
+        rusqlite::params![id, now_secs() - 300, now_secs() - 3],
+    )
+    .expect("set heartbeat");
+    drop(conn);
+
+    let reclaimed = store.reclaim_stale(60).expect("reclaim");
+    assert_eq!(reclaimed, 0);
+
+    let conn = Connection::open(db_path).expect("reopen sqlite");
+    let status = conn
+        .query_row(
+            "SELECT status FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("query status");
+    assert_eq!(status, "claimed");
+}


### PR DESCRIPTION
## Summary
- add fork-ext v1 queue schema and  claim-confirm implementation
- cover enqueue/claim/confirm/fail/heartbeat/reclaim flows with new queue tests
- expose  in  and update fork-ext regression expectations

## Verification
- 
running 101 tests
test aaak::signals::tests::test_empty_content_yields_sentinel_defaults ... ok
test aaak::signals::tests::test_importance_stars_defaults_to_2_for_uncategorized_text ... ok
test aaak::signals::tests::test_whitespace_content_matches_empty_sentinel_behavior ... ok
test aaak::signals::tests::test_analyze_entities_never_empty_after_code_mapping ... ok
test aaak::spec::tests::test_unique_flag_names_matches_allowed_flags ... ok
test core::protocol::tests::contains_peek_partner_tool_name ... ok
test core::protocol::tests::contains_cowork_push_tool_name ... ok
test aaak::spec::tests::test_generate_spec_contains_emotion_codes ... ok
test aaak::spec::tests::test_generate_spec_contains_all_flags ... ok
test core::protocol::tests::contains_rule_10_cowork_push ... ok
test core::protocol::tests::contains_rule_8_partner_awareness ... ok
test cowork::claude::tests::encoded_cwd_replaces_slashes_with_dashes ... ok
test core::protocol::tests::contains_rule_9_decision_capture ... ok
test aaak::spec::tests::test_generate_spec_contains_live_example ... ok
test cowork::claude::tests::honors_limit_by_taking_tail_and_sets_truncated ... ok
test cowork::claude::tests::filters_tool_use_blocks_and_is_meta_entries ... ok
test cowork::claude::tests::since_filter_compares_instants_not_strings ... ok
test cowork::claude::tests::reads_plain_text_and_structured_content ... ok
test cowork::codex::tests::reads_session_meta_cwd_from_first_line ... ok
test cowork::codex::tests::honors_limit_by_tail_and_sets_truncated_codex ... ok
test cowork::codex::tests::scan_window_excludes_sessions_outside_the_9_day_span ... ok
test cowork::codex::tests::parses_codex_messages_filtering_event_and_reasoning ... ok
test cowork::inbox::tests::drain_empty_inbox_returns_empty_vec ... ok
test cowork::codex::tests::walks_codex_dir_excludes_other_projects ... ok
test cowork::codex::tests::walks_codex_dir_filtering_by_cwd ... ok
test cowork::inbox::tests::encode_project_identity_rejects_relative_path ... ok
test cowork::inbox::tests::drain_is_isolated_per_distinct_project ... ok
test cowork::codex::tests::scan_window_covers_utc_tomorrow_for_positive_offset_tz ... ok
test cowork::inbox::tests::encode_project_identity_replaces_slashes_with_dashes ... ok
test cowork::inbox::tests::encode_project_identity_rejects_parent_traversal ... ok
test cowork::inbox::tests::format_codex_hook_json_empty_returns_empty_string ... ok
test cowork::inbox::tests::drain_nonexistent_inbox_dir_returns_empty_vec ... ok
test cowork::inbox::tests::drain_is_one_shot_file_disappears ... ok
test cowork::inbox::tests::format_plain_empty_messages_returns_empty_string ... ok
test cowork::inbox::tests::format_plain_includes_count_and_message_lines ... ok
test cowork::inbox::tests::drain_round_trip_preserves_content_bytes ... ok
test cowork::inbox::tests::format_codex_hook_json_wraps_plain_in_correct_envelope ... ok
test cowork::inbox::tests::mempal_home_resolves_from_home_env_var ... ok
test cowork::inbox::tests::inbox_path_composes_home_target_and_encoded_identity ... ok
test cowork::inbox::tests::project_identity_falls_back_to_raw_cwd_without_git ... ok
test cowork::inbox::tests::drain_preserves_unicode_bytes_round_trip ... ok
test cowork::inbox::tests::push_rejects_content_over_max_size ... ok
test cowork::inbox::tests::push_rejects_cwd_with_parent_traversal ... ok
test cowork::inbox::tests::project_identity_walks_to_git_root_from_subdir ... ok
test cowork::peek::tests::auto_mode_errors_without_caller_tool ... ok
test cowork::inbox::tests::push_rejects_self_push ... ok
test cowork::peek::tests::infer_partner_maps_claude_to_codex_and_vice_versa ... ok
test cowork::peek::tests::from_target_str_rejects_auto_and_unknown ... ok
test cowork::peek::tests::is_active_true_when_mtime_within_30_minutes ... ok
test cowork::inbox::tests::drain_preserves_fifo_order ... ok
test cowork::peek::tests::peek_response_serializes_with_snake_case_fields ... ok
test cowork::peek::tests::rejects_self_peek_when_caller_is_same_tool ... ok
test cowork::peek::tests::rfc3339_handles_fractional_seconds ... ok
test cowork::peek::tests::rfc3339_parses_utc_z ... ok
test cowork::peek::tests::rfc3339_rejects_malformed_inputs ... ok
test cowork::peek::tests::rfc3339_rejects_impossible_calendar_dates ... ok
test cowork::peek::tests::rfc3339_handles_positive_and_negative_offsets ... ok
test cowork::peek::tests::tool_parses_compound_names ... ok
test cowork::peek::tests::tool_parses_from_str ... ok
test cowork::peek::tests::tool_recognizes_codex_mcp_client_identity ... ok
test factcheck::contradictions::tests::test_incompatible_unknown_predicates_returns_false ... ok
test factcheck::contradictions::tests::test_incompatible_predicates_symmetric ... ok
test factcheck::names::tests::test_edit_distance_empty_vs_nonempty ... ok
test factcheck::names::tests::test_edit_distance_equal_zero ... ok
test factcheck::names::tests::test_edit_distance_insertion_plus_deletion ... ok
test factcheck::names::tests::test_edit_distance_one_substitution ... ok
test factcheck::names::tests::test_is_name_like_requires_capital_alpha ... ok
test factcheck::names::tests::test_similar_name_detects_bob_vs_bobby ... ok
test factcheck::names::tests::test_similar_name_ignores_identical ... ok
test factcheck::relations::tests::test_empty_input_returns_empty ... ok
test cowork::inbox::tests::push_rejects_when_prospective_count_would_exceed_limit ... ok
test factcheck::relations::tests::test_extracts_possessive_relation ... ok
test factcheck::relations::tests::test_extracts_works_at ... ok
test factcheck::relations::tests::test_extracts_role_of_without_article ... ok
test factcheck::relations::tests::test_extracts_works_for_variant ... ok
test factcheck::relations::tests::test_lowercase_subject_rejected ... ok
test factcheck::relations::tests::test_punctuation_on_tokens_does_not_break_match ... ok
test factcheck::relations::tests::test_unknown_sentence_returns_empty ... ok
test factcheck::relations::tests::test_extracts_role_of_with_article ... ok
test ingest::lock::tests::test_acquire_then_release_round_trip ... ok
test ingest::lock::tests::test_invalid_source_key_with_slash_rejected ... ok
test ingest::lock::tests::test_source_key_is_deterministic ... ok
test ingest::lock::tests::test_invalid_source_key_with_traversal_rejected ... ok
test ingest::lock::tests::test_source_key_is_fs_safe ... ok
test mcp::tools::tests::test_with_signals_applies_empty_content_sentinels ... ok
test mcp::tools::tests::test_with_signals_preserves_raw_content_and_citations ... ok
test cowork::inbox::tests::push_rejects_when_prospective_bytes_would_cross_limit ... ok
test cowork::inbox::tests::push_accepts_when_prospective_bytes_exactly_at_limit_and_rejects_one_more ... ok
test mcp::server::tests::test_mcp_push_rejects_explicit_auto_target ... ok
test mcp::server::tests::test_mcp_push_without_client_info_rejects_auto_target ... ok
test mcp::server::tests::test_mcp_push_self_push_rejected_via_inbox_error_mapping ... ok
test mcp::server::tests::test_mcp_push_explicit_target_overrides_auto_inference ... ok
test mcp::server::tests::test_mcp_push_succeeds_with_captured_client_name_and_auto_target ... ok
test mcp::server::tests::test_mcp_fact_check_invalid_now_maps_to_invalid_params ... ok
test mcp::server::tests::test_mcp_fact_check_invalid_scope_maps_to_invalid_params ... ok
test mcp::server::tests::test_mcp_fact_check_round_trip ... ok
test mcp::server::tests::test_mempal_search_returns_empty_results_when_filters_exclude_all_drawers ... ok
test mcp::server::tests::test_mempal_search_has_no_db_side_effects ... ok
test ingest::lock::tests::test_concurrent_holders_serialize ... ok
test mcp::server::tests::test_mcp_ingest_response_exposes_lock_wait ... ok
test mcp::server::tests::test_mempal_search_includes_structured_signals_and_preserves_raw_fields ... ok

test result: ok. 101 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s


running 9 tests
test longmemeval::tests::test_build_corpus_assigns_unique_drawer_ids_for_duplicate_session_ids ... ok
test longmemeval::tests::test_build_corpus_session_granularity ... ok
test longmemeval::tests::test_build_corpus_assigns_unique_drawer_ids_for_duplicate_content ... ok
test longmemeval::tests::test_evaluate_retrieval_matches_expected_metrics ... ok
test longmemeval::tests::test_build_corpus_turn_granularity ... ok
test longmemeval::tests::test_load_entries_accepts_numeric_answer ... ok
test longmemeval::tests::test_build_corpus_aaak_mode_uses_encoded_text ... ok
test longmemeval::tests::test_run_benchmark_raw_small_sample ... ok
test longmemeval::tests::test_run_benchmark_rooms_small_sample ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 10 tests
test test_mcp_status_returns_config_version ... ok
test test_prototype_hot_reload_deferred_to_restart ... ok
test test_rapid_edits_coalesced_by_debounce ... ok
test test_embedder_backend_change_warns_and_ignores ... ok
test test_privacy_pattern_hot_reload_applies_on_next_ingest ... ok
test test_request_scoped_snapshot_prevents_mid_flight_mutation ... ok
test test_hot_reload_disabled_no_watcher ... ok
test test_parse_failure_preserves_previous_config ... ok
test test_notify_watcher_crash_falls_back_to_poll ... ok
test test_status_prints_config_version_and_loaded_at ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.80s


running 18 tests
test concurrent_drain_is_winner_takes_all_at_most_once ... ok
test push_and_drain_have_no_palace_db_side_effects ... ok
test cowork_drain_cli_rejects_auto_target ... ok
test cowork_drain_reads_cwd_from_stdin_json_codex_path ... ok
test cowork_install_hooks_writes_correct_codex_hooks_json_shape ... ok
test cowork_install_hooks_heals_stale_claude_settings_entry ... ok
test cowork_install_hooks_heals_stale_codex_drain_entry ... ok
test cowork_install_hooks_preserves_existing_unrelated_settings_json_hooks ... ok
test cowork_install_hooks_writes_claude_hook_script_with_exec_bit ... ok
test cowork_install_hooks_warns_when_codex_hooks_feature_explicitly_false ... ok
test cowork_install_hooks_registers_claude_user_prompt_submit_in_settings_json ... ok
test cowork_status_cli_lists_both_inboxes_without_draining ... ok
test cowork_drain_cli_graceful_degrade_when_mempal_home_missing ... ok
test cowork_install_hooks_warns_when_codex_hooks_feature_flag_missing ... ok
test cowork_install_hooks_no_warning_when_codex_hooks_feature_enabled ... ok
test cowork_install_hooks_is_idempotent_for_claude_settings_json ... ok
test cowork_drain_stdin_json_malformed_payload_graceful_degrade ... ok
test cowork_install_hooks_is_idempotent_for_global_codex ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 7 tests
test test_peek_partner_auto_mode_errors_without_client_info ... ok
test test_peek_partner_returns_empty_when_no_session ... ok
test test_peek_partner_auto_mode_infers_partner ... ok
test test_peek_partner_claude_reads_codex_session ... ok
test test_peek_partner_filters_by_project_cwd ... ok
test test_peek_partner_reports_inactive_session ... ok
test test_peek_partner_has_no_mempal_side_effects ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 13 tests
test test_validate_scope_rejects_room_without_wing ... ok
test test_scope_filters_known_entities ... ok
test test_custom_now_overrides_current_time ... ok
test test_consistent_text_no_issues ... ok
test test_report_serializes_to_json_round_trip ... ok
test test_similar_name_conflict_detected ... ok
test test_relation_contradiction_detected ... ok
test test_stale_fact_detected ... ok
test test_unknown_entity_no_false_positive ... ok
test test_fact_check_has_no_db_side_effects ... ok
test test_empty_text_no_issues ... ok
test test_current_time_default_path_works ... ok
test test_cli_fact_check_from_stdin ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s


running 4 tests
test test_fork_ext_meta_table_exists_after_init ... ok
test test_upstream_user_version_preserved_after_fork_ext_init ... ok
test test_fork_ext_migrations_idempotent ... ok
test test_fork_ext_version_is_one_on_fresh_db_after_phase2 ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 8 tests
test test_lock_released_on_guard_drop ... ok
test test_panic_in_critical_section_releases_lock ... ok
test test_ingest_records_lock_wait_ms_field ... ok
test test_dry_run_does_not_acquire_lock ... ok
test test_concurrent_ingest_different_source_no_blocking ... ok
test test_concurrent_ingest_same_source_single_drawer ... ok
test test_double_check_after_lock_skips_duplicate ... ok
test test_lock_timeout_returns_error ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.46s


running 7 tests
test test_fork_ext_migration_v0_to_v1_creates_pending_messages_table ... ok
test test_claim_is_exclusive ... ok
test test_mark_failed_sets_backoff_next_attempt ... ok
test test_concurrent_claim_winner_takes_all ... ok
test test_enqueue_claim_confirm_basic ... ok
test test_max_retries_marks_failed_permanently ... ok
test test_crash_recovery_reclaims_and_reissues_claim ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 3 tests
test test_refresh_heartbeat_updates_claimed_row ... ok
test test_reclaim_stale_rolls_back_on_heartbeat_silence ... ok
test test_reclaim_stale_preserves_heartbeating_claim ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 4 tests
test test_fork_ext_version_is_one_on_fresh_db_after_phase2 ... ok
test test_fork_ext_meta_table_exists_after_init ... ok
test test_fork_ext_migrations_idempotent ... ok
test test_upstream_user_version_preserved_after_fork_ext_init ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 7 tests
test test_fork_ext_migration_v0_to_v1_creates_pending_messages_table ... ok
test test_concurrent_claim_winner_takes_all ... ok
test test_enqueue_claim_confirm_basic ... ok
test test_mark_failed_sets_backoff_next_attempt ... ok
test test_claim_is_exclusive ... ok
test test_crash_recovery_reclaims_and_reissues_claim ... ok
test test_max_retries_marks_failed_permanently ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 3 tests
test test_refresh_heartbeat_updates_claimed_row ... ok
test test_reclaim_stale_preserves_heartbeating_claim ... ok
test test_reclaim_stale_rolls_back_on_heartbeat_silence ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
- 
running 1 test
test test_status_prints_config_version_and_loaded_at ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 9 filtered out; finished in 0.01s

## Notes
- left the pre-existing local  change untouched and out of this PR
- kept  unchanged per task scope
