### PR TITLE
fix(p0): embed + daemon nits cleanup (#24 + #26)

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -108,6 +108,19 @@ impl Config {
                 "hooks.daemon_claim_ttl_secs must be greater than 0".to_string(),
             ));
         }
+        if let Some(path) = self
+            .embed
+            .alert
+            .script_path
+            .as_deref()
+            .filter(|path| !path.trim().is_empty())
+            && !Path::new(path).is_absolute()
+        {
+            eprintln!(
+                "warning: alerting script_path is not absolute: {}; CWD at invocation may differ from expectation",
+                path
+            );
+        }
         let _ = self.compile_privacy()?;
         Ok(())
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+use std::{future::Future, pin::Pin};
 
 use crate::core::{
     db::Database,
@@ -52,12 +53,12 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
             break;
         }
 
-        match context
-            .store
-            .claim_next(&worker_id, claim_ttl_secs)
-            .context("failed to claim next pending message")?
+        match poll_claim_next(&context.store, &worker_id, claim_ttl_secs, |duration| {
+            Box::pin(tokio::time::sleep(duration))
+        })
+        .await
         {
-            Some(message) => {
+            ClaimPollResult::Claimed(message) => {
                 let message_id = message.id.clone();
                 let result = process_claimed_message_with_embedder(
                     &context.db,
@@ -86,13 +87,60 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                     }
                 }
             }
-            None => {
+            ClaimPollResult::Idle => {
                 tokio::time::sleep(poll_interval).await;
             }
+            ClaimPollResult::RetryAfterError => continue,
         }
     }
 
     Ok(())
+}
+
+trait ClaimNextSource {
+    fn claim_next(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+    ) -> crate::core::queue::Result<Option<ClaimedMessage>>;
+}
+
+impl ClaimNextSource for PendingMessageStore {
+    fn claim_next(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+    ) -> crate::core::queue::Result<Option<ClaimedMessage>> {
+        PendingMessageStore::claim_next(self, worker_id, claim_ttl_secs)
+    }
+}
+
+enum ClaimPollResult {
+    Claimed(ClaimedMessage),
+    Idle,
+    RetryAfterError,
+}
+
+type SleepFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+async fn poll_claim_next<'a, S>(
+    store: &impl ClaimNextSource,
+    worker_id: &str,
+    claim_ttl_secs: i64,
+    sleep_on_error: S,
+) -> ClaimPollResult
+where
+    S: Fn(Duration) -> SleepFuture<'a>,
+{
+    match store.claim_next(worker_id, claim_ttl_secs) {
+        Ok(Some(message)) => ClaimPollResult::Claimed(message),
+        Ok(None) => ClaimPollResult::Idle,
+        Err(error) => {
+            tracing::warn!(?error, "claim_next failed");
+            sleep_on_error(Duration::from_secs(1)).await;
+            ClaimPollResult::RetryAfterError
+        }
+    }
 }
 
 pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
