### PR TITLE
feat(p9): session self-review via hook_session_end

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -21,6 +21,9 @@ const DEFAULT_HOOK_WING: &str = "agent-diary";
 const DEFAULT_HOOK_POLL_INTERVAL_MS: u64 = 500;
 const DEFAULT_HOOK_CLAIM_TTL_SECS: u64 = 120;
 const DEFAULT_DAEMON_LOG_PATH: &str = "~/.mempal/daemon.log";
+const DEFAULT_SESSION_REVIEW_WING: &str = "session-reviews";
+const DEFAULT_SESSION_REVIEW_MIN_LENGTH: usize = 100;
+const DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES: usize = 1;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
@@ -106,6 +109,11 @@ impl Config {
         if self.hooks.daemon_claim_ttl_secs == 0 {
             return Err(ConfigError::InvalidConfig(
                 "hooks.daemon_claim_ttl_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.hooks.session_end.trailing_messages == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "hooks.session_end.trailing_messages must be greater than 0".to_string(),
             ));
         }
         if let Some(path) = self
@@ -292,12 +300,21 @@ impl Default for HooksConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct HooksSessionEndConfig {
-    pub enabled: bool,
+    #[serde(alias = "enabled")]
+    pub extract_self_review: bool,
+    pub trailing_messages: usize,
+    pub min_length: usize,
+    pub wing: String,
 }
 
 impl Default for HooksSessionEndConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            extract_self_review: false,
+            trailing_messages: DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES,
+            min_length: DEFAULT_SESSION_REVIEW_MIN_LENGTH,
+            wing: DEFAULT_SESSION_REVIEW_WING.to_string(),
+        }
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -26,6 +26,7 @@ use serde_json::{Value, json};
 
 use crate::daemon_bootstrap::DaemonContext;
 use crate::hook::CapturedHookEnvelope;
+use crate::session_review::{SessionReviewOutcome, extract_session_review};
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     let context = DaemonContext::bootstrap(config_path, foreground)?;
@@ -142,6 +143,16 @@ pub struct DaemonIngestContext<'a> {
     pub mempal_home: &'a Path,
 }
 
+struct DrawerIngestContext<'a, E: Embedder + ?Sized> {
+    db: &'a Database,
+    store: &'a PendingMessageStore,
+    worker_id: &'a str,
+    message: &'a ClaimedMessage,
+    embedder: &'a E,
+    daemon: &'a DaemonIngestContext<'a>,
+    envelope: &'a CapturedHookEnvelope,
+}
+
 async fn poll_claim_next<'a, S>(
     store: &impl ClaimNextSource,
     worker_id: &str,
