### PR TITLE
feat(fork-ext): p8 embed-qwen3-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +392,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "compact_str"
@@ -950,6 +969,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1113,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1603,6 +1642,7 @@ dependencies = [
  "blake3",
  "clap",
  "jieba-rs",
+ "mockito",
  "model2vec-rs",
  "notify",
  "ort",
@@ -1655,6 +1695,31 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -2685,6 +2750,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,5 +71,6 @@ panic = "abort"        # no unwinding — smaller binary, faster panic
 
 [dev-dependencies]
 axum = "0.8"
+mockito = "1"
 serde_json = "1"
 tempfile = "3"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -8,9 +8,15 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
-const DEFAULT_EMBED_BACKEND: &str = "model2vec";
+const DEFAULT_EMBED_BACKEND: &str = "openai_compat";
 const DEFAULT_HOT_RELOAD_DEBOUNCE_MS: u64 = 250;
 const DEFAULT_HOT_RELOAD_POLL_FALLBACK_SECS: u64 = 5;
+const DEFAULT_OPENAI_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_OPENAI_DIM: usize = 4096;
+const DEFAULT_RETRY_INTERVAL_SECS: u64 = 2;
+const DEFAULT_SEARCH_DEADLINE_SECS: u64 = 5;
+const DEFAULT_ALERT_EVERY_N_FAILURES: u64 = 100;
+const DEFAULT_DEGRADE_AFTER_N_FAILURES: u64 = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
@@ -64,6 +70,26 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.embed.retry.interval_secs == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "embed.retry.interval_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.embed.retry.search_deadline_secs == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "embed.retry.search_deadline_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.embed.alert.alert_every_n_failures == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "embed.alert.alert_every_n_failures must be greater than 0".to_string(),
+            ));
+        }
+        if self.embed.degradation.degrade_after_n_failures == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "embed.degradation.degrade_after_n_failures must be greater than 0".to_string(),
+            ));
+        }
         let _ = self.compile_privacy()?;
         Ok(())
     }
@@ -129,6 +155,9 @@ impl Config {
         if self.embed.backend != other.embed.backend {
             fields.push("embedder.backend");
         }
+        if self.embed.fallback != other.embed.fallback {
+            fields.push("embedder.fallback");
+        }
         if self.embed.base_url != other.embed.base_url {
             fields.push("embedder.base_url");
         }
@@ -138,13 +167,35 @@ impl Config {
         if self.embed.api_model != other.embed.api_model {
             fields.push("embedder.api_model");
         }
+        if self.embed.openai_compat.base_url != other.embed.openai_compat.base_url {
+            fields.push("embedder.openai_compat.base_url");
+        }
+        if self.embed.openai_compat.model != other.embed.openai_compat.model {
+            fields.push("embedder.openai_compat.model");
+        }
+        if self.embed.openai_compat.api_key_env != other.embed.openai_compat.api_key_env {
+            fields.push("embedder.openai_compat.api_key_env");
+        }
+        if self.embed.openai_compat.request_timeout_secs
+            != other.embed.openai_compat.request_timeout_secs
+        {
+            fields.push("embedder.openai_compat.request_timeout_secs");
+        }
+        if self.embed.openai_compat.dim != other.embed.openai_compat.dim {
+            fields.push("embedder.openai_compat.dim");
+        }
         fields
     }
 
     pub fn merge_runtime_allowed(&self, candidate: &Self) -> Self {
         let mut effective = candidate.clone();
         effective.db_path = self.db_path.clone();
-        effective.embed = self.embed.clone();
+        effective.embed.backend = self.embed.backend.clone();
+        effective.embed.fallback = self.embed.fallback.clone();
+        effective.embed.model = self.embed.model.clone();
+        effective.embed.base_url = self.embed.base_url.clone();
+        effective.embed.api_model = self.embed.api_model.clone();
+        effective.embed.openai_compat = self.embed.openai_compat.clone();
         effective
     }
 }