@@ -371,5 +419,85 @@ impl Embedder for DaemonEmbedder {
 
     fn name(&self) -> &str {
         self.primary.name()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::core::queue::{ClaimedMessage, QueueError};
+
+    use super::{ClaimNextSource, ClaimPollResult, poll_claim_next};
+
+    struct StubClaimSource {
+        responses: Mutex<VecDeque<Result<Option<ClaimedMessage>, QueueError>>>,
+    }
+
+    impl StubClaimSource {
+        fn new(responses: Vec<Result<Option<ClaimedMessage>, QueueError>>) -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::from(responses)),
+            }
+        }
+    }
+
+    impl ClaimNextSource for StubClaimSource {
+        fn claim_next(
+            &self,
+            _worker_id: &str,
+            _claim_ttl_secs: i64,
+        ) -> crate::core::queue::Result<Option<ClaimedMessage>> {
+            self.responses
+                .lock()
+                .expect("responses mutex")
+                .pop_front()
+                .expect("stub response")
+        }
+    }
+
+    fn claimed_message(id: &str) -> ClaimedMessage {
+        ClaimedMessage {
+            id: id.to_string(),
+            kind: "hook_user_prompt".to_string(),
+            payload: "{}".to_string(),
+            retry_count: 0,
+            claim_token: "worker:claim".to_string(),
+            source_hash: "hash".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_daemon_survives_transient_claim_error() {
+        let store = StubClaimSource::new(vec![
+            Err(QueueError::Sqlite(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error {
+                    code: rusqlite::ErrorCode::DatabaseBusy,
+                    extended_code: rusqlite::ffi::SQLITE_BUSY,
+                },
+                Some("database is locked".to_string()),
+            ))),
+            Ok(Some(claimed_message("msg-1"))),
+        ]);
+        let slept = AtomicUsize::new(0);
+
+        let first = poll_claim_next(&store, "worker-a", 60, |_| {
+            slept.fetch_add(1, Ordering::SeqCst);
+            Box::pin(std::future::ready(()))
+        })
+        .await;
+        let second =
+            poll_claim_next(&store, "worker-a", 60, |_| Box::pin(std::future::ready(()))).await;
+
+        assert!(matches!(first, ClaimPollResult::RetryAfterError));
+        assert_eq!(slept.load(Ordering::SeqCst), 1);
+        match second {
+            ClaimPollResult::Claimed(message) => assert_eq!(message.id, "msg-1"),
+            ClaimPollResult::Idle | ClaimPollResult::RetryAfterError => {
+                panic!("expected claimed message on retry")
+            }
+        }
     }
 }

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -9,6 +9,15 @@ use crate::core::{
 };
 use anyhow::{Context, Result};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    Daemonize,