@@ -172,199 +183,22 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
 ) -> Result<String> {
     let envelope: CapturedHookEnvelope =
         serde_json::from_str(&message.payload).context("failed to decode queued hook envelope")?;
-
-    let record = build_drawer_record(&envelope, context.config, context.mempal_home)?;
-    let drawer_id = build_drawer_id(&record.wing, Some(record.room.as_str()), &record.content);
-    let candidate = build_gating_candidate(&envelope, &record);
-    let mut gating_decision = evaluate_tier1(&candidate, &context.config.ingest_gating);
-    if gating_decision.is_none() && !tier2_enabled(&context.config.ingest_gating) {
-        gating_decision = Some(GatingDecision::accepted(
-            0,
-            Some("tier2_disabled".to_string()),
-            None,
-        ));
-    }
-    if let Some(decision) = gating_decision.as_ref()
-        && decision.is_rejected()
-    {
-        db.record_gating_audit(&drawer_id, decision)
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
-        return Ok(drawer_id);
-    }
-
-    let heartbeat_store = store.clone();
-    let heartbeat_message_id = message.id.clone();
-    let heartbeat_worker_id = worker_id.to_string();
-    let heartbeat = move || -> crate::embed::Result<()> {
-        heartbeat_store
-            .refresh_heartbeat(&heartbeat_message_id, &heartbeat_worker_id)
-            .map_err(|error| EmbedError::Runtime(format!("refresh heartbeat failed: {error}")))?;
-        Ok(())
-    };
-
-    let mut vector = None;
-    let mut gating_audit_recorded = false;
-    if gating_decision.is_none()
-        && let Some(classifier) = context.prototype_classifier
-    {
-        let candidate_vector =
-            embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?;
-        let decision = classifier.decide(
-            &candidate_vector,
-            context.config.ingest_gating.embedding_classifier.threshold,
-        );
-        db.record_gating_audit(&drawer_id, &decision)
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
-        gating_audit_recorded = true;
-        if decision.is_rejected() {
-            return Ok(drawer_id);
-        }
-        gating_decision = Some(decision);
-        vector = Some(candidate_vector);
-    }
-    if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
-        db.record_gating_audit(&drawer_id, decision)
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
-    }
-
-    let vector = match vector {
-        Some(vector) => vector,
-        None => embed_text_with_heartbeat(embedder, &record.content, Some(&heartbeat)).await?,
-    };
-    let novelty = evaluate_novelty(
+    let records = build_drawer_records(&envelope, context.config, context.mempal_home)?;
+    let drawer_context = DrawerIngestContext {
         db,
-        &NoveltyCandidate {
-            wing: record.wing.clone(),
-            room: Some(record.room.clone()),
-        },
-        &vector,
-        &context.config.ingest_gating.novelty,
-    );
-    match novelty.action {
-        NoveltyAction::Insert => {
-            if novelty.should_audit {
-                db.record_novelty_audit(
-                    &drawer_id,
-                    NoveltyAction::Insert,
-                    novelty.near_drawer_id.as_deref(),
-                    novelty.cosine,
-                    novelty.audit_decision,
-                )
-                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-            }
-            let drawer = Drawer {
-                id: drawer_id.clone(),
-                content: record.content,
-                wing: record.wing,
-                room: Some(record.room),
-                source_file: Some(record.source_file),
-                source_type: SourceType::Manual,
-                added_at: current_timestamp(),
-                chunk_index: Some(0),
-                importance: 0,
-            };
-            db.insert_drawer(&drawer)
-                .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
-            db.insert_vector(&drawer.id, &vector)
-                .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
-            Ok(drawer_id)
-        }
-        NoveltyAction::Drop => {
-            if novelty.should_audit {
-                db.record_novelty_audit(
-                    &drawer_id,
-                    NoveltyAction::Drop,
-                    novelty.near_drawer_id.as_deref(),
-                    novelty.cosine,
-                    novelty.audit_decision,
-                )
-                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-            }
-            Ok(novelty.near_drawer_id.unwrap_or(drawer_id))
-        }
-        NoveltyAction::Merge => {
-            let target_id = novelty
-                .near_drawer_id
-                .clone()
-                .unwrap_or_else(|| drawer_id.clone());
-            let _target_lock = if target_id == drawer_id {
-                None
-            } else {
-                Some(
-                    crate::ingest::lock::acquire_source_lock(
-                        context.mempal_home,
-                        &target_id,
-                        Duration::from_secs(5),
-                    )
-                    .with_context(|| format!("failed to lock merge target {}", target_id))?,
-                )
-            };
-            let (existing_content, merge_count) = db
-                .drawer_merge_state(&target_id)
-                .with_context(|| format!("failed to load merge target {}", target_id))?
-                .ok_or_else(|| anyhow::anyhow!("novelty merge target missing: {}", target_id))?;
-            let merged_at = current_timestamp();
-            let merged_content = format!(
-                "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{}",
-                record.content
-            );
-            let capped = merge_count >= context.config.ingest_gating.novelty.max_merges_per_drawer
-                || merged_content.len()
-                    > context
-                        .config
-                        .ingest_gating
-                        .novelty
-                        .max_content_bytes_per_drawer;
-            if capped {
-                db.record_novelty_audit(
-                    &drawer_id,
-                    NoveltyAction::Insert,
-                    Some(target_id.as_str()),
-                    novelty.cosine,
-                    Some("insert_due_to_merge_cap"),
-                )
-                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-                let drawer = Drawer {
-                    id: drawer_id.clone(),
-                    content: record.content,
-                    wing: record.wing,
-                    room: Some(record.room),
-                    source_file: Some(record.source_file),
-                    source_type: SourceType::Manual,
-                    added_at: current_timestamp(),
-                    chunk_index: Some(0),
-                    importance: 0,
-                };
-                db.insert_drawer(&drawer)
-                    .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
-                db.insert_vector(&drawer.id, &vector)
-                    .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
-                Ok(drawer_id)
-            } else {
-                let merged_vector =
-                    embed_text_with_heartbeat(embedder, &merged_content, Some(&heartbeat)).await?;
-                db.record_novelty_audit(
-                    &drawer_id,
-                    NoveltyAction::Merge,
-                    Some(target_id.as_str()),
-                    novelty.cosine,
-                    novelty.audit_decision,
-                )
-                .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-                let mut db_for_merge = Database::open(db.path())
-                    .with_context(|| format!("failed to reopen db for merge {}", target_id))?;
-                db_for_merge
-                    .update_drawer_after_merge(
-                        &target_id,
-                        &merged_content,
-                        &merged_at,
-                        &merged_vector,
-                    )
-                    .with_context(|| format!("failed to merge hook drawer {}", target_id))?;
-                Ok(target_id)
-            }
-        }
+        store,
+        worker_id,
+        message,
+        embedder,
+        daemon: &context,
+        envelope: &envelope,
+    };
+    let mut last_drawer_id = None;
+    for record in records {
+        last_drawer_id = Some(ingest_drawer_record(&drawer_context, record).await?);
     }
+
+    Ok(last_drawer_id.unwrap_or_else(|| message.id.clone()))
 }
 
 fn build_gating_candidate(
@@ -417,9 +251,40 @@ struct DrawerRecord {
     room: String,
     source_file: String,
     content: String,
+    importance: i32,
+    bypass_novelty: bool,
 }
 
-fn build_drawer_record(
+fn build_drawer_records(
+    envelope: &CapturedHookEnvelope,
+    config: &crate::core::config::Config,
+    mempal_home: &Path,
+) -> Result<Vec<DrawerRecord>> {
+    let mut records = vec![build_audit_drawer_record(envelope, config, mempal_home)?];
+    if envelope.event == crate::hook::HookEvent::SessionEnd.display_name() && !envelope.truncated {
+        match extract_session_review(
+            envelope.payload.as_deref(),
+            &envelope.agent,
+            &config.hooks.session_end,
+        )? {
+            SessionReviewOutcome::Review(review) => records.push(DrawerRecord {
+                wing: review.wing,
+                room: review.room,
+                source_file: review.source_file,
+                content: config.scrub_content(&review.content),
+                importance: review.importance,
+                bypass_novelty: true,
+            }),
+            SessionReviewOutcome::Skipped(reason) => {
+                tracing::info!(?reason, "session self-review skipped");
+            }
+        }
+    }
+
+    Ok(records)
+}
+
+fn build_audit_drawer_record(
     envelope: &CapturedHookEnvelope,
     config: &crate::core::config::Config,
     mempal_home: &Path,
@@ -446,6 +311,8 @@ fn build_drawer_record(
             room: "truncated".to_string(),
             source_file,
             content,
+            importance: 0,
+            bypass_novelty: false,
         });
     }
 
@@ -464,13 +331,298 @@ fn build_drawer_record(
         }
     }))
     .context("failed to serialize hook diary drawer")?;
