### PR TITLE
feat(p10): project vector isolation (ext_v4 → ext_v5)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,9 +1,9 @@
 use crate::core::{
-    config::Config,
+    config::ConfigHandle,
     db::Database,
     project::{ProjectSearchScope, resolve_project_id},
     types::{Drawer, RouteDecision, SearchResult, SourceType, TaxonomyEntry},
-    utils::{build_drawer_id, current_timestamp, source_file_or_synthetic},
+    utils::{current_timestamp, source_file_or_synthetic},
 };
 use crate::search::{resolve_route, search_with_vector};
 use axum::{
@@ -148,12 +148,13 @@ async fn search_handler(
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let route = resolve_route(&db, &query.q, query.wing.as_deref(), query.room.as_deref())
         .map_err(internal_error)?;
-    let config = Config::default();
+    let config = ConfigHandle::current();
     let scope = ProjectSearchScope::from_request(
-        resolve_project_id(query.project_id.as_deref(), &config, None).map_err(internal_error)?,
+        resolve_project_id(query.project_id.as_deref(), config.as_ref(), None)
+            .map_err(internal_error)?,
         query.include_global.unwrap_or(false),
         query.all_projects.unwrap_or(false),
-        false,
+        config.search.strict_project_isolation,
     );
     let results = search_with_vector(
         &db,
@@ -192,12 +193,19 @@ async fn ingest_handler(
             )
         })?;
     let db = Database::open(&state.db_path).map_err(internal_error)?;
-    let drawer_id = build_drawer_id(&request.wing, request.room.as_deref(), &request.content);
-    let config = Config::default();
-    let project_id =
-        resolve_project_id(request.project_id.as_deref(), &config, None).map_err(internal_error)?;
+    let config = ConfigHandle::current();
+    let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
+        .map_err(internal_error)?;
+    let (drawer_id, drawer_exists) = db
+        .resolve_ingest_drawer_id(
+            &request.wing,
+            request.room.as_deref(),
+            &request.content,
+            project_id.as_deref(),
+        )
+        .map_err(internal_error)?;
 
-    if !db.drawer_exists(&drawer_id).map_err(internal_error)? {
+    if !drawer_exists {
         let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
         db.insert_drawer_with_project(
             &Drawer {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,5 +1,7 @@
 use crate::core::{
+    config::Config,
     db::Database,
+    project::{ProjectSearchScope, resolve_project_id},
     types::{Drawer, RouteDecision, SearchResult, SourceType, TaxonomyEntry},
     utils::{build_drawer_id, current_timestamp, source_file_or_synthetic},
 };
@@ -60,6 +62,9 @@ struct SearchQuery {
     wing: Option<String>,
     room: Option<String>,
     top_k: Option<usize>,
+    project_id: Option<String>,
+    include_global: Option<bool>,
+    all_projects: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -68,6 +73,7 @@ struct IngestRequest {
     wing: String,
     room: Option<String>,
     source: Option<String>,
+    project_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -97,6 +103,7 @@ struct SearchResultDto {
     wing: String,
     room: Option<String>,
     source_file: String,
+    source: String,
     similarity: f32,
     route: RouteDecisionDto,
 }
@@ -141,11 +148,19 @@ async fn search_handler(
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let route = resolve_route(&db, &query.q, query.wing.as_deref(), query.room.as_deref())
         .map_err(internal_error)?;
+    let config = Config::default();
+    let scope = ProjectSearchScope::from_request(
+        resolve_project_id(query.project_id.as_deref(), &config, None).map_err(internal_error)?,
+        query.include_global.unwrap_or(false),
+        query.all_projects.unwrap_or(false),
+        false,
+    );
     let results = search_with_vector(
         &db,
         &query.q,
         &query_vector,
         route,
+        &scope,
         query.top_k.unwrap_or(10),
     )
     .map_err(internal_error)?;
@@ -178,22 +193,28 @@ async fn ingest_handler(
         })?;
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let drawer_id = build_drawer_id(&request.wing, request.room.as_deref(), &request.content);
+    let config = Config::default();
+    let project_id =
+        resolve_project_id(request.project_id.as_deref(), &config, None).map_err(internal_error)?;
 
     if !db.drawer_exists(&drawer_id).map_err(internal_error)? {
         let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
-        db.insert_drawer(&Drawer {
-            id: drawer_id.clone(),
-            content: request.content,
-            wing: request.wing,
-            room: request.room,
-            source_file: Some(source_file),
-            source_type: SourceType::Manual,
-            added_at: current_timestamp(),
-            chunk_index: Some(0),
-            importance: 0,
-        })
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: drawer_id.clone(),
+                content: request.content,
+                wing: request.wing,
+                room: request.room,
+                source_file: Some(source_file),
+                source_type: SourceType::Manual,
+                added_at: current_timestamp(),
+                chunk_index: Some(0),
+                importance: 0,
+            },
+            project_id.as_deref(),
+        )
         .map_err(internal_error)?;
-        db.insert_vector(&drawer_id, &vector)
+        db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
             .map_err(internal_error)?;
     }
 
@@ -276,6 +297,7 @@ impl From<SearchResult> for SearchResultDto {
             wing: value.wing,
             room: value.room,
             source_file: value.source_file,
+            source: value.source.as_str().to_string(),
             similarity: value.similarity,
             route: value.route.into(),
         }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub db_path: String,
     #[serde(alias = "embedder")]
     pub embed: EmbedConfig,
+    pub project: ProjectConfig,
     pub privacy: PrivacyConfig,
     pub config_hot_reload: ConfigHotReloadConfig,
     pub search: SearchConfig,
@@ -44,6 +45,7 @@ impl Default for Config {
         Self {
             db_path: DEFAULT_DB_PATH.to_string(),
             embed: EmbedConfig::default(),
+            project: ProjectConfig::default(),
             privacy: PrivacyConfig::default(),
             config_hot_reload: ConfigHotReloadConfig::default(),
             search: SearchConfig::default(),
@@ -81,6 +83,10 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<(), ConfigError> {
+        if let Some(project_id) = self.project.id.as_deref() {
+            super::project::validate_project_id(project_id)
+                .map_err(|error| ConfigError::InvalidConfig(error.to_string()))?;
+        }
         if self.embed.retry.interval_secs == 0 {
             return Err(ConfigError::InvalidConfig(
                 "embed.retry.interval_secs must be greater than 0".to_string(),
@@ -574,6 +580,12 @@ impl Default for ConfigHotReloadConfig {
 #[serde(default)]
 pub struct SearchConfig {
     pub strict_project_isolation: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct ProjectConfig {
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -125,6 +125,14 @@ impl Database {
     }
 
     pub fn insert_drawer(&self, drawer: &Drawer) -> Result<(), DbError> {
+        self.insert_drawer_with_project(drawer, None)
+    }
+
+    pub fn insert_drawer_with_project(
+        &self,
+        drawer: &Drawer,
+        project_id: Option<&str>,
+    ) -> Result<(), DbError> {
         self.conn.execute(
             r#"
             INSERT INTO drawers (
@@ -136,9 +144,10 @@ impl Database {
                 source_type,
                 added_at,
                 chunk_index,
-                importance
+                importance,
+                project_id
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
             "#,
             params![
                 drawer.id,
@@ -150,6 +159,7 @@ impl Database {
                 drawer.added_at,
                 drawer.chunk_index,
                 drawer.importance,
+                project_id,
             ],
         )?;
 
@@ -224,9 +234,14 @@ impl Database {
             params![drawer_id, merged_content, updated_at],
         )?;
         transaction.execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
+        let project_id = transaction.query_row(
+            "SELECT project_id FROM drawers WHERE id = ?1",
+            [drawer_id],
+            |row| row.get::<_, Option<String>>(0),
+        )?;
         transaction.execute(
-            "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, vec_f32(?2))",
-            params![drawer_id, vector_json],
+            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+            params![drawer_id, vector_json, project_id],
         )?;
         transaction.commit()?;
         Ok(())
@@ -382,11 +397,20 @@ impl Database {
     }
 
     pub fn insert_vector(&self, drawer_id: &str, vector: &[f32]) -> Result<(), DbError> {
+        self.insert_vector_with_project(drawer_id, vector, None)
+    }
+
+    pub fn insert_vector_with_project(
+        &self,
+        drawer_id: &str,
+        vector: &[f32],
+        project_id: Option<&str>,
+    ) -> Result<(), DbError> {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
         self.conn.execute(
-            "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, vec_f32(?2))",
-            (drawer_id, vector_json.as_str()),
+            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+            params![drawer_id, vector_json.as_str(), project_id],
         )?;
         Ok(())
     }
@@ -441,8 +465,14 @@ impl Database {
     /// Ensure drawer_vectors table exists with the right dimension.
     /// Creates it on first call; errors on dimension mismatch.
     fn ensure_vectors_table(&self, dim: usize) -> Result<(), DbError> {
+        let fork_ext_version = db_fork_ext::read_fork_ext_version(&self.conn)?;
+        let project_column = if fork_ext_version >= 5 {
+            ", +project_id TEXT"
+        } else {
+            ""
+        };
         self.conn.execute_batch(&format!(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]);"
+            "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]{project_column});"
         ))?;
         Ok(())
     }
@@ -535,6 +565,18 @@ impl Database {
         }
     }
 
+    pub fn drawer_project_id(&self, drawer_id: &str) -> Result<Option<String>, DbError> {
+        let value = self
+            .conn
+            .query_row(
+                "SELECT project_id FROM drawers WHERE id = ?1 AND deleted_at IS NULL",
+                [drawer_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?;
+        Ok(value.flatten())
+    }
+
     pub fn soft_delete_drawer(&self, drawer_id: &str) -> Result<bool, DbError> {
         let timestamp = super::utils::current_timestamp();
         let affected = self.conn.execute(
@@ -598,6 +640,8 @@ impl Database {
         query: &str,
         wing: Option<&str>,
         room: Option<&str>,
+        project_mode: &str,
+        project_id: Option<&str>,
         limit: usize,
     ) -> Result<Vec<(String, f64)>, DbError> {
         let Some(match_query) = build_fts_match_query(query) else {
@@ -605,25 +649,113 @@ impl Database {
         };
         let limit =
             i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let mut stmt = self
+            .conn
+            .prepare(&crate::search::filter::build_fts_runtime_sql())?;
+        let rows = stmt
+            .query_map(
+                (
+                    match_query.as_str(),
+                    wing,
+                    room,
+                    project_mode,
+                    project_id,
+                    limit,
+                ),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)),
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn project_breakdown(&self) -> Result<Vec<(Option<String>, i64)>, DbError> {
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT d.id, fts.rank
-            FROM drawers_fts fts
-            JOIN drawers d ON d.rowid = fts.rowid
-            WHERE drawers_fts MATCH ?1
-              AND d.deleted_at IS NULL
-              AND (?2 IS NULL OR d.wing = ?2)
-              AND (?3 IS NULL OR d.room = ?3)
-            ORDER BY fts.rank
-            LIMIT ?4
+            SELECT project_id, COUNT(*)
+            FROM drawers
+            WHERE deleted_at IS NULL
+            GROUP BY project_id
+            ORDER BY project_id
             "#,
         )?;
         let rows = stmt
-            .query_map((match_query.as_str(), wing, room, limit), |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+            .query_map([], |row| {
+                Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+
+    pub fn tunnel_drawers_for_room(
+        &self,
+        room: &str,
+        exclude_drawer_id: &str,
+        current_project_id: Option<&str>,
+    ) -> Result<Vec<(Drawer, Option<String>)>, DbError> {
+        let Some(current_project_id) = current_project_id else {
+            return Ok(Vec::new());
+        };
+
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, content, wing, room, source_file, source_type, added_at, chunk_index,
+                   COALESCE(importance, 0) as importance, project_id
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND room = ?1
+              AND id != ?2
+              AND project_id IS NOT NULL
+              AND project_id != ?3
+            ORDER BY CAST(added_at AS INTEGER) DESC, id DESC
+            "#,
+        )?;
+        let rows = stmt
+            .query_map([room, exclude_drawer_id, current_project_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<i64>>(7)?,
+                    row.get::<_, i32>(8)?,
+                    row.get::<_, Option<String>>(9)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        rows.into_iter()
+            .map(
+                |(
+                    id,
+                    content,
+                    wing,
+                    room,
+                    source_file,
+                    source_type,
+                    added_at,
+                    chunk_index,
+                    importance,
+                    project_id,
+                )| {
+                    Ok((
+                        Drawer {
+                            id,
+                            content,
+                            wing,
+                            room,
+                            source_file,
+                            source_type: source_type_from_str(&source_type)?,
+                            added_at,
+                            chunk_index,
+                            importance,
+                        },
+                        project_id,
+                    ))
+                },
+            )
+            .collect()
     }
 
     // --- Triples (Knowledge Graph) ---
@@ -817,12 +949,18 @@ impl Database {
     /// Drop and recreate the drawer_vectors table with the specified dimension.
     /// All existing vectors are lost — caller must re-embed after this.
     pub fn recreate_vectors_table(&self, dim: usize) -> Result<(), DbError> {
+        let fork_ext_version = db_fork_ext::read_fork_ext_version(&self.conn)?;
+        let project_column = if fork_ext_version >= 5 {
+            ", +project_id TEXT"
+        } else {
+            ""
+        };
         self.conn.execute_batch(&format!(
             r#"
             DROP TABLE IF EXISTS drawer_vectors;
             CREATE VIRTUAL TABLE drawer_vectors USING vec0(
                 id TEXT PRIMARY KEY,
-                embedding FLOAT[{dim}]
+                embedding FLOAT[{dim}]{project_column}
             );
             "#
         ))?;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -8,7 +8,10 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde_json::Value;
 use thiserror::Error;
 
-use super::types::{Drawer, SourceType, TaxonomyEntry, Triple, TripleStats};
+use super::{
+    types::{Drawer, SourceType, TaxonomyEntry, Triple, TripleStats},
+    utils::{build_drawer_id, build_scoped_drawer_id},
+};
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
@@ -396,6 +399,40 @@ impl Database {
         Ok(exists == 1)
     }
 
+    pub fn resolve_ingest_drawer_id(
+        &self,
+        wing: &str,
+        room: Option<&str>,
+        content: &str,
+        project_id: Option<&str>,
+    ) -> Result<(String, bool), DbError> {
+        if let Some(existing_id) =
+            self.find_active_drawer_id_by_identity(wing, room, content, project_id)?
+        {
+            return Ok((existing_id, true));
+        }
+
+        let base_id = build_drawer_id(wing, room, content);
+        if !self.drawer_id_in_use(&base_id)? {
+            return Ok((base_id, false));
+        }
+
+        let scoped_seed = project_id.unwrap_or("__global_collision__");
+        let scoped_id = build_scoped_drawer_id(wing, room, content, Some(scoped_seed));
+        if scoped_id != base_id && !self.drawer_id_in_use(&scoped_id)? {
+            return Ok((scoped_id, false));
+        }
+
+        let mut suffix = 2usize;
+        loop {
+            let candidate = format!("{scoped_id}_{suffix}");
+            if !self.drawer_id_in_use(&candidate)? {
+                return Ok((candidate, false));
+            }
+            suffix += 1;
+        }
+    }
+
     pub fn insert_vector(&self, drawer_id: &str, vector: &[f32]) -> Result<(), DbError> {
         self.insert_vector_with_project(drawer_id, vector, None)
     }
@@ -575,6 +612,43 @@ impl Database {
             )
             .optional()?;
         Ok(value.flatten())
+    }
+
+    fn drawer_id_in_use(&self, drawer_id: &str) -> Result<bool, DbError> {
+        let exists = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM drawers WHERE id = ?1)",
+            [drawer_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(exists == 1)
+    }
+
+    fn find_active_drawer_id_by_identity(
+        &self,
+        wing: &str,
+        room: Option<&str>,
+        content: &str,
+        project_id: Option<&str>,
+    ) -> Result<Option<String>, DbError> {
+        let value = self
+            .conn
+            .query_row(
+                r#"
+                SELECT id
+                FROM drawers
+                WHERE deleted_at IS NULL
+                  AND wing = ?1
+                  AND content = ?2
+                  AND ((room IS NULL AND ?3 IS NULL) OR room = ?3)
+                  AND ((project_id IS NULL AND ?4 IS NULL) OR project_id = ?4)
+                ORDER BY id
+                LIMIT 1
+                "#,
+                params![wing, content, room, project_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(value)
     }
 
     pub fn soft_delete_drawer(&self, drawer_id: &str) -> Result<bool, DbError> {

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -154,6 +154,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 4,
             up: apply_v4,
         },
+        Migration {
+            version: 5,
+            up: apply_v5,
+        },
     ]
 }
 
@@ -171,6 +175,118 @@ fn apply_v3(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v4(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V4_SCHEMA_SQL)
+}
+
+fn apply_v5(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_project_column(conn, "drawers", "TEXT")?;
+    ensure_project_column(conn, "triples", "TEXT")?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_drawers_project_id ON drawers(project_id);",
+    )?;
+    recreate_drawer_vectors_with_project_id(conn)?;
+    Ok(())
+}
+
+fn ensure_project_column(conn: &Connection, table: &str, ty: &str) -> rusqlite::Result<()> {
+    if table_has_column(conn, table, "project_id")? {
+        return Ok(());
+    }
+    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN project_id {ty};"))
+}
+
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> rusqlite::Result<bool> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&pragma)?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(columns.iter().any(|name| name == column))
+}
+
+fn recreate_drawer_vectors_with_project_id(conn: &Connection) -> rusqlite::Result<()> {
+    let table_sql = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'drawer_vectors'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let Some(table_sql) = table_sql else {
+        return Ok(());
+    };
+    if table_sql.contains("project_id") {
+        return Ok(());
+    }
+
+    let dimension = vector_dimension(conn, &table_sql)?;
+    let expected_count = conn.query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+        row.get::<_, i64>(0)
+    })?;
+
+    conn.execute_batch(
+        r#"
+        DROP TABLE IF EXISTS _drawer_vectors_backup;
+        CREATE TEMP TABLE _drawer_vectors_backup (
+            id TEXT PRIMARY KEY,
+            embedding BLOB NOT NULL
+        );
+        INSERT INTO _drawer_vectors_backup (id, embedding)
+            SELECT id, embedding FROM drawer_vectors;
+        DROP TABLE drawer_vectors;
+        "#,
+    )?;
+    conn.execute_batch(&format!(
+        r#"
+        CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+            id TEXT PRIMARY KEY,
+            embedding FLOAT[{dimension}],
+            +project_id TEXT
+        );
+        "#
+    ))?;
+    conn.execute_batch(
+        r#"
+        INSERT INTO drawer_vectors (id, embedding, project_id)
+            SELECT id, embedding, NULL FROM _drawer_vectors_backup;
+        "#,
+    )?;
+
+    let actual_count = conn.query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+        row.get::<_, i64>(0)
+    })?;
+    if actual_count != expected_count {
+        return Err(rusqlite::Error::ExecuteReturnedResults);
+    }
+
+    conn.execute_batch("DROP TABLE _drawer_vectors_backup;")?;
+    Ok(())
+}
+
+fn vector_dimension(conn: &Connection, table_sql: &str) -> rusqlite::Result<usize> {
+    let by_row = conn
+        .query_row(
+            "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .map(|value| value as usize);
+    if let Some(by_row) = by_row {
+        return Ok(by_row);
+    }
+
+    let marker = "FLOAT[";
+    let Some(start) = table_sql.find(marker) else {
+        return Err(rusqlite::Error::InvalidQuery);
+    };
+    let rest = &table_sql[start + marker.len()..];
+    let Some(end) = rest.find(']') else {
+        return Err(rusqlite::Error::InvalidQuery);
+    };
+    rest[..end]
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| rusqlite::Error::InvalidQuery)
 }
 
 pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod db;
 pub mod hot_reload;
+pub mod project;
 pub mod protocol;
 pub mod queue;
 pub mod reindex;

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -1,0 +1,326 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::config::Config;
+
+pub const PROJECT_MIGRATION_BATCH_SIZE: usize = 1_000;
+pub const PROJECT_MIGRATION_RETRY_DELAYS_MS: [u64; 3] = [500, 1_000, 2_000];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectFilterMode {
+    AllProjects,
+    ProjectScoped,
+    ProjectPlusGlobal,
+    NullOnly,
+}
+
+impl ProjectFilterMode {
+    pub fn as_sql_mode(self) -> &'static str {
+        match self {
+            Self::AllProjects => "all",
+            Self::ProjectScoped => "project",
+            Self::ProjectPlusGlobal => "project_plus_global",
+            Self::NullOnly => "null_only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchResultSource {
+    Project,
+    Global,
+    TunnelCrossProject,
+}
+
+impl SearchResultSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Global => "global",
+            Self::TunnelCrossProject => "tunnel_cross_project",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectSearchScope {
+    pub project_id: Option<String>,
+    pub mode: ProjectFilterMode,
+}
+
+impl ProjectSearchScope {
+    pub fn all_projects() -> Self {
+        Self {
+            project_id: None,
+            mode: ProjectFilterMode::AllProjects,
+        }
+    }
+
+    pub fn from_request(
+        resolved_project_id: Option<String>,
+        include_global: bool,
+        all_projects: bool,
+        strict_project_isolation: bool,
+    ) -> Self {
+        if all_projects {
+            return Self::all_projects();
+        }
+
+        match resolved_project_id {
+            Some(project_id) if include_global => Self {
+                project_id: Some(project_id),
+                mode: ProjectFilterMode::ProjectPlusGlobal,
+            },
+            Some(project_id) => Self {
+                project_id: Some(project_id),
+                mode: ProjectFilterMode::ProjectScoped,
+            },
+            None if strict_project_isolation => Self {
+                project_id: None,
+                mode: ProjectFilterMode::NullOnly,
+            },
+            None => Self::all_projects(),
+        }
+    }
+
+    pub fn mode_param(&self) -> &'static str {
+        self.mode.as_sql_mode()
+    }
+
+    pub fn classify_row(&self, row_project_id: Option<&str>) -> SearchResultSource {
+        match row_project_id {
+            Some(_) => SearchResultSource::Project,
+            None => SearchResultSource::Global,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectMigrationProgress {
+    pub batch_index: usize,
+    pub updated: usize,
+    pub remaining: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectMigrationEvent {
+    Busy { delay_ms: u64 },
+    Progress(ProjectMigrationProgress),
+}
+
+#[derive(Debug, Error)]
+pub enum ProjectError {
+    #[error("project id cannot be empty")]
+    Empty,
+    #[error("project id cannot start or end with whitespace")]
+    SurroundingWhitespace,
+    #[error("project id cannot contain '/'")]
+    Slash,
+    #[error("project id cannot contain NUL")]
+    Nul,
+    #[error("failed to read current directory")]
+    CurrentDir(#[source] std::io::Error),
+    #[error("failed to run git to infer project root")]
+    Git(#[source] std::io::Error),
+    #[error("invalid UTF-8 in project path")]
+    InvalidUtf8Path,
+    #[error("project path has no basename: {0}")]
+    MissingBasename(PathBuf),
+    #[error("database busy while assigning project ids")]
+    DatabaseBusy,
+    #[error("failed to run project migration query")]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+pub fn resolve_project_id(
+    explicit: Option<&str>,
+    config: &Config,
+    cwd: Option<&Path>,
+) -> Result<Option<String>, ProjectError> {
+    if let Some(explicit) = explicit {
+        return Ok(Some(validate_project_id(explicit)?));
+    }
+    if let Some(configured) = config.project.id.as_deref() {
+        return Ok(Some(validate_project_id(configured)?));
+    }
+    if let Some(from_env) = env::var("MEMPAL_PROJECT_ID").ok().as_deref() {
+        return Ok(Some(validate_project_id(from_env)?));
+    }
+    if let Some(cwd) = cwd {
+        return infer_project_id_from_path(cwd);
+    }
+    Ok(None)
+}
+
+pub fn infer_project_id_from_path(path: &Path) -> Result<Option<String>, ProjectError> {
+    let candidate_root = git_repo_root(path)?.unwrap_or_else(|| path.to_path_buf());
+    match candidate_root.file_name().and_then(|name| name.to_str()) {
+        Some(name) => Ok(Some(validate_project_id(name)?)),
+        None if candidate_root.as_os_str().is_empty() => Ok(None),
+        None => Err(ProjectError::MissingBasename(candidate_root)),
+    }
+}
+
+fn git_repo_root(path: &Path) -> Result<Option<PathBuf>, ProjectError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .map_err(ProjectError::Git)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8(output.stdout).map_err(|_| ProjectError::InvalidUtf8Path)?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(PathBuf::from(trimmed)))
+}
+
+pub fn validate_project_id(raw: &str) -> Result<String, ProjectError> {
+    if raw.is_empty() {
+        return Err(ProjectError::Empty);
+    }
+    if raw.trim() != raw {
+        return Err(ProjectError::SurroundingWhitespace);
+    }
+    if raw.contains('/') {
+        return Err(ProjectError::Slash);
+    }
+    if raw.contains('\0') {
+        return Err(ProjectError::Nul);
+    }
+    Ok(raw.to_string())
+}
+
+pub fn migrate_null_project_ids<F>(
+    db_path: &Path,
+    project_id: &str,
+    wing: Option<&str>,
+    mut on_event: F,
+) -> Result<(), ProjectError>
+where
+    F: FnMut(ProjectMigrationEvent),
+{
+    let project_id = validate_project_id(project_id)?;
+    let wing = wing.map(ToOwned::to_owned);
+    let mut batch_index = 0usize;
+
+    loop {
+        let conn = Connection::open(db_path)?;
+        conn.busy_timeout(Duration::from_millis(0))?;
+        match conn.execute_batch("BEGIN IMMEDIATE") {
+            Ok(()) => {}
+            Err(rusqlite::Error::SqliteFailure(error, _))
+                if error.code == rusqlite::ErrorCode::DatabaseBusy =>
+            {
+                for delay_ms in PROJECT_MIGRATION_RETRY_DELAYS_MS {
+                    on_event(ProjectMigrationEvent::Busy { delay_ms });
+                    thread::sleep(Duration::from_millis(delay_ms));
+                }
+                continue;
+            }
+            Err(error) => return Err(ProjectError::Sqlite(error)),
+        }
+
+        let result = (|| {
+            let ids = collect_batch_ids(&conn, wing.as_deref())?;
+            if ids.is_empty() {
+                conn.execute_batch("COMMIT")?;
+                return Ok(None);
+            }
+
+            update_project_ids(&conn, "drawers", &ids, &project_id)?;
+            update_project_ids(&conn, "drawer_vectors", &ids, &project_id)?;
+            let remaining = count_remaining(&conn, wing.as_deref())?;
+            conn.execute_batch("COMMIT")?;
+            Ok(Some((ids.len(), remaining)))
+        })();
+
+        match result {
+            Ok(Some((updated, remaining))) => {
+                batch_index += 1;
+                on_event(ProjectMigrationEvent::Progress(ProjectMigrationProgress {
+                    batch_index,
+                    updated,
+                    remaining,
+                }));
+                thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) => return Ok(()),
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(error);
+            }
+        }
+    }
+}
+
+fn collect_batch_ids(conn: &Connection, wing: Option<&str>) -> Result<Vec<String>, ProjectError> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT id
+        FROM drawers
+        WHERE project_id IS NULL
+          AND (?1 IS NULL OR wing = ?1)
+        ORDER BY id
+        LIMIT ?2
+        "#,
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                wing,
+                i64::try_from(PROJECT_MIGRATION_BATCH_SIZE).unwrap_or(1_000)
+            ],
+            |row| row.get::<_, String>(0),
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+fn update_project_ids(
+    conn: &Connection,
+    table: &str,
+    ids: &[String],
+    project_id: &str,
+) -> Result<(), ProjectError> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let placeholders = (0..ids.len()).map(|_| "?").collect::<Vec<_>>().join(", ");
+    let sql = format!("UPDATE {table} SET project_id = ?1 WHERE id IN ({placeholders})");
+    let mut params = Vec::<&dyn rusqlite::ToSql>::with_capacity(ids.len() + 1);
+    params.push(&project_id);
+    for id in ids {
+        params.push(id);
+    }
+    conn.execute(&sql, params.as_slice())?;
+    Ok(())
+}
+
+fn count_remaining(conn: &Connection, wing: Option<&str>) -> Result<usize, ProjectError> {
+    let remaining = conn.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM drawers
+        WHERE project_id IS NULL
+          AND (?1 IS NULL OR wing = ?1)
+        "#,
+        [wing],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(remaining as usize)
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::core::project::SearchResultSource;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SourceType {
     Project,
@@ -66,6 +68,7 @@ pub struct SearchResult {
     pub wing: String,
     pub room: Option<String>,
     pub source_file: String,
+    pub source: SearchResultSource,
     pub similarity: f32,
     pub route: RouteDecision,
     /// Other wings that share this result's room (tunnel hints).

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -8,9 +8,22 @@ use super::types::TaxonomyEntry;
 pub const DEFAULT_ROOM: &str = "default";
 
 pub fn build_drawer_id(wing: &str, room: Option<&str>, content: &str) -> String {
+    build_scoped_drawer_id(wing, room, content, None)
+}
+
+pub fn build_scoped_drawer_id(
+    wing: &str,
+    room: Option<&str>,
+    content: &str,
+    scope_seed: Option<&str>,
+) -> String {
     let room = room.unwrap_or(DEFAULT_ROOM);
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
+    if let Some(scope_seed) = scope_seed {
+        hasher.update([0]);
+        hasher.update(scope_seed.as_bytes());
+    }
     let digest = format!("{:x}", hasher.finalize());
 
     format!(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,7 @@ use crate::core::{
     db::Database,
     queue::{ClaimedMessage, PendingMessageStore},
     types::{Drawer, SourceType},
-    utils::{build_drawer_id, current_timestamp, synthetic_source_file},
+    utils::{current_timestamp, synthetic_source_file},
 };
 use crate::embed::{
     EmbedError, Embedder, build_backend_from_name, global_embed_status,
@@ -408,12 +408,21 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     context: &DrawerIngestContext<'_, E>,
     record: DrawerRecord,
 ) -> Result<String> {
-    let drawer_id = build_drawer_id(&record.wing, Some(record.room.as_str()), &record.content);
-    if context
+    let (drawer_id, exists) = context
         .db
-        .drawer_exists(&drawer_id)
-        .with_context(|| format!("failed to check existing drawer {}", drawer_id))?
-    {
+        .resolve_ingest_drawer_id(
+            &record.wing,
+            Some(record.room.as_str()),
+            &record.content,
+            None,
+        )
+        .with_context(|| {
+            format!(
+                "failed to resolve drawer identity for {}/{}",
+                record.wing, record.room
+            )
+        })?;
+    if exists {
         return Ok(drawer_id);
     }
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -224,14 +224,18 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     let mut pending = Vec::new();
 
     for (chunk_index, chunk) in chunks.iter().enumerate() {
-        let drawer_id = build_drawer_id(wing, Some(resolved_room.as_str()), chunk);
-        if db
-            .drawer_exists(&drawer_id)
+        let (drawer_id, exists) = db
+            .resolve_ingest_drawer_id(
+                wing,
+                Some(resolved_room.as_str()),
+                chunk,
+                options.project_id,
+            )
             .map_err(|source| IngestError::CheckDrawer {
-                drawer_id: drawer_id.clone(),
+                drawer_id: build_drawer_id(wing, Some(resolved_room.as_str()), chunk),
                 source,
-            })?
-        {
+            })?;
+        if exists {
             stats.skipped += 1;
             continue;
         }

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -57,6 +57,7 @@ pub struct IngestOptions<'a> {
     pub room: Option<&'a str>,
     pub source_root: Option<&'a Path>,
     pub dry_run: bool,
+    pub project_id: Option<&'a str>,
 }
 
 pub type Result<T> = std::result::Result<T, IngestError>;
@@ -141,6 +142,7 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
             room,
             source_root: path.parent(),
             dry_run: false,
+            project_id: None,
         },
     )
     .await
@@ -287,12 +289,12 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             importance: 0,
         };
 
-        db.insert_drawer(&drawer)
+        db.insert_drawer_with_project(&drawer, options.project_id)
             .map_err(|source| IngestError::InsertDrawer {
                 drawer_id: drawer.id.clone(),
                 source,
             })?;
-        db.insert_vector(&drawer_id, &vector)
+        db.insert_vector_with_project(&drawer_id, &vector, options.project_id)
             .map_err(|source| IngestError::InsertVector {
                 drawer_id: drawer.id.clone(),
                 source,
@@ -319,6 +321,7 @@ pub async fn ingest_dir<E: Embedder + ?Sized>(
             room,
             source_root: Some(dir),
             dry_run: false,
+            project_id: None,
         },
     )
     .await

--- a/src/longmemeval.rs
+++ b/src/longmemeval.rs
@@ -9,6 +9,7 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::core::{
     config::Config,
     db::Database,
+    project::ProjectSearchScope,
     types::{Drawer, SourceType, TaxonomyEntry},
     utils::{build_drawer_id, route_room_from_taxonomy},
 };
@@ -277,9 +278,18 @@ async fn run_benchmark_with_embedder<E: Embedder + ?Sized>(
 
         ingest_corpus(&db, embedder, &corpus_items, args.mode).await?;
 
-        let results = search(&db, embedder, &entry.question, None, None, args.top_k)
-            .await
-            .with_context(|| format!("search failed for question {}", entry.question_id))?;
+        let scope = ProjectSearchScope::all_projects();
+        let results = search(
+            &db,
+            embedder,
+            &entry.question,
+            None,
+            None,
+            &scope,
+            args.top_k,
+        )
+        .await
+        .with_context(|| format!("search failed for question {}", entry.question_id))?;
         let rankings = map_results_to_rankings(&results, &corpus_items);
         let entry_metrics = score_entry(entry, &rankings, &corpus_items, &ks);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::core::{
     config::{Config, ConfigHandle, default_config_path},
     db::Database,
+    project::{
+        ProjectMigrationEvent, ProjectSearchScope, migrate_null_project_ids, resolve_project_id,
+    },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     reindex::ReindexProgressStore,
     types::TaxonomyEntry,
@@ -22,7 +25,7 @@ use mempal::core::{
 };
 use mempal::embed::build_backend_from_name;
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
-use mempal::ingest::{IngestOptions, IngestStats, ingest_dir, ingest_dir_with_options};
+use mempal::ingest::{IngestOptions, IngestStats, ingest_dir_with_options};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::search;
 
@@ -35,6 +38,17 @@ use crate::longmemeval::{BenchMode, LongMemEvalArgs, LongMemEvalGranularity, def
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+struct SearchCommandOptions<'a> {
+    query: &'a str,
+    wing: Option<&'a str>,
+    room: Option<&'a str>,
+    top_k: usize,
+    project: Option<&'a str>,
+    include_global: bool,
+    all_projects: bool,
+    json: bool,
 }
 
 #[derive(Subcommand)]
@@ -51,6 +65,8 @@ enum Commands {
         #[arg(long)]
         format: Option<String>,
         #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
         dry_run: bool,
     },
     Search {
@@ -62,7 +78,17 @@ enum Commands {
         #[arg(long, default_value_t = 10)]
         top_k: usize,
         #[arg(long)]
+        project: Option<String>,
+        #[arg(long, default_value_t = false)]
+        include_global: bool,
+        #[arg(long, default_value_t = false)]
+        all_projects: bool,
+        #[arg(long)]
         json: bool,
+    },
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
     },
     WakeUp {
         #[arg(long)]
@@ -204,6 +230,16 @@ enum KgCommands {
 }
 
 #[derive(Subcommand)]
+enum ProjectCommands {
+    Migrate {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        wing: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum BenchCommands {
     #[command(name = "longmemeval")]
     LongMemEval {
@@ -275,6 +311,7 @@ fn run() -> Result<()> {
             dir,
             wing,
             format,
+            project,
             dry_run,
         } => block_on_result(ingest_command(
             &db,
@@ -282,6 +319,7 @@ fn run() -> Result<()> {
             &dir,
             &wing,
             format,
+            project.as_deref(),
             dry_run,
         )),
         Commands::Search {
@@ -289,16 +327,25 @@ fn run() -> Result<()> {
             wing,
             room,
             top_k,
+            project,
+            include_global,
+            all_projects,
             json,
         } => block_on_result(search_command(
             &db,
             config.as_ref(),
-            &query,
-            wing.as_deref(),
-            room.as_deref(),
-            top_k,
-            json,
+            SearchCommandOptions {
+                query: &query,
+                wing: wing.as_deref(),
+                room: room.as_deref(),
+                top_k,
+                project: project.as_deref(),
+                include_global,
+                all_projects,
+                json,
+            },
         )),
+        Commands::Project { command } => project_command(&db, command),
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
         Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
@@ -405,6 +452,7 @@ async fn ingest_command(
     dir: &Path,
     wing: &str,
     format: Option<String>,
+    project: Option<&str>,
     dry_run: bool,
 ) -> Result<()> {
     if let Some(format) = format.as_deref()
@@ -413,6 +461,8 @@ async fn ingest_command(
         bail!("unsupported --format value: {format}");
     }
 
+    let project_id = resolve_project_id(project, config, Some(dir))
+        .context("failed to resolve ingest project id")?;
     let stats = if dry_run {
         ingest_dir_with_options(
             db,
@@ -423,12 +473,25 @@ async fn ingest_command(
                 room: None,
                 source_root: Some(dir),
                 dry_run: true,
+                project_id: project_id.as_deref(),
             },
         )
         .await?
     } else {
         let embedder = build_embedder(config).await?;
-        ingest_dir(db, &*embedder, dir, wing, None).await?
+        ingest_dir_with_options(
+            db,
+            &*embedder,
+            dir,
+            wing,
+            IngestOptions {
+                room: None,
+                source_root: Some(dir),
+                dry_run: false,
+                project_id: project_id.as_deref(),
+            },
+        )
+        .await?
     };
 
     append_ingest_audit_log(db, dir, wing, format.as_deref(), dry_run, stats)
@@ -500,16 +563,30 @@ fn append_ingest_audit_log(
 async fn search_command(
     db: &Database,
     config: &Config,
-    query: &str,
-    wing: Option<&str>,
-    room: Option<&str>,
-    top_k: usize,
-    json: bool,
+    options: SearchCommandOptions<'_>,
 ) -> Result<()> {
+    let current_dir = env::current_dir().ok();
+    let resolved_project = resolve_project_id(options.project, config, current_dir.as_deref())
+        .context("failed to resolve search project id")?;
+    let scope = ProjectSearchScope::from_request(
+        resolved_project,
+        options.include_global,
+        options.all_projects,
+        config.search.strict_project_isolation,
+    );
     let embedder = build_embedder(config).await?;
-    let results = search(db, &*embedder, query, wing, room, top_k).await?;
+    let results = search(
+        db,
+        &*embedder,
+        options.query,
+        options.wing,
+        options.room,
+        &scope,
+        options.top_k,
+    )
+    .await?;
 
-    if json {
+    if options.json {
         println!(
             "{}",
             serde_json::to_string_pretty(&results).context("failed to serialize search results")?
@@ -530,6 +607,7 @@ async fn search_command(
             result.similarity, result.wing, room, result.drawer_id
         );
         println!("source: {source_file}");
+        println!("scope: {}", result.source.as_str());
         if !result.tunnel_hints.is_empty() {
             println!("tunnel: also in {}", result.tunnel_hints.join(", "));
         }
@@ -538,6 +616,27 @@ async fn search_command(
     }
 
     Ok(())
+}
+
+fn project_command(db: &Database, command: ProjectCommands) -> Result<()> {
+    match command {
+        ProjectCommands::Migrate { project, wing } => {
+            migrate_null_project_ids(db.path(), &project, wing.as_deref(), |event| match event {
+                ProjectMigrationEvent::Busy { delay_ms } => {
+                    println!("batch busy, retrying in {delay_ms}ms");
+                    let _ = std::io::stdout().flush();
+                }
+                ProjectMigrationEvent::Progress(progress) => {
+                    println!(
+                        "batch {}: {} drawers updated, {} remaining",
+                        progress.batch_index, progress.updated, progress.remaining
+                    );
+                    let _ = std::io::stdout().flush();
+                }
+            })
+            .context("failed to migrate project ids")
+        }
+    }
 }
 
 fn wake_up_command(db: &Database, format: Option<&str>) -> Result<()> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,7 +6,7 @@ use crate::core::{
     db::Database,
     project::{ProjectSearchScope, resolve_project_id},
     types::{Drawer, SourceType, Triple},
-    utils::{build_drawer_id, build_triple_id, current_timestamp, source_file_or_synthetic},
+    utils::{build_triple_id, current_timestamp, source_file_or_synthetic},
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
 use crate::embed::{EmbedderFactory, global_embed_status};
@@ -228,7 +228,15 @@ impl MempalMcpServer {
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
-        let drawer_id = build_drawer_id(&request.wing, room, &scrubbed_content);
+        let db = self.open_db()?;
+        let (drawer_id, _drawer_exists) = db
+            .resolve_ingest_drawer_id(
+                &request.wing,
+                room,
+                &scrubbed_content,
+                project_id.as_deref(),
+            )
+            .map_err(db_error)?;
 
         if request.dry_run.unwrap_or(false) {
             return Ok(Json(IngestResponse {
@@ -255,7 +263,6 @@ impl MempalMcpServer {
         if let Some(decision) = gating_decision.as_ref()
             && decision.is_rejected()
         {
-            let db = self.open_db()?;
             db.record_gating_audit(&drawer_id, decision)
                 .map_err(db_error)?;
             return Ok(Json(IngestResponse {
@@ -271,7 +278,7 @@ impl MempalMcpServer {
             }));
         }
 
-        let mut db = self.open_db()?;
+        let mut db = db;
 
         // P9-B reordered this path so the same-content lock is acquired
         // before the expensive embedder call. That keeps concurrent manual
@@ -289,6 +296,9 @@ impl MempalMcpServer {
         )
         .map_err(|e| ErrorData::internal_error(format!("ingest lock: {e}"), None))?;
         let lock_wait_ms = Some(lock_guard.wait_duration().as_millis() as u64);
+        // Re-check after waiting: another request may have inserted this drawer
+        // while we were blocked on the same drawer_id lock.
+        let drawer_exists = db.drawer_exists(&drawer_id).map_err(db_error)?;
 
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
@@ -388,7 +398,7 @@ impl MempalMcpServer {
                 }
                 novelty_action = Some(NoveltyAction::Insert);
                 near_drawer_id = novelty.near_drawer_id.clone();
-                if !db.drawer_exists(&drawer_id).map_err(db_error)? {
+                if !drawer_exists {
                     let source_file =
                         source_file_or_synthetic(&drawer_id, request.source.as_deref());
                     db.insert_drawer_with_project(
@@ -467,7 +477,7 @@ impl MempalMcpServer {
                     .map_err(db_error)?;
                     novelty_action = Some(NoveltyAction::Insert);
                     near_drawer_id = Some(target_id);
-                    if !db.drawer_exists(&drawer_id).map_err(db_error)? {
+                    if !drawer_exists {
                         let source_file =
                             source_file_or_synthetic(&drawer_id, request.source.as_deref());
                         db.insert_drawer_with_project(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use crate::core::{
     config::ConfigHandle,
     db::Database,
+    project::{ProjectSearchScope, resolve_project_id},
     types::{Drawer, SourceType, Triple},
     utils::{build_drawer_id, build_triple_id, current_timestamp, source_file_or_synthetic},
 };
@@ -163,6 +164,17 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<SearchRequest>,
     ) -> std::result::Result<Json<SearchResponse>, ErrorData> {
+        let config = ConfigHandle::current();
+        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
+            .map_err(|error| {
+            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+        })?;
+        let scope = ProjectSearchScope::from_request(
+            project_id,
+            request.include_global.unwrap_or(false),
+            request.all_projects.unwrap_or(false),
+            config.search.strict_project_isolation,
+        );
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
         })?;
@@ -186,6 +198,7 @@ impl MempalMcpServer {
             &request.query,
             &query_vector,
             route,
+            &scope,
             request.top_k.unwrap_or(10),
         )
         .map_err(|error| ErrorData::internal_error(format!("search failed: {error}"), None))?;
@@ -208,6 +221,10 @@ impl MempalMcpServer {
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
+            .map_err(|error| {
+            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+        })?;
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
@@ -374,19 +391,23 @@ impl MempalMcpServer {
                 if !db.drawer_exists(&drawer_id).map_err(db_error)? {
                     let source_file =
                         source_file_or_synthetic(&drawer_id, request.source.as_deref());
-                    db.insert_drawer(&Drawer {
-                        id: drawer_id.clone(),
-                        content: scrubbed_content.clone(),
-                        wing: request.wing.clone(),
-                        room: request.room.clone(),
-                        source_file: Some(source_file),
-                        source_type: SourceType::Manual,
-                        added_at: current_timestamp(),
-                        chunk_index: Some(0),
-                        importance: request.importance.unwrap_or(0),
-                    })
+                    db.insert_drawer_with_project(
+                        &Drawer {
+                            id: drawer_id.clone(),
+                            content: scrubbed_content.clone(),
+                            wing: request.wing.clone(),
+                            room: request.room.clone(),
+                            source_file: Some(source_file),
+                            source_type: SourceType::Manual,
+                            added_at: current_timestamp(),
+                            chunk_index: Some(0),
+                            importance: request.importance.unwrap_or(0),
+                        },
+                        project_id.as_deref(),
+                    )
                     .map_err(db_error)?;
-                    db.insert_vector(&drawer_id, &vector).map_err(db_error)?;
+                    db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+                        .map_err(db_error)?;
                 }
             }
             NoveltyAction::Drop => {
@@ -449,19 +470,23 @@ impl MempalMcpServer {
                     if !db.drawer_exists(&drawer_id).map_err(db_error)? {
                         let source_file =
                             source_file_or_synthetic(&drawer_id, request.source.as_deref());
-                        db.insert_drawer(&Drawer {
-                            id: drawer_id.clone(),
-                            content: scrubbed_content.clone(),
-                            wing: request.wing.clone(),
-                            room: request.room.clone(),
-                            source_file: Some(source_file),
-                            source_type: SourceType::Manual,
-                            added_at: current_timestamp(),
-                            chunk_index: Some(0),
-                            importance: request.importance.unwrap_or(0),
-                        })
+                        db.insert_drawer_with_project(
+                            &Drawer {
+                                id: drawer_id.clone(),
+                                content: scrubbed_content.clone(),
+                                wing: request.wing.clone(),
+                                room: request.room.clone(),
+                                source_file: Some(source_file),
+                                source_type: SourceType::Manual,
+                                added_at: current_timestamp(),
+                                chunk_index: Some(0),
+                                importance: request.importance.unwrap_or(0),
+                            },
+                            project_id.as_deref(),
+                        )
                         .map_err(db_error)?;
-                        db.insert_vector(&drawer_id, &vector).map_err(db_error)?;
+                        db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+                            .map_err(db_error)?;
                     }
                 } else {
                     let merged_vector = embedder
@@ -1030,7 +1055,8 @@ fn check_semantic_duplicate(
         confidence: 0.0,
         reason: "dedup check".to_string(),
     };
-    let results = crate::search::search_by_vector(db, vector, route, 1).ok()?;
+    let scope = ProjectSearchScope::all_projects();
+    let results = crate::search::search_by_vector(db, vector, route, &scope, 1).ok()?;
     let top = results.first()?;
     if top.similarity >= DEDUP_THRESHOLD {
         Some(DuplicateWarning {
@@ -1221,6 +1247,9 @@ mod tests {
                 wing: wing.map(str::to_string),
                 room: room.map(str::to_string),
                 top_k: Some(top_k),
+                project_id: None,
+                include_global: None,
+                all_projects: None,
             }))
             .await
             .expect("search should succeed")
@@ -1432,6 +1461,7 @@ mod tests {
             wing: "mempal".to_string(),
             room: Some("review".to_string()),
             source: None,
+            project_id: None,
             importance: None,
             dry_run: None,
         };

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -26,6 +26,18 @@ pub struct SearchRequest {
 
     /// Maximum number of results to return. Defaults to 10 when omitted.
     pub top_k: Option<usize>,
+
+    /// Optional explicit project scope. When omitted, mempal resolves the
+    /// current project from config/env/git root and scopes the query there by
+    /// default. Set `all_projects=true` to bypass project scoping.
+    pub project_id: Option<String>,
+
+    /// Include legacy/global drawers (`project_id IS NULL`) alongside the
+    /// current project. Ignored when `all_projects=true`.
+    pub include_global: Option<bool>,
+
+    /// Opt-in override to search across all projects for this request.
+    pub all_projects: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -42,6 +54,7 @@ pub struct SearchResultDto {
     pub wing: String,
     pub room: Option<String>,
     pub source_file: String,
+    pub source: String,
     pub similarity: f32,
     pub route: RouteDecisionDto,
     /// Other wings sharing this room (tunnel cross-references).
@@ -73,6 +86,7 @@ pub struct IngestRequest {
     pub wing: String,
     pub room: Option<String>,
     pub source: Option<String>,
+    pub project_id: Option<String>,
 
     /// If true, return the drawer_id that WOULD be created without actually
     /// writing to the database. Use this to preview before committing.
@@ -393,6 +407,7 @@ impl SearchResultDto {
             wing: value.wing,
             room: value.room,
             source_file: value.source_file,
+            source: value.source.as_str().to_string(),
             similarity: value.similarity,
             route: value.route.into(),
             tunnel_hints: value.tunnel_hints,
@@ -440,6 +455,7 @@ mod tests {
             wing: "mempal".to_string(),
             room: Some("signals".to_string()),
             source_file: "/tmp/signals.md".to_string(),
+            source: crate::core::project::SearchResultSource::Project,
             similarity: 0.91,
             route: RouteDecision {
                 wing: Some("mempal".to_string()),

--- a/src/search/filter.rs
+++ b/src/search/filter.rs
@@ -1,4 +1,12 @@
-pub fn build_filter_clause(alias: &str, wing_param: usize, room_param: usize) -> String {
+use crate::core::project::ProjectFilterMode;
+
+pub fn build_filter_clause(
+    alias: &str,
+    wing_param: usize,
+    room_param: usize,
+    project_mode_param: usize,
+    project_id_param: usize,
+) -> String {
     let prefix = if alias.is_empty() {
         String::new()
     } else {
@@ -8,6 +16,87 @@ pub fn build_filter_clause(alias: &str, wing_param: usize, room_param: usize) ->
     format!(
         "WHERE {prefix}deleted_at IS NULL \
          AND (?{wing_param} IS NULL OR {prefix}wing = ?{wing_param}) \
-         AND (?{room_param} IS NULL OR {prefix}room = ?{room_param})"
+         AND (?{room_param} IS NULL OR {prefix}room = ?{room_param}) \
+         AND (\
+             ?{project_mode_param} = 'all' \
+             OR (?{project_mode_param} = 'project' AND {prefix}project_id = ?{project_id_param}) \
+             OR (?{project_mode_param} = 'project_plus_global' AND ({prefix}project_id = ?{project_id_param} OR {prefix}project_id IS NULL)) \
+             OR (?{project_mode_param} = 'null_only' AND {prefix}project_id IS NULL)\
+         )"
     )
+}
+
+pub fn build_vector_search_sql() -> String {
+    format!(
+        r#"
+        WITH matches AS (
+            SELECT id, distance
+            FROM drawer_vectors v
+            WHERE embedding MATCH vec_f32(?1)
+              AND k = ?2
+              AND (
+                  ?3 = 'all'
+                  OR (?3 = 'project' AND v.project_id = ?4)
+                  OR (?3 = 'project_plus_global' AND (v.project_id = ?4 OR v.project_id IS NULL))
+                  OR (?3 = 'null_only' AND v.project_id IS NULL)
+              )
+        )
+        SELECT d.id, d.content, d.wing, d.room, d.source_file, d.project_id, matches.distance
+        FROM matches
+        JOIN drawers d ON d.id = matches.id
+        {}
+        ORDER BY matches.distance ASC
+        LIMIT ?7
+        "#,
+        build_filter_clause("d", 5, 6, 3, 4)
+    )
+}
+
+pub fn build_fts_runtime_sql() -> String {
+    r#"
+        SELECT d.id, fts.rank
+        FROM drawers_fts fts
+        JOIN drawers d ON d.rowid = fts.rowid
+        WHERE drawers_fts MATCH ?1
+          AND (?2 IS NULL OR d.wing = ?2)
+          AND (?3 IS NULL OR d.room = ?3)
+          AND d.deleted_at IS NULL
+          AND (
+              ?4 = 'all'
+              OR (?4 = 'project' AND d.project_id = ?5)
+              OR (?4 = 'project_plus_global' AND (d.project_id = ?5 OR d.project_id IS NULL))
+              OR (?4 = 'null_only' AND d.project_id IS NULL)
+          )
+        ORDER BY fts.rank
+        LIMIT ?6
+        "#
+    .to_string()
+}
+
+pub fn build_fts_search_sql(mode: ProjectFilterMode) -> String {
+    build_fts_runtime_sql().replace("?4", &format!("'{}'", mode.as_sql_mode()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_fts_search_sql, build_vector_search_sql};
+    use crate::core::project::ProjectFilterMode;
+
+    #[test]
+    fn test_vector_recall_project_filter_pushed_to_sql() {
+        let sql = build_vector_search_sql();
+        assert!(
+            sql.contains("v.project_id = ?4"),
+            "vector SQL must push project_id filter into the vector CTE: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_fts5_recall_project_filter_pushed_to_sql() {
+        let sql = build_fts_search_sql(ProjectFilterMode::ProjectScoped);
+        assert!(
+            sql.contains("d.project_id = ?5") || sql.contains("d.project_id = 'project'"),
+            "fts SQL must reference project_id in SQL: {sql}"
+        );
+    }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,13 +2,14 @@
 
 use crate::core::{
     db::Database,
+    project::{ProjectSearchScope, SearchResultSource},
     types::{RouteDecision, SearchResult},
     utils::source_file_or_synthetic,
 };
 use crate::embed::{EmbedError, Embedder};
 use thiserror::Error;
 
-use crate::search::filter::build_filter_clause;
+use crate::search::filter::{build_filter_clause, build_vector_search_sql};
 use rusqlite::OptionalExtension;
 
 pub mod filter;
@@ -53,6 +54,7 @@ pub async fn search<E: Embedder + ?Sized>(
     query: &str,
     wing: Option<&str>,
     room: Option<&str>,
+    scope: &ProjectSearchScope,
     top_k: usize,
 ) -> Result<Vec<SearchResult>> {
     if top_k == 0 {
@@ -78,7 +80,7 @@ pub async fn search<E: Embedder + ?Sized>(
         });
     }
 
-    search_with_vector(db, query, &query_vector, route, top_k)
+    search_with_vector(db, query, &query_vector, route, scope, top_k)
 }
 
 fn current_vector_dim(
@@ -110,6 +112,7 @@ pub fn search_with_vector(
     query: &str,
     query_vector: &[f32],
     route: RouteDecision,
+    scope: &ProjectSearchScope,
     top_k: usize,
 ) -> Result<Vec<SearchResult>> {
     if top_k == 0 {
@@ -117,27 +120,39 @@ pub fn search_with_vector(
     }
 
     // Hybrid search: vector + BM25, merged via RRF
-    let vector_results = search_by_vector(db, query_vector, route.clone(), top_k)?;
+    let vector_results = search_by_vector(db, query_vector, route.clone(), scope, top_k)?;
 
     let fts_ids = db
-        .search_fts(query, route.wing.as_deref(), route.room.as_deref(), top_k)
+        .search_fts(
+            query,
+            route.wing.as_deref(),
+            route.room.as_deref(),
+            scope.mode_param(),
+            scope.project_id.as_deref(),
+            top_k,
+        )
         .map_err(SearchError::KeywordSearch)?;
 
     let mut results = if fts_ids.is_empty() {
         vector_results
     } else {
-        rrf_merge(vector_results, &fts_ids, &route, db, top_k)
+        rrf_merge(vector_results, &fts_ids, &route, scope, db, top_k)
     };
 
     // Inject tunnel hints: for each result, check if its room exists in other wings
-    inject_tunnel_hints(db, &mut results);
+    inject_tunnel_hints_and_results(db, &mut results, scope);
 
     Ok(results)
 }
 
 /// For each search result, check if its room appears in other wings (tunnel).
-/// If so, add the other wing names as tunnel_hints.
-fn inject_tunnel_hints(db: &Database, results: &mut [SearchResult]) {
+/// If so, add the other wing names as tunnel_hints and append any explicit
+/// cross-project tunnel targets without applying the project filter.
+fn inject_tunnel_hints_and_results(
+    db: &Database,
+    results: &mut Vec<SearchResult>,
+    scope: &ProjectSearchScope,
+) {
     let tunnels = match db.find_tunnels() {
         Ok(t) => t,
         Err(_) => return,
@@ -152,6 +167,11 @@ fn inject_tunnel_hints(db: &Database, results: &mut [SearchResult]) {
         .map(|(room, wings)| (room.as_str(), wings.as_slice()))
         .collect();
 
+    let mut tunnel_results = Vec::new();
+    let mut seen_ids = results
+        .iter()
+        .map(|result| result.drawer_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
     for result in results.iter_mut() {
         if let Some(room) = result.room.as_deref() {
             if let Some(wings) = tunnel_map.get(room) {
@@ -161,8 +181,31 @@ fn inject_tunnel_hints(db: &Database, results: &mut [SearchResult]) {
                     .cloned()
                     .collect();
             }
+            if let Ok(drawers) =
+                db.tunnel_drawers_for_room(room, &result.drawer_id, scope.project_id.as_deref())
+            {
+                for (drawer, _) in drawers {
+                    if seen_ids.insert(drawer.id.clone()) {
+                        tunnel_results.push(SearchResult {
+                            drawer_id: drawer.id.clone(),
+                            content: drawer.content,
+                            wing: drawer.wing,
+                            room: drawer.room,
+                            source_file: source_file_or_synthetic(
+                                &drawer.id,
+                                drawer.source_file.as_deref(),
+                            ),
+                            source: SearchResultSource::TunnelCrossProject,
+                            similarity: result.similarity,
+                            route: result.route.clone(),
+                            tunnel_hints: vec![],
+                        });
+                    }
+                }
+            }
         }
     }
+    results.extend(tunnel_results);
 }
 
 /// Reciprocal Rank Fusion: merge vector and BM25 ranked lists.
@@ -171,6 +214,7 @@ fn rrf_merge(
     vector_results: Vec<SearchResult>,
     fts_ids: &[(String, f64)],
     route: &RouteDecision,
+    scope: &ProjectSearchScope,
     db: &Database,
     top_k: usize,
 ) -> Vec<SearchResult> {
@@ -204,6 +248,8 @@ fn rrf_merge(
                         wing: drawer.wing,
                         room: drawer.room,
                         source_file: source_file_or_synthetic(id, drawer.source_file.as_deref()),
+                        source: scope
+                            .classify_row(db.drawer_project_id(id).ok().flatten().as_deref()),
                         similarity: 0.0, // will be overwritten below
                         route: route.clone(),
                         tunnel_hints: vec![],
@@ -235,6 +281,7 @@ pub fn search_by_vector(
     db: &Database,
     query_vector: &[f32],
     route: RouteDecision,
+    scope: &ProjectSearchScope,
     top_k: usize,
 ) -> Result<Vec<SearchResult>> {
     if top_k == 0 {
@@ -246,11 +293,20 @@ pub fn search_by_vector(
 
     let count_sql = format!(
         "SELECT COUNT(*) FROM drawers d {}",
-        build_filter_clause("d", 1, 2)
+        build_filter_clause("d", 1, 2, 3, 4)
     );
     let candidate_count: i64 = db
         .conn()
-        .query_row(&count_sql, (applied_wing, applied_room), |row| row.get(0))
+        .query_row(
+            &count_sql,
+            (
+                applied_wing,
+                applied_room,
+                scope.mode_param(),
+                scope.project_id.as_deref(),
+            ),
+            |row| row.get(0),
+        )
         .map_err(SearchError::CountCandidateDrawers)?;
     if candidate_count == 0 {
         return Ok(Vec::new());
@@ -268,23 +324,7 @@ pub fn search_by_vector(
         serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
     let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
 
-    let search_sql = format!(
-        r#"
-        WITH matches AS (
-            SELECT id, distance
-            FROM drawer_vectors
-            WHERE embedding MATCH vec_f32(?1)
-              AND k = ?2
-        )
-        SELECT d.id, d.content, d.wing, d.room, d.source_file, matches.distance
-        FROM matches
-        JOIN drawers d ON d.id = matches.id
-        {}
-        ORDER BY matches.distance ASC
-        LIMIT ?5
-        "#,
-        build_filter_clause("d", 3, 4)
-    );
+    let search_sql = build_vector_search_sql();
 
     let mut statement = db
         .conn()
@@ -295,20 +335,24 @@ pub fn search_by_vector(
             (
                 query_json.as_str(),
                 total_count,
+                scope.mode_param(),
+                scope.project_id.as_deref(),
                 applied_wing,
                 applied_room,
                 top_k,
             ),
             |row| {
-                let distance: f64 = row.get(5)?;
+                let distance: f64 = row.get(6)?;
                 let drawer_id: String = row.get(0)?;
                 let source_file = row.get::<_, Option<String>>(4)?;
+                let row_project_id = row.get::<_, Option<String>>(5)?;
                 Ok(SearchResult {
                     drawer_id: drawer_id.clone(),
                     content: row.get(1)?,
                     wing: row.get(2)?,
                     room: row.get(3)?,
                     source_file: source_file_or_synthetic(&drawer_id, source_file.as_deref()),
+                    source: scope.classify_row(row_project_id.as_deref()),
                     similarity: (1.0_f64 - distance) as f32,
                     route: route.clone(),
                     tunnel_hints: vec![],

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -243,6 +243,7 @@ async fn ingest(server: &MempalMcpServer, content: &str) -> String {
             wing: "mempal".to_string(),
             room: Some("config-hot-reload".to_string()),
             source: None,
+            project_id: None,
             dry_run: None,
             importance: None,
         }))
@@ -339,6 +340,7 @@ async fn test_ingest_gating_hot_reload_applies_without_server_restart() {
             wing: "mempal".to_string(),
             room: Some("config-hot-reload".to_string()),
             source: None,
+            project_id: None,
             dry_run: None,
             importance: None,
         }))
@@ -539,7 +541,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 4"),
+            .any(|line| line.trim() == "fork_ext_version: 5"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/embedder_degraded_state.rs
+++ b/tests/embedder_degraded_state.rs
@@ -88,6 +88,7 @@ async fn test_degraded_state_blocks_mcp_writes() {
             wing: "test".to_string(),
             room: Some("room".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -103,6 +104,9 @@ async fn test_degraded_state_blocks_mcp_writes() {
             wing: None,
             room: None,
             top_k: Some(5),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
         }))
         .await
         .expect("search should still work")

--- a/tests/embedder_dim_mismatch.rs
+++ b/tests/embedder_dim_mismatch.rs
@@ -73,6 +73,7 @@ request_timeout_secs = 5
             wing: "test".to_string(),
             room: Some("room".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -71,6 +71,7 @@ async fn test_embedder_fallback_to_model2vec_when_lan_unreachable() {
             wing: "test".to_string(),
             room: Some("fallback".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_four_after_novelty_phase() {
+fn test_fork_ext_version_is_five_after_project_isolation_phase() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 #[test]

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -16,7 +16,7 @@ fn test_fork_ext_v4_migration() {
     let (_tmp, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 
     let table_exists = db
         .conn()
@@ -57,5 +57,5 @@ fn test_fork_ext_v4_migration_is_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -151,6 +151,7 @@ prototypes = ["accept"]
             wing: "code-memory".to_string(),
             room: Some("gating".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -218,6 +219,7 @@ prototypes = ["accept-prototype"]
             wing: "code-memory".to_string(),
             room: Some("gating".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -230,6 +232,7 @@ prototypes = ["accept-prototype"]
             wing: "code-memory".to_string(),
             room: Some("gating".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -368,6 +371,7 @@ prototypes = ["accept-prototype"]
             wing: "code-memory".to_string(),
             room: Some("gating".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -178,6 +178,7 @@ async fn test_novelty_drop_near_duplicate() {
             wing: "code-memory".to_string(),
             room: Some("novelty".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -220,6 +221,7 @@ async fn test_novelty_merge_similar_but_extended() {
             wing: "code-memory".to_string(),
             room: Some("novelty".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -262,6 +264,7 @@ async fn test_novelty_insert_distinct() {
             wing: "code-memory".to_string(),
             room: Some("novelty".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -302,6 +305,7 @@ async fn test_merge_preserves_raw_verbatim() {
             wing: "code-memory".to_string(),
             room: Some("novelty".to_string()),
             source: None,
+            project_id: None,
             dry_run: Some(false),
             importance: None,
         }))
@@ -347,6 +351,7 @@ async fn test_novelty_merge_waits_for_target_lock() {
                 wing: "code-memory".to_string(),
                 room: Some("novelty".to_string()),
                 source: None,
+                project_id: None,
                 dry_run: Some(false),
                 importance: None,
             }))
@@ -385,6 +390,16 @@ CREATE TABLE drawers (
     chunk_index INTEGER,
     deleted_at TEXT,
     importance INTEGER DEFAULT 0
+);
+CREATE TABLE triples (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL,
+    predicate TEXT NOT NULL,
+    object TEXT NOT NULL,
+    valid_from TEXT,
+    valid_to TEXT,
+    confidence REAL DEFAULT 1.0,
+    source_drawer TEXT REFERENCES drawers(id)
 );
 CREATE VIRTUAL TABLE drawers_fts USING fts5(
     content,

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -1,0 +1,683 @@
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{MempalMcpServer, SearchRequest};
+use rmcp::handler::server::wrapper::Parameters;
+use rusqlite::{Connection, OptionalExtension, params};
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+#[path = "../src/core/db_fork_ext.rs"]
+mod db_fork_ext;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+async fn config_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn home_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .expect("home mutex poisoned")
+}
+
+#[derive(Clone)]
+struct StaticEmbedderFactory {
+    vector: Vec<f32>,
+}
+
+struct StaticEmbedder {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbedderFactory for StaticEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(StaticEmbedder {
+            vector: self.vector.clone(),
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for StaticEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "static"
+    }
+}
+
+struct SearchEnv {
+    _tmp: TempDir,
+    config_path: PathBuf,
+    db_path: PathBuf,
+}
+
+impl SearchEnv {
+    fn new(project_id: Option<&str>, strict_project_isolation: bool) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let config_path = mempal_home.join("config.toml");
+        let db_path = mempal_home.join("palace.db");
+        let config = search_config(&db_path, project_id, strict_project_isolation);
+        write_config_atomic(&config_path, &config);
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        Self {
+            _tmp: tmp,
+            config_path,
+            db_path,
+        }
+    }
+
+    fn server(&self) -> MempalMcpServer {
+        MempalMcpServer::new_with_factory(
+            self.db_path.clone(),
+            Arc::new(StaticEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+    }
+}
+
+fn search_config(
+    db_path: &Path,
+    project_id: Option<&str>,
+    strict_project_isolation: bool,
+) -> String {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"
+db_path = "{}"
+{}
+[embedder]
+backend = "api"
+base_url = "http://127.0.0.1:9/v1/"
+api_model = "test-model"
+
+[config_hot_reload]
+enabled = true
+debounce_ms = 250
+poll_fallback_secs = 1
+
+[search]
+strict_project_isolation = {}
+"#,
+        db_path.display(),
+        project_section,
+        strict_project_isolation
+    )
+}
+
+fn cli_config(db_path: &Path) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embedder]
+backend = "api"
+base_url = "http://127.0.0.1:9/v1/"
+api_model = "test-model"
+
+[search]
+strict_project_isolation = false
+"#,
+        db_path.display()
+    )
+}
+
+fn write_config_atomic(path: &Path, contents: &str) {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, contents).expect("write temp config");
+    fs::rename(&tmp, path).expect("rename config");
+}
+
+fn wait_for_config_version_change(previous: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let current = ConfigHandle::version();
+        if current != previous {
+            return current;
+        }
+        assert!(Instant::now() < deadline, "config version did not change");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+    let sql = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&sql).expect("prepare table_info");
+    stmt.query_map([], |row| row.get::<_, String>(1))
+        .expect("query table_info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect columns")
+}
+
+fn sqlite_master_sql(conn: &Connection, table: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type IN ('table', 'index') AND name = ?1",
+        [table],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .expect("sqlite_master sql")
+}
+
+fn insert_projected_drawer(
+    db_path: &Path,
+    id: &str,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: wing.to_string(),
+        room: room.map(str::to_string),
+        source_file: Some(format!("{id}.md")),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    })
+    .expect("insert drawer");
+    db.insert_vector(id, &[0.1, 0.2, 0.3])
+        .expect("insert vector");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET project_id = ?2 WHERE id = ?1",
+            params![id, project_id],
+        )
+        .expect("update drawer project");
+    db.conn()
+        .execute(
+            "UPDATE drawer_vectors SET project_id = ?2 WHERE id = ?1",
+            params![id, project_id],
+        )
+        .expect("update vector project");
+}
+
+async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_json::Value {
+    let response = server
+        .mempal_search(Parameters(SearchRequest {
+            query: query.to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+        }))
+        .await
+        .expect("search should succeed")
+        .0;
+    serde_json::to_value(response).expect("serialize search response")
+}
+
+fn install_cli_home(tmp: &TempDir) -> PathBuf {
+    let home = tmp.path().join("home");
+    let mempal_home = home.join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create cli mempal home");
+    home
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal")
+}
+
+#[test]
+fn test_ext_v5_migration_adds_project_id_column() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
+    assert_eq!(version, 5);
+
+    let drawer_columns = column_names(db.conn(), "drawers");
+    assert!(
+        drawer_columns.iter().any(|name| name == "project_id"),
+        "drawers columns missing project_id: {drawer_columns:?}"
+    );
+    let triple_columns = column_names(db.conn(), "triples");
+    assert!(
+        triple_columns.iter().any(|name| name == "project_id"),
+        "triples columns missing project_id: {triple_columns:?}"
+    );
+
+    let index_sql =
+        sqlite_master_sql(db.conn(), "idx_drawers_project_id").expect("project index sql");
+    assert!(
+        index_sql.contains("project_id"),
+        "project_id index missing expected SQL: {index_sql}"
+    );
+}
+
+#[test]
+fn test_ext_v5_migration_idempotent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+
+    let before_drawers = column_names(db.conn(), "drawers");
+    let before_vectors = sqlite_master_sql(db.conn(), "drawer_vectors");
+
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("reapply once");
+    db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("reapply twice");
+
+    let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
+    assert_eq!(version, 5);
+    assert_eq!(before_drawers, column_names(db.conn(), "drawers"));
+    assert_eq!(
+        before_vectors,
+        sqlite_master_sql(db.conn(), "drawer_vectors")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_excludes_other_projects_by_default() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "state lives in proj A",
+        "code",
+        Some("room-a"),
+        Some("proj-A"),
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "state lives in proj B",
+        "docs",
+        Some("room-b"),
+        Some("proj-B"),
+    );
+
+    let json = search_response_json(&env.server(), "state").await;
+    let results = json["results"].as_array().expect("results array");
+    let ids = results
+        .iter()
+        .map(|value| {
+            value["drawer_id"]
+                .as_str()
+                .expect("drawer_id string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        ids.iter().any(|id| id == "drawer-a"),
+        "missing project-A hit: {ids:?}"
+    );
+    assert!(
+        ids.iter().all(|id| id != "drawer-b"),
+        "project-B hit leaked into scoped search: {ids:?}"
+    );
+    let source = results
+        .iter()
+        .find(|value| value["drawer_id"] == "drawer-a")
+        .and_then(|value| value["source"].as_str())
+        .expect("project result source");
+    assert_eq!(source, "project");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tunnel_resolver_bypasses_project_filter() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "anchor query text stays in project A",
+        "code",
+        Some("shared-room"),
+        Some("proj-A"),
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "cross project docs drawer",
+        "docs",
+        Some("shared-room"),
+        Some("proj-B"),
+    );
+
+    let json = search_response_json(&env.server(), "anchor").await;
+    let results = json["results"].as_array().expect("results array");
+    let ids = results
+        .iter()
+        .map(|value| {
+            value["drawer_id"]
+                .as_str()
+                .expect("drawer_id string")
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        ids.iter().any(|id| id == "drawer-a"),
+        "missing anchor result: {ids:?}"
+    );
+    assert!(
+        ids.iter().any(|id| id == "drawer-b"),
+        "tunnel did not surface cross-project drawer: {ids:?}"
+    );
+    let tunnel_source = results
+        .iter()
+        .find(|value| value["drawer_id"] == "drawer-b")
+        .and_then(|value| value["source"].as_str())
+        .expect("tunnel result source");
+    assert_eq!(tunnel_source, "tunnel_cross_project");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_strict_project_isolation_config_hot_reload() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "reload query from project A",
+        "code",
+        Some("reload"),
+        Some("proj-A"),
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-global",
+        "reload query from global drawer",
+        "code",
+        Some("reload"),
+        None,
+    );
+
+    let before = search_response_json(&env.server(), "reload").await;
+    let before_ids = before["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|value| value["drawer_id"].as_str().expect("drawer_id").to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        before_ids.iter().any(|id| id == "drawer-a")
+            && before_ids.iter().any(|id| id == "drawer-global"),
+        "strict=false should see project + global drawers: {before_ids:?}"
+    );
+
+    let previous = ConfigHandle::version();
+    write_config_atomic(&env.config_path, &search_config(&env.db_path, None, true));
+    wait_for_config_version_change(&previous);
+
+    let after = search_response_json(&env.server(), "reload").await;
+    let after_ids = after["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|value| value["drawer_id"].as_str().expect("drawer_id").to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(after_ids, vec!["drawer-global".to_string()]);
+}
+
+#[test]
+fn test_project_migrate_batched_does_not_block_ingest() {
+    let _guard = home_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_config(&db_path),
+    );
+    Database::open(&db_path).expect("open db");
+
+    for index in 0..5_000 {
+        let id = format!("code-{index}");
+        insert_projected_drawer(
+            &db_path,
+            &id,
+            &format!("code memory drawer {index}"),
+            "code-memory",
+            Some("migration"),
+            None,
+        );
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let latencies = Arc::new(Mutex::new(Vec::<Duration>::new()));
+    let errors = Arc::new(Mutex::new(Vec::<String>::new()));
+    let db_for_writer = db_path.clone();
+    let stop_for_writer = Arc::clone(&stop);
+    let latencies_for_writer = Arc::clone(&latencies);
+    let errors_for_writer = Arc::clone(&errors);
+    let writer = thread::spawn(move || {
+        let mut index = 0usize;
+        while !stop_for_writer.load(Ordering::SeqCst) {
+            let started = Instant::now();
+            loop {
+                let db = Database::open(&db_for_writer).expect("open writer db");
+                let result = db.insert_drawer(&Drawer {
+                    id: format!("writer-{index}"),
+                    content: format!("writer content {index}"),
+                    wing: "logs".to_string(),
+                    room: Some("writer".to_string()),
+                    source_file: Some(format!("writer-{index}.md")),
+                    source_type: SourceType::Manual,
+                    added_at: "1713000000".to_string(),
+                    chunk_index: Some(0),
+                    importance: 0,
+                });
+                match result {
+                    Ok(()) => {
+                        latencies_for_writer
+                            .lock()
+                            .expect("latencies mutex poisoned")
+                            .push(started.elapsed());
+                        break;
+                    }
+                    Err(error) if error.to_string().contains("database is locked") => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => {
+                        errors_for_writer
+                            .lock()
+                            .expect("errors mutex poisoned")
+                            .push(error.to_string());
+                        return;
+                    }
+                }
+            }
+            index += 1;
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    });
+
+    let started = Instant::now();
+    let output = run_mempal(
+        &home,
+        &[
+            "project",
+            "migrate",
+            "--project",
+            "proj-A",
+            "--wing",
+            "code-memory",
+        ],
+    );
+    let elapsed = started.elapsed();
+    stop.store(true, Ordering::SeqCst);
+    writer.join().expect("join writer");
+
+    assert!(
+        output.status.success(),
+        "project migrate failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "migration took too long: {elapsed:?}"
+    );
+    assert!(
+        errors.lock().expect("errors mutex poisoned").is_empty(),
+        "writer saw errors: {:?}",
+        errors.lock().expect("errors mutex poisoned")
+    );
+    let latencies = latencies.lock().expect("latencies mutex poisoned");
+    assert!(!latencies.is_empty(), "writer never made progress");
+    let mut millis = latencies
+        .iter()
+        .map(|duration| duration.as_millis() as u64)
+        .collect::<Vec<_>>();
+    millis.sort_unstable();
+    let p99 = millis[((millis.len() - 1) * 99) / 100];
+    assert!(p99 < 200, "writer latency p99 too high: {p99}ms");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    let updated: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM drawers WHERE wing = 'code-memory' AND project_id = 'proj-A'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count migrated drawers");
+    assert_eq!(updated, 5_000);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let progress_lines = stdout
+        .lines()
+        .filter(|line| line.starts_with("batch "))
+        .count();
+    assert!(
+        progress_lines >= 5,
+        "expected at least 5 batch progress lines, got {progress_lines}:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_project_migrate_begin_immediate_fails_fast() {
+    let _guard = home_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_config(&db_path),
+    );
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "locked-drawer",
+        "locked content",
+        "code-memory",
+        Some("migration"),
+        None,
+    );
+
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let db_for_lock = db_path.clone();
+    let lock_thread = thread::spawn(move || {
+        let conn = Connection::open(&db_for_lock).expect("open lock connection");
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .expect("begin immediate");
+        conn.execute(
+            "UPDATE drawers SET content = content WHERE id = 'locked-drawer'",
+            [],
+        )
+        .expect("touch locked row");
+        ready_tx.send(()).expect("signal ready");
+        std::thread::sleep(Duration::from_secs(1));
+        conn.execute_batch("COMMIT").expect("commit");
+    });
+    ready_rx.recv().expect("lock holder ready");
+
+    let mut child = Command::new(mempal_bin())
+        .args([
+            "project",
+            "migrate",
+            "--project",
+            "proj-A",
+            "--wing",
+            "code-memory",
+        ])
+        .env("HOME", &home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal project migrate");
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let mut reader = BufReader::new(stdout);
+
+    let started = Instant::now();
+    let mut lines = Vec::new();
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).expect("read line");
+        if read == 0 {
+            break;
+        }
+        let trimmed = line.trim().to_string();
+        lines.push(trimmed.clone());
+        if trimmed.contains("batch busy") {
+            break;
+        }
+    }
+
+    let busy_elapsed = started.elapsed();
+    let output = child.wait_with_output().expect("wait with output");
+    lock_thread.join().expect("join lock thread");
+
+    assert!(
+        busy_elapsed < Duration::from_millis(100),
+        "busy retry was not fail-fast: {busy_elapsed:?}"
+    );
+    assert!(
+        output.status.success(),
+        "project migrate failed:\nstdout={:?}\nstderr={}",
+        lines,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        lines.iter().any(|line| line.contains("batch busy")),
+        "missing busy retry output: {lines:?}"
+    );
+}

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -8,15 +8,25 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+#[cfg(feature = "rest")]
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+#[cfg(feature = "rest")]
+use mempal::api::{ApiState, router as api_router};
 use mempal::core::config::ConfigHandle;
 use mempal::core::db::Database;
 use mempal::core::types::{Drawer, SourceType};
+use mempal::core::utils::build_drawer_id;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
-use mempal::mcp::{MempalMcpServer, SearchRequest};
+use mempal::mcp::{IngestRequest, MempalMcpServer, SearchRequest};
 use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::{Connection, OptionalExtension, params};
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+#[cfg(feature = "rest")]
+use tower::ServiceExt;
 
 #[path = "../src/core/db_fork_ext.rs"]
 mod db_fork_ext;
@@ -101,6 +111,16 @@ impl SearchEnv {
 
     fn server(&self) -> MempalMcpServer {
         MempalMcpServer::new_with_factory(
+            self.db_path.clone(),
+            Arc::new(StaticEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+    }
+
+    #[cfg(feature = "rest")]
+    fn api_state(&self) -> ApiState {
+        ApiState::new(
             self.db_path.clone(),
             Arc::new(StaticEmbedderFactory {
                 vector: vec![0.1, 0.2, 0.3],
@@ -232,8 +252,9 @@ fn insert_projected_drawer(
 }
 
 async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_json::Value {
-    let response = server
-        .mempal_search(Parameters(SearchRequest {
+    search_response_json_with_request(
+        server,
+        SearchRequest {
             query: query.to_string(),
             wing: None,
             room: None,
@@ -241,11 +262,38 @@ async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_js
             project_id: None,
             include_global: None,
             all_projects: None,
-        }))
+        },
+    )
+    .await
+}
+
+async fn search_response_json_with_request(
+    server: &MempalMcpServer,
+    request: SearchRequest,
+) -> serde_json::Value {
+    let response = server
+        .mempal_search(Parameters(request))
         .await
         .expect("search should succeed")
         .0;
     serde_json::to_value(response).expect("serialize search response")
+}
+
+#[cfg(feature = "rest")]
+async fn rest_json_response(
+    env: &SearchEnv,
+    request: Request<Body>,
+) -> (StatusCode, serde_json::Value) {
+    let response = api_router(env.api_state())
+        .oneshot(request)
+        .await
+        .expect("router request");
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let json = serde_json::from_slice(&body).expect("parse json response");
+    (status, json)
 }
 
 fn install_cli_home(tmp: &TempDir) -> PathBuf {
@@ -456,6 +504,160 @@ async fn test_strict_project_isolation_config_hot_reload() {
         .map(|value| value["drawer_id"].as_str().expect("drawer_id").to_string())
         .collect::<Vec<_>>();
     assert_eq!(after_ids, vec!["drawer-global".to_string()]);
+}
+
+#[cfg(feature = "rest")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_rest_search_uses_configured_project_scope() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "state lives in proj A",
+        "code",
+        Some("room-a"),
+        Some("proj-A"),
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "state lives in proj B",
+        "docs",
+        Some("room-b"),
+        Some("proj-B"),
+    );
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/search?q=state")
+        .body(Body::empty())
+        .expect("build search request");
+    let (status, json) = rest_json_response(&env, request).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let results = json.as_array().expect("results array");
+    let ids = results
+        .iter()
+        .map(|value| value["drawer_id"].as_str().expect("drawer id").to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        ids.iter().any(|id| id == "drawer-a"),
+        "missing proj-A hit: {ids:?}"
+    );
+    assert!(
+        ids.iter().all(|id| id != "drawer-b"),
+        "proj-B hit leaked through REST scope: {ids:?}"
+    );
+}
+
+#[cfg(feature = "rest")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_rest_ingest_uses_configured_project_scope() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/ingest")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({
+                "content": "rest scoped insert",
+                "wing": "code",
+                "room": "api",
+            })
+            .to_string(),
+        ))
+        .expect("build ingest request");
+    let (status, json) = rest_json_response(&env, request).await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let drawer_id = json["drawer_id"]
+        .as_str()
+        .expect("drawer id in REST ingest response");
+    let db = Database::open(&env.db_path).expect("open db");
+    let stored_project = db
+        .drawer_project_id(drawer_id)
+        .expect("read drawer project id");
+    assert_eq!(stored_project.as_deref(), Some("proj-A"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_allows_same_content_in_different_projects() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    let shared_content = "shared memory across repos";
+    let original_id = build_drawer_id("code", Some("shared"), shared_content);
+    insert_projected_drawer(
+        &env.db_path,
+        &original_id,
+        shared_content,
+        "code",
+        Some("shared"),
+        Some("proj-A"),
+    );
+
+    let response = env
+        .server()
+        .mempal_ingest(Parameters(IngestRequest {
+            content: shared_content.to_string(),
+            wing: "code".to_string(),
+            room: Some("shared".to_string()),
+            source: None,
+            project_id: Some("proj-B".to_string()),
+            dry_run: None,
+            importance: None,
+        }))
+        .await
+        .expect("cross-project ingest should succeed")
+        .0;
+
+    assert_ne!(
+        response.drawer_id, original_id,
+        "cross-project ingest must allocate a distinct drawer id"
+    );
+
+    let conn = Connection::open(&env.db_path).expect("open sqlite");
+    let rows = conn
+        .prepare(
+            r#"
+            SELECT project_id
+            FROM drawers
+            WHERE content = ?1 AND wing = 'code' AND room = 'shared' AND deleted_at IS NULL
+            ORDER BY project_id
+            "#,
+        )
+        .expect("prepare drawer query")
+        .query_map([shared_content], |row| row.get::<_, Option<String>>(0))
+        .expect("query drawers")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect drawers");
+    assert_eq!(
+        rows,
+        vec![Some("proj-A".to_string()), Some("proj-B".to_string())]
+    );
+
+    let proj_b_results = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "shared memory".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: Some("proj-B".to_string()),
+            include_global: None,
+            all_projects: None,
+        },
+    )
+    .await;
+    let ids = proj_b_results["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|value| value["drawer_id"].as_str().expect("drawer id").to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec![response.drawer_id]);
 }
 
 #[test]

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -24,7 +24,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 }
 
 #[test]
-fn test_fork_ext_migration_v0_to_v4_preserves_pending_messages_table() {
+fn test_fork_ext_migration_v0_to_v5_preserves_pending_messages_table() {
     let (_tmp, db_path, _store) = new_store();
     let conn = Connection::open(db_path).expect("open sqlite");
 
@@ -35,7 +35,7 @@ fn test_fork_ext_migration_v0_to_v4_preserves_pending_messages_table() {
             |row| row.get::<_, String>(0),
         )
         .expect("read fork_ext_version");
-    assert_eq!(version, "4");
+    assert_eq!(version, "5");
 
     let exists = conn
         .query_row(


### PR DESCRIPTION
## Summary
- implement `specs/fork-ext/p10-project-vector-isolation.spec.md`
- advance fork-ext schema from ext_v4 to ext_v5 with `drawers.project_id`, `triples.project_id`, and vec-table recreation carrying `project_id`
- push project filtering down into both vector recall and FTS5 recall SQL so wrong-project rows never leave the query
- keep tunnel resolution exempt from project filtering and tag cross-project tunnel rows as `source: "tunnel_cross_project"`
- add batched `BEGIN IMMEDIATE` project backfill migration that fails fast under writer contention
- wire `strict_project_isolation` into request-scoped search behavior and hot-reload coverage

## Rationale
CLAUDE.md records the 2026-04-16 mktd debate outcome that `p10-project-vector-isolation` must land before `p9-progressive-disclosure`; otherwise cross-repo recall pollution could be misdiagnosed as a preview UX problem. This PR lands that isolation boundary first.

## Tests
New or updated coverage in this PR:
- `test_ext_v5_migration_adds_project_id_column`
- `test_ext_v5_migration_idempotent`
- `test_search_excludes_other_projects_by_default`
- `test_vector_recall_project_filter_pushed_to_sql`
- `test_fts5_recall_project_filter_pushed_to_sql`
- `test_tunnel_resolver_bypasses_project_filter`
- `test_project_migrate_batched_does_not_block_ingest`
- `test_project_migrate_begin_immediate_fails_fast`
- `test_strict_project_isolation_config_hot_reload`
- `test_fork_ext_migration_v0_to_v5_preserves_pending_messages_table`

Validation run:
- `just pre-commit`

## Ambiguities And Choices
- `project_id` source of truth: requests may pass an explicit `project_id`; otherwise config may set `project.id`; otherwise `MEMPAL_PROJECT_ID` is honored; CLI fallback infers from the provided cwd by preferring git-root basename and then cwd basename. MCP/API deliberately do not silently infer from the server process cwd.
- Tunnel DTO tagging: the returned search DTO uses `source: "tunnel_cross_project"` for tunnel-exempt cross-project rows.
- `strict_project_isolation` default: kept the config default at `false` because the spec already defines fallback behavior for `project_id == None`; current-project default scoping is enforced at the CLI/MCP request layer instead of flipping the global default.

## Notes
- This PR does not close a GitHub issue.
- It is an architectural prerequisite for Phase 4 work.