+    Runtime,
+    ConfigHandleBootstrap,
+    Database,
+    Tracing,
+}
+
 pub struct DaemonContext {
     pub runtime: tokio::runtime::Runtime,
     pub db: Database,
@@ -38,7 +47,7 @@ impl DaemonContext {
 }
 
 pub trait BootstrapObserver: Send + Sync {
-    fn record(&self, stage: &str);
+    fn record(&self, stage: Stage);
 }
 
 #[derive(Clone, Copy, Default)]
@@ -61,23 +70,24 @@ fn bootstrap_inner(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    record_stage(observer, "daemonize");
+    record_stage(observer, Stage::Daemonize);
     perform_daemonize(foreground, &mempal_home, &log_path)?;
 
-    record_stage(observer, "runtime");
+    record_stage(observer, Stage::Runtime);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("failed to build daemon runtime")?;
 
-    record_stage(observer, "database");
-    let db = Database::open(&db_path).context("failed to open daemon database")?;
-
+    record_stage(observer, Stage::ConfigHandleBootstrap);
     ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
     let config = ConfigHandle::current();
+
+    record_stage(observer, Stage::Database);
+    let db = Database::open(&db_path).context("failed to open daemon database")?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
 
-    record_stage(observer, "tracing");
+    record_stage(observer, Stage::Tracing);
     init_tracing_subscriber();
 
     let pid_guard = PidFileGuard::create(mempal_home.join("daemon.pid"))?;
@@ -181,7 +191,7 @@ fn expand_home_path(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn record_stage(observer: BootstrapObserverRef, stage: &str) {
+fn record_stage(observer: BootstrapObserverRef, stage: Stage) {
     if let Some(observer) = observer.0 {
         observer.record(stage);
     }

--- a/src/embed/retry.rs
+++ b/src/embed/retry.rs
@@ -14,13 +14,14 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<Vec<Vec<f32>>>>,
 {
+    let config = status.retry_config_snapshot();
     loop {
         match operation().await {
             Ok(vectors) => return Ok(vectors),
             Err(error) => {
-                status.record_failure(&error);
+                status.record_failure_with_snapshot(&error, &config);
                 refresh_heartbeat(heartbeat);
-                tokio::time::sleep(Duration::from_secs(status.retry_interval_secs())).await;
+                tokio::time::sleep(Duration::from_secs(config.retry_interval_secs)).await;
                 refresh_heartbeat(heartbeat);
             }
         }

--- a/src/embed/status.rs
+++ b/src/embed/status.rs
@@ -25,6 +25,15 @@ pub struct EmbedHealthSnapshot {
     pub fallback_warning: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetryConfigSnapshot {
+    pub retry_interval_secs: u64,
+    pub alert_threshold: u64,
+    pub degrade_threshold: u64,
+    pub alert_script: Option<PathBuf>,
+    pub alert_enabled: bool,
+}
+
 pub struct EmbedStatus {
     fail_count: AtomicU64,
     degraded: AtomicBool,
@@ -93,6 +102,23 @@ impl EmbedStatus {
         self.alert_script.store(alert_script);
     }
 
+    pub fn retry_config_snapshot(&self) -> RetryConfigSnapshot {
+        let config = ConfigHandle::current();
+        RetryConfigSnapshot {
+            retry_interval_secs: config.embed.retry.interval_secs,
+            alert_threshold: config.embed.alert.alert_every_n_failures,
+            degrade_threshold: config.embed.degradation.degrade_after_n_failures,
+            alert_script: config
+                .embed
+                .alert
+                .script_path
+                .as_deref()
+                .filter(|path| !path.trim().is_empty())
+                .map(PathBuf::from),
+            alert_enabled: config.embed.alert.enabled,
+        }
+    }
+
     pub fn retry_interval_secs(&self) -> u64 {
         self.sync_from_config();
         **self.retry_interval_secs.load()
@@ -109,6 +135,21 @@ impl EmbedStatus {
             self.degraded.store(true, Ordering::SeqCst);
         }
         self.maybe_fire_alert(fail_count, &message);
+    }
+
+    pub fn record_failure_with_snapshot(
+        &self,
+        error: &impl std::fmt::Display,
+        snapshot: &RetryConfigSnapshot,
+    ) {
+        let message = error.to_string();
+        self.last_error
+            .store(Some(std::sync::Arc::new(message.clone())));
+        let fail_count = self.fail_count.fetch_add(1, Ordering::SeqCst) + 1;
+        if fail_count > snapshot.degrade_threshold {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
+        self.maybe_fire_alert_with_snapshot(snapshot, fail_count, &message);
     }
 
     pub fn record_primary_success(&self) {
@@ -196,6 +237,24 @@ impl EmbedStatus {
         };
         alerting::fire_alert(&path, fail_count, error_message);
     }
+
+    fn maybe_fire_alert_with_snapshot(
+        &self,
+        snapshot: &RetryConfigSnapshot,
+        fail_count: u64,
+        error_message: &str,
+    ) {
+        if !snapshot.alert_enabled {
+            return;
+        }
+        if snapshot.alert_threshold == 0 || fail_count % snapshot.alert_threshold != 0 {
+            return;
+        }
+        let Some(path) = snapshot.alert_script.as_ref() else {
+            return;
+        };
+        alerting::fire_alert(path, fail_count, error_message);
+    }
 }
 
 pub fn global_embed_status() -> &'static EmbedStatus {
@@ -205,7 +264,7 @@ pub fn global_embed_status() -> &'static EmbedStatus {
 fn now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
         .unwrap_or(0)
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -139,7 +139,7 @@ fn capture_stdin_payload(bytes: Vec<u8>, mempal_home: &Path) -> Result<CapturedP
     let original_size_bytes = bytes.len();
     if original_size_bytes <= MAX_INLINE_PAYLOAD_BYTES {
         return Ok(CapturedPayload {
-            inline_payload: Some(String::from_utf8_lossy(&bytes).to_string()),
+            inline_payload: Some(decode_stdin_bytes(&bytes)),
             payload_path: None,
             preview: None,
             original_size_bytes,
@@ -190,22 +190,47 @@ fn truncate_to_byte_boundary(input: &str, max_bytes: usize) -> &str {
     &input[..index]
 }
 
+fn decode_stdin_bytes(bytes: &[u8]) -> String {
+    match std::str::from_utf8(bytes) {
+        Ok(value) => value.to_owned(),
+        Err(_) => String::from_utf8_lossy(bytes).into_owned(),
+    }
+}
+
 fn infer_agent_name(payload: Option<&str>) -> String {
     let Some(payload) = payload else {
         return "claude".to_string();
     };
 
-    let lower = payload.to_ascii_lowercase();
-    if lower.contains("gpt-5-codex")
-        || lower.contains("\"originator\":\"codex")
-        || lower.contains("\"hook_event_name\":\"userpromptsubmit\"")
-    {
-        return "codex".to_string();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) {
+        for field in ["agent", "originator", "model"] {
+            if let Some(name) = value.get(field).and_then(|value| value.as_str())
+                && let Some(inferred) = classify_agent_name(name)
+            {
+                return inferred.to_string();
+            }
+        }
+    }
+
+    if let Some(inferred) = classify_agent_name(payload) {
+        return inferred.to_string();
+    }
+
+    "claude".to_string()
+}
+
+fn classify_agent_name(value: &str) -> Option<&'static str> {
+    let lower = value.to_ascii_lowercase();
+    if lower.contains("codex") {
+        return Some("codex");
     }
     if lower.contains("gemini") {
-        return "gemini".to_string();
+        return Some("gemini");
     }
-    "claude".to_string()
+    if lower.contains("claude") {
+        return Some("claude");
+    }
+    None
 }
 
 fn current_working_directory() -> String {

--- a/src/hook_install.rs
+++ b/src/hook_install.rs
@@ -101,13 +101,15 @@ pub fn install_claude_code(
         let event_array = ensure_hook_event_array(&mut root, event_name)?;
         let before_len = event_array.len();
         event_array.retain(|entry| !entry_contains_command(entry, command));
-        removed_commands += before_len.saturating_sub(event_array.len());
+        let removed = before_len.saturating_sub(event_array.len());
+        removed_commands += removed;
 
-        if !uninstall
+        let inserted = !uninstall
             && !event_array
                 .iter()
-                .any(|entry| entry_contains_command(entry, command))
-        {
+                .any(|entry| entry_contains_command(entry, command));
+
+        if inserted {
             event_array.push(json!({
                 "hooks": [{
                     "type": "command",
@@ -116,8 +118,7 @@ pub fn install_claude_code(
             }));
         }
 
-        changed |=
-            before_len != event_array.len() || (!uninstall && before_len == event_array.len());
+        changed |= removed > 0 || inserted;
     }
 
     let rendered =

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -6,8 +6,9 @@ use std::time::{Duration, Instant};
 
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
-use mempal::daemon_bootstrap::{BootstrapObserver, DaemonContext};
+use mempal::daemon_bootstrap::{BootstrapObserver, DaemonContext, Stage};
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use mockito::Server;
 use tempfile::TempDir;
 
 fn mempal_bin() -> String {
@@ -15,15 +16,12 @@ fn mempal_bin() -> String {
 }
 
 struct RecordingObserver {
-    stages: Mutex<Vec<String>>,
+    stages: Mutex<Vec<Stage>>,
 }
 
 impl BootstrapObserver for RecordingObserver {
-    fn record(&self, stage: &str) {
-        self.stages
-            .lock()
-            .expect("observer mutex")
-            .push(stage.to_string());
+    fn record(&self, stage: Stage) {
+        self.stages.lock().expect("observer mutex").push(stage);
     }
 }
 
@@ -70,7 +68,16 @@ fn test_daemon_context_bootstrap_ordering() {
     let stages = observer.stages.lock().expect("observer mutex").clone();
     let pid_path = context.mempal_home.join("daemon.pid");
 
-    assert_eq!(stages, vec!["daemonize", "runtime", "database", "tracing"]);
+    assert_eq!(
+        stages,
+        vec![
+            Stage::Daemonize,
+            Stage::Runtime,
+            Stage::ConfigHandleBootstrap,
+            Stage::Database,
+            Stage::Tracing,
+        ]
+    );
     assert!(
         pid_path.exists(),
         "pid file must exist during daemon lifetime"
@@ -83,6 +90,41 @@ fn test_daemon_context_bootstrap_ordering() {
 #[test]
 fn test_daemon_sigterm_graceful() {
     let (tmp, db_path, _config_path) = setup_daemon_home();
+    let mut server = Server::new();
+    let _mock = server
+        .mock("POST", "/embeddings")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#)
+        .create();
+    fs::write(
+        tmp.path().join(".mempal/config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 3
+request_timeout_secs = 5
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 100
+
+[daemon]
+log_path = "{}"
+"#,
+            db_path.display(),
+            server.url(),
+            tmp.path().join(".mempal/daemon.log").display()
+        ),
+    )
+    .expect("rewrite config");
     let store = PendingMessageStore::new(&db_path).expect("store");
     let envelope = CapturedHookEnvelope {
         event: HookEvent::SessionStart.display_name().to_string(),

--- a/tests/hook_agent_infer.rs
+++ b/tests/hook_agent_infer.rs
@@ -1,0 +1,70 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use mempal::core::db::Database;
+use rusqlite::Connection;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[hooks]
+enabled = true
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
+#[test]
+fn test_infer_agent_name_from_field_not_substring() {
+    let (home, db_path) = setup_home();
+    let payload =
+        r#"{"agent":"claude","notes":"mention gpt-5-codex here should not flip inference"}"#;
+
+    let mut child = Command::new(mempal_bin())
+        .args(["hook", "hook_user_prompt"])
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook command");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload.as_bytes())
+        .expect("write payload");
+    let output = child.wait_with_output().expect("wait output");
+    assert_eq!(output.status.code(), Some(0));
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let envelope: String = conn
+        .query_row(
+            "SELECT payload FROM pending_messages ORDER BY created_at DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query queue");
+    let envelope_json: Value = serde_json::from_str(&envelope).expect("envelope json");
+    assert_eq!(envelope_json["agent"], "claude");
+}

--- a/tests/hook_install.rs
+++ b/tests/hook_install.rs
@@ -1,9 +1,9 @@
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
-use std::sync::{Mutex, OnceLock};
+use std::process::Command;
 
-use mempal::hook_install::{HookInstallTarget, install, install_claude_code};
+use mempal::hook_install::install_claude_code;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -11,12 +11,8 @@ fn parse_json(path: &std::path::Path) -> Value {
     serde_json::from_str(&fs::read_to_string(path).expect("read json")).expect("parse json")
 }
 
-fn env_guard() -> std::sync::MutexGuard<'static, ()> {
-    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    GUARD
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .expect("env mutex")
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
 }
 
 #[test]
@@ -185,24 +181,23 @@ fn test_hook_install_refuses_agent_instruction_targets() {
 
 #[test]
 fn test_hook_install_public_wrapper_uses_home_env() {
-    let _guard = env_guard();
     let tmp = TempDir::new().expect("tempdir");
     let cwd = tmp.path().join("repo");
     let home = tmp.path().join("home");
     fs::create_dir_all(&cwd).expect("create cwd");
     fs::create_dir_all(&home).expect("create home");
 
-    let original_cwd = std::env::current_dir().expect("current dir");
-    let original_home = std::env::var_os("HOME");
-    std::env::set_current_dir(&cwd).expect("set current dir");
-    // SAFETY: the mutex above serializes process-global env mutation for this test.
-    unsafe { std::env::set_var("HOME", &home) };
-    install(HookInstallTarget::ClaudeCode, false, false).expect("wrapper install");
-    std::env::set_current_dir(original_cwd).expect("restore current dir");
-    if let Some(home) = original_home {
-        // SAFETY: guarded by the mutex above.
-        unsafe { std::env::set_var("HOME", home) };
-    }
+    let output = Command::new(mempal_bin())
+        .args(["hook", "install", "--target", "claude-code"])
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .output()
+        .expect("wrapper install");
+    assert!(
+        output.status.success(),
+        "install command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let parsed = parse_json(&home.join(".claude/settings.json"));
     assert_eq!(

--- a/tests/hook_stdin_utf8.rs
+++ b/tests/hook_stdin_utf8.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use mempal::core::db::Database;
+use rusqlite::Connection;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[hooks]
+enabled = true
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
+fn run_hook(home: &TempDir, bytes: &[u8]) -> std::process::Output {
+    let mut child = Command::new(mempal_bin())
+        .args(["hook", "hook_user_prompt"])
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook command");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(bytes)
+        .expect("write payload");
+    child.wait_with_output().expect("wait output")
+}
+
+fn last_envelope_payload(db_path: &PathBuf) -> String {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let envelope: String = conn
+        .query_row(
+            "SELECT payload FROM pending_messages ORDER BY created_at DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query queue");
+    let envelope_json: Value = serde_json::from_str(&envelope).expect("envelope json");
+    envelope_json["payload"]
+        .as_str()
+        .expect("payload string")
+        .to_string()
+}
+
+#[test]
+fn test_hook_reads_valid_utf8_without_replacement() {
+    let (home, db_path) = setup_home();
+    let payload = "继续处理 UTF-8 payload";
+
+    let output = run_hook(&home, payload.as_bytes());
+    assert_eq!(output.status.code(), Some(0));
+
+    let stored = last_envelope_payload(&db_path);
+    assert_eq!(stored, payload);
+    assert!(
+        !stored.contains('\u{fffd}'),
+        "valid UTF-8 must not be lossy-decoded: {stored}"
+    );
+}
+
+#[test]
+fn test_hook_reads_invalid_utf8_with_replacement_char() {
+    let (home, db_path) = setup_home();
+    let payload = b"prefix\xffsuffix";
+
+    let output = run_hook(&home, payload);
+    assert_eq!(output.status.code(), Some(0));
+
+    let stored = last_envelope_payload(&db_path);
+    assert_eq!(stored, "prefix\u{fffd}suffix");
+}


### PR DESCRIPTION
## Summary
This closes the remaining Phase 0c follow-up nits from #24 and #26.

## Issue #24 residuals
- N2: snapshot embed retry config once at retry-loop entry so a single retry sequence no longer re-reads hot-reload config every iteration
- N3: replace lossy `as_millis() as u64` in `src/embed/status.rs` with saturating `u64::try_from(...).unwrap_or(u64::MAX)`
- N4: warn when `embed.alert.script_path` is configured with a non-absolute path, without failing validation
- N5: audit `EmbedError::ReadApiKeyEnv` formatting sites and keep Display-only exposure paths (no Debug leak path remains)

## Issue #26 residuals
- N1: make daemon `claim_next` resilient to transient queue errors by warning, sleeping 1s, and continuing instead of exiting the loop
- N2: add UTF-8 fast-path decoding for `mempal hook` stdin while preserving lossy fallback for invalid bytes
- N3: parse hook payload JSON once for `infer_agent_name` and inspect explicit fields instead of substring-matching raw payload text
- N4: add `Stage::ConfigHandleBootstrap` and emit it between daemonize/fd redirect and database open during bootstrap
- N5: switch `test_hook_install_public_wrapper_uses_home_env` to `CARGO_BIN_EXE_mempal` command execution with no process-global env mutation
- N6: simplify hook install `changed` logic without changing behavior

## Tests
- `just pre-commit`
- Added/updated regression coverage for daemon claim retry handling, hook UTF-8 stdin handling, hook agent inference, daemon bootstrap ordering, daemon SIGTERM lifecycle, and hook install wrapper behavior

Closes #24
Closes #26
