### PR TITLE
fix(p0): config + MCP nits cleanup (#18 + #22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -3080,6 +3081,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ notify = "8"
 ort = { version = "2.0.0-rc.9", optional = true }
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-rmcp = { version = "1.3.0", features = ["server", "macros", "schemars", "transport-async-rw", "transport-io"] }
+rmcp = { version = "1.3.0", features = ["client", "server", "macros", "schemars", "transport-async-rw", "transport-io"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -136,7 +136,13 @@ impl Config {
     pub fn scrub_content(&self, input: &str) -> String {
         match self.compile_privacy() {
             Ok(compiled) => self.scrub_content_with_compiled(input, &compiled),
-            Err(_) => input.to_string(),
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "scrub_content regex compile failed, falling back to no-op"
+                );
+                input.to_string()
+            }
         }
     }
 
@@ -149,14 +155,34 @@ impl Config {
             return input.to_string();
         }
 
-        compiled
-            .patterns
-            .iter()
-            .fold(input.to_string(), |content, (name, regex)| {
-                regex
-                    .replace_all(&content, format!("[REDACTED:{name}]"))
-                    .into_owned()
-            })
+        let mut content = input.to_string();
+        let mut stats = ScrubStats::default();
+
+        for (name, regex) in &compiled.patterns {
+            let matches = regex.find_iter(&content).collect::<Vec<_>>();
+            if matches.is_empty() {
+                continue;
+            }
+
+            let matched_count = matches.len() as u64;
+            let bytes_redacted = matches
+                .iter()
+                .map(|matched| matched.as_str().len() as u64)
+                .sum::<u64>();
+            stats.record_match(name, matched_count, bytes_redacted);
+            content = regex
+                .replace_all(&content, format!("[REDACTED:{name}]"))
+                .into_owned();
+        }
+
+        if stats.total_patterns_matched > 0 {
+            global_scrub_stats()
+                .lock()
+                .expect("scrub stats mutex poisoned")
+                .merge(&stats);
+        }
+
+        content
     }
 
     pub fn effective_hash(&self) -> Result<String, ConfigError> {
@@ -467,6 +493,35 @@ pub struct CompiledPrivacyConfig {
     patterns: Vec<(String, Regex)>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ScrubStats {
+    pub total_patterns_matched: u64,
+    pub bytes_redacted: u64,
+    pub redactions_per_pattern: std::collections::BTreeMap<String, u64>,
+}
+
+impl ScrubStats {
+    fn record_match(&mut self, pattern_name: &str, matched_count: u64, bytes_redacted: u64) {
+        self.total_patterns_matched += matched_count;
+        self.bytes_redacted += bytes_redacted;
+        *self
+            .redactions_per_pattern
+            .entry(pattern_name.to_string())
+            .or_default() += matched_count;
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.total_patterns_matched += other.total_patterns_matched;
+        self.bytes_redacted += other.bytes_redacted;
+        for (pattern_name, count) in &other.redactions_per_pattern {
+            *self
+                .redactions_per_pattern
+                .entry(pattern_name.clone())
+                .or_default() += count;
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ConfigHotReloadConfig {
@@ -569,6 +624,13 @@ impl ConfigHandle {
         super::hot_reload::global_hot_reload_state().snapshot_meta()
     }
 
+    pub fn scrub_stats() -> ScrubStats {
+        global_scrub_stats()
+            .lock()
+            .expect("scrub stats mutex poisoned")
+            .clone()
+    }
+
     pub fn version() -> String {
         Self::snapshot_meta().version
     }
@@ -592,4 +654,9 @@ impl ConfigHandle {
     pub fn simulate_notify_failure() {
         super::hot_reload::global_hot_reload_state().simulate_notify_failure();
     }
+}
+
+fn global_scrub_stats() -> &'static Mutex<ScrubStats> {
+    static SCRUB_STATS: OnceLock<Mutex<ScrubStats>> = OnceLock::new();
+    SCRUB_STATS.get_or_init(|| Mutex::new(ScrubStats::default()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1061,6 +1061,7 @@ fn fact_check_command(
 
 fn status_command(db: &Database) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
+    let scrub_stats = ConfigHandle::scrub_stats();
     let embed_status = global_embed_status().snapshot();
     let queue_stats = mempal::core::queue::PendingMessageStore::new(db.path())
         .context("failed to open pending message store")?
@@ -1121,6 +1122,23 @@ fn status_command(db: &Database) -> Result<()> {
     match queue_stats.oldest_pending_age_secs {
         Some(age) => println!("  oldest_pending_age_secs: {age}"),
         None => println!("  oldest_pending_age_secs: none"),
+    }
+    println!("Scrub:");
+    println!(
+        "  total_patterns_matched: {}",
+        scrub_stats.total_patterns_matched
+    );
+    println!("  bytes_redacted: {}", scrub_stats.bytes_redacted);
+    if scrub_stats.redactions_per_pattern.is_empty() {
+        println!("  redactions_per_pattern: none");
+    } else {
+        let per_pattern = scrub_stats
+            .redactions_per_pattern
+            .iter()
+            .map(|(pattern_name, count)| format!("{pattern_name}={count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  redactions_per_pattern: {per_pattern}");
     }
 
     let counts = db.scope_counts().context("failed to query scope counts")?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -22,8 +22,9 @@ use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
     EmbedStatusDto, FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest,
     KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, QueueStatsDto,
-    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, SystemWarning,
-    TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
+    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, StatusResponse,
+    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto,
+    TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -126,6 +127,7 @@ impl MempalMcpServer {
                 failed: queue_stats.failed,
                 oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
             },
+            scrub_stats: ScrubStatsDto::from(ConfigHandle::scrub_stats()),
             system_warnings: current_system_warnings(),
         }))
     }
@@ -138,7 +140,6 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<SearchRequest>,
     ) -> std::result::Result<Json<SearchResponse>, ErrorData> {
-        let _cfg = ConfigHandle::current();
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
         })?;
@@ -202,8 +203,10 @@ impl MempalMcpServer {
 
         let db = self.open_db()?;
 
-        // Same-content manual ingests should serialize before the expensive
-        // embedder call so concurrent duplicates do not race past the lock.
+        // P9-B reordered this path so the same-content lock is acquired
+        // before the expensive embedder call. That keeps concurrent manual
+        // ingests from racing past the dedup gate and writing duplicate
+        // drawers/vectors for identical content.
         let mempal_home = db
             .path()
             .parent()
@@ -268,7 +271,6 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<DeleteRequest>,
     ) -> std::result::Result<Json<DeleteResponse>, ErrorData> {
-        let _cfg = ConfigHandle::current();
         let db = self.open_db()?;
         let deleted = db
             .soft_delete_drawer(&request.drawer_id)
@@ -294,7 +296,6 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<TaxonomyRequest>,
     ) -> std::result::Result<Json<TaxonomyResponse>, ErrorData> {
-        let _cfg = ConfigHandle::current();
         let db = self.open_db()?;
         match request.action.as_str() {
             "list" => {
@@ -348,7 +349,6 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<KgRequest>,
     ) -> std::result::Result<Json<KgResponse>, ErrorData> {
-        let _cfg = ConfigHandle::current();
         let block_writes = global_embed_status().should_block_writes();
         let db = self.open_db()?;
         match request.action.as_str() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::core::types::{RouteDecision, SearchResult, TaxonomyEntry};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct SearchRequest {
@@ -131,8 +132,26 @@ pub struct StatusResponse {
     pub memory_protocol: String,
     pub embed_status: EmbedStatusDto,
     pub queue_stats: QueueStatsDto,
+    pub scrub_stats: ScrubStatsDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct ScrubStatsDto {
+    pub total_patterns_matched: u64,
+    pub bytes_redacted: u64,
+    pub redactions_per_pattern: BTreeMap<String, u64>,
+}
+
+impl From<crate::core::config::ScrubStats> for ScrubStatsDto {
+    fn from(value: crate::core::config::ScrubStats) -> Self {
+        Self {
+            total_patterns_matched: value.total_patterns_matched,
+            bytes_redacted: value.bytes_redacted,
+            redactions_per_pattern: value.redactions_per_pattern,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -11,7 +11,9 @@ use mempal::core::db::Database;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{model::CallToolRequestParams, serve_client};
 use tempfile::TempDir;
+use tokio::process::Command as TokioCommand;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 fn mempal_bin() -> String {
@@ -496,6 +498,10 @@ async fn test_status_prints_config_version_and_loaded_at() {
         .expect("system time after epoch")
         .as_millis() as u64;
     assert!(now_ms.saturating_sub(loaded_ms) < 600_000);
+    assert!(stdout.contains("Scrub:\n"));
+    assert!(stdout.contains("  total_patterns_matched: 0"));
+    assert!(stdout.contains("  bytes_redacted: 0"));
+    assert!(stdout.contains("  redactions_per_pattern: none"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -527,6 +533,76 @@ async fn test_mcp_status_returns_config_version() {
     let second = server.mempal_status().await.expect("status").0;
     assert_ne!(first.config_version, second.config_version);
     assert!(second.config_loaded_at_unix_ms >= first.config_loaded_at_unix_ms);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_stdio_child_hot_reloads() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let config_path = mempal_home.join("config.toml");
+    let initial_config = base_config(&db_path);
+    write_config_atomic(&config_path, &initial_config);
+
+    let mut child = TokioCommand::new(mempal_bin())
+        .arg("serve")
+        .arg("--mcp")
+        .env("HOME", tmp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal serve --mcp");
+
+    let stdout = child.stdout.take().expect("child stdout");
+    let stdin = child.stdin.take().expect("child stdin");
+    let client = serve_client((), (stdout, stdin))
+        .await
+        .expect("initialize mcp stdio client");
+
+    let first: serde_json::Value = client
+        .call_tool(CallToolRequestParams::new("mempal_status"))
+        .await
+        .expect("first mempal_status call")
+        .into_typed()
+        .expect("decode first status");
+    let first_version = first
+        .get("config_version")
+        .and_then(serde_json::Value::as_str)
+        .expect("first config_version");
+    assert_eq!(first_version.len(), 12);
+
+    let changed = initial_config.replace(
+        "strict_project_isolation = false",
+        "strict_project_isolation = true",
+    );
+    write_config_atomic(&config_path, &changed);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let second: serde_json::Value = client
+        .call_tool(CallToolRequestParams::new("mempal_status"))
+        .await
+        .expect("second mempal_status call")
+        .into_typed()
+        .expect("decode second status");
+    let second_version = second
+        .get("config_version")
+        .and_then(serde_json::Value::as_str)
+        .expect("second config_version");
+    assert_ne!(first_version, second_version);
+
+    client.cancel().await.expect("cancel mcp client");
+    match tokio::time::timeout(Duration::from_secs(3), child.wait()).await {
+        Ok(Ok(status)) => assert!(status.success(), "child exited with {status}"),
+        Ok(Err(err)) => panic!("failed waiting for child: {err}"),
+        Err(_) => {
+            child.kill().await.expect("kill stuck child");
+            panic!("mcp stdio child did not exit after client shutdown");
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/privacy_scrubbing.rs
+++ b/tests/privacy_scrubbing.rs
@@ -3,10 +3,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
-use mempal::core::config::ConfigHandle;
+use mempal::core::config::{Config, ConfigHandle, ScrubStats};
 use mempal::core::db::Database;
 use mempal::embed::{EmbedError, Embedder};
 use mempal::ingest::ingest_file_with_options;
+use mempal::mcp::MempalMcpServer;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
@@ -111,6 +112,32 @@ fn drawer_contents(db: &Database) -> Vec<String> {
         .expect("collect drawer rows")
 }
 
+fn scrub_stats_delta(before: &ScrubStats, after: &ScrubStats) -> ScrubStats {
+    let mut delta = ScrubStats {
+        total_patterns_matched: after
+            .total_patterns_matched
+            .saturating_sub(before.total_patterns_matched),
+        bytes_redacted: after.bytes_redacted.saturating_sub(before.bytes_redacted),
+        ..ScrubStats::default()
+    };
+
+    for (pattern_name, after_count) in &after.redactions_per_pattern {
+        let before_count = before
+            .redactions_per_pattern
+            .get(pattern_name)
+            .copied()
+            .unwrap_or(0);
+        let diff = after_count.saturating_sub(before_count);
+        if diff > 0 {
+            delta
+                .redactions_per_pattern
+                .insert(pattern_name.clone(), diff);
+        }
+    }
+
+    delta
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_scrub_catches_cross_chunk_secret() {
     let _guard = test_guard().await;
@@ -207,7 +234,7 @@ async fn test_private_tag_stripped() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_compiled_privacy_cache_reused_via_handle() {
+async fn test_scrub_regex_compile_once_across_calls() {
     let _guard = test_guard().await;
     let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
     let config = config_text(&env.db_path, true);
@@ -216,13 +243,94 @@ async fn test_compiled_privacy_cache_reused_via_handle() {
     ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
 
     let first = ConfigHandle::current_compiled_privacy();
+    let once = ConfigHandle::scrub_content("Bearer abcdefghijklmnopqrstuvwxyz0123456789");
     let second = ConfigHandle::current_compiled_privacy();
+    let twice = ConfigHandle::scrub_content("Bearer zyxwvutsrqponmlkjihgfedcba9876543210");
+    let third = ConfigHandle::current_compiled_privacy();
 
     assert!(Arc::ptr_eq(&first, &second));
-    let cfg = ConfigHandle::current();
-    let scrubbed = cfg.scrub_content_with_compiled(
-        "Bearer abcdefghijklmnopqrstuvwxyz0123456789",
-        first.as_ref(),
+    assert!(Arc::ptr_eq(&second, &third));
+    assert_eq!(once, "[REDACTED:bearer_token]");
+    assert_eq!(twice, "[REDACTED:bearer_token]");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_scrub_stats_accumulates_across_ingests() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
+    let config = config_text(&env.db_path, true);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let before = ConfigHandle::scrub_stats();
+    let embedder = RecordingEmbedder::default();
+    let secret = "sk-abcdef1234567890abcdef1234567890abcd";
+    let private_block = "<private>keep this out</private>";
+    let first = write_fixture(
+        env.db_path.parent().expect("db parent"),
+        "scrub-stats-1.txt",
+        &format!("alpha {secret} beta {secret}"),
     );
+    let second = write_fixture(
+        env.db_path.parent().expect("db parent"),
+        "scrub-stats-2.txt",
+        &format!("prefix {private_block} suffix"),
+    );
+
+    ingest_file_with_options(&env.db(), &embedder, &first, "test", Default::default())
+        .await
+        .expect("ingest first scrub fixture");
+    ingest_file_with_options(&env.db(), &embedder, &second, "test", Default::default())
+        .await
+        .expect("ingest second scrub fixture");
+
+    let after = ConfigHandle::scrub_stats();
+    let delta = scrub_stats_delta(&before, &after);
+    assert_eq!(delta.total_patterns_matched, 3, "{delta:?}");
+    assert_eq!(
+        delta.bytes_redacted,
+        (secret.len() * 2 + private_block.len()) as u64
+    );
+    assert_eq!(delta.redactions_per_pattern.get("openai_key"), Some(&2));
+    assert_eq!(delta.redactions_per_pattern.get("private_tag"), Some(&1));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_status_surfaces_scrub_stats() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&config_text(Path::new("/tmp/placeholder"), true));
+    let config = config_text(&env.db_path, true);
+    let config_path = env.db_path.parent().expect("db parent").join("config.toml");
+    fs::write(&config_path, config).expect("rewrite config");
+    ConfigHandle::bootstrap(&config_path).expect("rebootstrap config");
+
+    let before = ConfigHandle::scrub_stats();
+    let scrubbed = ConfigHandle::scrub_content("Bearer abcdefghijklmnopqrstuvwxyz0123456789");
     assert_eq!(scrubbed, "[REDACTED:bearer_token]");
+    let expected = ConfigHandle::scrub_stats();
+    let delta = scrub_stats_delta(&before, &expected);
+    assert_eq!(delta.total_patterns_matched, 1, "{delta:?}");
+
+    let server = MempalMcpServer::new(
+        env.db_path.clone(),
+        Config {
+            db_path: env.db_path.display().to_string(),
+            ..Config::default()
+        },
+    );
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(
+        response.scrub_stats.total_patterns_matched,
+        expected.total_patterns_matched
+    );
+    assert_eq!(response.scrub_stats.bytes_redacted, expected.bytes_redacted);
+    assert_eq!(
+        response
+            .scrub_stats
+            .redactions_per_pattern
+            .get("bearer_token"),
+        expected.redactions_per_pattern.get("bearer_token")
+    );
 }


### PR DESCRIPTION
Closes #18
Closes #22

## Summary
- add the scenario-11 MCP stdio hot-reload integration test and enable `rmcp` client support for the child-process harness
- remove leftover no-op `ConfigHandle::current()` probes in MCP handlers
- warn when the compat scrub regex compile path fails open, and verify compiled regex reuse across repeated scrub calls
- add global `ScrubStats` accumulation and surface it through both `mempal_status` and `mempal status`
- extend scrub/privacy coverage with stats and status assertions
- restore the P9-B attribution comment at the lock-before-embed reorder site

## Verification
- `just pre-commit`
- `cargo test --test config_hot_reload --test privacy_scrubbing --test mcp_status_queue_stats --features rest`

## Notes
- `fork_ext_version` remains 2
- left the existing dirty `weave.lock` change untouched