### PR TITLE
feat(fork-ext): p8 privacy-scrubbing ingest-edge integration + pre-compile

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -64,30 +64,54 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<(), ConfigError> {
-        for pattern in &self.privacy.scrub_patterns {
-            Regex::new(&pattern.pattern).map_err(|source| ConfigError::InvalidRegex {
-                name: pattern.name.clone(),
-                source,
-            })?;
-        }
+        let _ = self.compile_privacy()?;
         Ok(())
     }
 
+    pub fn compile_privacy(&self) -> Result<CompiledPrivacyConfig, ConfigError> {
+        let patterns = self
+            .privacy
+            .scrub_patterns
+            .iter()
+            .map(|pattern| {
+                Regex::new(&pattern.pattern)
+                    .map(|regex| (pattern.name.clone(), regex))
+                    .map_err(|source| ConfigError::InvalidRegex {
+                        name: pattern.name.clone(),
+                        source,
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(CompiledPrivacyConfig {
+            enabled: self.privacy.enabled,
+            patterns,
+        })
+    }
+
     pub fn scrub_content(&self, input: &str) -> String {
-        if !self.privacy.enabled {
+        match self.compile_privacy() {
+            Ok(compiled) => self.scrub_content_with_compiled(input, &compiled),
+            Err(_) => input.to_string(),
+        }
+    }
+
+    pub fn scrub_content_with_compiled(
+        &self,
+        input: &str,
+        compiled: &CompiledPrivacyConfig,
+    ) -> String {
+        if !self.privacy.enabled || !compiled.enabled || compiled.patterns.is_empty() {
             return input.to_string();
         }
 
-        self.privacy
-            .scrub_patterns
+        compiled
+            .patterns
             .iter()
-            .fold(input.to_string(), |content, pattern| {
-                match Regex::new(&pattern.pattern) {
-                    Ok(regex) => regex
-                        .replace_all(&content, format!("[REDACTED:{}]", pattern.name))
-                        .into_owned(),
-                    Err(_) => content,
-                }
+            .fold(input.to_string(), |content, (name, regex)| {
+                regex
+                    .replace_all(&content, format!("[REDACTED:{name}]"))
+                    .into_owned()
             })
     }
 
@@ -147,11 +171,51 @@ impl Default for EmbedConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct PrivacyConfig {
     pub enabled: bool,
     pub scrub_patterns: Vec<ScrubPattern>,
+}
+
+impl PrivacyConfig {
+    fn default_scrub_patterns() -> Vec<ScrubPattern> {
+        vec![
+            ScrubPattern {
+                name: "private_tag".to_string(),
+                pattern: r"(?is)<private>.*?</private>".to_string(),
+            },
+            ScrubPattern {
+                name: "openai_key".to_string(),
+                pattern: r"sk-[A-Za-z0-9]{32,}".to_string(),
+            },
+            ScrubPattern {
+                name: "anthropic_key".to_string(),
+                pattern: r"sk-ant-[A-Za-z0-9_-]{64,}".to_string(),
+            },
+            ScrubPattern {
+                name: "aws_access".to_string(),
+                pattern: r"AKIA[0-9A-Z]{16}".to_string(),
+            },
+            ScrubPattern {
+                name: "bearer_token".to_string(),
+                pattern: r"Bearer\s+[A-Za-z0-9._-]{20,}".to_string(),
+            },
+            ScrubPattern {
+                name: "hex_token".to_string(),
+                pattern: r"\b[a-f0-9]{32,}\b".to_string(),
+            },
+        ]
+    }
+}
+
+impl Default for PrivacyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scrub_patterns: Self::default_scrub_patterns(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -159,6 +223,12 @@ pub struct ScrubPattern {
     pub name: String,
     #[serde(alias = "regex")]
     pub pattern: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledPrivacyConfig {
+    enabled: bool,
+    patterns: Vec<(String, Regex)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -242,6 +312,19 @@ impl ConfigHandle {
 
     pub fn current() -> Arc<Config> {
         super::hot_reload::global_hot_reload_state().current()
+    }
+
+    pub fn current_compiled_privacy() -> Arc<CompiledPrivacyConfig> {
+        super::hot_reload::global_hot_reload_state().current_compiled_privacy()
+    }
+
+    pub fn current_privacy_snapshot() -> (Arc<Config>, Arc<CompiledPrivacyConfig>) {
+        super::hot_reload::global_hot_reload_state().current_privacy_snapshot()
+    }
+
+    pub fn scrub_content(input: &str) -> String {
+        let (config, compiled) = Self::current_privacy_snapshot();
+        config.scrub_content_with_compiled(input, compiled.as_ref())
     }
 
     pub fn snapshot_meta() -> ConfigSnapshotMeta {

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -9,23 +9,26 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use arc_swap::ArcSwap;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
-use super::config::{Config, ConfigError, ConfigSnapshotMeta};
+use super::config::{CompiledPrivacyConfig, Config, ConfigError, ConfigSnapshotMeta};
 
 const MAX_EVENT_LOG: usize = 64;
 
 #[derive(Debug)]
 struct ConfigSnapshot {
     config: Arc<Config>,
+    compiled_privacy: Arc<CompiledPrivacyConfig>,
     version: String,
     loaded_at_unix_ms: u64,
 }
 
 impl ConfigSnapshot {
     fn from_config(config: Config) -> Result<Self, ConfigError> {
+        let compiled_privacy = Arc::new(config.compile_privacy()?);
         Ok(Self {
             version: config.effective_hash()?,
             loaded_at_unix_ms: now_unix_ms(),
             config: Arc::new(config),
+            compiled_privacy,
         })
     }
 }
@@ -105,6 +108,18 @@ impl HotReloadState {
 
     pub fn current(&self) -> Arc<Config> {
         Arc::clone(&self.snapshot.load_full().config)
+    }
+
+    pub fn current_compiled_privacy(&self) -> Arc<CompiledPrivacyConfig> {
+        Arc::clone(&self.snapshot.load_full().compiled_privacy)
+    }
+
+    pub fn current_privacy_snapshot(&self) -> (Arc<Config>, Arc<CompiledPrivacyConfig>) {
+        let snapshot = self.snapshot.load_full();
+        (
+            Arc::clone(&snapshot.config),
+            Arc::clone(&snapshot.compiled_privacy),
+        )
     }
 
     pub fn snapshot_meta(&self) -> ConfigSnapshotMeta {
@@ -299,12 +314,16 @@ impl HotReloadState {
             return;
         }
 
-        let loaded_at_unix_ms = now_unix_ms();
-        self.snapshot.store(Arc::new(ConfigSnapshot {
-            config: Arc::new(effective),
-            version: next_version.clone(),
-            loaded_at_unix_ms,
-        }));
+        let next_snapshot = match ConfigSnapshot::from_config(effective) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                self.push_event(format!(
+                    "config hot-reload: parse failed, keeping previous version: {error}"
+                ));
+                return;
+            }
+        };
+        self.snapshot.store(Arc::new(next_snapshot));
         self.push_event(format!(
             "config hot-reload: version changed from {} to {}",
             previous.version, next_version

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -8,6 +8,7 @@ pub mod normalize;
 use std::path::{Path, PathBuf};
 
 use crate::core::{
+    config::ConfigHandle,
     db::Database,
     types::{Drawer, SourceType},
     utils::{build_drawer_id, current_timestamp, route_room_from_taxonomy},
@@ -164,6 +165,8 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             path: path.to_path_buf(),
             source,
         })?;
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    let scrubbed = config.scrub_content_with_compiled(&normalized, compiled_privacy.as_ref());
     let resolved_room = match options.room {
         Some(room) => room.to_string(),
         None => {
@@ -173,14 +176,14 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                     wing: wing.to_string(),
                     source,
                 })?;
-            route_room_from_taxonomy(&normalized, wing, &taxonomy)
+            route_room_from_taxonomy(&scrubbed, wing, &taxonomy)
         }
     };
     let chunks = match format {
         Format::ClaudeJsonl | Format::ChatGptJson | Format::CodexJsonl | Format::SlackJson => {
-            chunk_conversation(&normalized)
+            chunk_conversation(&scrubbed)
         }
-        Format::PlainText => chunk_text(&normalized, CHUNK_WINDOW, CHUNK_OVERLAP),
+        Format::PlainText => chunk_text(&scrubbed, CHUNK_WINDOW, CHUNK_OVERLAP),
     };
     if chunks.is_empty() {
         return Ok(IngestStats {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -157,8 +157,7 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
-        let cfg = ConfigHandle::current();
-        let scrubbed_content = cfg.scrub_content(&request.content);
+        let scrubbed_content = ConfigHandle::scrub_content(&request.content);
         let room = request.room.as_deref();
         let drawer_id = build_drawer_id(&request.wing, room, &scrubbed_content);
 
@@ -170,22 +169,10 @@ impl MempalMcpServer {
             }));
         }
 
-        let embedder = self.embedder_factory.build().await.map_err(|error| {
-            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
-        })?;
-        let vector = embedder
-            .embed(&[scrubbed_content.as_str()])
-            .await
-            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
-            .into_iter()
-            .next()
-            .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
         let db = self.open_db()?;
 
-        // P9-B: per-source ingest lock guards the dedup/insert critical
-        // section. Lock key derives from the drawer_id (content-addressed,
-        // filesystem-safe). Two concurrent mempal_ingest calls with the
-        // same content serialize here.
+        // Same-content manual ingests should serialize before the expensive
+        // embedder call so concurrent duplicates do not race past the lock.
         let mempal_home = db
             .path()
             .parent()
@@ -198,6 +185,17 @@ impl MempalMcpServer {
         )
         .map_err(|e| ErrorData::internal_error(format!("ingest lock: {e}"), None))?;
         let lock_wait_ms = Some(lock_guard.wait_duration().as_millis() as u64);
+
+        let embedder = self.embedder_factory.build().await.map_err(|error| {
+            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+        })?;
+        let vector = embedder
+            .embed(&[scrubbed_content.as_str()])
+            .await
+            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
 
         // Semantic dedup check: find most similar existing drawer
         let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);

--- a/tests/privacy_scrubbing.rs
+++ b/tests/privacy_scrubbing.rs
@@ -1,0 +1,228 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::embed::{EmbedError, Embedder};
+use mempal::ingest::ingest_file_with_options;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Default)]
+struct RecordingEmbedder {
+    seen_inputs: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl Embedder for RecordingEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        self.seen_inputs
+            .lock()
+            .expect("seen_inputs mutex poisoned")
+            .extend(texts.iter().map(|text| (*text).to_string()));
+        Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "recording"
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new(config_text: &str) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+
+        let config_path = mempal_home.join("config.toml");
+        fs::write(&config_path, config_text).expect("write config");
+
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+
+        Self { _tmp: tmp, db_path }
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+}
+
+fn config_text(db_path: &Path, privacy_enabled: bool) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[privacy]
+enabled = {}
+
+[config_hot_reload]
+enabled = false
+"#,
+        db_path.display(),
+        privacy_enabled
+    )
+}
+
+fn write_fixture(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, content).expect("write fixture");
+    path
+}
+
+fn drawer_contents(db: &Database) -> Vec<String> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT content
+            FROM drawers
+            WHERE deleted_at IS NULL
+            ORDER BY COALESCE(chunk_index, 0), id
+            "#,
+        )
+        .expect("prepare drawer query");
+
+    statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query drawers")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect drawer rows")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_scrub_catches_cross_chunk_secret() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
+    let config = config_text(&env.db_path, true);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let embedder = RecordingEmbedder::default();
+    let secret = "sk-abcdef1234567890abcdef1234567890abcd";
+    let content = format!("{}{} trailing text after boundary", "g".repeat(798), secret);
+    let file = write_fixture(
+        env.db_path.parent().expect("db parent"),
+        "cross-chunk.txt",
+        &content,
+    );
+
+    let stats = ingest_file_with_options(&env.db(), &embedder, &file, "test", Default::default())
+        .await
+        .expect("ingest cross chunk");
+
+    let stored = drawer_contents(&env.db());
+    assert!(
+        stored.len() >= 2,
+        "expected multi-chunk ingest, got {stored:?}"
+    );
+    assert_eq!(stats.chunks, stored.len());
+    assert!(stored.iter().all(|chunk| !chunk.contains(secret)));
+    assert!(
+        stored
+            .iter()
+            .any(|chunk| chunk.contains("[REDACTED:openai_key]"))
+    );
+
+    let seen = embedder
+        .seen_inputs
+        .lock()
+        .expect("seen inputs mutex poisoned")
+        .clone();
+    assert_eq!(seen.len(), stored.len());
+    assert!(seen.iter().all(|chunk| !chunk.contains(secret)));
+    assert!(
+        seen.iter()
+            .any(|chunk| chunk.contains("[REDACTED:openai_key]"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_privacy_disabled_skips_scrub() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), false));
+    let config = config_text(&env.db_path, false);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let embedder = RecordingEmbedder::default();
+    let original = "keep sk-abcdef1234567890abcdef1234567890abcd and <private>literal</private>";
+    let file = write_fixture(
+        env.db_path.parent().expect("db parent"),
+        "privacy-disabled.txt",
+        original,
+    );
+
+    let stats = ingest_file_with_options(&env.db(), &embedder, &file, "test", Default::default())
+        .await
+        .expect("ingest disabled");
+
+    let stored = drawer_contents(&env.db());
+    assert_eq!(stats.chunks, 1);
+    assert_eq!(stored, vec![original.to_string()]);
+    let seen = embedder
+        .seen_inputs
+        .lock()
+        .expect("seen inputs mutex poisoned")
+        .clone();
+    assert_eq!(seen, vec![original.to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_private_tag_stripped() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
+    let config = config_text(&env.db_path, true);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let scrubbed = ConfigHandle::scrub_content("Here is the key: <private>sk-1234</private> done");
+    assert_eq!(scrubbed, "Here is the key: [REDACTED:private_tag] done");
+    assert!(!scrubbed.contains("<private>"));
+    assert!(!scrubbed.contains("sk-1234"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_compiled_privacy_cache_reused_via_handle() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
+    let config = config_text(&env.db_path, true);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let first = ConfigHandle::current_compiled_privacy();
+    let second = ConfigHandle::current_compiled_privacy();
+
+    assert!(Arc::ptr_eq(&first, &second));
+    let cfg = ConfigHandle::current();
+    let scrubbed = cfg.scrub_content_with_compiled(
+        "Bearer abcdefghijklmnopqrstuvwxyz0123456789",
+        first.as_ref(),
+    );
+    assert_eq!(scrubbed, "[REDACTED:bearer_token]");
+}


### PR DESCRIPTION
## What changed
- moved privacy scrubbing into the file ingest edge after normalization and before chunking
- added `CompiledPrivacyConfig` caching in the hot-reload snapshot so regexes are compiled once per config version
- shipped default scrub patterns including `<private>...</private>` stripping
- added Phase 3 privacy integration coverage for cross-chunk redaction, disabled fast path, tag stripping, and cache reuse
- aligned `mempal_ingest` same-content locking so concurrent manual ingests serialize before embedding

## Why
Phase 3 needs redaction to happen on the normalized full text before chunking so secrets never reach FTS or embeddings. The compiled snapshot removes the Phase 1 per-call regex recompilation nit from issue #18, and the manual-ingest lock timing change makes the existing lock-wait contract deterministic again.

## Validation
- `cargo test --test privacy_scrubbing`
- `cargo test --test config_hot_reload test_privacy_pattern_hot_reload_applies_on_next_ingest`
- `cargo test --test ingest_lock`
- `just pre-commit`