+    let (wing, room) = audit_target_for_event(&envelope.event, raw_payload, config);
 
     Ok(DrawerRecord {
-        wing: config.hooks.wing.clone(),
-        room: envelope.agent.clone(),
+        wing,
+        room,
         source_file: payload_path,
         content,
+        importance: 0,
+        bypass_novelty: false,
     })
+}
+
+fn audit_target_for_event(
+    event: &str,
+    raw_payload: &str,
+    config: &crate::core::config::Config,
+) -> (String, String) {
+    match event {
+        "PostToolUse" => (
+            "hooks-raw".to_string(),
+            serde_json::from_str::<Value>(raw_payload)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("tool_name")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+                .unwrap_or_else(|| "unknown-tool".to_string()),
+        ),
+        "UserPromptSubmit" => ("hooks-raw".to_string(), "user-prompt".to_string()),
+        "SessionStart" | "SessionEnd" => ("hooks-raw".to_string(), "session-lifecycle".to_string()),
+        _ => (
+            config.hooks.wing.clone(),
+            envelope_agent_fallback(raw_payload),
+        ),
+    }
+}
+
+fn envelope_agent_fallback(raw_payload: &str) -> String {
+    serde_json::from_str::<Value>(raw_payload)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("agent")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| "unknown-agent".to_string())
+}
+
+async fn ingest_drawer_record<E: Embedder + ?Sized>(
+    context: &DrawerIngestContext<'_, E>,
+    record: DrawerRecord,
+) -> Result<String> {
+    let drawer_id = build_drawer_id(&record.wing, Some(record.room.as_str()), &record.content);
+    if context
+        .db
+        .drawer_exists(&drawer_id)
+        .with_context(|| format!("failed to check existing drawer {}", drawer_id))?
+    {
+        return Ok(drawer_id);
+    }
+
+    let candidate = build_gating_candidate(context.envelope, &record);
+    let mut gating_decision = evaluate_tier1(&candidate, &context.daemon.config.ingest_gating);
+    if gating_decision.is_none() && !tier2_enabled(&context.daemon.config.ingest_gating) {
+        gating_decision = Some(GatingDecision::accepted(
+            0,
+            Some("tier2_disabled".to_string()),
+            None,
+        ));
+    }
+    if let Some(decision) = gating_decision.as_ref()
+        && decision.is_rejected()
+    {
+        context
+            .db
+            .record_gating_audit(&drawer_id, decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        return Ok(drawer_id);
+    }
+
+    let heartbeat_store = context.store.clone();
+    let heartbeat_message_id = context.message.id.clone();
+    let heartbeat_worker_id = context.worker_id.to_string();
+    let heartbeat = move || -> crate::embed::Result<()> {
+        heartbeat_store
+            .refresh_heartbeat(&heartbeat_message_id, &heartbeat_worker_id)
+            .map_err(|error| EmbedError::Runtime(format!("refresh heartbeat failed: {error}")))?;
+        Ok(())
+    };
+
+    let mut vector = None;
+    let mut gating_audit_recorded = false;
+    if gating_decision.is_none()
+        && let Some(classifier) = context.daemon.prototype_classifier
+    {
+        let candidate_vector =
+            embed_text_with_heartbeat(context.embedder, &record.content, Some(&heartbeat)).await?;
+        let decision = classifier.decide(
+            &candidate_vector,
+            context
+                .daemon
+                .config
+                .ingest_gating
+                .embedding_classifier
+                .threshold,
+        );
+        context
+            .db
+            .record_gating_audit(&drawer_id, &decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        gating_audit_recorded = true;
+        if decision.is_rejected() {
+            return Ok(drawer_id);
+        }
+        gating_decision = Some(decision);
+        vector = Some(candidate_vector);
+    }
+    if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
+        context
+            .db
+            .record_gating_audit(&drawer_id, decision)
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+    }
+
+    let vector = match vector {
+        Some(vector) => vector,
+        None => {
+            embed_text_with_heartbeat(context.embedder, &record.content, Some(&heartbeat)).await?
+        }
+    };
+    if record.bypass_novelty {
+        insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+        return Ok(drawer_id);
+    }
+
+    let novelty = evaluate_novelty(
+        context.db,
+        &NoveltyCandidate {
+            wing: record.wing.clone(),
+            room: Some(record.room.clone()),
+        },
+        &vector,
+        &context.daemon.config.ingest_gating.novelty,
+    );
+    match novelty.action {
+        NoveltyAction::Insert => {
+            if novelty.should_audit {
+                context
+                    .db
+                    .record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Insert,
+                        novelty.near_drawer_id.as_deref(),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+            }
+            insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+            Ok(drawer_id)
+        }
+        NoveltyAction::Drop => {
+            if novelty.should_audit {
+                context
+                    .db
+                    .record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Drop,
+                        novelty.near_drawer_id.as_deref(),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+            }
+            Ok(novelty.near_drawer_id.unwrap_or(drawer_id))
+        }
+        NoveltyAction::Merge => {
+            let target_id = novelty
+                .near_drawer_id
+                .clone()
+                .unwrap_or_else(|| drawer_id.clone());
+            let _target_lock = if target_id == drawer_id {
+                None
+            } else {
+                Some(
+                    crate::ingest::lock::acquire_source_lock(
+                        context.daemon.mempal_home,
+                        &target_id,
+                        Duration::from_secs(5),
+                    )
+                    .with_context(|| format!("failed to lock merge target {}", target_id))?,
+                )
+            };
+            let (existing_content, merge_count) = context
+                .db
+                .drawer_merge_state(&target_id)
+                .with_context(|| format!("failed to load merge target {}", target_id))?
+                .ok_or_else(|| anyhow::anyhow!("novelty merge target missing: {}", target_id))?;
+            let merged_at = current_timestamp();
+            let merged_content = format!(
+                "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{}",
+                record.content
+            );
+            let capped = merge_count
+                >= context
+                    .daemon
+                    .config
+                    .ingest_gating
+                    .novelty
+                    .max_merges_per_drawer
+                || merged_content.len()
+                    > context
+                        .daemon
+                        .config
+                        .ingest_gating
+                        .novelty
+                        .max_content_bytes_per_drawer;
+            if capped {
+                context
+                    .db
+                    .record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Insert,
+                        Some(target_id.as_str()),
+                        novelty.cosine,
+                        Some("insert_due_to_merge_cap"),
+                    )
+                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+                Ok(drawer_id)
+            } else {
+                let merged_vector =
+                    embed_text_with_heartbeat(context.embedder, &merged_content, Some(&heartbeat))
+                        .await?;
+                context
+                    .db
+                    .record_novelty_audit(
+                        &drawer_id,
+                        NoveltyAction::Merge,
+                        Some(target_id.as_str()),
+                        novelty.cosine,
+                        novelty.audit_decision,
+                    )
+                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                let mut db_for_merge = Database::open(context.db.path())
+                    .with_context(|| format!("failed to reopen db for merge {}", target_id))?;
+                db_for_merge
+                    .update_drawer_after_merge(
+                        &target_id,
+                        &merged_content,
+                        &merged_at,
+                        &merged_vector,
+                    )
+                    .with_context(|| format!("failed to merge hook drawer {}", target_id))?;
+                Ok(target_id)
+            }
+        }
+    }
+}
+
+fn insert_drawer_with_vector(
+    db: &Database,
+    drawer_id: &str,
+    record: &DrawerRecord,
+    vector: &[f32],
+) -> Result<()> {
+    if db
+        .drawer_exists(drawer_id)
+        .with_context(|| format!("failed to re-check existing drawer {}", drawer_id))?
+    {
+        return Ok(());
+    }
+
+    let drawer = Drawer {
+        id: drawer_id.to_string(),
+        content: record.content.clone(),
+        wing: record.wing.clone(),
+        room: Some(record.room.clone()),
+        source_file: Some(record.source_file.clone()),
+        source_type: SourceType::Manual,
+        added_at: current_timestamp(),
+        chunk_index: Some(0),
+        importance: record.importance,
+    };
+    db.insert_drawer(&drawer)
+        .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
+    db.insert_vector(&drawer.id, vector)
+        .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
+    Ok(())
 }
 
 fn preview_for_event(event: &str, raw_payload: &str) -> String {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -261,9 +261,14 @@ fn build_drawer_records(
     mempal_home: &Path,
 ) -> Result<Vec<DrawerRecord>> {
     let mut records = vec![build_audit_drawer_record(envelope, config, mempal_home)?];
-    if envelope.event == crate::hook::HookEvent::SessionEnd.display_name() && !envelope.truncated {
+    if envelope.event == crate::hook::HookEvent::SessionEnd.display_name() {
+        let session_review_payload = if config.hooks.session_end.extract_self_review {
+            load_session_review_payload(envelope)?
+        } else {
+            None
+        };
         match extract_session_review(
-            envelope.payload.as_deref(),
+            session_review_payload.as_deref(),
             &envelope.agent,
             &config.hooks.session_end,
         )? {
@@ -282,6 +287,23 @@ fn build_drawer_records(
     }
 
     Ok(records)
+}
+
+fn load_session_review_payload(envelope: &CapturedHookEnvelope) -> Result<Option<String>> {
+    if !envelope.truncated {
+        return Ok(envelope.payload.clone());
+    }
+
+    let payload_path = envelope
+        .payload_path
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("truncated session_end missing payload_path"))?;
+    fs::read_to_string(payload_path).map(Some).with_context(|| {
+        format!(
+            "failed to read truncated session_end payload {}",
+            payload_path
+        )
+    })
 }
 
 fn build_audit_drawer_record(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod hook_install;
 pub mod ingest;
 pub mod mcp;
 pub mod search;
+pub mod session_review;

--- a/src/session_review.rs
+++ b/src/session_review.rs
@@ -1,0 +1,217 @@
+use anyhow::{Context, Result, anyhow};
+use serde::Deserialize;
+
+use crate::core::config::HooksSessionEndConfig;
+
+const SESSION_METADATA_SENTINEL: &str = "\n\n--- session_metadata ---\n";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionMetadata {
+    pub session_id: Option<String>,
+    pub linked_drawer_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionReviewRecord {
+    pub wing: String,
+    pub room: String,
+    pub source_file: String,
+    pub raw_content: String,
+    pub content: String,
+    pub importance: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionReviewSkipReason {
+    Disabled,
+    MissingPayload,
+    NoAssistantMessage,
+    TooShort { chars: usize, min_length: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionReviewOutcome {
+    Review(SessionReviewRecord),
+    Skipped(SessionReviewSkipReason),
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionEndPayload {
+    session_id: String,
+    #[serde(default)]
+    agent: Option<String>,
+    messages: Vec<SessionMessage>,
+    #[serde(default)]
+    tool_calls: Vec<SessionToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionToolCall {
+    drawer_id: String,
+}
+
+pub fn extract_session_review(
+    payload: Option<&str>,
+    envelope_agent: &str,
+    config: &HooksSessionEndConfig,
+) -> Result<SessionReviewOutcome> {
+    if !config.extract_self_review {
+        return Ok(SessionReviewOutcome::Skipped(
+            SessionReviewSkipReason::Disabled,
+        ));
+    }
+
+    let Some(payload) = payload else {
+        return Ok(SessionReviewOutcome::Skipped(
+            SessionReviewSkipReason::MissingPayload,
+        ));
+    };
+
+    // TODO(specs/fork-ext/p9-session-self-review.spec.md:27,49-53):
+    // The spec mixes two concerns: extraction comes from payload.messages,
+    // while sentinel+rfind validation applies only to the stored metadata
+    // suffix. This implementation keeps extraction on payload.messages and
+    // uses the sentinel exclusively for the appended metadata block.
+    let payload: SessionEndPayload =
+        serde_json::from_str(payload).context("failed to parse session_end payload")?;
+    let session_id = payload.session_id.trim();
+    if session_id.is_empty() {
+        return Err(anyhow!("session_end payload missing non-empty session_id"));
+    }
+
+    let assistant_messages = payload
+        .messages
+        .iter()
+        .rev()
+        .filter(|message| message.role == "assistant")
+        .take(config.trailing_messages)
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>();
+    if assistant_messages.is_empty() {
+        return Ok(SessionReviewOutcome::Skipped(
+            SessionReviewSkipReason::NoAssistantMessage,
+        ));
+    }
+
+    let raw_content = assistant_messages
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n---\n");
+    let char_count = raw_content.chars().count();
+    if char_count < config.min_length {
+        return Ok(SessionReviewOutcome::Skipped(
+            SessionReviewSkipReason::TooShort {
+                chars: char_count,
+                min_length: config.min_length,
+            },
+        ));
+    }
+
+    let room = payload
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|agent| !agent.is_empty())
+        .or_else(|| {
+            let agent = envelope_agent.trim();
+            (!agent.is_empty()).then_some(agent)
+        })
+        .unwrap_or("unknown-agent")
+        .to_string();
+    let linked_drawer_ids = payload
+        .tool_calls
+        .into_iter()
+        .map(|call| call.drawer_id)
+        .collect::<Vec<_>>();
+    let content = append_session_metadata(
+        &raw_content,
+        &SessionMetadata {
+            session_id: Some(session_id.to_string()),
+            linked_drawer_ids,
+        },
+    );
+
+    Ok(SessionReviewOutcome::Review(SessionReviewRecord {
+        wing: config.wing.clone(),
+        room,
+        source_file: session_id.to_string(),
+        raw_content,
+        content,
+        importance: 3,
+    }))
+}
+
+pub fn split_session_metadata(content: &str) -> (&str, SessionMetadata) {
+    let Some(index) = content.rfind(SESSION_METADATA_SENTINEL) else {
+        return (content, SessionMetadata::default());
+    };
+
+    let metadata_start = index + SESSION_METADATA_SENTINEL.len();
+    let Some(metadata) = parse_metadata_block(&content[metadata_start..]) else {
+        return (content, SessionMetadata::default());
+    };
+
+    (&content[..index], metadata)
+}
+
+fn append_session_metadata(content: &str, metadata: &SessionMetadata) -> String {
+    let mut lines = Vec::new();
+    if let Some(session_id) = metadata
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("session_id: {session_id}"));
+    }
+    if !metadata.linked_drawer_ids.is_empty() {
+        lines.push(format!(
+            "linked_drawer_ids: {}",
+            metadata.linked_drawer_ids.join(", ")
+        ));
+    }
+    if lines.is_empty() {
+        return content.to_string();
+    }
+
+    format!("{content}{SESSION_METADATA_SENTINEL}{}", lines.join("\n"))
+}
+
+fn parse_metadata_block(block: &str) -> Option<SessionMetadata> {
+    let mut metadata = SessionMetadata::default();
+    let mut saw_key_value = false;
+
+    for line in block.lines() {
+        let (key, value) = line.split_once(": ")?;
+        if key.is_empty()
+            || value.is_empty()
+            || !key
+                .chars()
+                .all(|char| char.is_ascii_lowercase() || char == '_')
+        {
+            return None;
+        }
+        saw_key_value = true;
+        match key {
+            "session_id" => metadata.session_id = Some(value.to_string()),
+            "linked_drawer_ids" => {
+                metadata.linked_drawer_ids = value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect();
+            }
+            _ => {}
+        }
+    }
+
+    saw_key_value.then_some(metadata)
+}

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -1,0 +1,552 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::Config;
+use mempal::core::db::Database;
+use mempal::core::queue::PendingMessageStore;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
+use mempal::embed::{EmbedError, Embedder};
+use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use mempal::session_review::{
+    SessionMetadata, SessionReviewOutcome, extract_session_review, split_session_metadata,
+};
+use rusqlite::Connection;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct DeterministicEmbedder {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+}
+
+#[async_trait]
+impl Embedder for DeterministicEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .map(|text| {
+                self.vectors
+                    .get(*text)
+                    .cloned()
+                    .unwrap_or_else(|| self.default_vector.clone())
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.default_vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "deterministic"
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+    mempal_home: PathBuf,
+    config: Config,
+    store: PendingMessageStore,
+}
+
+impl TestEnv {
+    fn new(
+        extra_hooks: &str,
+        extra_privacy: &str,
+        extra_novelty: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let tmp = TempDir::new()?;
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home)?;
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path)?;
+        let config_text = format!(
+            r#"
+db_path = "{}"
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 100
+
+[hooks.session_end]
+{}
+
+[privacy]
+{}
+
+[ingest_gating]
+enabled = false
+
+[ingest_gating.novelty]
+{}
+"#,
+            db_path.display(),
+            extra_hooks,
+            extra_privacy,
+            extra_novelty,
+        );
+        let config = Config::parse(&config_text)?;
+        let store = PendingMessageStore::new(&db_path)?;
+        Ok(Self {
+            _tmp: tmp,
+            db_path,
+            mempal_home,
+            config,
+            store,
+        })
+    }
+
+    fn enqueue_session_end(&self, payload: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::SessionEnd.display_name().to_string(),
+            kind: HookEvent::SessionEnd.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "1713000000".to_string(),
+            claude_cwd: "/tmp/project".to_string(),
+            payload: Some(payload.to_string()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope)?;
+        Ok(self
+            .store
+            .enqueue(HookEvent::SessionEnd.queue_kind(), &payload)?)
+    }
+
+    async fn process_once(
+        &self,
+        embedder: &DeterministicEmbedder,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let claimed = self
+            .store
+            .claim_next("worker-session-review", 120)?
+            .expect("claimed message");
+        let db = Database::open(&self.db_path)?;
+        Ok(process_claimed_message_with_embedder(
+            &db,
+            &self.store,
+            "worker-session-review",
+            &claimed,
+            embedder,
+            DaemonIngestContext {
+                prototype_classifier: None,
+                config: &self.config,
+                mempal_home: &self.mempal_home,
+            },
+        )
+        .await?)
+    }
+}
+
+fn count_drawers_by_wing(db_path: &Path, wing: &str) -> i64 {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        "SELECT COUNT(*) FROM drawers WHERE deleted_at IS NULL AND wing = ?1",
+        [wing],
+        |row| row.get(0),
+    )
+    .expect("query drawer count by wing")
+}
+
+fn latest_drawer_in_wing(db_path: &Path, wing: &str) -> (String, String, String, i32) {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        r#"
+        SELECT content, COALESCE(room, ''), COALESCE(source_file, ''), importance
+        FROM drawers
+        WHERE deleted_at IS NULL AND wing = ?1
+        ORDER BY rowid DESC
+        LIMIT 1
+        "#,
+        [wing],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+    )
+    .expect("query latest drawer")
+}
+
+fn novelty_audit_count_for_drawer(db_path: &Path, drawer_id: &str) -> i64 {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        "SELECT COUNT(*) FROM novelty_audit WHERE candidate_hash = ?1",
+        [drawer_id],
+        |row| row.get(0),
+    )
+    .expect("query novelty audit count")
+}
+
+fn long_assistant_message(suffix: &str) -> String {
+    format!(
+        "I finished refactor X, decided to keep the payload raw, documented the boundary, and kept the retry path deterministic for auditability. {}",
+        suffix
+    )
+}
+
+#[test]
+fn test_session_self_review_disabled_by_default() {
+    let config = Config::default();
+
+    assert!(!config.hooks.session_end.extract_self_review);
+    assert_eq!(config.hooks.session_end.trailing_messages, 1);
+    assert_eq!(config.hooks.session_end.min_length, 100);
+    assert_eq!(config.hooks.session_end.wing, "session-reviews");
+}
+
+#[test]
+fn test_sentinel_false_positive_rejected_by_structure_check() {
+    let content =
+        "assistant body\n--- session_metadata ---\nthis is just an example in prose".to_string();
+
+    let (body, metadata) = split_session_metadata(&content);
+
+    assert_eq!(body, content);
+    assert_eq!(metadata, SessionMetadata::default());
+}
+
+#[test]
+fn test_session_self_review_zero_external_llm_calls() {
+    let session_review_src = include_str!("../src/session_review.rs");
+    let daemon_src = include_str!("../src/daemon.rs");
+
+    for forbidden in [
+        "api.openai",
+        "api.anthropic",
+        "generativelanguage",
+        ".claude/sessions/",
+    ] {
+        assert!(
+            !session_review_src.contains(forbidden),
+            "session_review.rs unexpectedly references {forbidden}"
+        );
+        assert!(
+            !daemon_src.contains(forbidden),
+            "daemon.rs unexpectedly references {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn test_missing_agent_falls_back() {
+    let config = Config::parse(
+        r#"
+[hooks.session_end]
+extract_self_review = true
+min_length = 1
+"#,
+    )
+    .expect("config");
+    let payload = serde_json::json!({
+        "session_id": "missing-agent",
+        "messages": [
+            {"role": "assistant", "content": "summary"}
+        ]
+    });
+
+    let outcome = extract_session_review(Some(&payload.to_string()), "", &config.hooks.session_end)
+        .expect("extract");
+
+    match outcome {
+        SessionReviewOutcome::Review(record) => assert_eq!(record.room, "unknown-agent"),
+        other => panic!("expected review, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_session_end_hook_captures_final_assistant_message() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+trailing_messages = 1
+min_length = 100
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let assistant = long_assistant_message("This is the high-signal summary.");
+    let payload = serde_json::json!({
+        "session_id": "S1",
+        "agent": "claude",
+        "messages": [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": "D1"},
+            {"drawer_id": "D2"}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+    let (content, room, source_file, importance) =
+        latest_drawer_in_wing(&env.db_path, "session-reviews");
+    let (body, metadata) = split_session_metadata(&content);
+    assert_eq!(body, assistant);
+    assert_eq!(room, "claude");
+    assert_eq!(source_file, "S1");
+    assert_eq!(importance, 3);
+    assert_eq!(metadata.session_id.as_deref(), Some("S1"));
+    assert_eq!(metadata.linked_drawer_ids, vec!["D1", "D2"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_trailing_messages_concatenation() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+trailing_messages = 2
+min_length = 1
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let payload = serde_json::json!({
+        "session_id": "trail-1",
+        "messages": [
+            {"role": "assistant", "content": "A"},
+            {"role": "assistant", "content": "B"}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
+    let (body, metadata) = split_session_metadata(&stored);
+    assert_eq!(body, "A\n---\nB");
+    assert_eq!(metadata.session_id.as_deref(), Some("trail-1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_captured_drawer_is_raw_verbatim() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let assistant = "Line 1\nLine 2\nSymbols: <> [] {}\nUnicode: 你好".to_string();
+    let payload = serde_json::json!({
+        "session_id": "raw-1",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
+    let (body, metadata) = split_session_metadata(&stored);
+    assert_eq!(body, "Line 1\nLine 2\nSymbols: <> [] {}\nUnicode: 你好");
+    assert_eq!(metadata.session_id.as_deref(), Some("raw-1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_hooks_raw_audit_drawer_still_written() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let payload = serde_json::json!({
+        "session_id": "audit-1",
+        "messages": [
+            {"role": "assistant", "content": long_assistant_message("audit")}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
+    let (_, room, _, _) = latest_drawer_in_wing(&env.db_path, "hooks-raw");
+    assert_eq!(room, "session-lifecycle");
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_session_reviews_bypass_novelty_drop() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = false",
+        r#"
+enabled = true
+duplicate_threshold = 0.95
+merge_threshold = 0.80
+wing_scope = "same_wing"
+top_k_candidates = 1
+max_merges_per_drawer = 10
+max_content_bytes_per_drawer = 65536
+"#,
+    )
+    .expect("env");
+    let existing_body = long_assistant_message("existing");
+    let existing_content = format!(
+        "{}\n\n--- session_metadata ---\nsession_id: old-session",
+        existing_body
+    );
+    let db = Database::open(&env.db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: "existing-review".to_string(),
+        content: existing_content.clone(),
+        wing: "session-reviews".to_string(),
+        room: Some("claude".to_string()),
+        source_file: Some("old-session".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 3,
+    })
+    .expect("insert existing drawer");
+    db.insert_vector("existing-review", &[1.0, 0.0, 0.0])
+        .expect("insert existing vector");
+
+    let candidate_body = long_assistant_message("candidate");
+    let payload = serde_json::json!({
+        "session_id": "new-session",
+        "messages": [
+            {"role": "assistant", "content": candidate_body}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let session_review_content = format!(
+        "{}\n\n--- session_metadata ---\nsession_id: new-session",
+        long_assistant_message("candidate")
+    );
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::from([(
+            session_review_content,
+            vec![1.0, 0.0, 0.0],
+        )])),
+        default_vector: vec![0.0, 1.0, 0.0],
+    };
+
+    let inserted_id = env.process_once(&embedder).await.expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 2);
+    assert_eq!(
+        novelty_audit_count_for_drawer(&env.db_path, &inserted_id),
+        0
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_no_assistant_message_handler_skips() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let payload = serde_json::json!({
+        "session_id": "no-assistant",
+        "messages": [
+            {"role": "user", "content": "go"},
+            {"role": "tool", "content": "ls"}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
+    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_self_review_subject_to_privacy_scrub() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = true",
+        "enabled = false",
+    )
+    .expect("env");
+    let payload = serde_json::json!({
+        "session_id": "privacy-1",
+        "messages": [
+            {"role": "assistant", "content": "I used sk-abcdef1234567890abcdef1234567890abcd in the example and then removed it."}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
+    assert!(stored.contains("[REDACTED:openai_key]"));
+    assert!(!stored.contains("sk-abcdef1234567890abcdef1234567890abcd"));
+}

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -130,6 +130,32 @@ enabled = false
             .enqueue(HookEvent::SessionEnd.queue_kind(), &payload)?)
     }
 
+    fn enqueue_truncated_session_end(
+        &self,
+        payload: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let oversize_dir = self.mempal_home.join("hook-oversize");
+        fs::create_dir_all(&oversize_dir)?;
+        let payload_path = oversize_dir.join("session-end-oversize.json");
+        fs::write(&payload_path, payload)?;
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::SessionEnd.display_name().to_string(),
+            kind: HookEvent::SessionEnd.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "1713000000".to_string(),
+            claude_cwd: "/tmp/project".to_string(),
+            payload: None,
+            payload_path: Some(payload_path.to_string_lossy().to_string()),
+            payload_preview: Some(payload.chars().take(64).collect()),
+            original_size_bytes: payload.len(),
+            truncated: true,
+        };
+        let payload = serde_json::to_string(&envelope)?;
+        Ok(self
+            .store
+            .enqueue(HookEvent::SessionEnd.queue_kind(), &payload)?)
+    }
+
     async fn process_once(
         &self,
         embedder: &DeterministicEmbedder,
@@ -347,6 +373,51 @@ min_length = 1
     let (body, metadata) = split_session_metadata(&stored);
     assert_eq!(body, "A\n---\nB");
     assert_eq!(metadata.session_id.as_deref(), Some("trail-1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_truncated_session_end_still_creates_session_review() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+extract_self_review = true
+min_length = 10
+"#,
+        "enabled = false",
+        "enabled = false",
+    )
+    .expect("env");
+    let assistant = long_assistant_message("oversize payload should still produce a review.");
+    let payload = serde_json::json!({
+        "session_id": "oversize-1",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": "D-oversize"}
+        ]
+    });
+    env.enqueue_truncated_session_end(&payload.to_string())
+        .expect("enqueue");
+    let embedder = DeterministicEmbedder {
+        vectors: Arc::new(HashMap::new()),
+        default_vector: vec![0.1, 0.2, 0.3],
+    };
+
+    env.process_once(&embedder).await.expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+    let (content, room, source_file, importance) =
+        latest_drawer_in_wing(&env.db_path, "session-reviews");
+    let (body, metadata) = split_session_metadata(&content);
+    assert_eq!(body, assistant);
+    assert_eq!(room, "claude");
+    assert_eq!(source_file, "oversize-1");
+    assert_eq!(importance, 3);
+    assert_eq!(metadata.session_id.as_deref(), Some("oversize-1"));
+    assert_eq!(metadata.linked_drawer_ids, vec!["D-oversize"]);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f53f78366bf3d882524bf2babfdbb02c729f1969"
+commit = "582e10a291506dbc004aa225814ce64f6e707465"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- implement session self-review capture on `hook_session_end`
- persist the final assistant message as a raw-verbatim `session-reviews` drawer with appended metadata sentinel
- keep the existing `hooks-raw` audit drawer for session lifecycle events

## Traceability
- References #6 part 2 (session self-review only; #6 remains closed)
- Spec: `specs/fork-ext/p9-session-self-review.spec.md`

## R5 Debate Outcome
- Chosen path: sentinel + structural validation for the appended `session_metadata` block
- Rejected path: reading `.claude/sessions/*.jsonl`
- Implementation keeps extraction on `hook_session_end` payload `messages` and uses `rfind("\n\n--- session_metadata ---\n")` only for metadata parsing, so there is no coupling to Claude Code internal session storage

## Tests Added
- `test_session_self_review_disabled_by_default` — verifies opt-in default is off
- `test_session_end_hook_captures_final_assistant_message` — happy path capture into `session-reviews`
- `test_sentinel_false_positive_rejected_by_structure_check` — ignores prose occurrences of the sentinel without `key: value` lines
- `test_session_self_review_zero_external_llm_calls` — guards against OpenAI/Anthropic/Gemini API or `.claude/sessions` references in the capture path
- `test_missing_agent_falls_back` — falls back to `unknown-agent` when no agent is present
- `test_trailing_messages_concatenation` — concatenates the last N assistant messages with a stable separator
- `test_captured_drawer_is_raw_verbatim` — verifies the stored body matches the extracted assistant region exactly before metadata suffix
- `test_hooks_raw_audit_drawer_still_written` — preserves the P8 audit drawer side effect
- `test_session_reviews_bypass_novelty_drop` — ensures session reviews bypass novelty-drop auditing
- `test_no_assistant_message_handler_skips` — skips self-review capture without failing the hook message
- `test_self_review_subject_to_privacy_scrub` — applies privacy scrub before persistence

## Notes
- No schema bump; `fork_ext_version` remains 4
- `weave.lock` refresh is included as a separate chore commit to leave the branch clean per Rule 043
- Ambiguity note: the spec mixes payload-message extraction with sentinel parsing. This PR chooses the lower-risk interpretation and leaves an inline TODO near the extraction boundary pointing back to the spec lines
- Part 3 of #6 (tool-sequence extraction) remains deferred to a future spec
