### PR TITLE
feat(p9): judge-gating + novelty filter (ext_v3 -> ext_v4)

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -565,6 +565,7 @@ pub struct IngestGatingConfig {
     pub enabled: bool,
     pub rules: Vec<GatingRuleConfig>,
     pub embedding_classifier: EmbeddingClassifierConfig,
+    pub novelty: NoveltyConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
@@ -592,6 +593,32 @@ impl Default for EmbeddingClassifierConfig {
             enabled: false,
             threshold: 0.35,
             prototypes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct NoveltyConfig {
+    pub enabled: bool,
+    pub duplicate_threshold: f32,
+    pub merge_threshold: f32,
+    pub wing_scope: String,
+    pub top_k_candidates: usize,
+    pub max_merges_per_drawer: u32,
+    pub max_content_bytes_per_drawer: usize,
+}
+
+impl Default for NoveltyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            duplicate_threshold: 0.95,
+            merge_threshold: 0.80,
+            wing_scope: "same_wing".to_string(),
+            top_k_candidates: 5,
+            max_merges_per_drawer: 10,
+            max_content_bytes_per_drawer: 65_536,
         }
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -22,7 +22,7 @@ const DEFAULT_HOOK_POLL_INTERVAL_MS: u64 = 500;
 const DEFAULT_HOOK_CLAIM_TTL_SECS: u64 = 120;
 const DEFAULT_DAEMON_LOG_PATH: &str = "~/.mempal/daemon.log";
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub db_path: String,
@@ -559,16 +559,41 @@ pub struct SearchConfig {
     pub strict_project_isolation: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
 #[serde(default)]
 pub struct IngestGatingConfig {
+    pub enabled: bool,
+    pub rules: Vec<GatingRuleConfig>,
     pub embedding_classifier: EmbeddingClassifierConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(default)]
+pub struct GatingRuleConfig {
+    pub action: String,
+    pub tool: Option<String>,
+    pub tool_in: Option<Vec<String>>,
+    pub content_bytes_lt: Option<usize>,
+    pub content_bytes_gt: Option<usize>,
+    pub exit_code_eq: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
 pub struct EmbeddingClassifierConfig {
+    pub enabled: bool,
+    pub threshold: f32,
     pub prototypes: Vec<String>,
+}
+
+impl Default for EmbeddingClassifierConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            threshold: 0.35,
+            prototypes: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 
 use super::types::{Drawer, SourceType, TaxonomyEntry, Triple, TripleStats};
 use crate::ingest::gating::GatingDecision;
+use crate::ingest::novelty::NoveltyAction;
 
 const CURRENT_SCHEMA_VERSION: u32 = 4;
 
@@ -189,6 +190,82 @@ impl Database {
         Ok(())
     }
 
+    pub fn drawer_merge_state(&self, drawer_id: &str) -> Result<Option<(String, u32)>, DbError> {
+        let mut statement = self.conn.prepare(
+            "SELECT content, COALESCE(merge_count, 0) FROM drawers WHERE id = ?1 AND deleted_at IS NULL",
+        )?;
+        let mut rows = statement.query_map([drawer_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+        })?;
+        match rows.next() {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn update_drawer_after_merge(
+        &mut self,
+        drawer_id: &str,
+        merged_content: &str,
+        updated_at: &str,
+        vector: &[f32],
+    ) -> Result<(), DbError> {
+        self.ensure_vectors_table(vector.len())?;
+        let vector_json = serde_json::to_string(vector)?;
+        let transaction = self.conn.transaction()?;
+        transaction.execute(
+            r#"
+            UPDATE drawers
+            SET content = ?2,
+                updated_at = ?3,
+                merge_count = COALESCE(merge_count, 0) + 1
+            WHERE id = ?1
+            "#,
+            params![drawer_id, merged_content, updated_at],
+        )?;
+        transaction.execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
+        transaction.execute(
+            "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, vec_f32(?2))",
+            params![drawer_id, vector_json],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub fn record_novelty_audit(
+        &self,
+        candidate_hash: &str,
+        action: NoveltyAction,
+        near_drawer_id: Option<&str>,
+        cosine: Option<f32>,
+        audit_decision: Option<&str>,
+    ) -> Result<(), DbError> {
+        let created_at = super::utils::current_timestamp()
+            .parse::<i64>()
+            .unwrap_or_default();
+        let unique_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let decision = audit_decision
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| action.as_str().to_string());
+        let id_seed = format!(
+            "{candidate_hash}:{created_at}:{unique_nanos}:{decision}:{}:{}",
+            near_drawer_id.unwrap_or_default(),
+            cosine.unwrap_or_default()
+        );
+        let id = format!("novelty_{}", blake3::hash(id_seed.as_bytes()).to_hex());
+        self.conn.execute(
+            r#"
+            INSERT INTO novelty_audit (id, candidate_hash, decision, near_drawer_id, cosine, created_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            "#,
+            params![id, candidate_hash, decision, near_drawer_id, cosine, created_at],
+        )?;
+        Ok(())
+    }
+
     pub fn taxonomy_entries(&self) -> Result<Vec<TaxonomyEntry>, DbError> {
         let mut statement = self.conn.prepare(
             "SELECT wing, room, display_name, keywords FROM taxonomy ORDER BY wing, room",
@@ -312,6 +389,53 @@ impl Database {
             (drawer_id, vector_json.as_str()),
         )?;
         Ok(())
+    }
+
+    pub fn novelty_candidates(
+        &self,
+        query_vector: &[f32],
+        wing: Option<&str>,
+        room: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>, DbError> {
+        let vectors_exist: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+            [],
+            |row| row.get(0),
+        )?;
+        if !vectors_exist || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let query_json = serde_json::to_string(query_vector)?;
+        let limit =
+            i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let mut statement = self.conn.prepare(
+            r#"
+            WITH matches AS (
+                SELECT id
+                FROM drawer_vectors
+                WHERE embedding MATCH vec_f32(?1)
+                  AND k = ?2
+            )
+            SELECT d.id,
+                   CAST(1.0 - vec_distance_cosine(v.embedding, vec_f32(?1)) AS REAL) AS similarity
+            FROM matches
+            JOIN drawer_vectors v ON v.id = matches.id
+            JOIN drawers d ON d.id = matches.id
+            WHERE d.deleted_at IS NULL
+              AND (?3 IS NULL OR d.wing = ?3)
+              AND (?4 IS NULL OR d.room = ?4)
+            ORDER BY similarity DESC
+            LIMIT ?2
+            "#,
+        )?;
+        let rows = statement
+            .query_map((query_json.as_str(), limit, wing, room), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, f32>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Ensure drawer_vectors table exists with the right dimension.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -2,12 +2,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, params};
 use serde_json::Value;
 use thiserror::Error;
 
 use super::types::{Drawer, SourceType, TaxonomyEntry, Triple, TripleStats};
+use crate::ingest::gating::GatingDecision;
 
 const CURRENT_SCHEMA_VERSION: u32 = 4;
 
@@ -150,6 +152,40 @@ impl Database {
             ],
         )?;
 
+        Ok(())
+    }
+
+    pub fn record_gating_audit(
+        &self,
+        candidate_hash: &str,
+        decision: &GatingDecision,
+    ) -> Result<(), DbError> {
+        let explain_json = serde_json::to_string(decision)?;
+        let created_at = super::utils::current_timestamp()
+            .parse::<i64>()
+            .unwrap_or_default();
+        let unique_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let id_seed = format!(
+            "{candidate_hash}:{created_at}:{unique_nanos}:{}",
+            explain_json
+        );
+        let id = format!("gating_{}", blake3::hash(id_seed.as_bytes()).to_hex());
+        self.conn.execute(
+            r#"
+            INSERT INTO gating_audit (id, candidate_hash, decision, explain_json, created_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![
+                id,
+                candidate_hash,
+                decision.decision,
+                explain_json,
+                created_at,
+            ],
+        )?;
         Ok(())
     }
 

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -43,6 +43,21 @@ CREATE TABLE IF NOT EXISTS reindex_progress (
 );
 "#;
 
+pub const FORK_EXT_V3_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS gating_audit (
+    id TEXT PRIMARY KEY,
+    candidate_hash TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    explain_json TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_gating_audit_created_at
+    ON gating_audit(created_at);
+CREATE INDEX IF NOT EXISTS idx_gating_audit_candidate_hash
+    ON gating_audit(candidate_hash);
+"#;
+
 struct Migration {
     version: u32,
     up: fn(&Connection) -> rusqlite::Result<()>,
@@ -100,6 +115,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 2,
             up: apply_v2,
         },
+        Migration {
+            version: 3,
+            up: apply_v3,
+        },
     ]
 }
 
@@ -109,6 +128,10 @@ fn apply_v1(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v2(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V2_SCHEMA_SQL)
+}
+
+fn apply_v3(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V3_SCHEMA_SQL)
 }
 
 pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -58,6 +58,37 @@ CREATE INDEX IF NOT EXISTS idx_gating_audit_candidate_hash
     ON gating_audit(candidate_hash);
 "#;
 
+pub const FORK_EXT_V4_SCHEMA_SQL: &str = r#"
+ALTER TABLE drawers ADD COLUMN merge_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE drawers ADD COLUMN updated_at TEXT;
+
+CREATE TABLE IF NOT EXISTS novelty_audit (
+    id TEXT PRIMARY KEY,
+    candidate_hash TEXT NOT NULL,
+    decision TEXT NOT NULL,
+    near_drawer_id TEXT,
+    cosine REAL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_novelty_audit_created_at
+    ON novelty_audit(created_at);
+CREATE INDEX IF NOT EXISTS idx_novelty_audit_candidate_hash
+    ON novelty_audit(candidate_hash);
+
+-- TODO(spec ambiguity): earlier spec drafts referred to this trigger as
+-- `drawers_au_fts`, while the task prompt provided the concrete
+-- `drawers_fts_after_update` name. Standardize on the prompt name here and
+-- drop the older draft name if it exists.
+DROP TRIGGER IF EXISTS drawers_au_fts;
+DROP TRIGGER IF EXISTS drawers_fts_after_update;
+CREATE TRIGGER drawers_fts_after_update
+AFTER UPDATE OF content ON drawers BEGIN
+    INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+    INSERT INTO drawers_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+"#;
+
 struct Migration {
     version: u32,
     up: fn(&Connection) -> rusqlite::Result<()>,
@@ -119,6 +150,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 3,
             up: apply_v3,
         },
+        Migration {
+            version: 4,
+            up: apply_v4,
+        },
     ]
 }
 
@@ -132,6 +167,10 @@ fn apply_v2(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v3(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V3_SCHEMA_SQL)
+}
+
+fn apply_v4(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V4_SCHEMA_SQL)
 }
 
 pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -16,6 +16,10 @@ use crate::embed::{
     EmbedError, Embedder, build_backend_from_name, global_embed_status,
     retry::{HeartbeatCallback, retry_embed_operation},
 };
+use crate::ingest::gating::{
+    GatingDecision, IngestCandidate, PrototypeClassifier, compile_classifier_from_embedder,
+    evaluate_tier1, tier2_enabled,
+};
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
@@ -38,6 +42,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     let embedder = DaemonEmbedder::from_config(context.config.as_ref())
         .await
         .context("failed to build daemon embedder")?;
+    let prototype_classifier =
+        compile_classifier_from_embedder(&embedder, &context.config.ingest_gating)
+            .await
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .context("gating prototype init failed")?;
     let worker_id = format!("mempal-daemon-{}", std::process::id());
     let claim_ttl_secs = context.config.hooks.daemon_claim_ttl_secs as i64;
     let poll_interval = Duration::from_millis(context.config.hooks.daemon_poll_interval_ms);
@@ -66,8 +75,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                     &worker_id,
                     &message,
                     &embedder,
-                    context.config.as_ref(),
-                    &context.mempal_home,
+                    DaemonIngestContext {
+                        prototype_classifier: prototype_classifier.as_ref(),
+                        config: context.config.as_ref(),
+                        mempal_home: &context.mempal_home,
+                    },
                 )
                 .await;
 
@@ -123,6 +135,12 @@ enum ClaimPollResult {
 
 type SleepFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
+pub struct DaemonIngestContext<'a> {
+    pub prototype_classifier: Option<&'a PrototypeClassifier>,
+    pub config: &'a crate::core::config::Config,
+    pub mempal_home: &'a Path,
+}
+
 async fn poll_claim_next<'a, S>(
     store: &impl ClaimNextSource,
     worker_id: &str,
@@ -149,13 +167,30 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
     worker_id: &str,
     message: &ClaimedMessage,
     embedder: &E,
-    config: &crate::core::config::Config,
-    mempal_home: &Path,
+    context: DaemonIngestContext<'_>,
 ) -> Result<String> {
     let envelope: CapturedHookEnvelope =
         serde_json::from_str(&message.payload).context("failed to decode queued hook envelope")?;
 
-    let record = build_drawer_record(&envelope, config, mempal_home)?;
+    let record = build_drawer_record(&envelope, context.config, context.mempal_home)?;
+    let drawer_id = build_drawer_id(&record.wing, Some(record.room.as_str()), &record.content);
+    let candidate = build_gating_candidate(&envelope, &record);
+    let mut gating_decision = evaluate_tier1(&candidate, &context.config.ingest_gating);
+    if gating_decision.is_none() && !tier2_enabled(&context.config.ingest_gating) {
+        gating_decision = Some(GatingDecision::accepted(
+            0,
+            Some("tier2_disabled".to_string()),
+            None,
+        ));
+    }
+    if let Some(decision) = gating_decision.as_ref()
+        && decision.is_rejected()
+    {
+        db.record_gating_audit(&drawer_id, decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        return Ok(drawer_id);
+    }
+
     let heartbeat_store = store.clone();
     let heartbeat_message_id = message.id.clone();
     let heartbeat_worker_id = worker_id.to_string();
@@ -166,8 +201,30 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
         Ok(())
     };
 
-    let vector = embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?;
-    let drawer_id = build_drawer_id(&record.wing, Some(record.room.as_str()), &record.content);
+    let mut vector = None;
+    let mut gating_audit_recorded = false;
+    if let Some(classifier) = context.prototype_classifier {
+        let candidate_vector =
+            embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?;
+        let decision = classifier.decide(&candidate_vector);
+        db.record_gating_audit(&drawer_id, &decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        gating_audit_recorded = true;
+        if decision.is_rejected() {
+            return Ok(drawer_id);
+        }
+        gating_decision = Some(decision);
+        vector = Some(candidate_vector);
+    }
+    if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
+        db.record_gating_audit(&drawer_id, decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+    }
+
+    let vector = match vector {
+        Some(vector) => vector,
+        None => embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?,
+    };
     let drawer = Drawer {
         id: drawer_id.clone(),
         content: record.content,
@@ -183,8 +240,35 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
         .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
     db.insert_vector(&drawer.id, &vector)
         .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
-
     Ok(drawer_id)
+}
+
+fn build_gating_candidate(
+    envelope: &CapturedHookEnvelope,
+    record: &DrawerRecord,
+) -> IngestCandidate {
+    let mut tool_name = None;
+    let mut exit_code = None;
+
+    if envelope.event == crate::hook::HookEvent::PostToolUse.display_name()
+        && let Some(payload) = envelope.payload.as_deref()
+        && let Ok(value) = serde_json::from_str::<Value>(payload)
+    {
+        tool_name = value
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        exit_code = value
+            .get("exit_code")
+            .and_then(Value::as_i64)
+            .and_then(|value| i32::try_from(value).ok());
+    }
+
+    IngestCandidate {
+        content: record.content.clone(),
+        tool_name,
+        exit_code,
+    }
 }
 
 async fn embed_text_with_heartbeat<E: Embedder + ?Sized>(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -204,10 +204,15 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
 
     let mut vector = None;
     let mut gating_audit_recorded = false;
-    if let Some(classifier) = context.prototype_classifier {
+    if gating_decision.is_none()
+        && let Some(classifier) = context.prototype_classifier
+    {
         let candidate_vector =
             embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?;
-        let decision = classifier.decide(&candidate_vector);
+        let decision = classifier.decide(
+            &candidate_vector,
+            context.config.ingest_gating.embedding_classifier.threshold,
+        );
         db.record_gating_audit(&drawer_id, &decision)
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         gating_audit_recorded = true;
@@ -282,6 +287,18 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
                 .near_drawer_id
                 .clone()
                 .unwrap_or_else(|| drawer_id.clone());
+            let _target_lock = if target_id == drawer_id {
+                None
+            } else {
+                Some(
+                    crate::ingest::lock::acquire_source_lock(
+                        context.mempal_home,
+                        &target_id,
+                        Duration::from_secs(5),
+                    )
+                    .with_context(|| format!("failed to lock merge target {}", target_id))?,
+                )
+            };
             let (existing_content, merge_count) = db
                 .drawer_merge_state(&target_id)
                 .with_context(|| format!("failed to load merge target {}", target_id))?

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,6 +20,7 @@ use crate::ingest::gating::{
     GatingDecision, IngestCandidate, PrototypeClassifier, compile_classifier_from_embedder,
     evaluate_tier1, tier2_enabled,
 };
+use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
@@ -225,22 +226,128 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
         Some(vector) => vector,
         None => embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?,
     };
-    let drawer = Drawer {
-        id: drawer_id.clone(),
-        content: record.content,
-        wing: record.wing,
-        room: Some(record.room),
-        source_file: Some(record.source_file),
-        source_type: SourceType::Manual,
-        added_at: current_timestamp(),
-        chunk_index: Some(0),
-        importance: 0,
-    };
-    db.insert_drawer(&drawer)
-        .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
-    db.insert_vector(&drawer.id, &vector)
-        .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
-    Ok(drawer_id)
+    let novelty = evaluate_novelty(
+        db,
+        &NoveltyCandidate {
+            wing: record.wing.clone(),
+            room: Some(record.room.clone()),
+        },
+        &vector,
+        &context.config.ingest_gating.novelty,
+    );
+    match novelty.action {
+        NoveltyAction::Insert => {
+            if novelty.should_audit {
+                db.record_novelty_audit(
+                    &drawer_id,
+                    NoveltyAction::Insert,
+                    novelty.near_drawer_id.as_deref(),
+                    novelty.cosine,
+                    novelty.audit_decision,
+                )
+                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+            }
+            let drawer = Drawer {
+                id: drawer_id.clone(),
+                content: record.content,
+                wing: record.wing,
+                room: Some(record.room),
+                source_file: Some(record.source_file),
+                source_type: SourceType::Manual,
+                added_at: current_timestamp(),
+                chunk_index: Some(0),
+                importance: 0,
+            };
+            db.insert_drawer(&drawer)
+                .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
+            db.insert_vector(&drawer.id, &vector)
+                .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
+            Ok(drawer_id)
+        }
+        NoveltyAction::Drop => {
+            if novelty.should_audit {
+                db.record_novelty_audit(
+                    &drawer_id,
+                    NoveltyAction::Drop,
+                    novelty.near_drawer_id.as_deref(),
+                    novelty.cosine,
+                    novelty.audit_decision,
+                )
+                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+            }
+            Ok(novelty.near_drawer_id.unwrap_or(drawer_id))
+        }
+        NoveltyAction::Merge => {
+            let target_id = novelty
+                .near_drawer_id
+                .clone()
+                .unwrap_or_else(|| drawer_id.clone());
+            let (existing_content, merge_count) = db
+                .drawer_merge_state(&target_id)
+                .with_context(|| format!("failed to load merge target {}", target_id))?
+                .ok_or_else(|| anyhow::anyhow!("novelty merge target missing: {}", target_id))?;
+            let merged_at = current_timestamp();
+            let merged_content = format!(
+                "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{}",
+                record.content
+            );
+            let capped = merge_count >= context.config.ingest_gating.novelty.max_merges_per_drawer
+                || merged_content.len()
+                    > context
+                        .config
+                        .ingest_gating
+                        .novelty
+                        .max_content_bytes_per_drawer;
+            if capped {
+                db.record_novelty_audit(
+                    &drawer_id,
+                    NoveltyAction::Insert,
+                    Some(target_id.as_str()),
+                    novelty.cosine,
+                    Some("insert_due_to_merge_cap"),
+                )
+                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                let drawer = Drawer {
+                    id: drawer_id.clone(),
+                    content: record.content,
+                    wing: record.wing,
+                    room: Some(record.room),
+                    source_file: Some(record.source_file),
+                    source_type: SourceType::Manual,
+                    added_at: current_timestamp(),
+                    chunk_index: Some(0),
+                    importance: 0,
+                };
+                db.insert_drawer(&drawer)
+                    .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
+                db.insert_vector(&drawer.id, &vector)
+                    .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
+                Ok(drawer_id)
+            } else {
+                let merged_vector =
+                    embed_text_with_heartbeat(embedder, &merged_content, Some(&heartbeat)).await?;
+                db.record_novelty_audit(
+                    &drawer_id,
+                    NoveltyAction::Merge,
+                    Some(target_id.as_str()),
+                    novelty.cosine,
+                    novelty.audit_decision,
+                )
+                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                let mut db_for_merge = Database::open(db.path())
+                    .with_context(|| format!("failed to reopen db for merge {}", target_id))?;
+                db_for_merge
+                    .update_drawer_after_merge(
+                        &target_id,
+                        &merged_content,
+                        &merged_at,
+                        &merged_vector,
+                    )
+                    .with_context(|| format!("failed to merge hook drawer {}", target_id))?;
+                Ok(target_id)
+            }
+        }
+    }
 }
 
 fn build_gating_candidate(

--- a/src/ingest/gating.rs
+++ b/src/ingest/gating.rs
@@ -1,0 +1,366 @@
+use std::sync::Arc;
+
+use crate::core::config::{
+    Config, EmbeddingClassifierConfig, GatingRuleConfig, IngestGatingConfig,
+};
+use crate::embed::{EmbedError, Embedder, EmbedderFactory};
+use rmcp::schemars::{self, JsonSchema};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::OnceCell;
+
+#[derive(Debug, Clone)]
+pub struct IngestCandidate {
+    pub content: String,
+    pub tool_name: Option<String>,
+    pub exit_code: Option<i32>,
+}
+
+impl IngestCandidate {
+    pub fn content_bytes(&self) -> usize {
+        self.content.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct GatingDecision {
+    pub decision: String,
+    pub tier: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_pattern: Option<String>,
+}
+
+impl GatingDecision {
+    pub fn accepted(tier: u8, label: impl Into<Option<String>>, score: Option<f32>) -> Self {
+        Self {
+            decision: "accepted".to_string(),
+            tier,
+            label: label.into(),
+            score,
+            matched_pattern: None,
+        }
+    }
+
+    pub fn rejected(tier: u8, matched_pattern: Option<String>, score: Option<f32>) -> Self {
+        Self {
+            decision: "rejected".to_string(),
+            tier,
+            label: None,
+            score,
+            matched_pattern,
+        }
+    }
+
+    pub fn is_rejected(&self) -> bool {
+        self.decision == "rejected"
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Tier2Outcome {
+    pub decision: GatingDecision,
+    pub vector: Option<Vec<f32>>,
+}
+
+#[derive(Debug, Clone)]
+struct EmbeddedPrototype {
+    label: String,
+    vector: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrototypeClassifier {
+    threshold: f32,
+    prototypes: Vec<EmbeddedPrototype>,
+}
+
+impl PrototypeClassifier {
+    pub fn decide(&self, vector: &[f32]) -> GatingDecision {
+        let (label, score) = self.classify(vector);
+        if score >= self.threshold {
+            GatingDecision::accepted(2, label.map(ToOwned::to_owned), Some(score))
+        } else {
+            GatingDecision::rejected(2, None, Some(score))
+        }
+    }
+
+    fn classify(&self, vector: &[f32]) -> (Option<&str>, f32) {
+        let mut best_label = None;
+        let mut best_score = f32::NEG_INFINITY;
+        for prototype in &self.prototypes {
+            let score = cosine_similarity(vector, &prototype.vector);
+            if score > best_score {
+                best_score = score;
+                best_label = Some(prototype.label.as_str());
+            }
+        }
+        if best_score.is_finite() {
+            (best_label, best_score)
+        } else {
+            (best_label, 0.0)
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum GatingInitError {
+    #[error("failed to build gating embedder")]
+    BuildEmbedder(#[source] EmbedError),
+    #[error("gating prototype init failed: label='{label}', reason='{source}'")]
+    PrototypeEmbed {
+        label: String,
+        #[source]
+        source: EmbedError,
+    },
+    #[error(
+        "gating prototype init failed: label='{label}', dimension mismatch expected {expected} got {actual}"
+    )]
+    PrototypeDimMismatch {
+        label: String,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+pub struct GatingRuntime {
+    config: Config,
+    factory: Arc<dyn EmbedderFactory>,
+    classifier: OnceCell<Option<PrototypeClassifier>>,
+}
+
+impl GatingRuntime {
+    pub fn new(config: Config, factory: Arc<dyn EmbedderFactory>) -> Self {
+        Self {
+            config,
+            factory,
+            classifier: OnceCell::new(),
+        }
+    }
+
+    pub async fn initialize(&self) -> Result<(), GatingInitError> {
+        let _ = self.classifier().await?;
+        Ok(())
+    }
+
+    pub async fn classifier(&self) -> Result<Option<PrototypeClassifier>, GatingInitError> {
+        let classifier = self
+            .classifier
+            .get_or_try_init(|| async {
+                let embedder = self
+                    .factory
+                    .build()
+                    .await
+                    .map_err(GatingInitError::BuildEmbedder)?;
+                compile_classifier(
+                    &self.config.ingest_gating.embedding_classifier,
+                    embedder.as_ref(),
+                )
+                .await
+            })
+            .await?;
+        Ok(classifier.clone())
+    }
+}
+
+pub fn evaluate_tier1(
+    candidate: &IngestCandidate,
+    gating: &IngestGatingConfig,
+) -> Option<GatingDecision> {
+    if !gating.enabled {
+        return Some(GatingDecision::accepted(
+            0,
+            Some("gating_disabled".to_string()),
+            None,
+        ));
+    }
+
+    for rule in &gating.rules {
+        let matched_pattern = match_rule(candidate, rule)?;
+        match normalize_rule_action(rule.action.as_str()) {
+            RuleAction::Reject => {
+                return Some(GatingDecision::rejected(
+                    1,
+                    Some(matched_pattern.to_string()),
+                    None,
+                ));
+            }
+            RuleAction::Accept => {
+                let mut decision =
+                    GatingDecision::accepted(1, Some("rule_accept".to_string()), None);
+                decision.matched_pattern = Some(matched_pattern.to_string());
+                return Some(decision);
+            }
+            RuleAction::Continue => continue,
+        }
+    }
+
+    None
+}
+
+pub fn tier2_enabled(gating: &IngestGatingConfig) -> bool {
+    gating.enabled
+        && gating.embedding_classifier.enabled
+        && !gating.embedding_classifier.prototypes.is_empty()
+}
+
+pub async fn compile_classifier_from_embedder<E: Embedder + ?Sized>(
+    embedder: &E,
+    gating: &IngestGatingConfig,
+) -> Result<Option<PrototypeClassifier>, GatingInitError> {
+    compile_classifier(&gating.embedding_classifier, embedder).await
+}
+
+pub async fn evaluate_tier2<E: Embedder + ?Sized>(
+    candidate: &IngestCandidate,
+    classifier: &PrototypeClassifier,
+    embedder: &E,
+) -> Tier2Outcome {
+    match embedder.embed(&[candidate.content.as_str()]).await {
+        Ok(vectors) => {
+            let vector = vectors.into_iter().next();
+            match vector {
+                Some(vector) => {
+                    let decision = classifier.decide(&vector);
+                    Tier2Outcome {
+                        decision,
+                        vector: Some(vector),
+                    }
+                }
+                None => Tier2Outcome {
+                    decision: GatingDecision::accepted(0, Some("embedder_error".to_string()), None),
+                    vector: None,
+                },
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                "gating tier-2 candidate embed failed; fail-open keep"
+            );
+            Tier2Outcome {
+                decision: GatingDecision::accepted(0, Some("embedder_error".to_string()), None),
+                vector: None,
+            }
+        }
+    }
+}
+
+async fn compile_classifier<E: Embedder + ?Sized>(
+    config: &EmbeddingClassifierConfig,
+    embedder: &E,
+) -> Result<Option<PrototypeClassifier>, GatingInitError> {
+    if !config.enabled || config.prototypes.is_empty() {
+        return Ok(None);
+    }
+
+    let mut prototypes = Vec::with_capacity(config.prototypes.len());
+    for label in &config.prototypes {
+        let vectors = embedder.embed(&[label.as_str()]).await.map_err(|source| {
+            GatingInitError::PrototypeEmbed {
+                label: label.clone(),
+                source,
+            }
+        })?;
+        if let Some(vector) = vectors.into_iter().next() {
+            let actual = vector.len();
+            let expected = embedder.dimensions();
+            if actual != expected {
+                return Err(GatingInitError::PrototypeDimMismatch {
+                    label: label.clone(),
+                    expected,
+                    actual,
+                });
+            }
+            prototypes.push(EmbeddedPrototype {
+                label: label.clone(),
+                vector,
+            });
+        }
+    }
+
+    Ok(Some(PrototypeClassifier {
+        threshold: config.threshold,
+        prototypes,
+    }))
+}
+
+fn match_rule<'a>(candidate: &IngestCandidate, rule: &'a GatingRuleConfig) -> Option<&'a str> {
+    let mut matched = None;
+
+    if let Some(tool) = &rule.tool {
+        if candidate.tool_name.as_deref() != Some(tool.as_str()) {
+            return None;
+        }
+        matched = Some("tool");
+    }
+
+    if let Some(tool_in) = &rule.tool_in {
+        let tool_name = candidate.tool_name.as_deref()?;
+        if !tool_in.iter().any(|item| item == tool_name) {
+            return None;
+        }
+        matched = Some("tool_in");
+    }
+
+    if let Some(content_bytes_lt) = rule.content_bytes_lt {
+        if candidate.content_bytes() >= content_bytes_lt {
+            return None;
+        }
+        matched = Some("content_bytes_lt");
+    }
+
+    if let Some(content_bytes_gt) = rule.content_bytes_gt {
+        if candidate.content_bytes() <= content_bytes_gt {
+            return None;
+        }
+        matched = Some("content_bytes_gt");
+    }
+
+    if let Some(exit_code_eq) = rule.exit_code_eq {
+        if candidate.exit_code != Some(exit_code_eq) {
+            return None;
+        }
+        matched = Some("exit_code_eq");
+    }
+
+    matched
+}
+
+fn cosine_similarity(left: &[f32], right: &[f32]) -> f32 {
+    if left.len() != right.len() || left.is_empty() {
+        return 0.0;
+    }
+
+    let mut dot = 0.0_f32;
+    let mut left_norm = 0.0_f32;
+    let mut right_norm = 0.0_f32;
+    for (lhs, rhs) in left.iter().zip(right.iter()) {
+        dot += lhs * rhs;
+        left_norm += lhs * lhs;
+        right_norm += rhs * rhs;
+    }
+
+    if left_norm == 0.0 || right_norm == 0.0 {
+        return 0.0;
+    }
+
+    dot / (left_norm.sqrt() * right_norm.sqrt())
+}
+
+enum RuleAction {
+    Reject,
+    Accept,
+    Continue,
+}
+
+fn normalize_rule_action(action: &str) -> RuleAction {
+    match action {
+        "reject" | "skip" => RuleAction::Reject,
+        "accept" | "keep" => RuleAction::Accept,
+        _ => RuleAction::Continue,
+    }
+}

--- a/src/ingest/gating.rs
+++ b/src/ingest/gating.rs
@@ -74,14 +74,13 @@ struct EmbeddedPrototype {
 
 #[derive(Debug, Clone)]
 pub struct PrototypeClassifier {
-    threshold: f32,
     prototypes: Vec<EmbeddedPrototype>,
 }
 
 impl PrototypeClassifier {
-    pub fn decide(&self, vector: &[f32]) -> GatingDecision {
+    pub fn decide(&self, vector: &[f32], threshold: f32) -> GatingDecision {
         let (label, score) = self.classify(vector);
-        if score >= self.threshold {
+        if score >= threshold {
             GatingDecision::accepted(2, label.map(ToOwned::to_owned), Some(score))
         } else {
             GatingDecision::rejected(2, None, Some(score))
@@ -218,13 +217,14 @@ pub async fn evaluate_tier2<E: Embedder + ?Sized>(
     candidate: &IngestCandidate,
     classifier: &PrototypeClassifier,
     embedder: &E,
+    threshold: f32,
 ) -> Tier2Outcome {
     match embedder.embed(&[candidate.content.as_str()]).await {
         Ok(vectors) => {
             let vector = vectors.into_iter().next();
             match vector {
                 Some(vector) => {
-                    let decision = classifier.decide(&vector);
+                    let decision = classifier.decide(&vector, threshold);
                     Tier2Outcome {
                         decision,
                         vector: Some(vector),
@@ -282,10 +282,7 @@ async fn compile_classifier<E: Embedder + ?Sized>(
         }
     }
 
-    Ok(Some(PrototypeClassifier {
-        threshold: config.threshold,
-        prototypes,
-    }))
+    Ok(Some(PrototypeClassifier { prototypes }))
 }
 
 fn match_rule<'a>(candidate: &IngestCandidate, rule: &'a GatingRuleConfig) -> Option<&'a str> {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -5,6 +5,7 @@ pub mod detect;
 pub mod gating;
 pub mod lock;
 pub mod normalize;
+pub mod novelty;
 
 use std::path::{Path, PathBuf};
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod chunk;
 pub mod detect;
+pub mod gating;
 pub mod lock;
 pub mod normalize;
 

--- a/src/ingest/novelty.rs
+++ b/src/ingest/novelty.rs
@@ -1,0 +1,112 @@
+use crate::core::config::NoveltyConfig;
+use crate::core::db::Database;
+use rmcp::schemars::{self, JsonSchema};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum NoveltyAction {
+    Insert,
+    Merge,
+    Drop,
+}
+
+impl NoveltyAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Insert => "insert",
+            Self::Merge => "merge",
+            Self::Drop => "drop",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoveltyCandidate {
+    pub wing: String,
+    pub room: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NoveltyDecision {
+    pub action: NoveltyAction,
+    pub near_drawer_id: Option<String>,
+    pub cosine: Option<f32>,
+    pub should_audit: bool,
+    pub audit_decision: Option<&'static str>,
+}
+
+impl NoveltyDecision {
+    pub fn insert() -> Self {
+        Self {
+            action: NoveltyAction::Insert,
+            near_drawer_id: None,
+            cosine: None,
+            should_audit: true,
+            audit_decision: None,
+        }
+    }
+}
+
+pub fn evaluate(
+    db: &Database,
+    candidate: &NoveltyCandidate,
+    vector: &[f32],
+    config: &NoveltyConfig,
+) -> NoveltyDecision {
+    if !config.enabled || candidate.wing == "agent-diary" {
+        return NoveltyDecision {
+            should_audit: false,
+            ..NoveltyDecision::insert()
+        };
+    }
+
+    let (wing, room) = novelty_scope(candidate, config);
+    let results = match db.novelty_candidates(
+        vector,
+        wing.as_deref(),
+        room.as_deref(),
+        config.top_k_candidates,
+    ) {
+        Ok(results) => results,
+        Err(error) => {
+            tracing::warn!(?error, "novelty search failed; fail-open insert");
+            return NoveltyDecision::insert();
+        }
+    };
+
+    let Some(top) = results.first() else {
+        return NoveltyDecision::insert();
+    };
+
+    if top.1 >= config.duplicate_threshold {
+        return NoveltyDecision {
+            action: NoveltyAction::Drop,
+            near_drawer_id: Some(top.0.clone()),
+            cosine: Some(top.1),
+            should_audit: true,
+            audit_decision: None,
+        };
+    }
+    if top.1 >= config.merge_threshold {
+        return NoveltyDecision {
+            action: NoveltyAction::Merge,
+            near_drawer_id: Some(top.0.clone()),
+            cosine: Some(top.1),
+            should_audit: true,
+            audit_decision: None,
+        };
+    }
+
+    NoveltyDecision::insert()
+}
+
+fn novelty_scope(
+    candidate: &NoveltyCandidate,
+    config: &NoveltyConfig,
+) -> (Option<String>, Option<String>) {
+    match config.wing_scope.as_str() {
+        "same_room" => (Some(candidate.wing.clone()), candidate.room.clone()),
+        "global" => (None, None),
+        _ => (Some(candidate.wing.clone()), None),
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -12,6 +12,7 @@ use crate::embed::{EmbedderFactory, global_embed_status};
 use crate::ingest::gating::{
     GatingDecision, GatingRuntime, IngestCandidate, evaluate_tier1, evaluate_tier2, tier2_enabled,
 };
+use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
 use crate::search::{resolve_route, search_with_vector};
 use anyhow::Context;
 use rmcp::{
@@ -216,6 +217,8 @@ impl MempalMcpServer {
             return Ok(Json(IngestResponse {
                 drawer_id,
                 gating_decision: None,
+                novelty_action: None,
+                near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
                 system_warnings: current_system_warnings(),
@@ -250,13 +253,15 @@ impl MempalMcpServer {
                 // Return the candidate-derived drawer_id for audit correlation.
                 drawer_id,
                 gating_decision,
+                novelty_action: None,
+                near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
                 system_warnings: current_system_warnings(),
             }));
         }
 
-        let db = self.open_db()?;
+        let mut db = self.open_db()?;
 
         // P9-B reordered this path so the same-content lock is acquired
         // before the expensive embedder call. That keeps concurrent manual
@@ -302,6 +307,8 @@ impl MempalMcpServer {
             return Ok(Json(IngestResponse {
                 drawer_id,
                 gating_decision,
+                novelty_action: None,
+                near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms,
                 system_warnings: current_system_warnings(),
@@ -327,29 +334,158 @@ impl MempalMcpServer {
 
         // Semantic dedup check: find most similar existing drawer
         let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);
-        if !db.drawer_exists(&drawer_id).map_err(db_error)? {
-            let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
-            db.insert_drawer(&Drawer {
-                id: drawer_id.clone(),
-                content: scrubbed_content.clone(),
-                wing: request.wing.clone(),
-                room: request.room.clone(),
-                source_file: Some(source_file),
-                source_type: SourceType::Manual,
-                added_at: current_timestamp(),
-                chunk_index: Some(0),
-                importance: request.importance.unwrap_or(0),
-            })
-            .map_err(db_error)?;
-            db.insert_vector(&drawer_id, &vector).map_err(db_error)?;
+        let novelty_candidate = NoveltyCandidate {
+            wing: request.wing.clone(),
+            room: request.room.clone(),
+        };
+        let novelty = evaluate_novelty(
+            &db,
+            &novelty_candidate,
+            &vector,
+            &self.config.ingest_gating.novelty,
+        );
+        let mut response_drawer_id = drawer_id.clone();
+        let (novelty_action, near_drawer_id);
+
+        match novelty.action {
+            NoveltyAction::Insert => {
+                if novelty.should_audit {
+                    db.record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Insert,
+                        novelty.near_drawer_id.as_deref(),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .map_err(db_error)?;
+                }
+                novelty_action = Some(NoveltyAction::Insert);
+                near_drawer_id = novelty.near_drawer_id.clone();
+                if !db.drawer_exists(&drawer_id).map_err(db_error)? {
+                    let source_file =
+                        source_file_or_synthetic(&drawer_id, request.source.as_deref());
+                    db.insert_drawer(&Drawer {
+                        id: drawer_id.clone(),
+                        content: scrubbed_content.clone(),
+                        wing: request.wing.clone(),
+                        room: request.room.clone(),
+                        source_file: Some(source_file),
+                        source_type: SourceType::Manual,
+                        added_at: current_timestamp(),
+                        chunk_index: Some(0),
+                        importance: request.importance.unwrap_or(0),
+                    })
+                    .map_err(db_error)?;
+                    db.insert_vector(&drawer_id, &vector).map_err(db_error)?;
+                }
+            }
+            NoveltyAction::Drop => {
+                if novelty.should_audit {
+                    db.record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Drop,
+                        novelty.near_drawer_id.as_deref(),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .map_err(db_error)?;
+                }
+                novelty_action = Some(NoveltyAction::Drop);
+                near_drawer_id = novelty.near_drawer_id.clone();
+                response_drawer_id = novelty.near_drawer_id.unwrap_or(drawer_id.clone());
+            }
+            NoveltyAction::Merge => {
+                let target_id = novelty.near_drawer_id.clone().ok_or_else(|| {
+                    ErrorData::internal_error("novelty merge missing target", None)
+                })?;
+                let (existing_content, merge_count) = db
+                    .drawer_merge_state(&target_id)
+                    .map_err(db_error)?
+                    .ok_or_else(|| {
+                        ErrorData::internal_error("novelty merge target missing", None)
+                    })?;
+                let merged_at = current_timestamp();
+                let merged_content = format!(
+                    "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{scrubbed_content}"
+                );
+                let capped = merge_count >= self.config.ingest_gating.novelty.max_merges_per_drawer
+                    || merged_content.len()
+                        > self
+                            .config
+                            .ingest_gating
+                            .novelty
+                            .max_content_bytes_per_drawer;
+                if capped {
+                    db.record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Insert,
+                        Some(target_id.as_str()),
+                        novelty.cosine,
+                        Some("insert_due_to_merge_cap"),
+                    )
+                    .map_err(db_error)?;
+                    novelty_action = Some(NoveltyAction::Insert);
+                    near_drawer_id = Some(target_id);
+                    if !db.drawer_exists(&drawer_id).map_err(db_error)? {
+                        let source_file =
+                            source_file_or_synthetic(&drawer_id, request.source.as_deref());
+                        db.insert_drawer(&Drawer {
+                            id: drawer_id.clone(),
+                            content: scrubbed_content.clone(),
+                            wing: request.wing.clone(),
+                            room: request.room.clone(),
+                            source_file: Some(source_file),
+                            source_type: SourceType::Manual,
+                            added_at: current_timestamp(),
+                            chunk_index: Some(0),
+                            importance: request.importance.unwrap_or(0),
+                        })
+                        .map_err(db_error)?;
+                        db.insert_vector(&drawer_id, &vector).map_err(db_error)?;
+                    }
+                } else {
+                    let merged_vector = embedder
+                        .embed(&[merged_content.as_str()])
+                        .await
+                        .map_err(|error| {
+                            ErrorData::internal_error(format!("embedding failed: {error}"), None)
+                        })?
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| {
+                            ErrorData::internal_error("embedder returned no vector", None)
+                        })?;
+                    ensure_vector_dim_matches(&db, merged_vector.len())?;
+                    db.update_drawer_after_merge(
+                        &target_id,
+                        &merged_content,
+                        &merged_at,
+                        &merged_vector,
+                    )
+                    .map_err(db_error)?;
+                    db.record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Merge,
+                        Some(target_id.as_str()),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .map_err(db_error)?;
+                    novelty_action = Some(NoveltyAction::Merge);
+                    near_drawer_id = Some(target_id.clone());
+                    response_drawer_id = target_id;
+                }
+            }
         }
 
         // lock_guard drops here, releasing the advisory lock.
         drop(lock_guard);
 
         Ok(Json(IngestResponse {
-            drawer_id,
+            drawer_id: response_drawer_id,
             gating_decision,
+            novelty_action,
+            near_drawer_id,
             duplicate_warning,
             lock_wait_ms,
             system_warnings: current_system_warnings(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,6 +9,9 @@ use crate::core::{
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
 use crate::embed::{EmbedderFactory, global_embed_status};
+use crate::ingest::gating::{
+    GatingDecision, GatingRuntime, IngestCandidate, evaluate_tier1, evaluate_tier2, tier2_enabled,
+};
 use crate::search::{resolve_route, search_with_vector};
 use anyhow::Context;
 use rmcp::{
@@ -30,6 +33,8 @@ use super::tools::{
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
+    config: crate::core::config::Config,
+    gating_runtime: Arc<GatingRuntime>,
     embedder_factory: Arc<dyn EmbedderFactory>,
     tool_router: ToolRouter<Self>,
     /// Captured via `initialize` override so `auto` peek mode can infer the
@@ -39,15 +44,30 @@ pub struct MempalMcpServer {
 
 impl MempalMcpServer {
     pub fn new(db_path: PathBuf, config: crate::core::config::Config) -> Self {
-        Self::new_with_factory(
+        Self::new_with_factory_and_config(
             db_path,
+            config.clone(),
             Arc::new(crate::embed::ConfiguredEmbedderFactory::new(config)),
         )
     }
 
     pub fn new_with_factory(db_path: PathBuf, embedder_factory: Arc<dyn EmbedderFactory>) -> Self {
+        Self::new_with_factory_and_config(
+            db_path,
+            crate::core::config::Config::default(),
+            embedder_factory,
+        )
+    }
+
+    pub fn new_with_factory_and_config(
+        db_path: PathBuf,
+        config: crate::core::config::Config,
+        embedder_factory: Arc<dyn EmbedderFactory>,
+    ) -> Self {
         Self {
             db_path,
+            config: config.clone(),
+            gating_runtime: Arc::new(GatingRuntime::new(config, Arc::clone(&embedder_factory))),
             embedder_factory,
             tool_router: Self::tool_router(),
             client_name: Arc::new(Mutex::new(None)),
@@ -57,6 +77,10 @@ impl MempalMcpServer {
     pub async fn serve_stdio(
         self,
     ) -> anyhow::Result<rmcp::service::RunningService<rmcp::RoleServer, Self>> {
+        self.gating_runtime
+            .initialize()
+            .await
+            .context("failed to initialize ingest gating")?;
         self.serve(rmcp::transport::stdio())
             .await
             .context("failed to initialize MCP stdio transport")
@@ -191,6 +215,7 @@ impl MempalMcpServer {
         if request.dry_run.unwrap_or(false) {
             return Ok(Json(IngestResponse {
                 drawer_id,
+                gating_decision: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
                 system_warnings: current_system_warnings(),
@@ -199,6 +224,36 @@ impl MempalMcpServer {
 
         if global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
+        }
+
+        let candidate = IngestCandidate {
+            content: scrubbed_content.clone(),
+            tool_name: None,
+            exit_code: None,
+        };
+        let mut gating_decision = evaluate_tier1(&candidate, &self.config.ingest_gating);
+        if gating_decision.is_none() && !tier2_enabled(&self.config.ingest_gating) {
+            gating_decision = Some(GatingDecision::accepted(
+                0,
+                Some("tier2_disabled".to_string()),
+                None,
+            ));
+        }
+        if let Some(decision) = gating_decision.as_ref()
+            && decision.is_rejected()
+        {
+            let db = self.open_db()?;
+            db.record_gating_audit(&drawer_id, decision)
+                .map_err(db_error)?;
+            return Ok(Json(IngestResponse {
+                // TODO(spec ambiguity): rejected ingests have no persisted drawer.
+                // Return the candidate-derived drawer_id for audit correlation.
+                drawer_id,
+                gating_decision,
+                duplicate_warning: None,
+                lock_wait_ms: None,
+                system_warnings: current_system_warnings(),
+            }));
         }
 
         let db = self.open_db()?;
@@ -223,25 +278,62 @@ impl MempalMcpServer {
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
         })?;
-        let vector = embedder
-            .embed(&[scrubbed_content.as_str()])
-            .await
-            .map_err(|error| ErrorData::internal_error(format!("embedding failed: {error}"), None))?
-            .into_iter()
-            .next()
-            .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
+        let mut vector = None;
+        let mut gating_audit_recorded = false;
+        if tier2_enabled(&self.config.ingest_gating) {
+            let classifier = self
+                .gating_runtime
+                .classifier()
+                .await
+                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+            if let Some(classifier) = classifier {
+                let tier2 = evaluate_tier2(&candidate, &classifier, embedder.as_ref()).await;
+                db.record_gating_audit(&drawer_id, &tier2.decision)
+                    .map_err(db_error)?;
+                gating_audit_recorded = true;
+                vector = tier2.vector;
+                gating_decision = Some(tier2.decision);
+            }
+        }
+        if let Some(decision) = gating_decision.as_ref()
+            && decision.is_rejected()
+        {
+            drop(lock_guard);
+            return Ok(Json(IngestResponse {
+                drawer_id,
+                gating_decision,
+                duplicate_warning: None,
+                lock_wait_ms,
+                system_warnings: current_system_warnings(),
+            }));
+        }
+        if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
+            db.record_gating_audit(&drawer_id, decision)
+                .map_err(db_error)?;
+        }
+        let vector = match vector {
+            Some(vector) => vector,
+            None => embedder
+                .embed(&[scrubbed_content.as_str()])
+                .await
+                .map_err(|error| {
+                    ErrorData::internal_error(format!("embedding failed: {error}"), None)
+                })?
+                .into_iter()
+                .next()
+                .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?,
+        };
         ensure_vector_dim_matches(&db, vector.len())?;
 
         // Semantic dedup check: find most similar existing drawer
         let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);
-
         if !db.drawer_exists(&drawer_id).map_err(db_error)? {
             let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
             db.insert_drawer(&Drawer {
                 id: drawer_id.clone(),
-                content: scrubbed_content,
-                wing: request.wing,
-                room: request.room,
+                content: scrubbed_content.clone(),
+                wing: request.wing.clone(),
+                room: request.room.clone(),
                 source_file: Some(source_file),
                 source_type: SourceType::Manual,
                 added_at: current_timestamp(),
@@ -257,6 +349,7 @@ impl MempalMcpServer {
 
         Ok(Json(IngestResponse {
             drawer_id,
+            gating_decision,
             duplicate_warning,
             lock_wait_ms,
             system_warnings: current_system_warnings(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,7 +10,7 @@ use crate::core::{
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
 use crate::embed::{EmbedderFactory, global_embed_status};
 use crate::ingest::gating::{
-    GatingDecision, GatingRuntime, IngestCandidate, evaluate_tier1, evaluate_tier2, tier2_enabled,
+    GatingDecision, GatingRuntime, IngestCandidate, evaluate_tier1, evaluate_tier2,
 };
 use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
 use crate::search::{resolve_route, search_with_vector};
@@ -34,7 +34,6 @@ use super::tools::{
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
-    config: crate::core::config::Config,
     gating_runtime: Arc<GatingRuntime>,
     embedder_factory: Arc<dyn EmbedderFactory>,
     tool_router: ToolRouter<Self>,
@@ -67,7 +66,6 @@ impl MempalMcpServer {
     ) -> Self {
         Self {
             db_path,
-            config: config.clone(),
             gating_runtime: Arc::new(GatingRuntime::new(config, Arc::clone(&embedder_factory))),
             embedder_factory,
             tool_router: Self::tool_router(),
@@ -209,7 +207,9 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
-        let scrubbed_content = ConfigHandle::scrub_content(&request.content);
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let scrubbed_content =
+            config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
         let drawer_id = build_drawer_id(&request.wing, room, &scrubbed_content);
 
@@ -234,14 +234,7 @@ impl MempalMcpServer {
             tool_name: None,
             exit_code: None,
         };
-        let mut gating_decision = evaluate_tier1(&candidate, &self.config.ingest_gating);
-        if gating_decision.is_none() && !tier2_enabled(&self.config.ingest_gating) {
-            gating_decision = Some(GatingDecision::accepted(
-                0,
-                Some("tier2_disabled".to_string()),
-                None,
-            ));
-        }
+        let mut gating_decision = evaluate_tier1(&candidate, &config.ingest_gating);
         if let Some(decision) = gating_decision.as_ref()
             && decision.is_rejected()
         {
@@ -285,19 +278,36 @@ impl MempalMcpServer {
         })?;
         let mut vector = None;
         let mut gating_audit_recorded = false;
-        if tier2_enabled(&self.config.ingest_gating) {
-            let classifier = self
-                .gating_runtime
-                .classifier()
-                .await
-                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
-            if let Some(classifier) = classifier {
-                let tier2 = evaluate_tier2(&candidate, &classifier, embedder.as_ref()).await;
+        if gating_decision.is_none() {
+            let tier2_classifier = if config.ingest_gating.enabled
+                && config.ingest_gating.embedding_classifier.enabled
+            {
+                self.gating_runtime
+                    .classifier()
+                    .await
+                    .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+            } else {
+                None
+            };
+            if let Some(classifier) = tier2_classifier.as_ref() {
+                let tier2 = evaluate_tier2(
+                    &candidate,
+                    classifier,
+                    embedder.as_ref(),
+                    config.ingest_gating.embedding_classifier.threshold,
+                )
+                .await;
                 db.record_gating_audit(&drawer_id, &tier2.decision)
                     .map_err(db_error)?;
                 gating_audit_recorded = true;
                 vector = tier2.vector;
                 gating_decision = Some(tier2.decision);
+            } else {
+                gating_decision = Some(GatingDecision::accepted(
+                    0,
+                    Some("tier2_disabled".to_string()),
+                    None,
+                ));
             }
         }
         if let Some(decision) = gating_decision.as_ref()
@@ -342,7 +352,7 @@ impl MempalMcpServer {
             &db,
             &novelty_candidate,
             &vector,
-            &self.config.ingest_gating.novelty,
+            &config.ingest_gating.novelty,
         );
         let mut response_drawer_id = drawer_id.clone();
         let (novelty_action, near_drawer_id);
@@ -398,6 +408,20 @@ impl MempalMcpServer {
                 let target_id = novelty.near_drawer_id.clone().ok_or_else(|| {
                     ErrorData::internal_error("novelty merge missing target", None)
                 })?;
+                let _target_lock = if target_id == drawer_id {
+                    None
+                } else {
+                    Some(
+                        crate::ingest::lock::acquire_source_lock(
+                            &mempal_home,
+                            &target_id,
+                            std::time::Duration::from_secs(5),
+                        )
+                        .map_err(|e| {
+                            ErrorData::internal_error(format!("merge target lock: {e}"), None)
+                        })?,
+                    )
+                };
                 let (existing_content, merge_count) = db
                     .drawer_merge_state(&target_id)
                     .map_err(db_error)?
@@ -408,13 +432,9 @@ impl MempalMcpServer {
                 let merged_content = format!(
                     "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{scrubbed_content}"
                 );
-                let capped = merge_count >= self.config.ingest_gating.novelty.max_merges_per_drawer
+                let capped = merge_count >= config.ingest_gating.novelty.max_merges_per_drawer
                     || merged_content.len()
-                        > self
-                            .config
-                            .ingest_gating
-                            .novelty
-                            .max_content_bytes_per_drawer;
+                        > config.ingest_gating.novelty.max_content_bytes_per_drawer;
                 if capped {
                     db.record_novelty_audit(
                         &drawer_id,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,5 +1,6 @@
 use crate::core::types::{RouteDecision, SearchResult, TaxonomyEntry};
 use crate::ingest::gating::GatingDecision;
+use crate::ingest::novelty::NoveltyAction;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -104,6 +105,10 @@ pub struct IngestResponse {
     pub drawer_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gating_decision: Option<GatingDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub novelty_action: Option<NoveltyAction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub near_drawer_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duplicate_warning: Option<DuplicateWarning>,
     /// Milliseconds spent waiting for the per-source ingest lock (P9-B).

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,4 +1,5 @@
 use crate::core::types::{RouteDecision, SearchResult, TaxonomyEntry};
+use crate::ingest::gating::GatingDecision;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -101,6 +102,8 @@ pub struct DeleteResponse {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IngestResponse {
     pub drawer_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gating_decision: Option<GatingDecision>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duplicate_warning: Option<DuplicateWarning>,
     /// Milliseconds spent waiting for the per-source ingest lock (P9-B).

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -474,7 +474,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 3"),
+            .any(|line| line.trim() == "fork_ext_version: 4"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -474,7 +474,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 2"),
+            .any(|line| line.trim() == "fork_ext_version: 3"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -221,6 +221,21 @@ prototypes = ["A", "B", "C"]
     )
 }
 
+fn config_with_tier1_reject_short(db_path: &Path) -> String {
+    base_config(db_path).replace(
+        "[ingest_gating.embedding_classifier]\nprototypes = [\"A\", \"B\", \"C\"]",
+        r#"[ingest_gating]
+enabled = true
+
+[[ingest_gating.rules]]
+action = "reject"
+content_bytes_lt = 12
+
+[ingest_gating.embedding_classifier]
+enabled = false"#,
+    )
+}
+
 async fn ingest(server: &MempalMcpServer, content: &str) -> String {
     let response = server
         .mempal_ingest(Parameters(IngestRequest {
@@ -285,6 +300,56 @@ async fn test_privacy_pattern_hot_reload_applies_on_next_ingest() {
     assert!(latest_event_contains(
         "config hot-reload: version changed from"
     ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_gating_hot_reload_applies_without_server_restart() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let factory = Arc::new(RecordingEmbedderFactory {
+        vector: vec![0.1, 0.2, 0.3],
+        delay: Duration::ZERO,
+        seen_inputs: Arc::new(Mutex::new(Vec::new())),
+        entered_tx: Arc::new(Mutex::new(None)),
+    });
+    let server = env.server(factory);
+
+    let first_id = ingest(&server, "this stays accepted before reload").await;
+    assert!(
+        env.db()
+            .get_drawer(&first_id)
+            .expect("get first drawer")
+            .is_some()
+    );
+
+    let previous = ConfigHandle::version();
+    write_config_atomic(
+        &env.config_path,
+        &config_with_tier1_reject_short(&env.db_path),
+    );
+    wait_for_version_change(&previous);
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "tiny".to_string(),
+            wing: "mempal".to_string(),
+            room: Some("config-hot-reload".to_string()),
+            source: None,
+            dry_run: None,
+            importance: None,
+        }))
+        .await
+        .expect("ingest should return structured reject")
+        .0;
+
+    let decision = response.gating_decision.expect("tier-1 decision");
+    assert_eq!(decision.decision, "rejected");
+    assert_eq!(decision.tier, 1);
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use mempal::core::{db::Database, queue::PendingMessageStore};
-use mempal::daemon::process_claimed_message_with_embedder;
+use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
 use mempal::embed::{EmbedError, Embedder};
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
 use rusqlite::Connection;
@@ -97,8 +97,11 @@ async fn test_daemon_heartbeat_fires_during_embed_retry() {
         "worker-heartbeat",
         &claimed,
         &embedder,
-        &config,
-        &mempal_home,
+        DaemonIngestContext {
+            prototype_classifier: None,
+            config: &config,
+            mempal_home: &mempal_home,
+        },
     )
     .await
     .expect("process message");

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_three_after_gating_phase() {
+fn test_fork_ext_version_is_four_after_novelty_phase() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 }
 
 #[test]
@@ -84,6 +84,22 @@ fn test_gating_audit_table_exists_after_ext_v3() {
         .conn()
         .query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+
+    assert_eq!(exists, 1);
+}
+
+#[test]
+fn test_novelty_audit_table_exists_after_ext_v4() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='novelty_audit'",
             [],
             |row| row.get::<_, i64>(0),
         )

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_two_on_fresh_db_after_phase4() {
+fn test_fork_ext_version_is_three_after_gating_phase() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 }
 
 #[test]
@@ -68,6 +68,22 @@ fn test_fork_ext_meta_table_exists_after_init() {
         .conn()
         .query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='fork_ext_meta'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+
+    assert_eq!(exists, 1);
+}
+
+#[test]
+fn test_gating_audit_table_exists_after_ext_v3() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
             [],
             |row| row.get::<_, i64>(0),
         )

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -12,11 +12,11 @@ fn new_test_db() -> (TempDir, Database) {
 }
 
 #[test]
-fn test_fork_ext_v3_migration() {
+fn test_fork_ext_v4_migration() {
     let (_tmp, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 
     let table_exists = db
         .conn()
@@ -37,15 +37,25 @@ fn test_fork_ext_v3_migration() {
         )
         .expect("query sqlite_master");
     assert_eq!(gating_exists, 1);
+
+    let novelty_exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='novelty_audit'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(novelty_exists, 1);
 }
 
 #[test]
-fn test_fork_ext_v3_migration_is_idempotent() {
+fn test_fork_ext_v4_migration_is_idempotent() {
     let (_tmp, db) = new_test_db();
 
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("first apply");
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
 }

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -12,11 +12,11 @@ fn new_test_db() -> (TempDir, Database) {
 }
 
 #[test]
-fn test_fork_ext_v2_migration() {
+fn test_fork_ext_v3_migration() {
     let (_tmp, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 
     let table_exists = db
         .conn()
@@ -27,15 +27,25 @@ fn test_fork_ext_v2_migration() {
         )
         .expect("query sqlite_master");
     assert_eq!(table_exists, 1);
+
+    let gating_exists = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query sqlite_master");
+    assert_eq!(gating_exists, 1);
 }
 
 #[test]
-fn test_fork_ext_v2_migration_is_idempotent() {
+fn test_fork_ext_v3_migration_is_idempotent() {
     let (_tmp, db) = new_test_db();
 
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("first apply");
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
 }

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -1,0 +1,389 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use mockito::Server;
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct DeterministicEmbedderFactory {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+    embed_calls: Arc<Mutex<Vec<String>>>,
+}
+
+struct DeterministicEmbedder {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+    embed_calls: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl EmbedderFactory for DeterministicEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(DeterministicEmbedder {
+            vectors: Arc::clone(&self.vectors),
+            default_vector: self.default_vector.clone(),
+            embed_calls: Arc::clone(&self.embed_calls),
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for DeterministicEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        let mut calls = self.embed_calls.lock().expect("embed_calls mutex");
+        for text in texts {
+            calls.push((*text).to_string());
+        }
+        drop(calls);
+
+        Ok(texts
+            .iter()
+            .map(|text| {
+                self.vectors
+                    .get(*text)
+                    .cloned()
+                    .unwrap_or_else(|| self.default_vector.clone())
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.default_vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "deterministic"
+    }
+}
+
+fn write_config(path: &Path, db_path: &Path, body: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"
+db_path = "{}"
+
+[config_hot_reload]
+enabled = false
+
+{}
+"#,
+            db_path.display(),
+            body
+        ),
+    )
+    .expect("write config");
+}
+
+fn drawer_count(db_path: &Path) -> i64 {
+    Database::open(db_path)
+        .expect("open db")
+        .drawer_count()
+        .expect("drawer count")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tier1_rule_reject_short_circuits_tier2() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+
+    let config_path = mempal_home.join("config.toml");
+    write_config(
+        &config_path,
+        &db_path,
+        r#"
+[ingest_gating]
+enabled = true
+
+[[ingest_gating.rules]]
+action = "reject"
+content_bytes_lt = 12
+
+[ingest_gating.embedding_classifier]
+enabled = true
+threshold = 0.8
+prototypes = ["accept"]
+"#,
+    );
+
+    let embed_calls = Arc::new(Mutex::new(Vec::new()));
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    let config = Config::load_from(&config_path).expect("load config");
+    let factory = Arc::new(DeterministicEmbedderFactory {
+        vectors: Arc::new(HashMap::from([("accept".to_string(), vec![1.0, 0.0])])),
+        default_vector: vec![0.0, 1.0],
+        embed_calls: Arc::clone(&embed_calls),
+    });
+    let server =
+        MempalMcpServer::new_with_factory_and_config(db_path.clone(), config.clone(), factory);
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "tiny".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("gating".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("gating request should succeed")
+        .0;
+
+    assert!(config.ingest_gating.enabled);
+    assert_eq!(drawer_count(&db_path), 0);
+    assert!(
+        embed_calls.lock().expect("embed_calls mutex").is_empty(),
+        "tier-1 reject must not touch prototype or candidate embedding"
+    );
+    let decision = response.gating_decision.expect("gating decision");
+    assert_eq!(decision.decision, "rejected");
+    assert_eq!(decision.tier, 1);
+    assert_eq!(
+        decision.matched_pattern.as_deref(),
+        Some("content_bytes_lt")
+    );
+    assert_eq!(decision.score, None);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tier2_prototype_cosine_classifier() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+
+    let config_path = mempal_home.join("config.toml");
+    write_config(
+        &config_path,
+        &db_path,
+        r#"
+[ingest_gating]
+enabled = true
+
+[ingest_gating.embedding_classifier]
+enabled = true
+threshold = 0.8
+prototypes = ["accept-prototype"]
+"#,
+    );
+
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    let config = Config::load_from(&config_path).expect("load config");
+    let factory = Arc::new(DeterministicEmbedderFactory {
+        vectors: Arc::new(HashMap::from([
+            ("accept-prototype".to_string(), vec![1.0, 0.0]),
+            ("candidate-keep".to_string(), vec![1.0, 0.0]),
+            ("candidate-drop".to_string(), vec![0.0, 1.0]),
+        ])),
+        default_vector: vec![0.0, 1.0],
+        embed_calls: Arc::new(Mutex::new(Vec::new())),
+    });
+    let server =
+        MempalMcpServer::new_with_factory_and_config(db_path.clone(), config.clone(), factory);
+
+    let accepted = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "candidate-keep".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("gating".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("accepted request")
+        .0;
+    let rejected = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "candidate-drop".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("gating".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("rejected request")
+        .0;
+
+    assert_eq!(config.ingest_gating.embedding_classifier.threshold, 0.8);
+    assert_eq!(
+        accepted
+            .gating_decision
+            .expect("accepted gating decision")
+            .decision,
+        "accepted"
+    );
+    let rejected_decision = rejected.gating_decision.expect("rejected gating decision");
+    assert_eq!(rejected_decision.decision, "rejected");
+    assert_eq!(rejected_decision.tier, 2);
+    assert!(rejected_decision.score.expect("tier-2 score") < 0.8);
+}
+
+#[test]
+fn test_prototype_init_failure_fails_fast() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+
+    let mut server = Server::new();
+    let _mock = server
+        .mock("POST", "/v1/embeddings")
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":"prototype boom"}"#)
+        .create();
+
+    let config_path = mempal_home.join("config.toml");
+    write_config(
+        &config_path,
+        &db_path,
+        &format!(
+            r#"
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{}/v1"
+model = "test-embed"
+dim = 3
+request_timeout_secs = 2
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 100
+
+[daemon]
+log_path = "{}"
+
+[ingest_gating]
+enabled = true
+
+[ingest_gating.embedding_classifier]
+enabled = true
+threshold = 0.5
+prototypes = ["accept-prototype"]
+"#,
+            server.url(),
+            mempal_home.join("daemon.log").display()
+        ),
+    );
+
+    let output = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("run daemon");
+
+    assert!(
+        !output.status.success(),
+        "daemon startup must fail when prototype init fails"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("gating prototype init failed"), "{stderr}");
+    assert!(stderr.contains("accept-prototype"), "{stderr}");
+    assert!(
+        !mempal_home.join("daemon.pid").exists(),
+        "pid file must not survive failed daemon startup"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gating_decision_explain_field_structured() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+
+    let config_path = mempal_home.join("config.toml");
+    write_config(
+        &config_path,
+        &db_path,
+        r#"
+[ingest_gating]
+enabled = true
+
+[[ingest_gating.rules]]
+action = "reject"
+content_bytes_lt = 32
+
+[ingest_gating.embedding_classifier]
+enabled = true
+threshold = 0.5
+prototypes = ["accept-prototype"]
+"#,
+    );
+
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    let config = Config::load_from(&config_path).expect("load config");
+    let factory = Arc::new(DeterministicEmbedderFactory {
+        vectors: Arc::new(HashMap::from([(
+            "accept-prototype".to_string(),
+            vec![1.0, 0.0],
+        )])),
+        default_vector: vec![0.0, 1.0],
+        embed_calls: Arc::new(Mutex::new(Vec::new())),
+    });
+    let server = MempalMcpServer::new_with_factory_and_config(db_path, config, factory);
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "reject me".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("gating".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("request")
+        .0;
+
+    let decision = response.gating_decision.expect("gating decision");
+    let json = serde_json::to_value(&decision).expect("serialize gating decision");
+    assert_eq!(json.get("tier").and_then(|value| value.as_u64()), Some(1));
+    assert_eq!(
+        json.get("matched_pattern").and_then(|value| value.as_str()),
+        Some("content_bytes_lt")
+    );
+    assert!(
+        json.get("score").is_none_or(|value| value.is_null()),
+        "tier-1 rule reject should not fabricate a cosine score: {json}"
+    );
+}

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -8,11 +8,13 @@ use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::types::{Drawer, SourceType};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::ingest::lock::acquire_source_lock;
 use mempal::mcp::{IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::Connection;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::time::{Duration, sleep};
 
 #[path = "../src/core/db_fork_ext.rs"]
 mod db_fork_ext;
@@ -312,6 +314,56 @@ async fn test_merge_preserves_raw_verbatim() {
     assert!(
         !content.contains("summary"),
         "merge must preserve raw verbatim"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_novelty_merge_waits_for_target_lock() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    Database::open(&db_path).expect("open db");
+    write_config(&config_path, &db_path);
+    insert_existing_drawer(&db_path, "Decision: use Arc<Mutex<>>", &[1.0, 0.0]);
+
+    let target_lock = acquire_source_lock(&mempal_home, "existing", Duration::from_secs(1))
+        .expect("acquire existing drawer lock");
+    let server = build_server(
+        &db_path,
+        &config_path,
+        HashMap::from([(
+            "Also: use RwLock when reads dominate".to_string(),
+            vec![0.85, 0.5267827],
+        )]),
+    );
+
+    let task = tokio::spawn(async move {
+        server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "Also: use RwLock when reads dominate".to_string(),
+                wing: "code-memory".to_string(),
+                room: Some("novelty".to_string()),
+                source: None,
+                dry_run: Some(false),
+                importance: None,
+            }))
+            .await
+    });
+
+    sleep(Duration::from_millis(100)).await;
+    assert!(
+        !task.is_finished(),
+        "merge should wait while the target drawer lock is held"
+    );
+    drop(target_lock);
+
+    let response = task.await.expect("join task").expect("merge response").0;
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Merge)
     );
 }
 

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -1,0 +1,389 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use rmcp::handler::server::wrapper::Parameters;
+use rusqlite::Connection;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+#[path = "../src/core/db_fork_ext.rs"]
+mod db_fork_ext;
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct DeterministicEmbedderFactory {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+}
+
+struct DeterministicEmbedder {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbedderFactory for DeterministicEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(DeterministicEmbedder {
+            vectors: Arc::clone(&self.vectors),
+            default_vector: self.default_vector.clone(),
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for DeterministicEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .map(|text| {
+                self.vectors
+                    .get(*text)
+                    .cloned()
+                    .unwrap_or_else(|| self.default_vector.clone())
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.default_vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "deterministic"
+    }
+}
+
+fn write_config(path: &Path, db_path: &Path) {
+    fs::write(
+        path,
+        format!(
+            r#"
+db_path = "{}"
+
+[config_hot_reload]
+enabled = false
+
+[ingest_gating]
+enabled = false
+
+[ingest_gating.novelty]
+enabled = true
+duplicate_threshold = 0.95
+merge_threshold = 0.80
+wing_scope = "same_wing"
+top_k_candidates = 1
+max_merges_per_drawer = 10
+max_content_bytes_per_drawer = 65536
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+}
+
+fn insert_existing_drawer(db_path: &Path, content: &str, vector: &[f32]) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: "existing".to_string(),
+        content: content.to_string(),
+        wing: "code-memory".to_string(),
+        room: Some("novelty".to_string()),
+        source_file: Some("existing.md".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    })
+    .expect("insert drawer");
+    db.insert_vector("existing", vector).expect("insert vector");
+}
+
+fn merged_content(db_path: &Path) -> String {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        "SELECT content FROM drawers WHERE id = 'existing'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .expect("query merged content")
+}
+
+fn merge_count_and_updated_at(db_path: &Path) -> (i64, Option<String>) {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        "SELECT merge_count, updated_at FROM drawers WHERE id = 'existing'",
+        [],
+        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?)),
+    )
+    .expect("query merge metadata")
+}
+
+fn build_server(
+    db_path: &Path,
+    config_path: &Path,
+    vectors: HashMap<String, Vec<f32>>,
+) -> MempalMcpServer {
+    ConfigHandle::bootstrap(config_path).expect("bootstrap config");
+    let config = Config::load_from(config_path).expect("load config");
+    MempalMcpServer::new_with_factory_and_config(
+        db_path.to_path_buf(),
+        config,
+        Arc::new(DeterministicEmbedderFactory {
+            vectors: Arc::new(vectors),
+            default_vector: vec![0.6, 0.8],
+        }),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_novelty_drop_near_duplicate() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    Database::open(&db_path).expect("open db");
+    write_config(&config_path, &db_path);
+    insert_existing_drawer(&db_path, "existing note", &[1.0, 0.0]);
+
+    let server = build_server(
+        &db_path,
+        &config_path,
+        HashMap::from([("candidate-drop".to_string(), vec![1.0, 0.0])]),
+    );
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "candidate-drop".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("novelty".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("drop response")
+        .0;
+
+    assert_eq!(drawer_count(&db_path), 1);
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Drop)
+    );
+    assert_eq!(response.near_drawer_id.as_deref(), Some("existing"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_novelty_merge_similar_but_extended() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    Database::open(&db_path).expect("open db");
+    write_config(&config_path, &db_path);
+    insert_existing_drawer(&db_path, "Decision: use Arc<Mutex<>>", &[1.0, 0.0]);
+
+    let server = build_server(
+        &db_path,
+        &config_path,
+        HashMap::from([(
+            "Also: use RwLock when reads dominate".to_string(),
+            vec![0.85, 0.5267827],
+        )]),
+    );
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "Also: use RwLock when reads dominate".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("novelty".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("merge response")
+        .0;
+
+    assert_eq!(drawer_count(&db_path), 1);
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Merge)
+    );
+    assert_eq!(response.near_drawer_id.as_deref(), Some("existing"));
+    let (merge_count, updated_at) = merge_count_and_updated_at(&db_path);
+    assert_eq!(merge_count, 1);
+    assert!(updated_at.is_some(), "updated_at must be set after merge");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_novelty_insert_distinct() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    Database::open(&db_path).expect("open db");
+    write_config(&config_path, &db_path);
+    insert_existing_drawer(&db_path, "existing note", &[1.0, 0.0]);
+
+    let server = build_server(
+        &db_path,
+        &config_path,
+        HashMap::from([("candidate-insert".to_string(), vec![0.2, 0.9797959])]),
+    );
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "candidate-insert".to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("novelty".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("insert response")
+        .0;
+
+    assert_eq!(drawer_count(&db_path), 2);
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Insert)
+    );
+    assert_eq!(response.near_drawer_id, None);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_merge_preserves_raw_verbatim() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    Database::open(&db_path).expect("open db");
+    write_config(&config_path, &db_path);
+    insert_existing_drawer(&db_path, "old raw content", &[1.0, 0.0]);
+
+    let new_content = "new raw continuation";
+    let server = build_server(
+        &db_path,
+        &config_path,
+        HashMap::from([(new_content.to_string(), vec![0.85, 0.5267827])]),
+    );
+
+    server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: new_content.to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("novelty".to_string()),
+            source: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("merge response");
+
+    let content = merged_content(&db_path);
+    assert!(content.starts_with("old raw content\n---\nSUPPLEMENTARY ("));
+    assert!(content.ends_with(&format!("):\n{new_content}")));
+    assert!(
+        !content.contains("summary"),
+        "merge must preserve raw verbatim"
+    );
+}
+
+#[test]
+fn test_migration_v3_to_v4_idempotent_trigger() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute_batch(
+        r#"
+CREATE TABLE drawers (
+    id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    wing TEXT NOT NULL,
+    room TEXT,
+    source_file TEXT,
+    source_type TEXT NOT NULL,
+    added_at TEXT NOT NULL,
+    chunk_index INTEGER,
+    deleted_at TEXT,
+    importance INTEGER DEFAULT 0
+);
+CREATE VIRTUAL TABLE drawers_fts USING fts5(
+    content,
+    content='drawers',
+    content_rowid='rowid'
+);
+CREATE TRIGGER drawers_ai AFTER INSERT ON drawers BEGIN
+    INSERT INTO drawers_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+CREATE TRIGGER drawers_au_softdelete AFTER UPDATE OF deleted_at ON drawers
+    WHEN new.deleted_at IS NOT NULL AND old.deleted_at IS NULL BEGIN
+    INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+END;
+"#,
+    )
+    .expect("create upstream schema");
+    conn.execute_batch(db_fork_ext::FORK_EXT_META_DDL)
+        .expect("fork ext meta");
+    conn.execute_batch(db_fork_ext::FORK_EXT_V1_SCHEMA_SQL)
+        .expect("ext v1");
+    conn.execute_batch(db_fork_ext::FORK_EXT_V2_SCHEMA_SQL)
+        .expect("ext v2");
+    conn.execute_batch(db_fork_ext::FORK_EXT_V3_SCHEMA_SQL)
+        .expect("ext v3");
+    db_fork_ext::set_fork_ext_version(&conn, 3).expect("set version 3");
+    conn.execute_batch(
+        r#"
+CREATE TRIGGER drawers_fts_after_update
+AFTER UPDATE ON drawers BEGIN
+    SELECT 1;
+END;
+"#,
+    )
+    .expect("create stale trigger");
+
+    db_fork_ext::apply_fork_ext_migrations(&conn).expect("first apply");
+    db_fork_ext::apply_fork_ext_migrations(&conn).expect("second apply");
+
+    let trigger_count = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name='drawers_fts_after_update'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("trigger count");
+    assert_eq!(trigger_count, 1);
+}
+
+fn drawer_count(db_path: &Path) -> i64 {
+    Database::open(db_path)
+        .expect("open db")
+        .drawer_count()
+        .expect("drawer count")
+}

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -24,7 +24,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 }
 
 #[test]
-fn test_fork_ext_migration_v0_to_v3_preserves_pending_messages_table() {
+fn test_fork_ext_migration_v0_to_v4_preserves_pending_messages_table() {
     let (_tmp, db_path, _store) = new_store();
     let conn = Connection::open(db_path).expect("open sqlite");
 
@@ -35,7 +35,7 @@ fn test_fork_ext_migration_v0_to_v3_preserves_pending_messages_table() {
             |row| row.get::<_, String>(0),
         )
         .expect("read fork_ext_version");
-    assert_eq!(version, "3");
+    assert_eq!(version, "4");
 
     let exists = conn
         .query_row(

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -24,7 +24,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 }
 
 #[test]
-fn test_fork_ext_migration_v0_to_v2_creates_pending_messages_table() {
+fn test_fork_ext_migration_v0_to_v3_preserves_pending_messages_table() {
     let (_tmp, db_path, _store) = new_store();
     let conn = Connection::open(db_path).expect("open sqlite");
 
@@ -35,7 +35,7 @@ fn test_fork_ext_migration_v0_to_v2_creates_pending_messages_table() {
             |row| row.get::<_, String>(0),
         )
         .expect("read fork_ext_version");
-    assert_eq!(version, "2");
+    assert_eq!(version, "3");
 
     let exists = conn
         .query_row(


### PR DESCRIPTION
## Summary
- add ext_v3 judge-mode ingest gating with tier-1 rules and tier-2 local model2vec prototype classification
- add ext_v4 novelty filtering with cosine-based `drop` / `merge` / `insert`
- keep drawers raw verbatim by appending merged content with a delimiter instead of rewriting content
- evolve fork-only schema axis from `fork_ext_version` 2 -> 3 -> 4 with idempotent migrations and FTS refresh on merge

## Validation
- `just pre-commit`
- `cargo test --no-default-features --features model2vec --test judge_gating --test novelty_filter --test fork_ext_schema_axis --test fork_ext_v2_migration --test queue_claim_confirm`
- verified the branch contains two sequential commits: ext_v3 gating, then ext_v4 novelty

## Notes
- zero external LLM API dependency in gating/novelty code paths; tier 2 uses local prototype vectors only
- `weave.lock` was pre-existing unrelated dirt and was intentionally left out of both commits
- parts 2-3 of #6 are deferred to Phase 2 (self-review) + future specs

Closes #3.
Closes #6 part 1 (novelty).