@@ -153,20 +204,129 @@ impl Config {
 #[serde(default)]
 pub struct EmbedConfig {
     pub backend: String,
+    pub fallback: Option<String>,
     /// Model identifier (e.g., "minishlab/potion-multilingual-128M" for model2vec).
     pub model: Option<String>,
     #[serde(alias = "api_endpoint")]
     pub base_url: Option<String>,
     pub api_model: Option<String>,
+    pub openai_compat: OpenAiCompatConfig,
+    pub retry: RetryConfig,
+    pub alert: AlertConfig,
+    pub degradation: DegradationConfig,
 }
 
 impl Default for EmbedConfig {
     fn default() -> Self {
         Self {
             backend: DEFAULT_EMBED_BACKEND.to_string(),
+            fallback: None,
             model: None,
             base_url: None,
             api_model: None,
+            openai_compat: OpenAiCompatConfig::default(),
+            retry: RetryConfig::default(),
+            alert: AlertConfig::default(),
+            degradation: DegradationConfig::default(),
+        }
+    }
+}
+
+impl EmbedConfig {
+    pub fn resolved_openai_base_url(&self) -> Option<&str> {
+        self.openai_compat
+            .base_url
+            .as_deref()
+            .or(self.base_url.as_deref())
+    }
+
+    pub fn resolved_openai_model(&self) -> Option<&str> {
+        self.openai_compat
+            .model
+            .as_deref()
+            .or(self.api_model.as_deref())
+    }
+
+    pub fn resolved_api_key_env(&self) -> Option<&str> {
+        self.openai_compat
+            .api_key_env
+            .as_deref()
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn resolved_openai_dim(&self) -> usize {
+        self.openai_compat.dim.unwrap_or(DEFAULT_OPENAI_DIM)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct OpenAiCompatConfig {
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+    pub api_key_env: Option<String>,
+    pub request_timeout_secs: u64,
+    pub dim: Option<usize>,
+}
+
+impl Default for OpenAiCompatConfig {
+    fn default() -> Self {
+        Self {
+            base_url: None,
+            model: None,
+            api_key_env: None,
+            request_timeout_secs: DEFAULT_OPENAI_TIMEOUT_SECS,
+            dim: Some(DEFAULT_OPENAI_DIM),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct RetryConfig {
+    pub interval_secs: u64,
+    pub search_deadline_secs: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            interval_secs: DEFAULT_RETRY_INTERVAL_SECS,
+            search_deadline_secs: DEFAULT_SEARCH_DEADLINE_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AlertConfig {
+    pub enabled: bool,
+    pub script_path: Option<String>,
+    pub alert_every_n_failures: u64,
+}
+
+impl Default for AlertConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            script_path: None,
+            alert_every_n_failures: DEFAULT_ALERT_EVERY_N_FAILURES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DegradationConfig {
+    pub degrade_after_n_failures: u64,
+    pub block_writes_when_degraded: bool,
+}
+
+impl Default for DegradationConfig {
+    fn default() -> Self {
+        Self {
+            degrade_after_n_failures: DEFAULT_DEGRADE_AFTER_N_FAILURES,
+            block_writes_when_degraded: true,
         }
     }
 }
@@ -288,6 +448,8 @@ pub enum ConfigError {
         #[source]
         source: toml::ser::Error,
     },
+    #[error("invalid config: {0}")]
+    InvalidConfig(String),
 }
 
 pub fn default_config_path() -> PathBuf {

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -32,6 +32,17 @@ CREATE INDEX IF NOT EXISTS idx_pending_source_hash
     ON pending_messages(source_hash);
 "#;
 
+pub const FORK_EXT_V2_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS reindex_progress (
+    source_path TEXT PRIMARY KEY,
+    last_processed_chunk_id INTEGER,
+    embedder_name TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('running', 'paused', 'done', 'failed'))
+);
+"#;
+
 struct Migration {
     version: u32,
     up: fn(&Connection) -> rusqlite::Result<()>,
@@ -80,14 +91,24 @@ pub fn set_fork_ext_version(conn: &Connection, v: u32) -> rusqlite::Result<()> {
 }
 
 fn fork_ext_migrations() -> &'static [Migration] {
-    &[Migration {
-        version: 1,
-        up: apply_v1,
-    }]
+    &[
+        Migration {
+            version: 1,
+            up: apply_v1,
+        },
+        Migration {
+            version: 2,
+            up: apply_v2,
+        },
+    ]
 }
 
 fn apply_v1(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V1_SCHEMA_SQL)
+}
+
+fn apply_v2(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V2_SCHEMA_SQL)
 }
 
 pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,5 +5,6 @@ pub mod db;
 pub mod hot_reload;
 pub mod protocol;
 pub mod queue;
+pub mod reindex;
 pub mod types;
 pub mod utils;

--- a/src/core/reindex.rs
+++ b/src/core/reindex.rs
@@ -1,0 +1,165 @@
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, OptionalExtension, params};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReindexProgressRow {
+    pub source_path: String,
+    pub last_processed_chunk_id: Option<i64>,
+    pub embedder_name: String,
+    pub started_at: i64,
+    pub updated_at: i64,
+    pub status: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ReindexProgressError {
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+pub type Result<T> = std::result::Result<T, ReindexProgressError>;
+
+#[derive(Debug, Clone)]
+pub struct ReindexProgressStore {
+    db_path: PathBuf,
+}
+
+impl ReindexProgressStore {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            db_path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn upsert_running(
+        &self,
+        source_path: &str,
+        last_processed_chunk_id: Option<i64>,
+        embedder_name: &str,
+    ) -> Result<()> {
+        self.upsert(
+            source_path,
+            last_processed_chunk_id,
+            embedder_name,
+            "running",
+        )
+    }
+
+    pub fn mark_paused(
+        &self,
+        source_path: &str,
+        last_processed_chunk_id: Option<i64>,
+        embedder_name: &str,
+    ) -> Result<()> {
+        self.upsert(
+            source_path,
+            last_processed_chunk_id,
+            embedder_name,
+            "paused",
+        )
+    }
+
+    pub fn mark_done(
+        &self,
+        source_path: &str,
+        last_processed_chunk_id: Option<i64>,
+        embedder_name: &str,
+    ) -> Result<()> {
+        self.upsert(source_path, last_processed_chunk_id, embedder_name, "done")
+    }
+
+    pub fn latest_resumable(
+        &self,
+        embedder_name: Option<&str>,
+    ) -> Result<Option<ReindexProgressRow>> {
+        let conn = self.open_connection()?;
+        let sql = match embedder_name {
+            Some(_) => {
+                r#"
+                SELECT source_path, last_processed_chunk_id, embedder_name, started_at, updated_at, status
+                FROM reindex_progress
+                WHERE status IN ('running', 'paused') AND embedder_name = ?1
+                ORDER BY updated_at DESC, source_path ASC
+                LIMIT 1
+                "#
+            }
+            None => {
+                r#"
+                SELECT source_path, last_processed_chunk_id, embedder_name, started_at, updated_at, status
+                FROM reindex_progress
+                WHERE status IN ('running', 'paused')
+                ORDER BY updated_at DESC, source_path ASC
+                LIMIT 1
+                "#
+            }
+        };
+
+        let row = match embedder_name {
+            Some(name) => conn.query_row(sql, [name], map_row).optional()?,
+            None => conn.query_row(sql, [], map_row).optional()?,
+        };
+        Ok(row)
+    }
+
+    fn upsert(
+        &self,
+        source_path: &str,
+        last_processed_chunk_id: Option<i64>,
+        embedder_name: &str,
+        status: &str,
+    ) -> Result<()> {
+        let now = now_secs();
+        let conn = self.open_connection()?;
+        conn.execute(
+            r#"
+            INSERT INTO reindex_progress (
+                source_path,
+                last_processed_chunk_id,
+                embedder_name,
+                started_at,
+                updated_at,
+                status
+            )
+            VALUES (?1, ?2, ?3, ?4, ?4, ?5)
+            ON CONFLICT(source_path) DO UPDATE SET
+                last_processed_chunk_id = excluded.last_processed_chunk_id,
+                embedder_name = excluded.embedder_name,
+                updated_at = excluded.updated_at,
+                status = excluded.status
+            "#,
+            params![
+                source_path,
+                last_processed_chunk_id,
+                embedder_name,
+                now,
+                status
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn open_connection(&self) -> Result<Connection> {
+        Ok(Connection::open(&self.db_path)?)
+    }
+}
+
+fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ReindexProgressRow> {
+    Ok(ReindexProgressRow {
+        source_path: row.get(0)?,
+        last_processed_chunk_id: row.get(1)?,
+        embedder_name: row.get(2)?,
+        started_at: row.get(3)?,
+        updated_at: row.get(4)?,
+        status: row.get(5)?,
+    })
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/src/embed/alerting.rs
+++ b/src/embed/alerting.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+pub fn fire_alert(script_path: &Path, fail_count: u64, error_message: &str) {
+    if !script_path.is_absolute() {
+        return;
+    }
+
+    if let Err(error) = Command::new(script_path)
+        .arg(fail_count.to_string())
+        .arg(error_message)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        eprintln!(
+            "mempal: failed to spawn embed alert script {}: {error}",
+            script_path.display()
+        );
+    }
+}

--- a/src/embed/factory.rs
+++ b/src/embed/factory.rs
@@ -1,10 +1,7 @@
 use crate::core::config::Config;
 use async_trait::async_trait;
 
-use super::{EmbedError, Embedder, Result, api::ApiEmbedder};
-
-/// Default embedding dimensions (used by API backend when no model is loaded).
-pub const DEFAULT_API_DIMENSIONS: usize = 384;
+use super::{Embedder, Result};
 
 #[async_trait]
 pub trait EmbedderFactory: Send + Sync {
@@ -25,33 +22,6 @@ impl ConfiguredEmbedderFactory {
 #[async_trait]
 impl EmbedderFactory for ConfiguredEmbedderFactory {
     async fn build(&self) -> Result<Box<dyn Embedder>> {
-        match self.config.embed.backend.as_str() {
-            #[cfg(feature = "model2vec")]
-            "model2vec" => {
-                let model_id = self
-                    .config
-                    .embed
-                    .model
-                    .as_deref()
-                    .unwrap_or("minishlab/potion-multilingual-128M");
-                Ok(Box::new(super::model2vec::Model2VecEmbedder::new(
-                    model_id,
-                )?))
-            }
-            #[cfg(feature = "onnx")]
-            "onnx" => Ok(Box::new(
-                super::onnx::OnnxEmbedder::new_or_download().await?,
-            )),
-            "api" => Ok(Box::new(ApiEmbedder::new(
-                self.config
-                    .embed
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| "http://localhost:11434/api/embeddings".to_string()),
-                self.config.embed.api_model.clone(),
-                DEFAULT_API_DIMENSIONS,
-            ))),
-            backend => Err(EmbedError::UnsupportedBackend(backend.to_string())),
-        }
+        super::from_config(&self.config).await
     }
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -2,16 +2,22 @@
 
 use std::path::PathBuf;
 
+use crate::core::config::Config;
 use thiserror::Error;
 
+pub mod alerting;
 pub mod api;
 pub mod factory;
 #[cfg(feature = "model2vec")]
 pub mod model2vec;
 #[cfg(feature = "onnx")]
 pub mod onnx;
+pub mod openai_compat;
+pub mod retry;
+pub mod status;
 
 pub use factory::{ConfiguredEmbedderFactory, EmbedderFactory};
+pub use status::{EmbedHealthSnapshot, EmbedStatus, global_embed_status};
 
 pub type Result<T> = std::result::Result<T, EmbedError>;
 
@@ -98,6 +104,14 @@ pub enum EmbedError {
     InvalidDimensions { expected: usize, actual: usize },
     #[error("unsupported embed backend: {0}")]
     UnsupportedBackend(String),
+    #[error("missing embed configuration: {0}")]
+    MissingConfiguration(String),
+    #[error("failed to read embed API key from env var {var}")]
+    ReadApiKeyEnv {
+        var: String,
+        #[source]
+        source: std::env::VarError,
+    },
 }
 
 #[async_trait::async_trait]
@@ -105,4 +119,90 @@ pub trait Embedder: Send + Sync {
     async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
     fn dimensions(&self) -> usize;
     fn name(&self) -> &str;
+}
+
+pub async fn from_config(config: &Config) -> Result<Box<dyn Embedder>> {
+    let primary_backend = build_backend_from_name(config, config.embed.backend.as_str()).await?;
+    let fallback_backend = match config.embed.fallback.as_deref() {
+        Some(name) if name.eq_ignore_ascii_case(config.embed.backend.as_str()) => None,
+        Some(name) => Some(build_backend_from_name(config, name).await?),
+        None => None,
+    };
+
+    Ok(Box::new(ManagedEmbedder::new(
+        primary_backend,
+        fallback_backend,
+    )))
+}
+
+pub async fn build_backend_from_name(config: &Config, backend: &str) -> Result<Box<dyn Embedder>> {
+    match backend {
+        #[cfg(feature = "model2vec")]
+        "model2vec" => {
+            let model_id = config
+                .embed
+                .model
+                .as_deref()
+                .unwrap_or("minishlab/potion-multilingual-128M");
+            Ok(Box::new(model2vec::Model2VecEmbedder::new(model_id)?))
+        }
+        #[cfg(feature = "onnx")]
+        "onnx" => Ok(Box::new(onnx::OnnxEmbedder::new_or_download().await?)),
+        "openai_compat" | "api" => Ok(Box::new(
+            openai_compat::OpenAiCompatibleEmbedder::from_config(config)?,
+        )),
+        other => Err(EmbedError::UnsupportedBackend(other.to_string())),
+    }
+}
+
+struct ManagedEmbedder {
+    primary: Box<dyn Embedder>,
+    fallback: Option<Box<dyn Embedder>>,
+}
+
+impl ManagedEmbedder {
+    fn new(primary: Box<dyn Embedder>, fallback: Option<Box<dyn Embedder>>) -> Self {
+        Self { primary, fallback }
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for ManagedEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let status = global_embed_status();
+        if let Some(fallback) = &self.fallback {
+            match self.primary.embed(texts).await {
+                Ok(vectors) => {
+                    status.record_primary_success();
+                    Ok(vectors)
+                }
+                Err(primary_error) => {
+                    status.record_failure(&primary_error);
+                    let message = format!(
+                        "embedder fallback active: {} failed, using {}",
+                        self.primary.name(),
+                        fallback.name()
+                    );
+                    let vectors = fallback.embed(texts).await?;
+                    status.record_fallback_success(message);
+                    Ok(vectors)
+                }
+            }
+        } else {
+            let vectors = retry::retry_embed_operation(status, None, || async {
+                self.primary.embed(texts).await
+            })
+            .await?;
+            status.record_primary_success();
+            Ok(vectors)
+        }
+    }
+
+    fn dimensions(&self) -> usize {
+        self.primary.dimensions()
+    }
+
+    fn name(&self) -> &str {
+        self.primary.name()
+    }
 }

--- a/src/embed/openai_compat.rs
+++ b/src/embed/openai_compat.rs
@@ -1,0 +1,154 @@
+use std::time::Duration;
+
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+
+use crate::core::config::Config;
+
+use super::{EmbedError, Embedder, Result};
+
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatibleEmbedder {
+    client: reqwest::Client,
+    endpoint: String,
+    model: String,
+    dimensions: usize,
+}
+
+impl OpenAiCompatibleEmbedder {
+    pub fn from_config(config: &Config) -> Result<Self> {
+        let base_url = config
+            .embed
+            .resolved_openai_base_url()
+            .ok_or_else(|| {
+                EmbedError::MissingConfiguration(
+                    "embed.openai_compat.base_url (or legacy embed.base_url)".to_string(),
+                )
+            })?
+            .trim_end_matches('/')
+            .to_string();
+        let model = config
+            .embed
+            .resolved_openai_model()
+            .ok_or_else(|| {
+                EmbedError::MissingConfiguration(
+                    "embed.openai_compat.model (or legacy embed.api_model)".to_string(),
+                )
+            })?
+            .to_string();
+        let endpoint = format!("{base_url}/embeddings");
+
+        let mut headers = HeaderMap::new();
+        if let Some(env_var) = config.embed.resolved_api_key_env() {
+            let api_key = std::env::var(env_var).map_err(|source| EmbedError::ReadApiKeyEnv {
+                var: env_var.to_string(),
+                source,
+            })?;
+            let header_value = HeaderValue::from_str(&format!("Bearer {api_key}"))
+                .map_err(|error| EmbedError::Runtime(error.to_string()))?;
+            headers.insert(AUTHORIZATION, header_value);
+        }
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(
+                config.embed.openai_compat.request_timeout_secs,
+            ))
+            .build()
+            .map_err(|error| EmbedError::Runtime(error.to_string()))?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            model,
+            dimensions: config.embed.resolved_openai_dim(),
+        })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for OpenAiCompatibleEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let endpoint = self.endpoint().to_string();
+        let response = self
+            .client
+            .post(self.endpoint())
+            .json(&OpenAiEmbeddingsRequest {
+                input: texts,
+                model: &self.model,
+            })
+            .send()
+            .await
+            .map_err(|source| EmbedError::HttpRequest {
+                endpoint: endpoint.clone(),
+                source,
+            })?
+            .error_for_status()
+            .map_err(|source| EmbedError::HttpStatus {
+                endpoint: endpoint.clone(),
+                source,
+            })?
+            .json::<OpenAiEmbeddingsResponse>()
+            .await
+            .map_err(|source| EmbedError::DecodeResponse { endpoint, source })?;
+
+        let vectors = response
+            .data
+            .into_iter()
+            .map(|item| item.embedding)
+            .collect::<Vec<_>>();
+        validate_vectors(&vectors, self.dimensions())?;
+        Ok(vectors)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn name(&self) -> &str {
+        "openai_compat"
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiEmbeddingsRequest<'a> {
+    input: &'a [&'a str],
+    model: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingsResponse {
+    data: Vec<OpenAiEmbeddingItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiEmbeddingItem {
+    embedding: Vec<f32>,
+}
+
+fn validate_vectors(vectors: &[Vec<f32>], expected_dimensions: usize) -> Result<()> {
+    if vectors.is_empty() {
+        return Err(EmbedError::EmptyVectors);
+    }
+
+    if let Some(actual) = vectors
+        .iter()
+        .map(Vec::len)
+        .find(|length| *length != expected_dimensions)
+    {
+        return Err(EmbedError::InvalidDimensions {
+            expected: expected_dimensions,
+            actual,
+        });
+    }
+
+    Ok(())
+}

--- a/src/embed/retry.rs
+++ b/src/embed/retry.rs
@@ -1,0 +1,34 @@
+use std::future::Future;
+use std::time::Duration;
+
+use super::{Result, status::EmbedStatus};
+
+pub type HeartbeatCallback = dyn Fn() -> Result<()> + Send + Sync;
+
+pub async fn retry_embed_operation<F, Fut>(
+    status: &EmbedStatus,
+    heartbeat: Option<&HeartbeatCallback>,
+    mut operation: F,
+) -> Result<Vec<Vec<f32>>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Vec<Vec<f32>>>>,
+{
+    loop {
+        match operation().await {
+            Ok(vectors) => return Ok(vectors),
+            Err(error) => {
+                status.record_failure(&error);
+                refresh_heartbeat(heartbeat);
+                tokio::time::sleep(Duration::from_secs(status.retry_interval_secs())).await;
+                refresh_heartbeat(heartbeat);
+            }
+        }
+    }
+}
+
+fn refresh_heartbeat(heartbeat: Option<&HeartbeatCallback>) {
+    if let Some(callback) = heartbeat {
+        let _ = callback();
+    }
+}

--- a/src/embed/status.rs
+++ b/src/embed/status.rs
@@ -1,0 +1,214 @@
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arc_swap::{ArcSwap, ArcSwapOption};
+
+use crate::core::config::ConfigHandle;
+
+use super::alerting;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbedWarning {
+    pub level: &'static str,
+    pub message: String,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbedHealthSnapshot {
+    pub fail_count: u64,
+    pub degraded: bool,
+    pub last_error: Option<String>,
+    pub last_success_at_unix_ms: Option<u64>,
+    pub fallback_warning: Option<String>,
+}
+
+pub struct EmbedStatus {
+    fail_count: AtomicU64,
+    degraded: AtomicBool,
+    retry_interval_secs: ArcSwap<u64>,
+    alert_threshold: ArcSwap<u64>,
+    degrade_threshold: ArcSwap<u64>,
+    alert_script: ArcSwapOption<PathBuf>,
+    block_writes: ArcSwap<bool>,
+    alert_enabled: ArcSwap<bool>,
+    last_error: ArcSwapOption<String>,
+    last_success_at_unix_ms: AtomicU64,
+    fallback_warning: ArcSwapOption<String>,
+}
+
+impl Default for EmbedStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmbedStatus {
+    pub fn global() -> &'static Self {
+        static INSTANCE: OnceLock<EmbedStatus> = OnceLock::new();
+        INSTANCE.get_or_init(Self::new)
+    }
+
+    pub fn new() -> Self {
+        Self {
+            fail_count: AtomicU64::new(0),
+            degraded: AtomicBool::new(false),
+            retry_interval_secs: ArcSwap::from_pointee(2),
+            alert_threshold: ArcSwap::from_pointee(100),
+            degrade_threshold: ArcSwap::from_pointee(10),
+            alert_script: ArcSwapOption::from(None),
+            block_writes: ArcSwap::from_pointee(true),
+            alert_enabled: ArcSwap::from_pointee(false),
+            last_error: ArcSwapOption::from(None),
+            last_success_at_unix_ms: AtomicU64::new(0),
+            fallback_warning: ArcSwapOption::from(None),
+        }
+    }
+
+    pub fn sync_from_config(&self) {
+        let config = ConfigHandle::current();
+        self.retry_interval_secs
+            .store(std::sync::Arc::new(config.embed.retry.interval_secs));
+        self.alert_threshold.store(std::sync::Arc::new(
+            config.embed.alert.alert_every_n_failures,
+        ));
+        self.degrade_threshold.store(std::sync::Arc::new(
+            config.embed.degradation.degrade_after_n_failures,
+        ));
+        self.block_writes.store(std::sync::Arc::new(
+            config.embed.degradation.block_writes_when_degraded,
+        ));
+        self.alert_enabled
+            .store(std::sync::Arc::new(config.embed.alert.enabled));
+        let alert_script = config
+            .embed
+            .alert
+            .script_path
+            .as_deref()
+            .filter(|path| !path.trim().is_empty())
+            .map(PathBuf::from)
+            .map(std::sync::Arc::new);
+        self.alert_script.store(alert_script);
+    }
+
+    pub fn retry_interval_secs(&self) -> u64 {
+        self.sync_from_config();
+        **self.retry_interval_secs.load()
+    }
+
+    pub fn record_failure(&self, error: &impl std::fmt::Display) {
+        self.sync_from_config();
+        let message = error.to_string();
+        self.last_error
+            .store(Some(std::sync::Arc::new(message.clone())));
+        let fail_count = self.fail_count.fetch_add(1, Ordering::SeqCst) + 1;
+        let degrade_after = **self.degrade_threshold.load();
+        if fail_count > degrade_after {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
+        self.maybe_fire_alert(fail_count, &message);
+    }
+
+    pub fn record_primary_success(&self) {
+        self.sync_from_config();
+        self.fail_count.store(0, Ordering::SeqCst);
+        self.degraded.store(false, Ordering::SeqCst);
+        self.last_error.store(None);
+        self.fallback_warning.store(None);
+        self.last_success_at_unix_ms
+            .store(now_unix_ms(), Ordering::SeqCst);
+    }
+
+    pub fn record_fallback_success(&self, message: String) {
+        self.sync_from_config();
+        self.fail_count.store(0, Ordering::SeqCst);
+        self.degraded.store(false, Ordering::SeqCst);
+        self.last_error.store(None);
+        self.fallback_warning
+            .store(Some(std::sync::Arc::new(message)));
+        self.last_success_at_unix_ms
+            .store(now_unix_ms(), Ordering::SeqCst);
+    }
+
+    pub fn should_block_writes(&self) -> bool {
+        self.sync_from_config();
+        self.degraded.load(Ordering::SeqCst) && **self.block_writes.load()
+    }
+
+    pub fn is_degraded(&self) -> bool {
+        self.degraded.load(Ordering::SeqCst)
+    }
+
+    pub fn snapshot(&self) -> EmbedHealthSnapshot {
+        self.sync_from_config();
+        EmbedHealthSnapshot {
+            fail_count: self.fail_count.load(Ordering::SeqCst),
+            degraded: self.degraded.load(Ordering::SeqCst),
+            last_error: self.last_error.load_full().as_deref().cloned(),
+            last_success_at_unix_ms: non_zero(self.last_success_at_unix_ms.load(Ordering::SeqCst)),
+            fallback_warning: self.fallback_warning.load_full().as_deref().cloned(),
+        }
+    }
+
+    pub fn collect_warnings(&self) -> Vec<EmbedWarning> {
+        let snapshot = self.snapshot();
+        let mut warnings = Vec::new();
+        if snapshot.degraded {
+            warnings.push(EmbedWarning {
+                level: "error",
+                message: format!(
+                    "embed backend degraded after {} failures; writes may be paused until recovery",
+                    snapshot.fail_count
+                ),
+                source: "embed",
+            });
+        }
+        if let Some(message) = snapshot.fallback_warning {
+            warnings.push(EmbedWarning {
+                level: "warn",
+                message,
+                source: "embed",
+            });
+        }
+        warnings
+    }
+
+    pub fn reset_for_tests(&self) {
+        self.fail_count.store(0, Ordering::SeqCst);
+        self.degraded.store(false, Ordering::SeqCst);
+        self.last_error.store(None);
+        self.last_success_at_unix_ms.store(0, Ordering::SeqCst);
+        self.fallback_warning.store(None);
+    }
+
+    fn maybe_fire_alert(&self, fail_count: u64, error_message: &str) {
+        if !**self.alert_enabled.load() {
+            return;
+        }
+        let threshold = **self.alert_threshold.load();
+        if threshold == 0 || fail_count % threshold != 0 {
+            return;
+        }
+        let Some(path) = self.alert_script.load_full().as_deref().cloned() else {
+            return;
+        };
+        alerting::fire_alert(&path, fail_count, error_message);
+    }
+}
+
+pub fn global_embed_status() -> &'static EmbedStatus {
+    EmbedStatus::global()
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn non_zero(value: u64) -> Option<u64> {
+    (value != 0).then_some(value)
+}

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -7,6 +7,8 @@ pub mod normalize;
 
 use std::path::{Path, PathBuf};
 
+use rusqlite::OptionalExtension;
+
 use crate::core::{
     config::ConfigHandle,
     db::Database,
@@ -101,6 +103,10 @@ pub enum IngestError {
         #[source]
         source: crate::core::db::DbError,
     },
+    #[error(
+        "embedding dimension mismatch: drawer_vectors uses {current_dim}d but embedder returned {new_dim}d; run `mempal reindex --embedder <name>` before ingesting more content"
+    )]
+    VectorDimensionMismatch { current_dim: usize, new_dim: usize },
     #[error("failed to acquire ingest lock: {0}")]
     Lock(#[from] lock::LockError),
     #[error("failed to read directory {path}")]
@@ -249,6 +255,22 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             path: path.to_path_buf(),
             source,
         })?;
+    if let Some(first_vector) = vectors.first()
+        && let Some(current_dim) =
+            current_vector_dim(db).map_err(|source| IngestError::InsertVector {
+                drawer_id: pending
+                    .first()
+                    .map(|(_, _, drawer_id)| drawer_id.clone())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                source,
+            })?
+        && current_dim != first_vector.len()
+    {
+        return Err(IngestError::VectorDimensionMismatch {
+            current_dim,
+            new_dim: first_vector.len(),
+        });
+    }
 
     for ((chunk_index, chunk, drawer_id), vector) in pending.into_iter().zip(vectors.into_iter()) {
         let drawer = Drawer {
@@ -356,6 +378,30 @@ fn should_skip_dir(path: &Path) -> bool {
         .and_then(|name| name.to_str())
         .map(|name| matches!(name, ".git" | "target" | "node_modules"))
         .unwrap_or(false)
+}
+
+fn current_vector_dim(
+    db: &Database,
+) -> std::result::Result<Option<usize>, crate::core::db::DbError> {
+    let exists: bool = db.conn().query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Ok(None);
+    }
+
+    let dimension = db
+        .conn()
+        .query_row(
+            "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .map(|value| value as usize);
+    Ok(dimension)
 }
 
 fn normalize_source_file(path: &Path, source_root: Option<&Path>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,12 @@ use mempal::core::{
     config::{Config, ConfigHandle, default_config_path},
     db::Database,
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
+    reindex::ReindexProgressStore,
     types::TaxonomyEntry,
     utils::{build_triple_id, current_timestamp},
 };
-use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
+use mempal::embed::build_backend_from_name;
+use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
 use mempal::ingest::{IngestOptions, IngestStats, ingest_dir, ingest_dir_with_options};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::search;
@@ -80,7 +82,12 @@ enum Commands {
         #[arg(long)]
         before: Option<String>,
     },
-    Reindex,
+    Reindex {
+        #[arg(long)]
+        embedder: String,
+        #[arg(long, default_value_t = false)]
+        resume: bool,
+    },
     Kg {
         #[command(subcommand)]
         command: KgCommands,
@@ -279,7 +286,9 @@ async fn run() -> Result<()> {
         Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
         Commands::Compress { text } => compress_command(&text),
         Commands::Bench { command } => bench_command(config.as_ref(), command).await,
-        Commands::Reindex => reindex_command(&db, config.as_ref()).await,
+        Commands::Reindex { embedder, resume } => {
+            reindex_command(&db, config.as_ref(), &embedder, resume).await
+        }
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Tunnels => tunnels_command(&db),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
@@ -625,45 +634,112 @@ fn compress_command(text: &str) -> Result<()> {
     Ok(())
 }
 
-async fn reindex_command(db: &Database, config: &Config) -> Result<()> {
-    let embedder = build_embedder(config).await?;
+async fn reindex_command(
+    db: &Database,
+    config: &Config,
+    embedder_name: &str,
+    resume: bool,
+) -> Result<()> {
+    let embedder = build_specific_embedder(config, embedder_name).await?;
     let new_dim = embedder.dimensions();
-    let current_dim = db.embedding_dim().context("failed to read embedding dim")?;
+    let current_dim = current_vector_dim(db).context("failed to read embedding dim")?;
+    let progress_store = ReindexProgressStore::new(db.path());
+    let resume_checkpoint = if resume {
+        progress_store
+            .latest_resumable(Some(embedder_name))
+            .context("failed to load reindex checkpoint")?
+    } else {
+        None
+    };
 
-    println!("embedder: {} ({}d)", embedder.name(), new_dim);
+    println!("embedder: {} ({}d)", embedder_name, new_dim);
     if let Some(dim) = current_dim {
         println!("current vector dim: {dim}");
     } else {
         println!("current vector dim: (empty table)");
     }
 
-    // Recreate vectors table with new dimension
-    println!("recreating drawer_vectors with {new_dim} dimensions...");
-    db.recreate_vectors_table(new_dim)
-        .context("failed to recreate vectors table")?;
+    if resume_checkpoint.is_none() {
+        println!("recreating drawer_vectors with {new_dim} dimensions...");
+        db.recreate_vectors_table(new_dim)
+            .context("failed to recreate vectors table")?;
+    } else {
+        println!("resume checkpoint found; preserving existing drawer_vectors table");
+    }
 
-    // Re-embed all active drawers
-    let drawers = db
-        .all_active_drawers()
-        .context("failed to load active drawers")?;
+    let drawers = reindex_rows(db).context("failed to load active drawers for reindex")?;
     let total = drawers.len();
     println!("re-embedding {total} drawers...");
 
-    let batch_size = 64;
     let mut done = 0;
-    for chunk in drawers.chunks(batch_size) {
-        let texts: Vec<&str> = chunk.iter().map(|(_, content)| content.as_str()).collect();
-        let vectors = embedder.embed(&texts).await.context("embedding failed")?;
+    let mut last_processed: Option<(String, i64)> = None;
+    let mut active_source: Option<String> = None;
+    let test_stop_after = std::env::var("MEMPAL_TEST_REINDEX_STOP_AFTER")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok());
 
-        for ((id, _), vector) in chunk.iter().zip(vectors.iter()) {
-            db.insert_vector(id, vector)
-                .with_context(|| format!("failed to insert vector for {id}"))?;
+    for row in drawers {
+        if should_skip_reindex_row(
+            resume_checkpoint.as_ref(),
+            &row.source_path,
+            row.chunk_index,
+        ) {
+            done += 1;
+            last_processed = Some((row.source_path.clone(), row.chunk_index));
+            active_source = Some(row.source_path.clone());
+            continue;
         }
 
-        done += chunk.len();
-        if total > batch_size {
-            println!("  {done}/{total}");
+        if let Some(previous_source) = active_source.as_ref()
+            && previous_source != &row.source_path
+            && let Some((source_path, chunk_index)) = last_processed.as_ref()
+            && source_path == previous_source
+        {
+            progress_store
+                .mark_done(source_path, Some(*chunk_index), embedder_name)
+                .context("failed to mark completed reindex source")?;
         }
+        active_source = Some(row.source_path.clone());
+
+        let single_input = [row.content.as_str()];
+        let embed_future = embedder.embed(&single_input);
+        let vectors = tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                if let Some((source_path, chunk_index)) = last_processed.as_ref() {
+                    progress_store
+                        .mark_paused(source_path, Some(*chunk_index), embedder_name)
+                        .context("failed to persist paused reindex checkpoint")?;
+                }
+                bail!("reindex interrupted; resume with `mempal reindex --embedder {embedder_name} --resume`");
+            }
+            result = embed_future => result.context("embedding failed during reindex")?,
+        };
+        let vector = vectors
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("embedder returned no vector during reindex"))?;
+        db.insert_vector(&row.id, &vector)
+            .with_context(|| format!("failed to insert vector for {}", row.id))?;
+        progress_store
+            .upsert_running(&row.source_path, Some(row.chunk_index), embedder_name)
+            .context("failed to persist reindex checkpoint")?;
+
+        done += 1;
+        last_processed = Some((row.source_path.clone(), row.chunk_index));
+        println!("  {done}/{total}");
+
+        if test_stop_after.is_some_and(|limit| done >= limit) {
+            progress_store
+                .mark_paused(&row.source_path, Some(row.chunk_index), embedder_name)
+                .context("failed to persist paused reindex checkpoint")?;
+            bail!("reindex interrupted for test after {done} drawers");
+        }
+    }
+
+    if let Some((source_path, chunk_index)) = last_processed.as_ref() {
+        progress_store
+            .mark_done(source_path, Some(*chunk_index), embedder_name)
+            .context("failed to finalize reindex checkpoint")?;
     }
 
     println!("reindex complete: {total} drawers, {new_dim}d vectors");
@@ -956,6 +1032,11 @@ fn fact_check_command(
 
 fn status_command(db: &Database) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
+    let embed_status = global_embed_status().snapshot();
+    let queue_stats = mempal::core::queue::PendingMessageStore::new(db.path())
+        .context("failed to open pending message store")?
+        .stats()
+        .context("failed to query pending message stats")?;
     let schema_version = db
         .schema_version()
         .context("failed to read schema version")?;
@@ -996,6 +1077,17 @@ fn status_command(db: &Database) -> Result<()> {
         "config: version={} loaded_unix_ms={}",
         cfg_meta.version, cfg_meta.loaded_at_unix_ms
     );
+    println!("embed_fail_count: {}", embed_status.fail_count);
+    println!("embed_degraded: {}", embed_status.degraded);
+    if let Some(last_error) = embed_status.last_error {
+        println!("embed_last_error: {last_error}");
+    }
+    if let Some(last_success_at) = embed_status.last_success_at_unix_ms {
+        println!("embed_last_success_at_unix_ms: {last_success_at}");
+    }
+    println!("queue_pending: {}", queue_stats.pending);
+    println!("queue_claimed: {}", queue_stats.claimed);
+    println!("queue_failed: {}", queue_stats.failed);
 
     let counts = db.scope_counts().context("failed to query scope counts")?;
 
@@ -1089,6 +1181,102 @@ async fn build_embedder(config: &Config) -> Result<Box<dyn Embedder>> {
         .build()
         .await
         .context("failed to initialize embedder")
+}
+
+async fn build_specific_embedder(config: &Config, backend: &str) -> Result<Box<dyn Embedder>> {
+    let mut selected = config.clone();
+    selected.embed.backend = backend.to_string();
+    selected.embed.fallback = None;
+    build_backend_from_name(&selected, backend)
+        .await
+        .context("failed to initialize requested embedder")
+}
+
+#[derive(Debug, Clone)]
+struct ReindexRow {
+    id: String,
+    content: String,
+    source_path: String,
+    chunk_index: i64,
+}
+
+fn reindex_rows(db: &Database) -> Result<Vec<ReindexRow>> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT
+                id,
+                content,
+                COALESCE(source_file, id) AS source_path,
+                COALESCE(chunk_index, 0) AS chunk_index
+            FROM drawers
+            WHERE deleted_at IS NULL
+            ORDER BY source_path ASC, chunk_index ASC, id ASC
+            "#,
+        )
+        .context("failed to prepare reindex query")?;
+
+    let rows = statement
+        .query_map([], |row| {
+            Ok(ReindexRow {
+                id: row.get(0)?,
+                content: row.get(1)?,
+                source_path: row.get(2)?,
+                chunk_index: row.get(3)?,
+            })
+        })
+        .context("failed to query reindex rows")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect reindex rows")?;
+    Ok(rows)
+}
+
+fn should_skip_reindex_row(
+    checkpoint: Option<&mempal::core::reindex::ReindexProgressRow>,
+    source_path: &str,
+    chunk_index: i64,
+) -> bool {
+    let Some(checkpoint) = checkpoint else {
+        return false;
+    };
+    if source_path < checkpoint.source_path.as_str() {
+        return true;
+    }
+    if source_path > checkpoint.source_path.as_str() {
+        return false;
+    }
+    checkpoint
+        .last_processed_chunk_id
+        .is_some_and(|last| chunk_index <= last)
+}
+
+fn current_vector_dim(db: &Database) -> Result<Option<usize>> {
+    use rusqlite::OptionalExtension;
+
+    let exists: bool = db
+        .conn()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to query vector table presence")?;
+    if !exists {
+        return Ok(None);
+    }
+
+    let dimension = db
+        .conn()
+        .query_row(
+            "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()
+        .context("failed to read vector dimension")?
+        .map(|value| value as usize);
+    Ok(dimension)
 }
 
 fn expand_home(path: &str) -> PathBuf {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,4 +4,4 @@ mod server;
 mod tools;
 
 pub use server::MempalMcpServer;
-pub use tools::{IngestRequest, IngestResponse, StatusResponse};
+pub use tools::{IngestRequest, IngestResponse, SearchRequest, SearchResponse, StatusResponse};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,7 +8,7 @@ use crate::core::{
     utils::{build_drawer_id, build_triple_id, current_timestamp, source_file_or_synthetic},
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
-use crate::embed::EmbedderFactory;
+use crate::embed::{EmbedderFactory, global_embed_status};
 use crate::search::{resolve_route, search_with_vector};
 use anyhow::Context;
 use rmcp::{
@@ -20,10 +20,10 @@ use rmcp::{
 
 use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
-    FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest, KgResponse,
-    KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount, SearchRequest,
-    SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
+    EmbedStatusDto, FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest,
+    KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount,
+    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, SystemWarning,
+    TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -77,6 +77,15 @@ impl MempalMcpServer {
     pub async fn mempal_status(&self) -> std::result::Result<Json<StatusResponse>, ErrorData> {
         let cfg_meta = ConfigHandle::snapshot_meta();
         let db = self.open_db()?;
+        let queue_stats = crate::core::queue::PendingMessageStore::new(db.path())
+            .map_err(|error| {
+                ErrorData::internal_error(format!("queue init failed: {error}"), None)
+            })?
+            .stats()
+            .map_err(|error| {
+                ErrorData::internal_error(format!("queue stats failed: {error}"), None)
+            })?;
+        let embed_snapshot = global_embed_status().snapshot();
         let schema_version = db.schema_version().map_err(db_error)?;
         let drawer_count = db.drawer_count().map_err(db_error)?;
         let taxonomy_count = db.taxonomy_count().map_err(db_error)?;
@@ -102,6 +111,16 @@ impl MempalMcpServer {
             scopes,
             aaak_spec: crate::aaak::generate_spec(),
             memory_protocol: crate::core::protocol::MEMORY_PROTOCOL.to_string(),
+            embed_status: EmbedStatusDto {
+                pending_count: queue_stats.pending,
+                claimed_count: queue_stats.claimed,
+                failed_count: queue_stats.failed,
+                degraded: embed_snapshot.degraded,
+                fail_count: embed_snapshot.fail_count,
+                last_error: embed_snapshot.last_error,
+                last_success_at_unix_ms: embed_snapshot.last_success_at_unix_ms,
+            },
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -146,6 +165,7 @@ impl MempalMcpServer {
                 .into_iter()
                 .map(SearchResultDto::with_signals_from_result)
                 .collect(),
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -166,7 +186,12 @@ impl MempalMcpServer {
                 drawer_id,
                 duplicate_warning: None,
                 lock_wait_ms: None,
+                system_warnings: current_system_warnings(),
             }));
+        }
+
+        if global_embed_status().should_block_writes() {
+            return Err(degraded_write_error());
         }
 
         let db = self.open_db()?;
@@ -196,6 +221,7 @@ impl MempalMcpServer {
             .into_iter()
             .next()
             .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
+        ensure_vector_dim_matches(&db, vector.len())?;
 
         // Semantic dedup check: find most similar existing drawer
         let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);
@@ -224,6 +250,7 @@ impl MempalMcpServer {
             drawer_id,
             duplicate_warning,
             lock_wait_ms,
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -249,6 +276,7 @@ impl MempalMcpServer {
             drawer_id: request.drawer_id,
             deleted,
             message,
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -273,6 +301,7 @@ impl MempalMcpServer {
                 Ok(Json(TaxonomyResponse {
                     action: "list".to_string(),
                     entries,
+                    system_warnings: current_system_warnings(),
                 }))
             }
             "edit" => {
@@ -295,6 +324,7 @@ impl MempalMcpServer {
                 Ok(Json(TaxonomyResponse {
                     action: "edit".to_string(),
                     entries: vec![TaxonomyEntryDto::from(entry)],
+                    system_warnings: current_system_warnings(),
                 }))
             }
             action => Err(ErrorData::invalid_params(
@@ -313,9 +343,13 @@ impl MempalMcpServer {
         Parameters(request): Parameters<KgRequest>,
     ) -> std::result::Result<Json<KgResponse>, ErrorData> {
         let _cfg = ConfigHandle::current();
+        let block_writes = global_embed_status().should_block_writes();
         let db = self.open_db()?;
         match request.action.as_str() {
             "add" => {
+                if block_writes {
+                    return Err(degraded_write_error());
+                }
                 let subject = request
                     .subject
                     .ok_or_else(|| ErrorData::invalid_params("missing subject", None))?;
@@ -341,6 +375,7 @@ impl MempalMcpServer {
                     action: "add".to_string(),
                     triples: vec![triple_to_dto(&triple)],
                     stats: None,
+                    system_warnings: current_system_warnings(),
                 }))
             }
             "query" => {
@@ -357,9 +392,13 @@ impl MempalMcpServer {
                     action: "query".to_string(),
                     triples: triples.iter().map(triple_to_dto).collect(),
                     stats: None,
+                    system_warnings: current_system_warnings(),
                 }))
             }
             "invalidate" => {
+                if block_writes {
+                    return Err(degraded_write_error());
+                }
                 let triple_id = request
                     .triple_id
                     .ok_or_else(|| ErrorData::invalid_params("missing triple_id", None))?;
@@ -373,6 +412,7 @@ impl MempalMcpServer {
                     action: message,
                     triples: vec![],
                     stats: None,
+                    system_warnings: current_system_warnings(),
                 }))
             }
             "timeline" => {
@@ -384,6 +424,7 @@ impl MempalMcpServer {
                     action: format!("timeline for {entity}"),
                     triples: triples.iter().map(triple_to_dto).collect(),
                     stats: None,
+                    system_warnings: current_system_warnings(),
                 }))
             }
             "stats" => {
@@ -398,6 +439,7 @@ impl MempalMcpServer {
                         entities: stats.entities,
                         top_predicates: stats.top_predicates,
                     }),
+                    system_warnings: current_system_warnings(),
                 }))
             }
             action => Err(ErrorData::invalid_params(
@@ -419,7 +461,10 @@ impl MempalMcpServer {
             .into_iter()
             .map(|(room, wings)| TunnelDto { room, wings })
             .collect();
-        Ok(Json(TunnelsResponse { tunnels }))
+        Ok(Json(TunnelsResponse {
+            tunnels,
+            system_warnings: current_system_warnings(),
+        }))
     }
 
     #[tool(
@@ -479,6 +524,7 @@ impl MempalMcpServer {
                 .map(PeekMessageDto::from)
                 .collect(),
             truncated: resp.truncated,
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -546,6 +592,7 @@ impl MempalMcpServer {
             inbox_path: path.to_string_lossy().to_string(),
             pushed_at,
             inbox_size_after: size,
+            system_warnings: current_system_warnings(),
         }))
     }
 
@@ -578,6 +625,7 @@ impl MempalMcpServer {
             issues: report.issues,
             checked_entities: report.checked_entities,
             kg_triples_scanned: report.kg_triples_scanned,
+            system_warnings: current_system_warnings(),
         }))
     }
 }
@@ -647,6 +695,69 @@ fn fact_check_error(error: crate::factcheck::FactCheckError) -> ErrorData {
             ErrorData::internal_error(format!("fact_check: {error}"), None)
         }
     }
+}
+
+fn ensure_vector_dim_matches(
+    db: &Database,
+    actual_dim: usize,
+) -> std::result::Result<(), ErrorData> {
+    let Some(current_dim) = current_vector_dim(db).map_err(db_error)? else {
+        return Ok(());
+    };
+    if current_dim == actual_dim {
+        return Ok(());
+    }
+    Err(ErrorData::internal_error(
+        format!(
+            "embedding dimension mismatch: drawer_vectors uses {current_dim}d but embedder returned {actual_dim}d; run `mempal reindex --embedder <name>` before ingesting more content"
+        ),
+        None,
+    ))
+}
+
+fn current_vector_dim(
+    db: &Database,
+) -> std::result::Result<Option<usize>, crate::core::db::DbError> {
+    use rusqlite::OptionalExtension;
+
+    let exists: bool = db.conn().query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Ok(None);
+    }
+
+    let dimension = db
+        .conn()
+        .query_row(
+            "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .map(|value| value as usize);
+    Ok(dimension)
+}
+
+fn degraded_write_error() -> ErrorData {
+    let warnings = current_system_warnings();
+    let message = "mempal embed backend degraded; writes are paused until recovery. Read operations remain available.";
+    let data = serde_json::to_value(&warnings).ok();
+    ErrorData::internal_error(message, data)
+}
+
+fn current_system_warnings() -> Vec<SystemWarning> {
+    global_embed_status()
+        .collect_warnings()
+        .into_iter()
+        .map(|warning| SystemWarning {
+            level: warning.level.to_string(),
+            message: warning.message,
+            source: warning.source.to_string(),
+        })
+        .collect()
 }
 
 const DEDUP_THRESHOLD: f32 = 0.85;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -28,6 +28,8 @@ pub struct SearchRequest {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct SearchResponse {
     pub results: Vec<SearchResultDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -91,6 +93,8 @@ pub struct DeleteResponse {
     pub drawer_id: String,
     pub deleted: bool,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -103,6 +107,8 @@ pub struct IngestResponse {
     /// concurrent ingest of the same content serialized with this call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lock_wait_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -123,6 +129,29 @@ pub struct StatusResponse {
     pub scopes: Vec<ScopeCount>,
     pub aaak_spec: String,
     pub memory_protocol: String,
+    pub embed_status: EmbedStatusDto,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct EmbedStatusDto {
+    pub pending_count: u64,
+    pub claimed_count: u64,
+    pub failed_count: u64,
+    pub degraded: bool,
+    pub fail_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_success_at_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SystemWarning {
+    pub level: String,
+    pub message: String,
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -144,6 +173,8 @@ pub struct TaxonomyRequest {
 pub struct TaxonomyResponse {
     pub action: String,
     pub entries: Vec<TaxonomyEntryDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -177,6 +208,8 @@ pub struct KgResponse {
     pub triples: Vec<TripleDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stats: Option<KgStatsDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -205,6 +238,8 @@ pub struct TripleDto {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct TunnelsResponse {
     pub tunnels: Vec<TunnelDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -239,6 +274,8 @@ pub struct PeekPartnerResponse {
     pub partner_active: bool,
     pub messages: Vec<PeekMessageDto>,
     pub truncated: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -282,6 +319,8 @@ pub struct CoworkPushResponse {
     pub inbox_path: String,
     pub pushed_at: String,
     pub inbox_size_after: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -303,6 +342,8 @@ pub struct FactCheckResponse {
     pub issues: Vec<crate::factcheck::FactIssue>,
     pub checked_entities: Vec<String>,
     pub kg_triples_scanned: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
 }
 
 impl SearchResultDto {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -9,6 +9,7 @@ use crate::embed::{EmbedError, Embedder};
 use thiserror::Error;
 
 use crate::search::filter::build_filter_clause;
+use rusqlite::OptionalExtension;
 
 pub mod filter;
 pub mod rerank;
@@ -40,6 +41,10 @@ pub enum SearchError {
     LoadTaxonomy(#[source] crate::core::db::DbError),
     #[error("failed to run keyword search")]
     KeywordSearch(#[source] crate::core::db::DbError),
+    #[error(
+        "embedding dimension mismatch: drawer_vectors uses {current_dim}d but embedder returned {new_dim}d; run `mempal reindex --embedder <name>` before searching with this backend"
+    )]
+    VectorDimensionMismatch { current_dim: usize, new_dim: usize },
 }
 
 pub async fn search<E: Embedder + ?Sized>(
@@ -64,8 +69,40 @@ pub async fn search<E: Embedder + ?Sized>(
         .into_iter()
         .next()
         .ok_or(SearchError::MissingQueryVector)?;
+    if let Some(current_dim) = current_vector_dim(db).map_err(SearchError::KeywordSearch)?
+        && current_dim != query_vector.len()
+    {
+        return Err(SearchError::VectorDimensionMismatch {
+            current_dim,
+            new_dim: query_vector.len(),
+        });
+    }
 
     search_with_vector(db, query, &query_vector, route, top_k)
+}
+
+fn current_vector_dim(
+    db: &Database,
+) -> std::result::Result<Option<usize>, crate::core::db::DbError> {
+    let exists: bool = db.conn().query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+        [],
+        |row| row.get(0),
+    )?;
+    if !exists {
+        return Ok(None);
+    }
+
+    let dimension = db
+        .conn()
+        .query_row(
+            "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .map(|value| value as usize);
+    Ok(dimension)
 }
 
 pub fn search_with_vector(

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -472,7 +472,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 1"),
+            .any(|line| line.trim() == "fork_ext_version: 2"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/embedder_alerting.rs
+++ b/tests/embedder_alerting.rs
@@ -1,0 +1,111 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use mempal::core::config::ConfigHandle;
+use mempal::embed::global_embed_status;
+use tempfile::TempDir;
+
+fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("test mutex poisoned")
+}
+
+fn write_config(path: &Path, script_path: &Path, threshold: u64) {
+    let tmp_path = path.with_extension("tmp");
+    fs::write(
+        &tmp_path,
+        format!(
+            r#"
+db_path = "/tmp/mempal-test.db"
+
+[embed]
+backend = "openai_compat"
+
+[embed.retry]
+interval_secs = 1
+search_deadline_secs = 5
+
+[embed.alert]
+enabled = true
+script_path = "{}"
+alert_every_n_failures = {}
+
+[config_hot_reload]
+enabled = true
+debounce_ms = 100
+poll_fallback_secs = 1
+"#,
+            script_path.display(),
+            threshold
+        ),
+    )
+    .expect("write temp config");
+    fs::rename(&tmp_path, path).expect("rename config");
+}
+
+fn wait_until(timeout: Duration, step: Duration, mut predicate: impl FnMut() -> bool) {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if predicate() {
+            return;
+        }
+        std::thread::sleep(step);
+    }
+    assert!(predicate(), "condition not met before timeout");
+}
+
+fn line_count(path: &Path) -> usize {
+    fs::read_to_string(path)
+        .map(|content| content.lines().count())
+        .unwrap_or(0)
+}
+
+#[test]
+fn test_alert_script_invoked_on_threshold() {
+    let _guard = test_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    let alert_log = tmp.path().join("alerts.log");
+    let script_path = tmp.path().join("alert.sh");
+    fs::write(
+        &script_path,
+        format!("#!/bin/sh\necho \"$1\" >> \"{}\"\n", alert_log.display()),
+    )
+    .expect("write script");
+    let mut permissions = fs::metadata(&script_path)
+        .expect("script metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script_path, permissions).expect("chmod script");
+
+    write_config(&config_path, &script_path, 3);
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    let previous_version = ConfigHandle::version();
+    let status = global_embed_status();
+    status.reset_for_tests();
+
+    for index in 0..6 {
+        status.record_failure(&format!("failure {index}"));
+    }
+    wait_until(Duration::from_secs(3), Duration::from_millis(50), || {
+        line_count(&alert_log) == 2
+    });
+
+    write_config(&config_path, &script_path, 1);
+    wait_until(Duration::from_secs(3), Duration::from_millis(50), || {
+        ConfigHandle::version() != previous_version
+    });
+
+    status.record_failure(&"one-more-failure");
+    wait_until(Duration::from_secs(3), Duration::from_millis(50), || {
+        line_count(&alert_log) == 3
+    });
+
+    status.reset_for_tests();
+}

--- a/tests/embedder_degraded_state.rs
+++ b/tests/embedder_degraded_state.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
+use mempal::mcp::{IngestRequest, MempalMcpServer, SearchRequest};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+
+async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+struct StubEmbedder;
+
+#[async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+#[derive(Clone)]
+struct StubEmbedderFactory;
+
+#[async_trait]
+impl EmbedderFactory for StubEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(StubEmbedder))
+    }
+}
+
+fn bootstrap_config(tmp: &TempDir) -> std::path::PathBuf {
+    let config_path = tmp.path().join("config.toml");
+    fs::write(
+        &config_path,
+        r#"
+db_path = "/tmp/mempal-test.db"
+
+[embed]
+backend = "openai_compat"
+
+[embed.degradation]
+degrade_after_n_failures = 10
+block_writes_when_degraded = true
+
+[embed.retry]
+interval_secs = 1
+search_deadline_secs = 5
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    config_path
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_degraded_state_blocks_mcp_writes() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let _config_path = bootstrap_config(&tmp);
+    let db_path = tmp.path().join("palace.db");
+    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory));
+    let status = global_embed_status();
+    status.reset_for_tests();
+
+    for index in 0..11 {
+        status.record_failure(&format!("synthetic failure {index}"));
+    }
+
+    let error = match server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "blocked".to_string(),
+            wing: "test".to_string(),
+            room: Some("room".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+    {
+        Ok(_) => panic!("write should be blocked"),
+        Err(error) => error,
+    };
+
+    let search = server
+        .mempal_search(Parameters(SearchRequest {
+            query: "blocked".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(5),
+        }))
+        .await
+        .expect("search should still work")
+        .0;
+
+    assert!(format!("{error:?}").contains("writes are paused"));
+    assert!(!search.system_warnings.is_empty());
+    assert!(
+        search
+            .system_warnings
+            .iter()
+            .any(|warning| warning.message.contains("degraded"))
+    );
+
+    status.reset_for_tests();
+}

--- a/tests/embedder_dim_mismatch.rs
+++ b/tests/embedder_dim_mismatch.rs
@@ -1,0 +1,89 @@
+use std::sync::{Arc, OnceLock};
+
+use mempal::core::config::Config;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::embed::global_embed_status;
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use mockito::{Matcher, Server};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+
+async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dim_mismatch_detected_before_reindex() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: "existing".to_string(),
+        content: "existing drawer".to_string(),
+        wing: "test".to_string(),
+        room: Some("room".to_string()),
+        source_file: Some("existing.txt".to_string()),
+        source_type: SourceType::Project,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    })
+    .expect("insert drawer");
+    db.insert_vector("existing", &[0.9, 0.8])
+        .expect("insert 2d vector");
+
+    let mut server = Server::new_async().await;
+    let _mock = server
+        .mock("POST", "/v1/embeddings")
+        .match_body(Matcher::Any)
+        .with_status(200)
+        .with_body(r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#)
+        .create();
+
+    let config = Config::parse(&format!(
+        r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{}/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+request_timeout_secs = 5
+"#,
+        db_path.display(),
+        server.url()
+    ))
+    .expect("parse config");
+    global_embed_status().reset_for_tests();
+
+    let service = MempalMcpServer::new(db_path, config);
+    let error = match service
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "new drawer".to_string(),
+            wing: "test".to_string(),
+            room: Some("room".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+    {
+        Ok(_) => panic!("ingest should fail on dim mismatch"),
+        Err(error) => error,
+    };
+
+    let rendered = format!("{error:?}");
+    assert!(rendered.contains("dimension mismatch"));
+    assert!(rendered.contains("mempal reindex"));
+    global_embed_status().reset_for_tests();
+}

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -1,0 +1,94 @@
+use std::fs;
+use std::sync::{Arc, OnceLock};
+
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::embed::global_embed_status;
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+
+async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn config_text(db_path: &std::path::Path) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+fallback = "model2vec"
+model = "minishlab/potion-base-8M"
+
+[embed.openai_compat]
+base_url = "http://127.0.0.1:9/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+request_timeout_secs = 1
+
+[embed.retry]
+interval_secs = 1
+search_deadline_secs = 5
+"#,
+        db_path.display()
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_embedder_fallback_to_model2vec_when_lan_unreachable() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    let hf_home = tmp.path().join("hf-home");
+    let xdg_cache_home = tmp.path().join("xdg-cache");
+    fs::create_dir_all(&hf_home).expect("create hf home");
+    fs::create_dir_all(&xdg_cache_home).expect("create xdg cache home");
+    let text = config_text(&db_path);
+    fs::write(&config_path, &text).expect("write config");
+    let config = Config::parse(&text).expect("parse config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    global_embed_status().reset_for_tests();
+    // SAFETY: this test serializes environment mutation with a process-wide async mutex.
+    unsafe {
+        std::env::set_var("HF_HOME", &hf_home);
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("XDG_CACHE_HOME", &xdg_cache_home);
+    }
+
+    let server = MempalMcpServer::new(db_path, config);
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "fallback path should still embed".to_string(),
+            wing: "test".to_string(),
+            room: Some("fallback".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("fallback ingest should succeed")
+        .0;
+
+    assert!(
+        response
+            .system_warnings
+            .iter()
+            .any(|warning| warning.message.contains("fallback active"))
+    );
+    // SAFETY: paired with the serialized mutation above.
+    unsafe {
+        std::env::remove_var("HF_HOME");
+        std::env::remove_var("HOME");
+        std::env::remove_var("XDG_CACHE_HOME");
+    }
+    global_embed_status().reset_for_tests();
+}

--- a/tests/embedder_retry_heartbeat.rs
+++ b/tests/embedder_retry_heartbeat.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use mempal::core::config::ConfigHandle;
+use mempal::embed::{EmbedError, retry::retry_embed_operation, status::EmbedStatus};
+use tempfile::TempDir;
+
+async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn bootstrap_retry_config() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+    fs::write(
+        &config_path,
+        r#"
+db_path = "/tmp/mempal-test.db"
+
+[embed]
+backend = "openai_compat"
+
+[embed.retry]
+interval_secs = 1
+search_deadline_secs = 5
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    tmp
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_embedder_calls_heartbeat_per_retry_iteration() {
+    let _guard = test_guard().await;
+    let _tmp = bootstrap_retry_config();
+    let status = EmbedStatus::new();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let heartbeats = Arc::new(AtomicUsize::new(0));
+    let heartbeat_counter = Arc::clone(&heartbeats);
+
+    let result = retry_embed_operation(
+        &status,
+        Some(&move || {
+            heartbeat_counter.fetch_add(1, Ordering::SeqCst);
+            Ok::<(), EmbedError>(())
+        }),
+        {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+                    if attempt < 2 {
+                        Err(EmbedError::Runtime(format!("transient failure {attempt}")))
+                    } else {
+                        Ok(vec![vec![0.1, 0.2, 0.3]])
+                    }
+                }
+            }
+        },
+    )
+    .await
+    .expect("retry succeeds");
+
+    assert_eq!(result, vec![vec![0.1, 0.2, 0.3]]);
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    assert_eq!(heartbeats.load(Ordering::SeqCst), 4);
+}

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_one_on_fresh_db_after_phase2() {
+fn test_fork_ext_version_is_two_on_fresh_db_after_phase4() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 1);
+    assert_eq!(version, 2);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 1);
+    assert_eq!(version, 2);
 }
 
 #[test]

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -1,0 +1,41 @@
+use mempal::core::db::Database;
+use tempfile::TempDir;
+
+#[path = "../src/core/db_fork_ext.rs"]
+mod db_fork_ext;
+
+fn new_test_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db)
+}
+
+#[test]
+fn test_fork_ext_v2_migration() {
+    let (_tmp, db) = new_test_db();
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
+    assert_eq!(version, 2);
+
+    let table_exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='reindex_progress'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(table_exists, 1);
+}
+
+#[test]
+fn test_fork_ext_v2_migration_is_idempotent() {
+    let (_tmp, db) = new_test_db();
+
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("first apply");
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
+    assert_eq!(version, 2);
+}

--- a/tests/openai_compat_embedder.rs
+++ b/tests/openai_compat_embedder.rs
@@ -1,0 +1,120 @@
+use std::sync::{Arc, OnceLock};
+
+use mempal::core::config::Config;
+use mempal::embed::{EmbedError, Embedder, openai_compat::OpenAiCompatibleEmbedder};
+use mockito::{Matcher, Server};
+
+async fn env_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn config_for(server: &Server, extra: &str) -> Config {
+    Config::parse(&format!(
+        r#"
+db_path = "/tmp/mempal-test.db"
+
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{}/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+request_timeout_secs = 5
+{}
+"#,
+        server.url(),
+        extra
+    ))
+    .expect("parse config")
+}
+
+#[tokio::test]
+async fn test_openai_compat_embed_happy_path() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/embeddings")
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "model": "Qwen/Qwen3-Embedding-8B",
+            "input": ["hello"]
+        })))
+        .with_status(200)
+        .with_body(r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#)
+        .create();
+    let config = config_for(&server, "");
+    let embedder = OpenAiCompatibleEmbedder::from_config(&config).expect("build embedder");
+
+    let vectors = embedder.embed(&["hello"]).await.expect("embed");
+
+    mock.assert();
+    assert_eq!(vectors, vec![vec![0.1, 0.2, 0.3]]);
+}
+
+#[tokio::test]
+async fn test_openai_compat_embed_api_error() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/embeddings")
+        .with_status(503)
+        .with_body("unavailable")
+        .create();
+    let config = config_for(&server, "");
+    let embedder = OpenAiCompatibleEmbedder::from_config(&config).expect("build embedder");
+
+    let error = embedder.embed(&["hello"]).await.expect_err("api error");
+
+    mock.assert();
+    assert!(matches!(error, EmbedError::HttpStatus { .. }));
+}
+
+#[tokio::test]
+async fn test_openai_compat_embed_malformed_response() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/embeddings")
+        .with_status(200)
+        .with_body(r#"{"data":[{"embedding":"bad"}]}"#)
+        .create();
+    let config = config_for(&server, "");
+    let embedder = OpenAiCompatibleEmbedder::from_config(&config).expect("build embedder");
+
+    let error = embedder
+        .embed(&["hello"])
+        .await
+        .expect_err("malformed response");
+
+    mock.assert();
+    assert!(matches!(error, EmbedError::DecodeResponse { .. }));
+}
+
+#[tokio::test]
+async fn test_api_key_from_env_var() {
+    let _guard = env_guard().await;
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/embeddings")
+        .match_header("authorization", "Bearer sk-test123")
+        .with_status(200)
+        .with_body(r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#)
+        .create();
+    // SAFETY: tests serialize environment mutation with a process-wide mutex.
+    unsafe {
+        std::env::set_var("MEMPAL_TEST_KEY", "sk-test123");
+    }
+    let config = config_for(&server, r#"api_key_env = "MEMPAL_TEST_KEY""#);
+    let embedder = OpenAiCompatibleEmbedder::from_config(&config).expect("build embedder");
+
+    let vectors = embedder.embed(&["hello"]).await.expect("embed with auth");
+
+    mock.assert();
+    assert_eq!(vectors[0].len(), 3);
+    // SAFETY: paired with the serialized mutation above.
+    unsafe {
+        std::env::remove_var("MEMPAL_TEST_KEY");
+    }
+}

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -24,7 +24,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 }
 
 #[test]
-fn test_fork_ext_migration_v0_to_v1_creates_pending_messages_table() {
+fn test_fork_ext_migration_v0_to_v2_creates_pending_messages_table() {
     let (_tmp, db_path, _store) = new_store();
     let conn = Connection::open(db_path).expect("open sqlite");
 
@@ -35,7 +35,7 @@ fn test_fork_ext_migration_v0_to_v1_creates_pending_messages_table() {
             |row| row.get::<_, String>(0),
         )
         .expect("read fork_ext_version");
-    assert_eq!(version, "1");
+    assert_eq!(version, "2");
 
     let exists = conn
         .query_row(

--- a/tests/reindex_progress.rs
+++ b/tests/reindex_progress.rs
@@ -1,0 +1,208 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+struct MockEmbeddingServer {
+    base_url: String,
+    requests: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl MockEmbeddingServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let requests_clone = Arc::clone(&requests);
+        let stop_clone = Arc::clone(&stop);
+        let join = thread::spawn(move || {
+            for stream in listener.incoming() {
+                if stop_clone.load(Ordering::SeqCst) {
+                    break;
+                }
+                let Ok(mut stream) = stream else {
+                    continue;
+                };
+                let mut buffer = [0_u8; 4096];
+                let _ = stream.read(&mut buffer);
+                requests_clone.fetch_add(1, Ordering::SeqCst);
+                let body = r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        Self {
+            base_url: format!("http://{addr}/v1"),
+            requests,
+            stop,
+            join: Some(join),
+        }
+    }
+
+    fn request_count(&self) -> usize {
+        self.requests.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for MockEmbeddingServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        let _ = std::net::TcpStream::connect(
+            self.base_url
+                .trim_start_matches("http://")
+                .trim_end_matches("/v1"),
+        );
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn write_config(home: &Path, db_path: &Path, base_url: &str) {
+    let mempal_home = home.join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{}"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+request_timeout_secs = 5
+
+[config_hot_reload]
+enabled = false
+"#,
+            db_path.display(),
+            base_url
+        ),
+    )
+    .expect("write config");
+}
+
+fn seed_db(db_path: &Path) {
+    let db = Database::open(db_path).expect("open db");
+    for index in 0..50 {
+        let id = format!("drawer-{index:02}");
+        db.insert_drawer(&Drawer {
+            id: id.clone(),
+            content: format!("drawer content {index}"),
+            wing: "test".to_string(),
+            room: Some("resume".to_string()),
+            source_file: Some("fixtures/source.txt".to_string()),
+            source_type: SourceType::Project,
+            added_at: format!("17130000{index:02}"),
+            chunk_index: Some(index as i64),
+            importance: 0,
+        })
+        .expect("insert drawer");
+        db.insert_vector(&id, &[0.9, 0.8])
+            .expect("insert old vector");
+    }
+}
+
+fn run_reindex(home: &Path, stop_after: Option<usize>, resume: bool) -> std::process::Output {
+    let mut command = Command::new(mempal_bin());
+    command
+        .env("HOME", home)
+        .arg("reindex")
+        .arg("--embedder")
+        .arg("openai_compat");
+    if let Some(limit) = stop_after {
+        command.env("MEMPAL_TEST_REINDEX_STOP_AFTER", limit.to_string());
+    }
+    if resume {
+        command.arg("--resume");
+    }
+    command.output().expect("run reindex command")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reindex_resume_from_checkpoint() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join("home");
+    let db_path = home.join(".mempal").join("palace.db");
+    let server = MockEmbeddingServer::start();
+
+    write_config(&home, &db_path, &server.base_url);
+    seed_db(&db_path);
+
+    let first = run_reindex(&home, Some(20), false);
+    assert!(!first.status.success());
+    assert!(String::from_utf8_lossy(&first.stderr).contains("interrupted for test"));
+    assert_eq!(server.request_count(), 20);
+
+    let db = Database::open(&db_path).expect("open db after interrupt");
+    let paused = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read paused checkpoint");
+    assert_eq!(paused, (19, "paused".to_string()));
+
+    let second = run_reindex(&home, None, true);
+    assert!(
+        second.status.success(),
+        "resume stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert_eq!(server.request_count(), 50);
+
+    let db = Database::open(&db_path).expect("open db after resume");
+    let state = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read final checkpoint");
+    assert_eq!(state, (49, "done".to_string()));
+
+    let vector_count = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count vectors");
+    assert_eq!(vector_count, 50);
+}


### PR DESCRIPTION
## Summary
- add `openai_compat` as the default embed backend with config-driven auth, retry, alerting, degraded-state tracking, and model2vec fallback
- add fork-ext v2 `reindex_progress` schema/store plus `mempal reindex --embedder <name> [--resume]`
- surface embed health and `system_warnings` through MCP/CLI status and guard writes on degraded backends or dimension mismatch

## Testing
- `cargo test --features rest`
- `just pre-commit`
