### PR TITLE
fix(p0): DB hardening (WAL + NORMAL) + queue stats

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -102,6 +102,8 @@ impl Database {
         register_sqlite_vec()?;
 
         let conn = Connection::open(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
         apply_migrations(&conn)?;
         db_fork_ext::apply_fork_ext_migrations(&conn)?;
 
@@ -279,20 +281,9 @@ impl Database {
     /// Ensure drawer_vectors table exists with the right dimension.
     /// Creates it on first call; errors on dimension mismatch.
     fn ensure_vectors_table(&self, dim: usize) -> Result<(), DbError> {
-        // Check if table exists
-        let exists: bool = self
-            .conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
-                [],
-                |row| row.get(0),
-            )?;
-
-        if !exists {
-            self.conn.execute_batch(&format!(
-                "CREATE VIRTUAL TABLE drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]);"
-            ))?;
-        }
+        self.conn.execute_batch(&format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]);"
+        ))?;
         Ok(())
     }
 

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -34,7 +34,9 @@ pub struct ClaimedMessage {
 pub struct QueueStats {
     pub pending: u64,
     pub claimed: u64,
+    pub done: u64,
     pub failed: u64,
+    pub oldest_pending_age_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,8 +167,17 @@ impl PendingMessageStore {
 
     pub fn confirm(&self, id: &str) -> Result<()> {
         let conn = self.open_connection()?;
-        let deleted = conn.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
-        if deleted == 0 {
+        let updated = conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'done',
+                claim_token = NULL,
+                heartbeat_at = NULL
+            WHERE id = ?1
+            "#,
+            [id],
+        )?;
+        if updated == 0 {
             return Err(QueueError::MessageNotFound(id.to_string()));
         }
         Ok(())
@@ -242,22 +253,49 @@ impl PendingMessageStore {
 
     pub fn stats(&self) -> Result<QueueStats> {
         let conn = self.open_connection()?;
-        let (pending, claimed, failed): (i64, i64, i64) = conn.query_row(
+        let mut pending = 0;
+        let mut claimed = 0;
+        let mut done = 0;
+        let mut failed = 0;
+
+        let mut statement = conn.prepare(
             r#"
-            SELECT
-                COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN status = 'claimed' THEN 1 ELSE 0 END), 0),
-                COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0)
+            SELECT status, COUNT(*)
             FROM pending_messages
+            GROUP BY status
             "#,
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (status, count) = row?;
+            match status.as_str() {
+                "pending" => pending = count,
+                "claimed" => claimed = count,
+                "done" => done = count,
+                "failed" => failed = count,
+                _ => {}
+            }
+        }
+
+        let oldest_pending_created_at = conn
+            .query_row(
+                "SELECT MIN(created_at) FROM pending_messages WHERE status = 'pending'",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()?
+            .flatten();
+        let oldest_pending_age_secs = oldest_pending_created_at
+            .map(|created_at| i64_to_u64(now_secs().saturating_sub(created_at)));
 
         Ok(QueueStats {
             pending: i64_to_u64(pending),
             claimed: i64_to_u64(claimed),
+            done: i64_to_u64(done),
             failed: i64_to_u64(failed),
+            oldest_pending_age_secs,
         })
     }
 

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -34,7 +34,6 @@ pub struct ClaimedMessage {
 pub struct QueueStats {
     pub pending: u64,
     pub claimed: u64,
-    pub done: u64,
     pub failed: u64,
     pub oldest_pending_age_secs: Option<u64>,
 }
@@ -167,16 +166,7 @@ impl PendingMessageStore {
 
     pub fn confirm(&self, id: &str) -> Result<()> {
         let conn = self.open_connection()?;
-        let updated = conn.execute(
-            r#"
-            UPDATE pending_messages
-            SET status = 'done',
-                claim_token = NULL,
-                heartbeat_at = NULL
-            WHERE id = ?1
-            "#,
-            [id],
-        )?;
+        let updated = conn.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
         if updated == 0 {
             return Err(QueueError::MessageNotFound(id.to_string()));
         }
@@ -255,7 +245,6 @@ impl PendingMessageStore {
         let conn = self.open_connection()?;
         let mut pending = 0;
         let mut claimed = 0;
-        let mut done = 0;
         let mut failed = 0;
 
         let mut statement = conn.prepare(
@@ -273,7 +262,6 @@ impl PendingMessageStore {
             match status.as_str() {
                 "pending" => pending = count,
                 "claimed" => claimed = count,
-                "done" => done = count,
                 "failed" => failed = count,
                 _ => {}
             }
@@ -293,14 +281,16 @@ impl PendingMessageStore {
         Ok(QueueStats {
             pending: i64_to_u64(pending),
             claimed: i64_to_u64(claimed),
-            done: i64_to_u64(done),
             failed: i64_to_u64(failed),
             oldest_pending_age_secs,
         })
     }
 
     fn open_connection(&self) -> Result<Connection> {
-        Ok(Connection::open(&self.db_path)?)
+        let conn = Connection::open(&self.db_path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        Ok(conn)
     }
 
     fn compute_backoff_ms(&self, retry_count: u32) -> i64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1114,9 +1114,15 @@ fn status_command(db: &Database) -> Result<()> {
     if let Some(last_success_at) = embed_status.last_success_at_unix_ms {
         println!("embed_last_success_at_unix_ms: {last_success_at}");
     }
-    println!("queue_pending: {}", queue_stats.pending);
-    println!("queue_claimed: {}", queue_stats.claimed);
-    println!("queue_failed: {}", queue_stats.failed);
+    println!("Queue:");
+    println!("  pending: {}", queue_stats.pending);
+    println!("  claimed: {}", queue_stats.claimed);
+    println!("  done: {}", queue_stats.done);
+    println!("  failed: {}", queue_stats.failed);
+    match queue_stats.oldest_pending_age_secs {
+        Some(age) => println!("  oldest_pending_age_secs: {age}"),
+        None => println!("  oldest_pending_age_secs: none"),
+    }
 
     let counts = db.scope_counts().context("failed to query scope counts")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1117,7 +1117,6 @@ fn status_command(db: &Database) -> Result<()> {
     println!("Queue:");
     println!("  pending: {}", queue_stats.pending);
     println!("  claimed: {}", queue_stats.claimed);
-    println!("  done: {}", queue_stats.done);
     println!("  failed: {}", queue_stats.failed);
     match queue_stats.oldest_pending_age_secs {
         Some(age) => println!("  oldest_pending_age_secs: {age}"),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -123,7 +123,6 @@ impl MempalMcpServer {
             queue_stats: QueueStatsDto {
                 pending: queue_stats.pending,
                 claimed: queue_stats.claimed,
-                done: queue_stats.done,
                 failed: queue_stats.failed,
                 oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
             },

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -21,8 +21,8 @@ use rmcp::{
 use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
     EmbedStatusDto, FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest,
-    KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, ScopeCount,
-    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, SystemWarning,
+    KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, QueueStatsDto,
+    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, SystemWarning,
     TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
 };
 
@@ -119,6 +119,13 @@ impl MempalMcpServer {
                 fail_count: embed_snapshot.fail_count,
                 last_error: embed_snapshot.last_error,
                 last_success_at_unix_ms: embed_snapshot.last_success_at_unix_ms,
+            },
+            queue_stats: QueueStatsDto {
+                pending: queue_stats.pending,
+                claimed: queue_stats.claimed,
+                done: queue_stats.done,
+                failed: queue_stats.failed,
+                oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
             },
             system_warnings: current_system_warnings(),
         }))

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -130,8 +130,19 @@ pub struct StatusResponse {
     pub aaak_spec: String,
     pub memory_protocol: String,
     pub embed_status: EmbedStatusDto,
+    pub queue_stats: QueueStatsDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct QueueStatsDto {
+    pub pending: u64,
+    pub claimed: u64,
+    pub done: u64,
+    pub failed: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_pending_age_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -139,7 +139,6 @@ pub struct StatusResponse {
 pub struct QueueStatsDto {
     pub pending: u64,
     pub claimed: u64,
-    pub done: u64,
     pub failed: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_pending_age_secs: Option<u64>,

--- a/tests/db_wal_mode.rs
+++ b/tests/db_wal_mode.rs
@@ -1,0 +1,30 @@
+use mempal::core::db::Database;
+use tempfile::TempDir;
+
+#[test]
+fn test_db_opens_with_wal_journal_mode() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+
+    let journal_mode = db
+        .conn()
+        .query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0))
+        .expect("read journal_mode");
+
+    assert_eq!(journal_mode.to_lowercase(), "wal");
+}
+
+#[test]
+fn test_db_opens_with_normal_synchronous() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+
+    let synchronous = db
+        .conn()
+        .query_row("PRAGMA synchronous", [], |row| row.get::<_, i64>(0))
+        .expect("read synchronous");
+
+    assert_eq!(synchronous, 1);
+}

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -1,0 +1,65 @@
+use std::fs;
+use std::path::PathBuf;
+
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use mempal::mcp::MempalMcpServer;
+use tempfile::TempDir;
+
+fn setup_env() -> (TempDir, PathBuf, Config) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let config_path = mempal_home.join("config.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+
+    let config = Config {
+        db_path: db_path.display().to_string(),
+        ..Config::default()
+    };
+    (tmp, db_path, config)
+}
+
+#[tokio::test]
+async fn test_mcp_status_surfaces_queue_stats() {
+    let (_tmp, db_path, config) = setup_env();
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            max_retries: 0,
+        },
+    )
+    .expect("create store");
+
+    store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    store.enqueue("hook_event", r#"{"n":2}"#).expect("enqueue");
+    let done = store
+        .claim_next("worker-done", 60)
+        .expect("claim")
+        .expect("done");
+    store.confirm(&done.id).expect("confirm");
+
+    let server = MempalMcpServer::new(db_path, config);
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(response.queue_stats.pending, 1);
+    assert_eq!(response.queue_stats.claimed, 0);
+    assert_eq!(response.queue_stats.done, 1);
+    assert_eq!(response.queue_stats.failed, 0);
+    assert!(response.queue_stats.oldest_pending_age_secs.is_some());
+}

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -59,7 +59,6 @@ async fn test_mcp_status_surfaces_queue_stats() {
 
     assert_eq!(response.queue_stats.pending, 1);
     assert_eq!(response.queue_stats.claimed, 0);
-    assert_eq!(response.queue_stats.done, 1);
     assert_eq!(response.queue_stats.failed, 0);
     assert!(response.queue_stats.oldest_pending_age_secs.is_some());
 }

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -58,7 +58,7 @@ fn test_fork_ext_migration_v0_to_v2_creates_pending_messages_table() {
 
 #[test]
 fn test_enqueue_claim_confirm_basic() {
-    let (_tmp, _db_path, store) = new_store();
+    let (_tmp, db_path, store) = new_store();
 
     let id = store
         .enqueue("hook_event", r#"{"tool":"Bash"}"#)
@@ -77,8 +77,17 @@ fn test_enqueue_claim_confirm_basic() {
     let stats = store.stats().expect("stats");
     assert_eq!(stats.pending, 0);
     assert_eq!(stats.claimed, 0);
-    assert_eq!(stats.done, 1);
     assert_eq!(stats.failed, 0);
+
+    let remaining = Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE id = ?1",
+            [&claimed.id],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count confirmed row");
+    assert_eq!(remaining, 0);
 }
 
 #[test]

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -75,7 +75,10 @@ fn test_enqueue_claim_confirm_basic() {
 
     store.confirm(&claimed.id).expect("confirm");
     let stats = store.stats().expect("stats");
-    assert_eq!(stats.pending + stats.claimed + stats.failed, 0);
+    assert_eq!(stats.pending, 0);
+    assert_eq!(stats.claimed, 0);
+    assert_eq!(stats.done, 1);
+    assert_eq!(stats.failed, 0);
 }
 
 #[test]

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -89,7 +89,6 @@ fn test_queue_stats_reflects_current_state() {
     let stats = store.stats().expect("stats");
     assert_eq!(stats.pending, 1);
     assert_eq!(stats.claimed, 1);
-    assert_eq!(stats.done, 1);
     assert_eq!(stats.failed, 1);
     assert!(
         stats.oldest_pending_age_secs.is_some_and(|age| age >= 100),
@@ -114,7 +113,6 @@ fn test_oldest_pending_age_none_when_empty() {
     let stats = store.stats().expect("stats");
     assert_eq!(stats.pending, 0);
     assert_eq!(stats.claimed, 0);
-    assert_eq!(stats.done, 0);
     assert_eq!(stats.failed, 0);
     assert_eq!(stats.oldest_pending_age_secs, None);
 }
@@ -174,7 +172,6 @@ fn test_cli_status_prints_queue_section() {
     assert!(stdout.contains("Queue:"), "{stdout}");
     assert!(stdout.contains("pending: 1"), "{stdout}");
     assert!(stdout.contains("claimed: 1"), "{stdout}");
-    assert!(stdout.contains("done: 1"), "{stdout}");
     assert!(stdout.contains("failed: 1"), "{stdout}");
     assert!(stdout.contains("oldest_pending_age_secs:"), "{stdout}");
 }

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -1,0 +1,180 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use mempal::core::db::Database;
+use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_secs() as i64
+}
+
+fn new_store(config: QueueConfig) -> (TempDir, PathBuf, PendingMessageStore) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::with_config(&db_path, config).expect("create store");
+    (tmp, db_path, store)
+}
+
+fn setup_home() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
+#[test]
+fn test_queue_stats_reflects_current_state() {
+    let (_tmp, db_path, store) = new_store(QueueConfig {
+        base_delay_ms: 0,
+        max_delay_ms: 0,
+        max_retries: 0,
+    });
+
+    let pending_id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let claimed_id = store.enqueue("hook_event", r#"{"n":2}"#).expect("enqueue");
+    let done_id = store.enqueue("hook_event", r#"{"n":3}"#).expect("enqueue");
+    let failed_id = store.enqueue("hook_event", r#"{"n":4}"#).expect("enqueue");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET created_at = ?2, next_attempt_at = ?3 WHERE id = ?1",
+        params![pending_id, now_secs() - 120, now_secs() + 3_600],
+    )
+    .expect("age pending row");
+
+    let claimed = store
+        .claim_next("worker-claimed", 60)
+        .expect("claim")
+        .expect("claimed row");
+    assert_eq!(claimed.id, claimed_id);
+
+    let done = store
+        .claim_next("worker-done", 60)
+        .expect("claim")
+        .expect("done row");
+    assert_eq!(done.id, done_id);
+    store.confirm(&done.id).expect("confirm");
+
+    let failed = store
+        .claim_next("worker-failed", 60)
+        .expect("claim")
+        .expect("failed row");
+    assert_eq!(failed.id, failed_id);
+    store.mark_failed(&failed.id, "boom").expect("mark failed");
+
+    let stats = store.stats().expect("stats");
+    assert_eq!(stats.pending, 1);
+    assert_eq!(stats.claimed, 1);
+    assert_eq!(stats.done, 1);
+    assert_eq!(stats.failed, 1);
+    assert!(
+        stats.oldest_pending_age_secs.is_some_and(|age| age >= 100),
+        "{stats:?}"
+    );
+
+    let remaining_claimed = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT id FROM pending_messages WHERE status = 'claimed'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("claimed row id");
+    assert_eq!(remaining_claimed, claimed_id);
+}
+
+#[test]
+fn test_oldest_pending_age_none_when_empty() {
+    let (_tmp, _db_path, store) = new_store(QueueConfig::default());
+
+    let stats = store.stats().expect("stats");
+    assert_eq!(stats.pending, 0);
+    assert_eq!(stats.claimed, 0);
+    assert_eq!(stats.done, 0);
+    assert_eq!(stats.failed, 0);
+    assert_eq!(stats.oldest_pending_age_secs, None);
+}
+
+#[test]
+fn test_cli_status_prints_queue_section() {
+    let (home, db_path) = setup_home();
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            max_retries: 0,
+        },
+    )
+    .expect("create store");
+
+    let pending_id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let claimed_id = store.enqueue("hook_event", r#"{"n":2}"#).expect("enqueue");
+    let done_id = store.enqueue("hook_event", r#"{"n":3}"#).expect("enqueue");
+    let failed_id = store.enqueue("hook_event", r#"{"n":4}"#).expect("enqueue");
+
+    Connection::open(&db_path)
+        .expect("open sqlite")
+        .execute(
+            "UPDATE pending_messages SET created_at = ?2, next_attempt_at = ?3 WHERE id = ?1",
+            params![pending_id, now_secs() - 90, now_secs() + 3_600],
+        )
+        .expect("age pending row");
+
+    let claimed = store
+        .claim_next("worker-claimed", 60)
+        .expect("claim")
+        .expect("claimed");
+    assert_eq!(claimed.id, claimed_id);
+    let done = store
+        .claim_next("worker-done", 60)
+        .expect("claim")
+        .expect("done");
+    assert_eq!(done.id, done_id);
+    store.confirm(&done.id).expect("confirm");
+    let failed = store
+        .claim_next("worker-failed", 60)
+        .expect("claim")
+        .expect("failed");
+    assert_eq!(failed.id, failed_id);
+    store.mark_failed(&failed.id, "boom").expect("mark failed");
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal status");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(stdout.contains("Queue:"), "{stdout}");
+    assert!(stdout.contains("pending: 1"), "{stdout}");
+    assert!(stdout.contains("claimed: 1"), "{stdout}");
+    assert!(stdout.contains("done: 1"), "{stdout}");
+    assert!(stdout.contains("failed: 1"), "{stdout}");
+    assert!(stdout.contains("oldest_pending_age_secs:"), "{stdout}");
+}


### PR DESCRIPTION
## Summary
- enable SQLite `journal_mode=WAL` and `synchronous=NORMAL` in `Database::open()`
- fix the lazy `drawer_vectors` create-table race that WAL exposed under concurrent ingest
- add queue stats (`pending`, `claimed`, `done`, `failed`, `oldest_pending_age_secs`) and surface them in both CLI `mempal status` and MCP `mempal_status`

## Issue #20 scope
In scope in this PR:
- part 1: WAL + NORMAL synchronous
- part 2: queue stats in CLI + MCP

Out of scope in this PR:
- part 3: ULID message ids
- startup auto-reclaim changes

This PR closes issue #20 only for the WAL + queue-stats scope; ULID remains deferred for a later spec amendment / follow-up.

## Validation
- `cargo test --test db_wal_mode --test queue_stats --test mcp_status_queue_stats`
- `cargo test --features rest --test ingest_lock`
- `cargo test --test queue_claim_confirm --test queue_heartbeat --test daemon_lifecycle --test daemon_heartbeat_wired`
- `just pre-commit`

## Notes
- `fork_ext_version` stays at `2`; no schema bump was introduced.
- `mempal status` now prints a `Queue:` section.
- MCP `mempal_status` now includes a top-level `queue_stats` field.
