### PR TITLE
feat(p9+p10): progressive disclosure + CLI dashboard

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -15,6 +15,7 @@ const DEFAULT_OPENAI_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_OPENAI_DIM: usize = 4096;
 const DEFAULT_RETRY_INTERVAL_SECS: u64 = 2;
 const DEFAULT_SEARCH_DEADLINE_SECS: u64 = 5;
+const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
 const DEFAULT_ALERT_EVERY_N_FAILURES: u64 = 100;
 const DEFAULT_DEGRADE_AFTER_N_FAILURES: u64 = 10;
 const DEFAULT_HOOK_WING: &str = "agent-diary";
@@ -95,6 +96,11 @@ impl Config {
         if self.embed.retry.search_deadline_secs == 0 {
             return Err(ConfigError::InvalidConfig(
                 "embed.retry.search_deadline_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.search.preview_chars == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "search.preview_chars must be greater than 0".to_string(),
             ));
         }
         if self.embed.alert.alert_every_n_failures == 0 {
@@ -576,10 +582,22 @@ impl Default for ConfigHotReloadConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct SearchConfig {
     pub strict_project_isolation: bool,
+    pub progressive_disclosure: bool,
+    pub preview_chars: usize,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            strict_project_isolation: false,
+            progressive_disclosure: false,
+            preview_chars: DEFAULT_SEARCH_PREVIEW_CHARS,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use super::{
-    types::{Drawer, SourceType, TaxonomyEntry, Triple, TripleStats},
+    types::{Drawer, DrawerDetails, SourceType, TaxonomyEntry, Triple, TripleStats},
     utils::{build_drawer_id, build_scoped_drawer_id},
 };
 use crate::ingest::gating::GatingDecision;
@@ -596,6 +596,72 @@ impl Database {
                     added_at,
                     chunk_index,
                     importance,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_drawer_details(&self, drawer_id: &str) -> Result<Option<DrawerDetails>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT id, content, wing, room, source_file, source_type, added_at, chunk_index,
+                   COALESCE(importance, 0) as importance,
+                   updated_at,
+                   COALESCE(merge_count, 0) as merge_count,
+                   project_id
+            FROM drawers
+            WHERE id = ?1 AND deleted_at IS NULL
+            "#,
+        )?;
+        let mut rows = statement.query_map([drawer_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, Option<i64>>(7)?,
+                row.get::<_, i32>(8)?,
+                row.get::<_, Option<String>>(9)?,
+                row.get::<_, u32>(10)?,
+                row.get::<_, Option<String>>(11)?,
+            ))
+        })?;
+
+        match rows.next() {
+            Some(row) => {
+                let (
+                    id,
+                    content,
+                    wing,
+                    room,
+                    source_file,
+                    source_type,
+                    added_at,
+                    chunk_index,
+                    importance,
+                    updated_at,
+                    merge_count,
+                    project_id,
+                ) = row?;
+                Ok(Some(DrawerDetails {
+                    drawer: Drawer {
+                        id,
+                        content,
+                        wing,
+                        room,
+                        source_file,
+                        source_type: source_type_from_str(&source_type)?,
+                        added_at,
+                        chunk_index,
+                        importance,
+                    },
+                    updated_at,
+                    merge_count,
+                    project_id,
                 }))
             }
             None => Ok(None),

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -173,6 +173,7 @@ impl Database {
         &self,
         candidate_hash: &str,
         decision: &GatingDecision,
+        project_id: Option<&str>,
     ) -> Result<(), DbError> {
         let explain_json = serde_json::to_string(decision)?;
         let created_at = super::utils::current_timestamp()
@@ -189,8 +190,8 @@ impl Database {
         let id = format!("gating_{}", blake3::hash(id_seed.as_bytes()).to_hex());
         self.conn.execute(
             r#"
-            INSERT INTO gating_audit (id, candidate_hash, decision, explain_json, created_at)
-            VALUES (?1, ?2, ?3, ?4, ?5)
+            INSERT INTO gating_audit (id, candidate_hash, decision, explain_json, created_at, project_id)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
             "#,
             params![
                 id,
@@ -198,6 +199,7 @@ impl Database {
                 decision.decision,
                 explain_json,
                 created_at,
+                project_id,
             ],
         )?;
         Ok(())
@@ -257,6 +259,7 @@ impl Database {
         near_drawer_id: Option<&str>,
         cosine: Option<f32>,
         audit_decision: Option<&str>,
+        project_id: Option<&str>,
     ) -> Result<(), DbError> {
         let created_at = super::utils::current_timestamp()
             .parse::<i64>()
@@ -276,10 +279,18 @@ impl Database {
         let id = format!("novelty_{}", blake3::hash(id_seed.as_bytes()).to_hex());
         self.conn.execute(
             r#"
-            INSERT INTO novelty_audit (id, candidate_hash, decision, near_drawer_id, cosine, created_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO novelty_audit (id, candidate_hash, decision, near_drawer_id, cosine, created_at, project_id)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             "#,
-            params![id, candidate_hash, decision, near_drawer_id, cosine, created_at],
+            params![
+                id,
+                candidate_hash,
+                decision,
+                near_drawer_id,
+                cosine,
+                created_at,
+                project_id
+            ],
         )?;
         Ok(())
     }

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -158,6 +158,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 5,
             up: apply_v5,
         },
+        Migration {
+            version: 6,
+            up: apply_v6,
+        },
     ]
 }
 
@@ -184,6 +188,32 @@ fn apply_v5(conn: &Connection) -> rusqlite::Result<()> {
         "CREATE INDEX IF NOT EXISTS idx_drawers_project_id ON drawers(project_id);",
     )?;
     recreate_drawer_vectors_with_project_id(conn)?;
+    Ok(())
+}
+
+fn apply_v6(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_project_column(conn, "gating_audit", "TEXT")?;
+    ensure_project_column(conn, "novelty_audit", "TEXT")?;
+    conn.execute_batch(
+        r#"
+        UPDATE gating_audit
+        SET project_id = (
+            SELECT project_id FROM drawers WHERE drawers.id = gating_audit.candidate_hash
+        )
+        WHERE project_id IS NULL;
+
+        UPDATE novelty_audit
+        SET project_id = (
+            SELECT project_id FROM drawers WHERE drawers.id = novelty_audit.candidate_hash
+        )
+        WHERE project_id IS NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_gating_audit_project_created_at
+            ON gating_audit(project_id, created_at);
+        CREATE INDEX IF NOT EXISTS idx_novelty_audit_project_created_at
+            ON novelty_audit(project_id, created_at);
+        "#,
+    )?;
     Ok(())
 }
 

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -95,6 +95,17 @@ impl ProjectSearchScope {
         self.mode.as_sql_mode()
     }
 
+    pub fn allows_row(&self, row_project_id: Option<&str>) -> bool {
+        match self.mode {
+            ProjectFilterMode::AllProjects => true,
+            ProjectFilterMode::ProjectScoped => row_project_id == self.project_id.as_deref(),
+            ProjectFilterMode::ProjectPlusGlobal => {
+                row_project_id.is_none() || row_project_id == self.project_id.as_deref()
+            }
+            ProjectFilterMode::NullOnly => row_project_id.is_none(),
+        }
+    }
+
     pub fn classify_row(&self, row_project_id: Option<&str>) -> SearchResultSource {
         match row_project_id {
             Some(_) => SearchResultSource::Project,

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -24,6 +24,14 @@ pub struct Drawer {
     pub importance: i32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrawerDetails {
+    pub drawer: Drawer,
+    pub updated_at: Option<String>,
+    pub merge_count: u32,
+    pub project_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Triple {
     pub id: String,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -440,7 +440,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     {
         context
             .db
-            .record_gating_audit(&drawer_id, decision)
+            .record_gating_audit(&drawer_id, decision, None)
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         return Ok(drawer_id);
     }
@@ -473,7 +473,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         );
         context
             .db
-            .record_gating_audit(&drawer_id, &decision)
+            .record_gating_audit(&drawer_id, &decision, None)
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         gating_audit_recorded = true;
         if decision.is_rejected() {
@@ -485,7 +485,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
         context
             .db
-            .record_gating_audit(&drawer_id, decision)
+            .record_gating_audit(&drawer_id, decision, None)
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
     }
 
@@ -520,6 +520,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
+                        None,
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
             }
@@ -536,6 +537,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
+                        None,
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
             }
@@ -591,6 +593,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         Some(target_id.as_str()),
                         novelty.cosine,
                         Some("insert_due_to_merge_cap"),
+                        None,
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
                 insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
@@ -607,6 +610,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         Some(target_id.as_str()),
                         novelty.cosine,
                         novelty.audit_decision,
+                        None,
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
                 let mut db_for_merge = Database::open(context.db.path())

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use mempal::mcp::MempalMcpServer;
 use mempal::search::search;
 
 mod longmemeval;
+mod observability;
 
 use crate::longmemeval::{BenchMode, LongMemEvalArgs, LongMemEvalGranularity, default_top_k};
 
@@ -129,6 +130,36 @@ enum Commands {
         mcp: bool,
     },
     Status,
+    Tail {
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+        #[arg(long, default_value_t = false)]
+        follow: bool,
+        #[arg(long)]
+        wing: Option<String>,
+        #[arg(long)]
+        room: Option<String>,
+        #[arg(long)]
+        since: Option<String>,
+    },
+    Timeline {
+        #[arg(long)]
+        wing: Option<String>,
+        #[arg(long)]
+        since: Option<String>,
+    },
+    Stats,
+    View {
+        drawer_id: String,
+        #[arg(long, default_value_t = false)]
+        raw: bool,
+    },
+    Audit {
+        #[arg(long)]
+        kind: Option<String>,
+        #[arg(long)]
+        since: Option<String>,
+    },
     /// Run offline contradiction check on text against KG triples +
     /// known-entity registry. Pure read, no LLM, no network.
     FactCheck {
@@ -359,6 +390,48 @@ fn run() -> Result<()> {
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::Serve { mcp } => block_on_result(serve_command(config.as_ref(), mcp)),
         Commands::Status => status_command(&db),
+        Commands::Tail {
+            limit,
+            follow,
+            wing,
+            room,
+            since,
+        } => observability::tail_command(
+            &db,
+            config.as_ref(),
+            observability::TailOptions {
+                limit,
+                follow,
+                wing: wing.as_deref(),
+                room: room.as_deref(),
+                since: since.as_deref(),
+            },
+        ),
+        Commands::Timeline { wing, since } => observability::timeline_command(
+            &db,
+            config.as_ref(),
+            observability::TimelineOptions {
+                wing: wing.as_deref(),
+                since: since.as_deref(),
+            },
+        ),
+        Commands::Stats => observability::stats_command(&db, config.as_ref()),
+        Commands::View { drawer_id, raw } => observability::view_command(
+            &db,
+            config.as_ref(),
+            observability::ViewOptions {
+                drawer_id: &drawer_id,
+                raw,
+            },
+        ),
+        Commands::Audit { kind, since } => observability::audit_command(
+            &db,
+            config.as_ref(),
+            observability::AuditOptions {
+                kind: kind.as_deref(),
+                since: since.as_deref(),
+            },
+        ),
         Commands::FactCheck {
             path,
             wing,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,4 +4,7 @@ mod server;
 mod tools;
 
 pub use server::MempalMcpServer;
-pub use tools::{IngestRequest, IngestResponse, SearchRequest, SearchResponse, StatusResponse};
+pub use tools::{
+    IngestRequest, IngestResponse, ReadDrawerRequest, ReadDrawerResponse, SearchRequest,
+    SearchResponse, StatusResponse,
+};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -228,13 +228,14 @@ impl MempalMcpServer {
         Parameters(request): Parameters<ReadDrawerRequest>,
     ) -> std::result::Result<Json<ReadDrawerResponse>, ErrorData> {
         let config = ConfigHandle::current();
-        let project_id = resolve_project_id(None, config.as_ref(), None).map_err(|error| {
+        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
+            .map_err(|error| {
             ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
         })?;
         let scope = ProjectSearchScope::from_request(
             project_id,
-            false,
-            false,
+            request.include_global.unwrap_or(false),
+            request.all_projects.unwrap_or(false),
             config.search.strict_project_isolation,
         );
         let db = self.open_db()?;
@@ -323,7 +324,7 @@ impl MempalMcpServer {
         if let Some(decision) = gating_decision.as_ref()
             && decision.is_rejected()
         {
-            db.record_gating_audit(&drawer_id, decision)
+            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
                 .map_err(db_error)?;
             return Ok(Json(IngestResponse {
                 // TODO(spec ambiguity): rejected ingests have no persisted drawer.
@@ -384,7 +385,7 @@ impl MempalMcpServer {
                     config.ingest_gating.embedding_classifier.threshold,
                 )
                 .await;
-                db.record_gating_audit(&drawer_id, &tier2.decision)
+                db.record_gating_audit(&drawer_id, &tier2.decision, project_id.as_deref())
                     .map_err(db_error)?;
                 gating_audit_recorded = true;
                 vector = tier2.vector;
@@ -412,7 +413,7 @@ impl MempalMcpServer {
             }));
         }
         if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
-            db.record_gating_audit(&drawer_id, decision)
+            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
                 .map_err(db_error)?;
         }
         let vector = match vector {
@@ -453,6 +454,7 @@ impl MempalMcpServer {
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
+                        project_id.as_deref(),
                     )
                     .map_err(db_error)?;
                 }
@@ -488,6 +490,7 @@ impl MempalMcpServer {
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
+                        project_id.as_deref(),
                     )
                     .map_err(db_error)?;
                 }
@@ -533,6 +536,7 @@ impl MempalMcpServer {
                         Some(target_id.as_str()),
                         novelty.cosine,
                         Some("insert_due_to_merge_cap"),
+                        project_id.as_deref(),
                     )
                     .map_err(db_error)?;
                     novelty_action = Some(NoveltyAction::Insert);
@@ -584,6 +588,7 @@ impl MempalMcpServer {
                         Some(target_id.as_str()),
                         novelty.cosine,
                         novelty.audit_decision,
+                        project_id.as_deref(),
                     )
                     .map_err(db_error)?;
                     novelty_action = Some(NoveltyAction::Merge);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -27,9 +27,9 @@ use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
     EmbedStatusDto, FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest,
     KgResponse, KgStatsDto, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, QueueStatsDto,
-    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, StatusResponse,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto,
-    TunnelsResponse,
+    ReadDrawerRequest, ReadDrawerResponse, ScopeCount, ScrubStatsDto, SearchRequest,
+    SearchResponse, SearchResultDto, StatusResponse, SystemWarning, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -206,9 +206,69 @@ impl MempalMcpServer {
         Ok(Json(SearchResponse {
             results: results
                 .into_iter()
-                .map(SearchResultDto::with_signals_from_result)
+                .map(|result| {
+                    SearchResultDto::with_signals_from_result(
+                        result,
+                        config.search.progressive_disclosure
+                            && !request.disable_progressive.unwrap_or(false),
+                        config.search.preview_chars,
+                    )
+                })
                 .collect(),
             system_warnings: current_system_warnings(),
+        }))
+    }
+
+    #[tool(
+        name = "mempal_read_drawer",
+        description = "Fetch one drawer's full raw verbatim content by drawer_id. Use this after mempal_search returns a truncated preview and you decide the specific drawer is worth reading in full."
+    )]
+    pub async fn mempal_read_drawer(
+        &self,
+        Parameters(request): Parameters<ReadDrawerRequest>,
+    ) -> std::result::Result<Json<ReadDrawerResponse>, ErrorData> {
+        let config = ConfigHandle::current();
+        let project_id = resolve_project_id(None, config.as_ref(), None).map_err(|error| {
+            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+        })?;
+        let scope = ProjectSearchScope::from_request(
+            project_id,
+            false,
+            false,
+            config.search.strict_project_isolation,
+        );
+        let db = self.open_db()?;
+        let details = db
+            .get_drawer_details(&request.drawer_id)
+            .map_err(db_error)?
+            .ok_or_else(|| {
+                ErrorData::invalid_params(format!("drawer {} not found", request.drawer_id), None)
+            })?;
+        if !scope.allows_row(details.project_id.as_deref()) {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "drawer {} is outside the current project scope",
+                    request.drawer_id
+                ),
+                None,
+            ));
+        }
+
+        let signals = crate::aaak::analyze(&details.drawer.content);
+        let drawer = details.drawer;
+        Ok(Json(ReadDrawerResponse {
+            drawer_id: drawer.id,
+            content: drawer.content,
+            wing: drawer.wing,
+            room: drawer.room,
+            source_file: source_file_or_synthetic(
+                &request.drawer_id,
+                drawer.source_file.as_deref(),
+            ),
+            created_at: drawer.added_at,
+            updated_at: details.updated_at,
+            merge_count: details.merge_count,
+            importance_stars: signals.importance_stars,
         }))
     }
 
@@ -1260,6 +1320,7 @@ mod tests {
                 project_id: None,
                 include_global: None,
                 all_projects: None,
+                disable_progressive: None,
             }))
             .await
             .expect("search should succeed")

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -89,6 +89,18 @@ pub struct RouteDecisionDto {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct ReadDrawerRequest {
     pub drawer_id: String,
+
+    /// Optional explicit project scope. When omitted, mempal resolves the
+    /// current project from config/env/git root and scopes the read there by
+    /// default. Set `all_projects=true` to bypass project scoping.
+    pub project_id: Option<String>,
+
+    /// Include legacy/global drawers (`project_id IS NULL`) alongside the
+    /// current project. Ignored when `all_projects=true`.
+    pub include_global: Option<bool>,
+
+    /// Opt-in override to read across all projects for this request.
+    pub all_projects: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -38,6 +38,10 @@ pub struct SearchRequest {
 
     /// Opt-in override to search across all projects for this request.
     pub all_projects: Option<bool>,
+
+    /// Return full verbatim content for this call even when progressive
+    /// disclosure is enabled globally.
+    pub disable_progressive: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -51,6 +55,8 @@ pub struct SearchResponse {
 pub struct SearchResultDto {
     pub drawer_id: String,
     pub content: String,
+    pub content_truncated: bool,
+    pub original_content_bytes: u64,
     pub wing: String,
     pub room: Option<String>,
     pub source_file: String,
@@ -78,6 +84,25 @@ pub struct RouteDecisionDto {
     pub room: Option<String>,
     pub confidence: f32,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ReadDrawerRequest {
+    pub drawer_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ReadDrawerResponse {
+    pub drawer_id: String,
+    pub content: String,
+    pub wing: String,
+    pub room: Option<String>,
+    pub source_file: String,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    pub merge_count: u32,
+    pub importance_stars: u8,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -398,19 +423,45 @@ pub struct FactCheckResponse {
 }
 
 impl SearchResultDto {
-    pub fn with_signals_from_result(value: SearchResult) -> Self {
-        let signals = crate::aaak::analyze(&value.content);
+    pub fn with_signals_from_result(
+        value: SearchResult,
+        progressive_disclosure: bool,
+        preview_chars: usize,
+    ) -> Self {
+        let crate::core::types::SearchResult {
+            drawer_id,
+            content,
+            wing,
+            room,
+            source_file,
+            source,
+            similarity,
+            route,
+            tunnel_hints,
+        } = value;
+        let signals = crate::aaak::analyze(&content);
+        let original_content_bytes = content.len() as u64;
+        let preview = if progressive_disclosure {
+            crate::search::preview::truncate(&content, preview_chars)
+        } else {
+            crate::search::preview::PreviewText {
+                content,
+                truncated: false,
+            }
+        };
 
         Self {
-            drawer_id: value.drawer_id,
-            content: value.content,
-            wing: value.wing,
-            room: value.room,
-            source_file: value.source_file,
-            source: value.source.as_str().to_string(),
-            similarity: value.similarity,
-            route: value.route.into(),
-            tunnel_hints: value.tunnel_hints,
+            drawer_id,
+            content: preview.content,
+            content_truncated: preview.truncated,
+            original_content_bytes,
+            wing,
+            room,
+            source_file,
+            source: source.as_str().to_string(),
+            similarity,
+            route: route.into(),
+            tunnel_hints,
             entities: signals.entities,
             topics: signals.topics,
             flags: signals.flags,
@@ -470,9 +521,11 @@ mod tests {
     #[test]
     fn test_with_signals_preserves_raw_content_and_citations() {
         let original = "We decided to use Arc<Mutex<>> for state because shared ownership mattered";
-        let dto = SearchResultDto::with_signals_from_result(sample_result(original));
+        let dto = SearchResultDto::with_signals_from_result(sample_result(original), false, 120);
 
         assert_eq!(dto.content, original);
+        assert!(!dto.content_truncated);
+        assert_eq!(dto.original_content_bytes, original.len() as u64);
         assert!(!dto.content.starts_with("V1|"));
         assert!(!dto.content.contains('★'));
         assert_eq!(dto.drawer_id, "drawer-1");
@@ -485,12 +538,24 @@ mod tests {
 
     #[test]
     fn test_with_signals_applies_empty_content_sentinels() {
-        let dto = SearchResultDto::with_signals_from_result(sample_result(""));
+        let dto = SearchResultDto::with_signals_from_result(sample_result(""), false, 120);
 
         assert_eq!(dto.entities, vec!["UNK".to_string()]);
         assert_eq!(dto.flags, vec!["CORE".to_string()]);
         assert_eq!(dto.emotions, vec!["determ".to_string()]);
         assert!(dto.topics.is_empty());
         assert_eq!(dto.importance_stars, 2);
+    }
+
+    #[test]
+    fn test_with_signals_truncates_preview_but_keeps_full_signal_analysis() {
+        let original = "prefix ".repeat(40)
+            + "We decided to keep signals computed from the full drawer content because the preview is only a projection.";
+        let dto = SearchResultDto::with_signals_from_result(sample_result(&original), true, 32);
+
+        assert!(dto.content_truncated);
+        assert!(dto.content.ends_with('…'));
+        assert_eq!(dto.original_content_bytes, original.len() as u64);
+        assert!(dto.flags.contains(&"DECISION".to_string()));
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -506,7 +506,8 @@ fn load_audit_records(
     let sql = match kind {
         "gating" => {
             r#"
-            SELECT a.id, a.candidate_hash, a.decision, a.created_at, d.project_id
+            SELECT a.id, a.candidate_hash, a.decision, a.created_at,
+                   COALESCE(a.project_id, d.project_id)
             FROM gating_audit a
             LEFT JOIN drawers d ON d.id = a.candidate_hash
             ORDER BY a.created_at DESC, a.id DESC
@@ -514,7 +515,8 @@ fn load_audit_records(
         }
         "novelty" => {
             r#"
-            SELECT a.id, a.candidate_hash, a.decision, a.created_at, d.project_id
+            SELECT a.id, a.candidate_hash, a.decision, a.created_at,
+                   COALESCE(a.project_id, d.project_id)
             FROM novelty_audit a
             LEFT JOIN drawers d ON d.id = a.candidate_hash
             ORDER BY a.created_at DESC, a.id DESC

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,649 @@
+use std::env;
+use std::ffi::OsStr;
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
+use std::sync::mpsc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::core::project::{ProjectSearchScope, resolve_project_id};
+use mempal::core::queue::PendingMessageStore;
+use mempal::cowork::peek::format_rfc3339;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+
+const FOLLOW_POLL_SECS: u64 = 2;
+const FOLLOW_DEBOUNCE_MS: u64 = 250;
+const PREVIEW_CHARS: usize = 120;
+
+pub struct TailOptions<'a> {
+    pub limit: usize,
+    pub follow: bool,
+    pub wing: Option<&'a str>,
+    pub room: Option<&'a str>,
+    pub since: Option<&'a str>,
+}
+
+pub struct TimelineOptions<'a> {
+    pub wing: Option<&'a str>,
+    pub since: Option<&'a str>,
+}
+
+pub struct ViewOptions<'a> {
+    pub drawer_id: &'a str,
+    pub raw: bool,
+}
+
+pub struct AuditOptions<'a> {
+    pub kind: Option<&'a str>,
+    pub since: Option<&'a str>,
+}
+
+#[derive(Clone)]
+struct DrawerRecord {
+    rowid: i64,
+    id: String,
+    content: String,
+    wing: String,
+    room: Option<String>,
+    added_at: String,
+    importance: i32,
+    project_id: Option<String>,
+}
+
+struct AuditRecord {
+    audit_id: String,
+    candidate_hash: String,
+    decision: String,
+    created_at: i64,
+    project_id: Option<String>,
+}
+
+pub fn tail_command(db: &Database, config: &Config, options: TailOptions<'_>) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(options.since)?;
+    let mut records = load_visible_drawers(db, &scope, options.wing, options.room, since_cutoff)?;
+    records.sort_by(|a, b| b.added_at.cmp(&a.added_at).then_with(|| b.id.cmp(&a.id)));
+
+    if options.follow {
+        let limit = options.limit;
+        if limit > 0 {
+            for record in records.iter().take(limit) {
+                println!("{}", format_tail_line(record));
+            }
+            io::stdout()
+                .flush()
+                .context("failed to flush tail output")?;
+        }
+        let last_seen_rowid = records.iter().map(|record| record.rowid).max().unwrap_or(0);
+        return follow_tail(
+            db,
+            &scope,
+            options.wing,
+            options.room,
+            since_cutoff,
+            last_seen_rowid,
+        );
+    }
+
+    for record in records.into_iter().take(options.limit) {
+        println!("{}", format_tail_line(&record));
+    }
+    Ok(())
+}
+
+pub fn timeline_command(
+    db: &Database,
+    config: &Config,
+    options: TimelineOptions<'_>,
+) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(options.since)?;
+    let mut records = load_visible_drawers(db, &scope, options.wing, None, since_cutoff)?;
+    records.sort_by(|a, b| {
+        a.added_at
+            .cmp(&b.added_at)
+            .then_with(|| b.importance.cmp(&a.importance))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    let mut current_day = None::<String>;
+    for record in records {
+        let day = format_day(&record.added_at);
+        if current_day.as_deref() != Some(day.as_str()) {
+            if current_day.is_some() {
+                println!();
+            }
+            println!("=== {day} ===");
+            current_day = Some(day);
+        }
+        println!(
+            "{} {}/{} {}",
+            format_time(&record.added_at),
+            record.wing,
+            render_room(record.room.as_deref()),
+            record.id
+        );
+        println!("  {}", preview(&record.content));
+    }
+    Ok(())
+}
+
+pub fn stats_command(db: &Database, config: &Config) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let records = load_visible_drawers(db, &scope, None, None, None)?;
+    let schema_version = db
+        .schema_version()
+        .context("failed to read schema version")?;
+    let fork_ext_version = db
+        .conn()
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = 'fork_ext_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(0);
+    let mut by_scope = std::collections::BTreeMap::<String, usize>::new();
+    let mut importance_total = 0i64;
+    for record in &records {
+        let key = format!("{}/{}", record.wing, render_room(record.room.as_deref()));
+        *by_scope.entry(key).or_default() += 1;
+        importance_total += i64::from(record.importance);
+    }
+    let avg_importance = if records.is_empty() {
+        0.0
+    } else {
+        importance_total as f64 / records.len() as f64
+    };
+
+    let queue_stats = PendingMessageStore::new(db.path())
+        .context("failed to open pending message store")?
+        .stats()
+        .context("failed to query queue stats")?;
+    let gating = load_audit_records(db, "gating", &scope, None)?;
+    let novelty = load_audit_records(db, "novelty", &scope, None)?;
+    let embed_count = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='drawer_vectors'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to inspect vectors table")?;
+    let vector_count = if embed_count == 0 {
+        0i64
+    } else {
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .context("failed to count vectors")?
+    };
+    let vector_dim = if embed_count == 0 {
+        None
+    } else {
+        db.embedding_dim().context("failed to read vector dim")?
+    };
+
+    println!("schema_version: {schema_version}");
+    println!("fork_ext_version: {fork_ext_version}");
+    println!("drawers total: {}", records.len());
+    println!("avg importance: {:.2}", avg_importance);
+    println!("drawers by scope:");
+    for (scope_key, count) in by_scope {
+        println!("  {scope_key}: {count}");
+    }
+    println!("queue:");
+    println!("  pending: {}", queue_stats.pending);
+    println!("  claimed: {}", queue_stats.claimed);
+    println!("  failed: {}", queue_stats.failed);
+    println!("gating:");
+    print_decision_counts(&gating);
+    println!("novelty:");
+    print_decision_counts(&novelty);
+    println!("privacy scrub:");
+    let scrub_stats = ConfigHandle::scrub_stats();
+    println!(
+        "  total_patterns_matched: {}",
+        scrub_stats.total_patterns_matched
+    );
+    println!("  bytes_redacted: {}", scrub_stats.bytes_redacted);
+    println!("vectors:");
+    println!("  dim: {:?}", vector_dim);
+    println!("  count: {vector_count}");
+    Ok(())
+}
+
+pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let details = db
+        .get_drawer_details(options.drawer_id)
+        .context("failed to load drawer")?
+        .ok_or_else(|| anyhow::anyhow!("drawer {} not found", options.drawer_id))?;
+    if !scope.allows_row(details.project_id.as_deref()) {
+        bail!(
+            "drawer {} is outside the current project scope",
+            options.drawer_id
+        );
+    }
+
+    let drawer = details.drawer;
+    println!("drawer_id: {}", drawer.id);
+    println!(
+        "scope: {}/{}",
+        drawer.wing,
+        render_room(drawer.room.as_deref())
+    );
+    println!("created_at: {}", format_timestamp(&drawer.added_at));
+    println!(
+        "updated_at: {}",
+        details.updated_at.as_deref().unwrap_or("none")
+    );
+    println!("merge_count: {}", details.merge_count);
+    println!(
+        "source_file: {}",
+        drawer.source_file.as_deref().unwrap_or("(synthetic)")
+    );
+    println!();
+    if options.raw {
+        println!("{}", drawer.content);
+    } else {
+        let signals = mempal::aaak::analyze(&drawer.content);
+        println!("flags: {}", signals.flags.join(", "));
+        println!("entities: {}", signals.entities.join(", "));
+        println!("topics: {}", signals.topics.join(", "));
+        println!();
+        println!("{}", drawer.content);
+    }
+    Ok(())
+}
+
+pub fn audit_command(db: &Database, config: &Config, options: AuditOptions<'_>) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(options.since)?;
+    match options.kind.unwrap_or("all") {
+        "all" => {
+            print_audit_section(
+                "gating",
+                &load_audit_records(db, "gating", &scope, since_cutoff)?,
+            );
+            print_audit_section(
+                "novelty",
+                &load_audit_records(db, "novelty", &scope, since_cutoff)?,
+            );
+        }
+        "gating" => {
+            print_audit_section(
+                "gating",
+                &load_audit_records(db, "gating", &scope, since_cutoff)?,
+            );
+        }
+        "novelty" => {
+            print_audit_section(
+                "novelty",
+                &load_audit_records(db, "novelty", &scope, since_cutoff)?,
+            );
+        }
+        other => bail!("unsupported audit kind: {other}"),
+    }
+    Ok(())
+}
+
+fn follow_tail(
+    db: &Database,
+    scope: &ProjectSearchScope,
+    wing: Option<&str>,
+    room: Option<&str>,
+    since_cutoff: Option<i64>,
+    mut last_seen_rowid: i64,
+) -> Result<()> {
+    let db_path = db.path().to_path_buf();
+    let db_file_name = db_path
+        .file_name()
+        .map(OsStr::to_os_string)
+        .unwrap_or_default();
+    let watch_dir = db_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| ".".into());
+    let (tx, rx) = mpsc::channel::<()>();
+    let mut watcher = create_db_watcher(tx.clone(), &db_file_name);
+    let watcher_active = if let Some(active_watcher) = watcher.as_mut() {
+        active_watcher
+            .watch(&watch_dir, RecursiveMode::NonRecursive)
+            .is_ok()
+    } else {
+        false
+    };
+    if !watcher_active {
+        watcher = None;
+    }
+
+    loop {
+        if watcher.is_some() {
+            rx.recv().context("tail watcher disconnected")?;
+            std::thread::sleep(Duration::from_millis(FOLLOW_DEBOUNCE_MS));
+            while rx.try_recv().is_ok() {}
+        } else {
+            std::thread::sleep(Duration::from_secs(FOLLOW_POLL_SECS));
+        }
+
+        let rows =
+            load_visible_drawers_after_rowid(db, scope, wing, room, since_cutoff, last_seen_rowid)?;
+        if rows.is_empty() {
+            continue;
+        }
+        for row in &rows {
+            println!("{}", format_tail_line(row));
+            last_seen_rowid = row.rowid;
+        }
+        io::stdout()
+            .flush()
+            .context("failed to flush tail follow output")?;
+    }
+}
+
+fn create_db_watcher(
+    tx: mpsc::Sender<()>,
+    db_file_name: &std::ffi::OsStr,
+) -> Option<RecommendedWatcher> {
+    let base = db_file_name.to_string_lossy().to_string();
+    notify::recommended_watcher(move |result: notify::Result<Event>| match result {
+        Ok(event) if is_db_event(&event, &base) => {
+            let _ = tx.send(());
+        }
+        Ok(_) => {}
+        Err(_) => {
+            let _ = tx.send(());
+        }
+    })
+    .ok()
+}
+
+fn is_db_event(event: &Event, db_file_name: &str) -> bool {
+    if !matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Any
+    ) {
+        return false;
+    }
+    let wal = format!("{db_file_name}-wal");
+    let shm = format!("{db_file_name}-shm");
+    event.paths.iter().any(|path| {
+        path.file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .is_some_and(|name| name == db_file_name || name == wal || name == shm)
+    })
+}
+
+fn dashboard_scope(config: &Config) -> Result<ProjectSearchScope> {
+    let current_dir = env::current_dir().ok();
+    let project_id = resolve_project_id(None, config, None)
+        .context("failed to resolve dashboard project scope")?
+        .or_else(|| {
+            current_dir
+                .as_deref()
+                .filter(|cwd| is_git_repo(cwd))
+                .and_then(|cwd| resolve_project_id(None, config, Some(cwd)).ok())
+                .flatten()
+        });
+    Ok(ProjectSearchScope::from_request(
+        project_id,
+        false,
+        false,
+        config.search.strict_project_isolation,
+    ))
+}
+
+fn is_git_repo(path: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn load_visible_drawers(
+    db: &Database,
+    scope: &ProjectSearchScope,
+    wing: Option<&str>,
+    room: Option<&str>,
+    since_cutoff: Option<i64>,
+) -> Result<Vec<DrawerRecord>> {
+    let mut stmt = db.conn().prepare(
+        r#"
+        SELECT rowid, id, content, wing, room, added_at,
+               COALESCE(importance, 0), project_id
+        FROM drawers
+        WHERE deleted_at IS NULL
+        ORDER BY CAST(added_at AS INTEGER) DESC, id DESC
+        "#,
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(DrawerRecord {
+                rowid: row.get::<_, i64>(0)?,
+                id: row.get::<_, String>(1)?,
+                content: row.get::<_, String>(2)?,
+                wing: row.get::<_, String>(3)?,
+                room: row.get::<_, Option<String>>(4)?,
+                added_at: row.get::<_, String>(5)?,
+                importance: row.get::<_, i32>(6)?,
+                project_id: row.get::<_, Option<String>>(7)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows
+        .into_iter()
+        .filter(|record| {
+            scope.allows_row(record.project_id.as_deref())
+                && wing.is_none_or(|expected| record.wing == expected)
+                && room.is_none_or(|expected| record.room.as_deref() == Some(expected))
+                && since_cutoff.is_none_or(|cutoff| {
+                    parse_added_at(&record.added_at).is_some_and(|ts| ts >= cutoff)
+                })
+        })
+        .collect())
+}
+
+fn load_visible_drawers_after_rowid(
+    db: &Database,
+    scope: &ProjectSearchScope,
+    wing: Option<&str>,
+    room: Option<&str>,
+    since_cutoff: Option<i64>,
+    last_seen_rowid: i64,
+) -> Result<Vec<DrawerRecord>> {
+    let mut stmt = db.conn().prepare(
+        r#"
+        SELECT rowid, id, content, wing, room, added_at,
+               COALESCE(importance, 0), project_id
+        FROM drawers
+        WHERE deleted_at IS NULL AND rowid > ?1
+        ORDER BY rowid ASC
+        "#,
+    )?;
+    let rows = stmt
+        .query_map([last_seen_rowid], |row| {
+            Ok(DrawerRecord {
+                rowid: row.get::<_, i64>(0)?,
+                id: row.get::<_, String>(1)?,
+                content: row.get::<_, String>(2)?,
+                wing: row.get::<_, String>(3)?,
+                room: row.get::<_, Option<String>>(4)?,
+                added_at: row.get::<_, String>(5)?,
+                importance: row.get::<_, i32>(6)?,
+                project_id: row.get::<_, Option<String>>(7)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows
+        .into_iter()
+        .filter(|record| {
+            scope.allows_row(record.project_id.as_deref())
+                && wing.is_none_or(|expected| record.wing == expected)
+                && room.is_none_or(|expected| record.room.as_deref() == Some(expected))
+                && since_cutoff.is_none_or(|cutoff| {
+                    parse_added_at(&record.added_at).is_some_and(|ts| ts >= cutoff)
+                })
+        })
+        .collect())
+}
+
+fn load_audit_records(
+    db: &Database,
+    kind: &str,
+    scope: &ProjectSearchScope,
+    since_cutoff: Option<i64>,
+) -> Result<Vec<AuditRecord>> {
+    let sql = match kind {
+        "gating" => {
+            r#"
+            SELECT a.id, a.candidate_hash, a.decision, a.created_at, d.project_id
+            FROM gating_audit a
+            LEFT JOIN drawers d ON d.id = a.candidate_hash
+            ORDER BY a.created_at DESC, a.id DESC
+            "#
+        }
+        "novelty" => {
+            r#"
+            SELECT a.id, a.candidate_hash, a.decision, a.created_at, d.project_id
+            FROM novelty_audit a
+            LEFT JOIN drawers d ON d.id = a.candidate_hash
+            ORDER BY a.created_at DESC, a.id DESC
+            "#
+        }
+        other => bail!("unsupported audit kind: {other}"),
+    };
+    let mut stmt = db.conn().prepare(sql)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(AuditRecord {
+                audit_id: row.get::<_, String>(0)?,
+                candidate_hash: row.get::<_, String>(1)?,
+                decision: row.get::<_, String>(2)?,
+                created_at: row.get::<_, i64>(3)?,
+                project_id: row.get::<_, Option<String>>(4)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| {
+            scope.allows_row(row.project_id.as_deref())
+                && since_cutoff.is_none_or(|cutoff| row.created_at >= cutoff)
+        })
+        .collect())
+}
+
+fn print_audit_section(kind: &str, rows: &[AuditRecord]) {
+    println!("{kind}:");
+    if rows.is_empty() {
+        println!("  none");
+        return;
+    }
+    for row in rows {
+        println!(
+            "  {} {} {} {}",
+            format_created_at(row.created_at),
+            row.candidate_hash,
+            row.decision,
+            row.audit_id
+        );
+    }
+}
+
+fn print_decision_counts(rows: &[AuditRecord]) {
+    let mut counts = std::collections::BTreeMap::<String, usize>::new();
+    for row in rows {
+        *counts.entry(row.decision.clone()).or_default() += 1;
+    }
+    if counts.is_empty() {
+        println!("  none");
+        return;
+    }
+    for (decision, count) in counts {
+        println!("  {decision}: {count}");
+    }
+}
+
+fn format_tail_line(record: &DrawerRecord) -> String {
+    format!(
+        "{} {}/{} {} {}",
+        format_time(&record.added_at),
+        record.wing,
+        render_room(record.room.as_deref()),
+        record.id,
+        preview(&record.content)
+    )
+}
+
+fn preview(content: &str) -> String {
+    mempal::search::preview::truncate(content, PREVIEW_CHARS).content
+}
+
+fn render_room(room: Option<&str>) -> &str {
+    room.unwrap_or("default")
+}
+
+fn parse_since_cutoff(raw: Option<&str>) -> Result<Option<i64>> {
+    raw.map(parse_duration_spec)
+        .transpose()
+        .map(|seconds| seconds.map(|seconds| now_unix_secs() - seconds))
+}
+
+fn parse_duration_spec(raw: &str) -> Result<i64> {
+    if raw.is_empty() {
+        bail!("empty duration");
+    }
+    let (digits, unit) = raw.split_at(raw.len() - 1);
+    let value = digits
+        .parse::<i64>()
+        .with_context(|| format!("invalid duration: {raw}"))?;
+    let multiplier = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 60 * 60 * 24,
+        other => bail!("unsupported duration unit: {other}"),
+    };
+    Ok(value * multiplier)
+}
+
+fn now_unix_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .as_secs() as i64
+}
+
+fn parse_added_at(value: &str) -> Option<i64> {
+    value.parse::<i64>().ok()
+}
+
+fn format_day(value: &str) -> String {
+    let secs = parse_added_at(value).unwrap_or_default().max(0) as u64;
+    format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))[..10].to_string()
+}
+
+fn format_time(value: &str) -> String {
+    let secs = parse_added_at(value).unwrap_or_default().max(0) as u64;
+    format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))[11..19].to_string()
+}
+
+fn format_timestamp(value: &str) -> String {
+    let secs = parse_added_at(value).unwrap_or_default().max(0) as u64;
+    format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))
+}
+
+fn format_created_at(value: i64) -> String {
+    let secs = value.max(0) as u64;
+    format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -13,6 +13,7 @@ use crate::search::filter::{build_filter_clause, build_vector_search_sql};
 use rusqlite::OptionalExtension;
 
 pub mod filter;
+pub mod preview;
 pub mod rerank;
 pub mod route;
 

--- a/src/search/preview.rs
+++ b/src/search/preview.rs
@@ -1,0 +1,126 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewText {
+    pub content: String,
+    pub truncated: bool,
+}
+
+pub fn truncate(content: &str, preview_chars: usize) -> PreviewText {
+    let total_chars = content.chars().count();
+    if total_chars <= preview_chars {
+        return PreviewText {
+            content: content.to_string(),
+            truncated: false,
+        };
+    }
+
+    let mut exact_end = 0usize;
+    let mut boundary_end = None;
+    let mut prev = None;
+
+    for (count, (idx, ch)) in content.char_indices().enumerate() {
+        if count >= preview_chars {
+            break;
+        }
+
+        if prev.is_some_and(is_boundary_char) {
+            boundary_end = Some(idx);
+        }
+
+        exact_end = idx + ch.len_utf8();
+
+        if is_cjk(ch) || is_boundary_char(ch) {
+            boundary_end = Some(exact_end);
+        }
+
+        prev = Some(ch);
+    }
+
+    let mut preview = content[..boundary_end.unwrap_or(exact_end)].to_string();
+    while preview
+        .chars()
+        .last()
+        .is_some_and(|ch| ch.is_whitespace() || is_boundary_char(ch))
+    {
+        preview.pop();
+    }
+    if preview.is_empty() {
+        preview = content[..exact_end].to_string();
+    }
+    preview.push('…');
+
+    PreviewText {
+        content: preview,
+        truncated: true,
+    }
+}
+
+fn is_boundary_char(ch: char) -> bool {
+    ch.is_whitespace()
+        || ch.is_ascii_punctuation()
+        || matches!(
+            ch,
+            '，' | '。'
+                | '、'
+                | '；'
+                | '：'
+                | '！'
+                | '？'
+                | '（'
+                | '）'
+                | '【'
+                | '】'
+                | '「'
+                | '」'
+                | '《'
+                | '》'
+        )
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x3040..=0x309F
+            | 0x30A0..=0x30FF
+            | 0xAC00..=0xD7AF
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate;
+
+    #[test]
+    fn test_short_content_not_truncated() {
+        let content = "short content";
+        let preview = truncate(content, 120);
+
+        assert_eq!(preview.content, content);
+        assert!(!preview.truncated);
+    }
+
+    #[test]
+    fn test_truncation_aligns_to_word_boundary() {
+        let preview = truncate("The quick brown fox jumps over the lazy dog", 20);
+
+        assert!(preview.truncated);
+        assert!(preview.content.ends_with('…'));
+        assert!(preview.content.chars().count() <= 21);
+        assert!(!preview.content.contains("fox j"));
+    }
+
+    #[test]
+    fn test_cjk_truncation_utf8_safe() {
+        let preview = truncate(
+            "系统决策：采用共享内存同步机制解决状态漂移问题的根本原因是并发安全",
+            10,
+        );
+
+        assert!(preview.truncated);
+        assert!(preview.content.ends_with('…'));
+        assert!(preview.content.chars().count() <= 11);
+        assert!(std::str::from_utf8(preview.content.as_bytes()).is_ok());
+    }
+}

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -1,0 +1,607 @@
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use blake3::Hasher;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::ingest::gating::GatingDecision;
+use mempal::ingest::novelty::NoveltyAction;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+struct DashboardEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    db_path: PathBuf,
+}
+
+impl DashboardEnv {
+    fn new(project_id: Option<&str>, strict_project_isolation: bool) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let mempal_home = home.join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        write_config_atomic(
+            &mempal_home.join("config.toml"),
+            &config_text(&db_path, project_id, strict_project_isolation),
+        );
+        Self {
+            _tmp: tmp,
+            home,
+            db_path,
+        }
+    }
+
+    fn cwd(&self) -> &Path {
+        &self.home
+    }
+}
+
+fn config_text(db_path: &Path, project_id: Option<&str>, strict_project_isolation: bool) -> String {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"
+db_path = "{}"
+{}
+[embedder]
+backend = "api"
+base_url = "http://127.0.0.1:9/v1/"
+api_model = "test-model"
+
+[search]
+strict_project_isolation = {}
+"#,
+        db_path.display(),
+        project_section,
+        strict_project_isolation
+    )
+}
+
+fn write_config_atomic(path: &Path, contents: &str) {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, contents).expect("write temp config");
+    fs::rename(&tmp, path).expect("rename config");
+}
+
+fn run_mempal(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .current_dir(cwd)
+        .output()
+        .expect("run mempal")
+}
+
+fn spawn_mempal(home: &Path, cwd: &Path, args: &[&str]) -> Child {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal")
+}
+
+struct DrawerSeed<'a> {
+    id: &'a str,
+    content: &'a str,
+    wing: &'a str,
+    room: Option<&'a str>,
+    added_at: String,
+    importance: i32,
+    project_id: Option<&'a str>,
+}
+
+fn insert_drawer(db_path: &Path, seed: DrawerSeed<'_>) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: seed.id.to_string(),
+        content: seed.content.to_string(),
+        wing: seed.wing.to_string(),
+        room: seed.room.map(str::to_string),
+        source_file: Some(format!("{}.md", seed.id)),
+        source_type: SourceType::Manual,
+        added_at: seed.added_at,
+        chunk_index: Some(0),
+        importance: seed.importance,
+    })
+    .expect("insert drawer");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET project_id = ?2 WHERE id = ?1",
+            rusqlite::params![seed.id, seed.project_id],
+        )
+        .expect("update drawer project");
+}
+
+fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool) {
+    let db = Database::open(db_path).expect("open db");
+    let decision = if accepted {
+        GatingDecision::accepted(1, Some("keep".to_string()), Some(0.9))
+    } else {
+        GatingDecision::rejected(1, Some("drop".to_string()), None)
+    };
+    db.record_gating_audit(drawer_id, &decision)
+        .expect("record gating audit");
+}
+
+fn record_novelty_audit(db_path: &Path, drawer_id: &str, action: NoveltyAction) {
+    let db = Database::open(db_path).expect("open db");
+    db.record_novelty_audit(drawer_id, action, Some(drawer_id), Some(0.91), None)
+        .expect("record novelty audit");
+}
+
+fn read_lines_until(
+    child: &mut Child,
+    expected_lines: usize,
+    timeout: Duration,
+) -> (Vec<String>, Option<Instant>) {
+    let stdout = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut first_at = None;
+    let mut lines = Vec::new();
+    while start.elapsed() < timeout && lines.len() < expected_lines {
+        if let Ok(line) = rx.recv_timeout(Duration::from_millis(100)) {
+            if first_at.is_none() && !line.trim().is_empty() {
+                first_at = Some(Instant::now());
+            }
+            if !line.trim().is_empty() {
+                lines.push(line);
+            }
+        }
+    }
+    (lines, first_at)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DbSnapshot {
+    drawer_count: i64,
+    triple_count: i64,
+    tunnel_count: usize,
+    digest: String,
+}
+
+fn snapshot_db(db_path: &Path) -> DbSnapshot {
+    let db = Database::open(db_path).expect("open db");
+    let drawer_count = db.drawer_count().expect("drawer count");
+    let triple_count = db.triple_count().expect("triple count");
+    let tunnels = db.find_tunnels().expect("find tunnels");
+
+    let mut hasher = Hasher::new();
+    let mut stmt = db
+        .conn()
+        .prepare(
+            "SELECT id, content, wing, COALESCE(room, ''), COALESCE(project_id, '') FROM drawers ORDER BY id",
+        )
+        .expect("prepare drawers");
+    let drawers = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .expect("query drawers")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect drawers");
+    for drawer in drawers {
+        hasher.update(drawer.0.as_bytes());
+        hasher.update(drawer.1.as_bytes());
+        hasher.update(drawer.2.as_bytes());
+        hasher.update(drawer.3.as_bytes());
+        hasher.update(drawer.4.as_bytes());
+    }
+    let mut stmt = db
+        .conn()
+        .prepare("SELECT id, subject, predicate, object FROM triples ORDER BY id")
+        .expect("prepare triples");
+    let triples = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .expect("query triples")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect triples");
+    for triple in triples {
+        hasher.update(triple.0.as_bytes());
+        hasher.update(triple.1.as_bytes());
+        hasher.update(triple.2.as_bytes());
+        hasher.update(triple.3.as_bytes());
+    }
+    for (room, wings) in tunnels {
+        hasher.update(room.as_bytes());
+        for wing in wings {
+            hasher.update(wing.as_bytes());
+        }
+    }
+
+    DbSnapshot {
+        drawer_count,
+        triple_count,
+        tunnel_count: db.find_tunnels().expect("find tunnels").len(),
+        digest: hasher.finalize().to_hex().to_string(),
+    }
+}
+
+fn unix_secs_days_ago(days: u64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .as_secs();
+    (now - days * 86_400).to_string()
+}
+
+fn day_label_days_ago(days: u64) -> String {
+    let secs = unix_secs_days_ago(days)
+        .parse::<u64>()
+        .expect("day timestamp as u64");
+    mempal::cowork::peek::format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))[..10].to_string()
+}
+
+#[test]
+fn test_mempal_tail_emits_most_recent_drawer_first() {
+    let env = DashboardEnv::new(None, false);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "oldest",
+            content: "old",
+            wing: "code",
+            room: Some("a"),
+            added_at: "1713000000".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "newer",
+            content: "new",
+            wing: "code",
+            room: Some("a"),
+            added_at: "1713000100".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "newest",
+            content: "latest",
+            wing: "docs",
+            room: Some("b"),
+            added_at: "1713000200".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail", "--limit", "2"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines = stdout.lines().collect::<Vec<_>>();
+
+    assert!(lines.first().is_some_and(|line| line.contains("newest")));
+    assert!(lines.get(1).is_some_and(|line| line.contains("newer")));
+}
+
+#[test]
+fn test_mempal_tail_follow_coalesces_event_storm() {
+    let env = DashboardEnv::new(None, false);
+    let mut child = spawn_mempal(&env.home, env.cwd(), &["tail", "--follow", "--limit", "0"]);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let burst_started = Instant::now();
+    for index in 0..20 {
+        let drawer_id = format!("follow-{index:02}");
+        let content = format!("burst drawer {index}");
+        insert_drawer(
+            &env.db_path,
+            DrawerSeed {
+                id: Box::leak(drawer_id.into_boxed_str()),
+                content: Box::leak(content.into_boxed_str()),
+                wing: "code",
+                room: Some("follow"),
+                added_at: format!("{}", 1713001000 + index),
+                importance: 1,
+                project_id: None,
+            },
+        );
+    }
+
+    let (lines, first_at) = read_lines_until(&mut child, 20, Duration::from_secs(5));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(lines.len(), 20, "stdout lines: {lines:?}");
+    let first_elapsed = first_at
+        .map(|instant| instant.duration_since(burst_started))
+        .expect("expected follow output");
+    assert!(
+        first_elapsed >= Duration::from_millis(200),
+        "follow output arrived too early for debounce: {first_elapsed:?}"
+    );
+    for index in 0..20 {
+        let needle = format!("follow-{index:02}");
+        assert!(
+            lines.iter().any(|line| line.contains(&needle)),
+            "missing follow line for {needle}: {lines:?}"
+        );
+    }
+}
+
+#[test]
+fn test_mempal_timeline_groups_by_day() {
+    let env = DashboardEnv::new(None, false);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "d1",
+            content: "day one",
+            wing: "code",
+            room: Some("a"),
+            added_at: unix_secs_days_ago(2),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "d2",
+            content: "day two",
+            wing: "code",
+            room: Some("a"),
+            added_at: unix_secs_days_ago(1),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "d3",
+            content: "day three",
+            wing: "code",
+            room: Some("a"),
+            added_at: unix_secs_days_ago(0),
+            importance: 1,
+            project_id: None,
+        },
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["timeline", "--since", "7d"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains(&format!("=== {} ===", day_label_days_ago(2))));
+    assert!(stdout.contains(&format!("=== {} ===", day_label_days_ago(1))));
+    assert!(stdout.contains(&format!("=== {} ===", day_label_days_ago(0))));
+}
+
+#[test]
+fn test_mempal_stats_counts_drawers_by_wing_room() {
+    let env = DashboardEnv::new(None, false);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "s1",
+            content: "one",
+            wing: "code",
+            room: Some("core"),
+            added_at: "1713000000".to_string(),
+            importance: 3,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "s2",
+            content: "two",
+            wing: "code",
+            room: Some("core"),
+            added_at: "1713000010".to_string(),
+            importance: 2,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "s3",
+            content: "three",
+            wing: "docs",
+            room: Some("notes"),
+            added_at: "1713000020".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    record_gating_audit(&env.db_path, "s1", true);
+    record_novelty_audit(&env.db_path, "s2", NoveltyAction::Merge);
+
+    let output = run_mempal(&env.home, env.cwd(), &["stats"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("drawers total: 3"));
+    assert!(stdout.contains("code/core: 2"));
+    assert!(stdout.contains("docs/notes: 1"));
+}
+
+#[test]
+fn test_mempal_view_drawer_id_prints_raw_verbatim() {
+    let env = DashboardEnv::new(None, false);
+    let content = "Decision: use raw output here.\nSecond line stays verbatim.";
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "view-1",
+            content,
+            wing: "code",
+            room: Some("view"),
+            added_at: "1713000000".to_string(),
+            importance: 4,
+            project_id: None,
+        },
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["view", "view-1", "--raw"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("view-1"));
+    assert!(stdout.contains(content));
+    assert!(!stdout.contains("\u{1b}["));
+}
+
+#[test]
+fn test_mempal_audit_respects_project_isolation() {
+    let env = DashboardEnv::new(Some("proj-A"), true);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "audit-a",
+            content: "project A drawer",
+            wing: "code",
+            room: Some("audit"),
+            added_at: "1713000000".to_string(),
+            importance: 1,
+            project_id: Some("proj-A"),
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "audit-b",
+            content: "project B drawer",
+            wing: "code",
+            room: Some("audit"),
+            added_at: "1713000001".to_string(),
+            importance: 1,
+            project_id: Some("proj-B"),
+        },
+    );
+    record_novelty_audit(&env.db_path, "audit-a", NoveltyAction::Insert);
+    record_novelty_audit(&env.db_path, "audit-b", NoveltyAction::Drop);
+
+    let output = run_mempal(
+        &env.home,
+        env.cwd(),
+        &["audit", "--kind", "novelty", "--since", "7d"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("audit-a"));
+    assert!(!stdout.contains("audit-b"));
+}
+
+#[test]
+fn test_dashboard_commands_do_not_mutate_db() {
+    let env = DashboardEnv::new(None, false);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "d1",
+            content: "drawer one",
+            wing: "code",
+            room: Some("same"),
+            added_at: "1713000000".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "d2",
+            content: "drawer two",
+            wing: "docs",
+            room: Some("same"),
+            added_at: "1713000001".to_string(),
+            importance: 1,
+            project_id: None,
+        },
+    );
+    record_gating_audit(&env.db_path, "d1", true);
+    record_novelty_audit(&env.db_path, "d2", NoveltyAction::Merge);
+
+    let before = snapshot_db(&env.db_path);
+
+    for args in [
+        vec!["tail", "--limit", "2"],
+        vec!["timeline", "--since", "7d"],
+        vec!["stats"],
+        vec!["view", "d1", "--raw"],
+        vec!["audit", "--since", "7d"],
+    ] {
+        let output = run_mempal(&env.home, env.cwd(), &args);
+        assert!(
+            output.status.success(),
+            "args={args:?} stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let after = snapshot_db(&env.db_path);
+    assert_eq!(before, after);
+}

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -126,21 +126,33 @@ fn insert_drawer(db_path: &Path, seed: DrawerSeed<'_>) {
         .expect("update drawer project");
 }
 
-fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool) {
+fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool, project_id: Option<&str>) {
     let db = Database::open(db_path).expect("open db");
     let decision = if accepted {
         GatingDecision::accepted(1, Some("keep".to_string()), Some(0.9))
     } else {
         GatingDecision::rejected(1, Some("drop".to_string()), None)
     };
-    db.record_gating_audit(drawer_id, &decision)
+    db.record_gating_audit(drawer_id, &decision, project_id)
         .expect("record gating audit");
 }
 
-fn record_novelty_audit(db_path: &Path, drawer_id: &str, action: NoveltyAction) {
+fn record_novelty_audit(
+    db_path: &Path,
+    drawer_id: &str,
+    action: NoveltyAction,
+    project_id: Option<&str>,
+) {
     let db = Database::open(db_path).expect("open db");
-    db.record_novelty_audit(drawer_id, action, Some(drawer_id), Some(0.91), None)
-        .expect("record novelty audit");
+    db.record_novelty_audit(
+        drawer_id,
+        action,
+        Some(drawer_id),
+        Some(0.91),
+        None,
+        project_id,
+    )
+    .expect("record novelty audit");
 }
 
 fn read_lines_until(
@@ -463,8 +475,8 @@ fn test_mempal_stats_counts_drawers_by_wing_room() {
             project_id: None,
         },
     );
-    record_gating_audit(&env.db_path, "s1", true);
-    record_novelty_audit(&env.db_path, "s2", NoveltyAction::Merge);
+    record_gating_audit(&env.db_path, "s1", true, None);
+    record_novelty_audit(&env.db_path, "s2", NoveltyAction::Merge, None);
 
     let output = run_mempal(&env.home, env.cwd(), &["stats"]);
     assert!(
@@ -536,8 +548,13 @@ fn test_mempal_audit_respects_project_isolation() {
             project_id: Some("proj-B"),
         },
     );
-    record_novelty_audit(&env.db_path, "audit-a", NoveltyAction::Insert);
-    record_novelty_audit(&env.db_path, "audit-b", NoveltyAction::Drop);
+    record_novelty_audit(
+        &env.db_path,
+        "audit-a",
+        NoveltyAction::Insert,
+        Some("proj-A"),
+    );
+    record_novelty_audit(&env.db_path, "audit-b", NoveltyAction::Drop, Some("proj-B"));
 
     let output = run_mempal(
         &env.home,
@@ -582,8 +599,8 @@ fn test_dashboard_commands_do_not_mutate_db() {
             project_id: None,
         },
     );
-    record_gating_audit(&env.db_path, "d1", true);
-    record_novelty_audit(&env.db_path, "d2", NoveltyAction::Merge);
+    record_gating_audit(&env.db_path, "d1", true, None);
+    record_novelty_audit(&env.db_path, "d2", NoveltyAction::Merge, None);
 
     let before = snapshot_db(&env.db_path);
 
@@ -604,4 +621,44 @@ fn test_dashboard_commands_do_not_mutate_db() {
 
     let after = snapshot_db(&env.db_path);
     assert_eq!(before, after);
+}
+
+#[test]
+fn test_mempal_audit_keeps_project_scoped_rejects_without_drawer_rows() {
+    let env = DashboardEnv::new(Some("proj-A"), true);
+    record_gating_audit(&env.db_path, "candidate-a", false, Some("proj-A"));
+    record_gating_audit(&env.db_path, "candidate-b", false, Some("proj-B"));
+
+    let output = run_mempal(
+        &env.home,
+        env.cwd(),
+        &["audit", "--kind", "gating", "--since", "7d"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("candidate-a"));
+    assert!(!stdout.contains("candidate-b"));
+}
+
+#[test]
+fn test_mempal_stats_counts_project_scoped_audit_rows_without_drawer_rows() {
+    let env = DashboardEnv::new(Some("proj-A"), true);
+    record_gating_audit(&env.db_path, "candidate-a", false, Some("proj-A"));
+    record_gating_audit(&env.db_path, "candidate-b", false, Some("proj-B"));
+
+    let output = run_mempal(&env.home, env.cwd(), &["stats"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("gating:"));
+    assert!(stdout.contains("  rejected: 1"));
 }

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -541,7 +541,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 5"),
+            .any(|line| line.trim() == "fork_ext_version: 6"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/embedder_degraded_state.rs
+++ b/tests/embedder_degraded_state.rs
@@ -107,6 +107,7 @@ async fn test_degraded_state_blocks_mcp_writes() {
             project_id: None,
             include_global: None,
             all_projects: None,
+            disable_progressive: None,
         }))
         .await
         .expect("search should still work")

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -29,12 +29,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_five_after_project_isolation_phase() {
+fn test_fork_ext_version_is_six_after_audit_project_scope_phase() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_fork_ext_migrations_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 }
 
 #[test]
@@ -106,4 +106,29 @@ fn test_novelty_audit_table_exists_after_ext_v4() {
         .expect("query sqlite_master");
 
     assert_eq!(exists, 1);
+}
+
+#[test]
+fn test_audit_tables_store_project_scope_after_ext_v6() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let gating_columns = db
+        .conn()
+        .prepare("PRAGMA table_info(gating_audit)")
+        .expect("prepare gating pragma")
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query gating pragma")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect gating columns");
+    assert!(gating_columns.iter().any(|name| name == "project_id"));
+
+    let novelty_columns = db
+        .conn()
+        .prepare("PRAGMA table_info(novelty_audit)")
+        .expect("prepare novelty pragma")
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query novelty pragma")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect novelty columns");
+    assert!(novelty_columns.iter().any(|name| name == "project_id"));
 }

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -16,7 +16,7 @@ fn test_fork_ext_v4_migration() {
     let (_tmp, db) = new_test_db();
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 
     let table_exists = db
         .conn()
@@ -57,5 +57,5 @@ fn test_fork_ext_v4_migration_is_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 }

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -312,6 +312,9 @@ async fn test_mempal_read_drawer_returns_raw_full_content() {
         .server()
         .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
             drawer_id: "drawer-read".to_string(),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
         }))
         .await
         .expect("read drawer should succeed")
@@ -339,6 +342,9 @@ async fn test_mempal_read_drawer_respects_project_isolation() {
         .server()
         .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
             drawer_id: "drawer-b".to_string(),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
         }))
         .await;
     let error = match result {
@@ -350,6 +356,105 @@ async fn test_mempal_read_drawer_respects_project_isolation() {
         error.to_string().contains("project"),
         "expected project isolation error, got: {error}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mempal_read_drawer_supports_all_projects_scope() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(Some("proj-A"), true, true, 16);
+    let content =
+        "cross-project drawer should stay readable when the caller explicitly widens scope.";
+    insert_drawer(
+        &env.db_path,
+        "drawer-cross",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/cross.md",
+        Some("proj-B"),
+    );
+
+    let search = env
+        .server()
+        .mempal_search(Parameters(SearchRequest {
+            query: "cross-project".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: Some(true),
+            disable_progressive: None,
+        }))
+        .await
+        .expect("search should succeed")
+        .0;
+    assert_eq!(search.results[0].drawer_id, "drawer-cross");
+    assert!(search.results[0].content_truncated);
+
+    let response = env
+        .server()
+        .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
+            drawer_id: "drawer-cross".to_string(),
+            project_id: None,
+            include_global: None,
+            all_projects: Some(true),
+        }))
+        .await
+        .expect("cross-project read should succeed when scope is widened")
+        .0;
+
+    assert_eq!(response.drawer_id, "drawer-cross");
+    assert_eq!(response.content, content);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mempal_read_drawer_supports_include_global_scope() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(Some("proj-A"), true, true, 16);
+    let content = "global drawer should stay readable when include_global is requested.";
+    insert_drawer(
+        &env.db_path,
+        "drawer-global",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/global.md",
+        None,
+    );
+
+    let search = env
+        .server()
+        .mempal_search(Parameters(SearchRequest {
+            query: "global drawer".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: Some(true),
+            all_projects: None,
+            disable_progressive: None,
+        }))
+        .await
+        .expect("search should succeed")
+        .0;
+    assert_eq!(search.results[0].drawer_id, "drawer-global");
+    assert!(search.results[0].content_truncated);
+
+    let response = env
+        .server()
+        .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
+            drawer_id: "drawer-global".to_string(),
+            project_id: None,
+            include_global: Some(true),
+            all_projects: None,
+        }))
+        .await
+        .expect("global read should succeed when include_global is set")
+        .0;
+
+    assert_eq!(response.drawer_id, "drawer-global");
+    assert_eq!(response.content, content);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -1,0 +1,394 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{MempalMcpServer, SearchRequest};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+async fn config_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct StaticEmbedderFactory {
+    vector: Vec<f32>,
+}
+
+struct StaticEmbedder {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbedderFactory for StaticEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(StaticEmbedder {
+            vector: self.vector.clone(),
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for StaticEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "static"
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    config_path: PathBuf,
+    db_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new(
+        project_id: Option<&str>,
+        strict_project_isolation: bool,
+        progressive_disclosure: bool,
+        preview_chars: usize,
+    ) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let config_path = mempal_home.join("config.toml");
+        let db_path = mempal_home.join("palace.db");
+        write_config_atomic(
+            &config_path,
+            &config_text(
+                &db_path,
+                project_id,
+                strict_project_isolation,
+                progressive_disclosure,
+                preview_chars,
+            ),
+        );
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        Self {
+            _tmp: tmp,
+            config_path,
+            db_path,
+        }
+    }
+
+    fn server(&self) -> MempalMcpServer {
+        MempalMcpServer::new_with_factory(
+            self.db_path.clone(),
+            Arc::new(StaticEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+    }
+}
+
+fn config_text(
+    db_path: &Path,
+    project_id: Option<&str>,
+    strict_project_isolation: bool,
+    progressive_disclosure: bool,
+    preview_chars: usize,
+) -> String {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"
+db_path = "{}"
+{}
+[embedder]
+backend = "api"
+base_url = "http://127.0.0.1:9/v1/"
+api_model = "test-model"
+
+[config_hot_reload]
+enabled = true
+debounce_ms = 250
+poll_fallback_secs = 1
+
+[search]
+strict_project_isolation = {}
+progressive_disclosure = {}
+preview_chars = {}
+"#,
+        db_path.display(),
+        project_section,
+        strict_project_isolation,
+        progressive_disclosure,
+        preview_chars
+    )
+}
+
+fn write_config_atomic(path: &Path, contents: &str) {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, contents).expect("write temp config");
+    fs::rename(&tmp, path).expect("rename config");
+}
+
+fn wait_for_config_version_change(previous: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let current = ConfigHandle::version();
+        if current != previous {
+            return current;
+        }
+        assert!(Instant::now() < deadline, "config version did not change");
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn insert_drawer(
+    db_path: &Path,
+    id: &str,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    source_file: &str,
+    project_id: Option<&str>,
+) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: wing.to_string(),
+        room: room.map(str::to_string),
+        source_file: Some(source_file.to_string()),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 4,
+    })
+    .expect("insert drawer");
+    db.insert_vector(id, &[0.1, 0.2, 0.3])
+        .expect("insert vector");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET project_id = ?2 WHERE id = ?1",
+            rusqlite::params![id, project_id],
+        )
+        .expect("update drawer project");
+    db.conn()
+        .execute(
+            "UPDATE drawer_vectors SET project_id = ?2 WHERE id = ?1",
+            rusqlite::params![id, project_id],
+        )
+        .expect("update vector project");
+}
+
+async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_json::Value {
+    let response = server
+        .mempal_search(Parameters(SearchRequest {
+            query: query.to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        }))
+        .await
+        .expect("search should succeed")
+        .0;
+    serde_json::to_value(response).expect("serialize response")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_result_has_content_truncated_field() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(None, false, true, 32);
+    insert_drawer(
+        &env.db_path,
+        "drawer-short",
+        "short content stays verbatim",
+        "code",
+        Some("preview"),
+        "/tmp/short.md",
+        None,
+    );
+
+    let json = search_response_json(&env.server(), "short").await;
+    let result = &json["results"][0];
+
+    assert!(
+        result.get("content_truncated").is_some(),
+        "missing content_truncated field: {json}"
+    );
+    assert!(
+        result.get("original_content_bytes").is_some(),
+        "missing original_content_bytes field: {json}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_preview_length_cap_applied() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(None, false, true, 24);
+    let content = "Decision: adopt deterministic replay for queue recovery because replay order is part of the audit contract and must stay stable across restarts.";
+    insert_drawer(
+        &env.db_path,
+        "drawer-long",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/long.md",
+        None,
+    );
+
+    let json = search_response_json(&env.server(), "deterministic").await;
+    let result = &json["results"][0];
+    let preview = result["content"].as_str().expect("content string");
+
+    assert!(preview.chars().count() <= 25, "preview too long: {preview}");
+    assert_eq!(result["content_truncated"], true);
+    assert_eq!(
+        result["original_content_bytes"].as_u64(),
+        Some(content.len() as u64)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_short_content_untruncated() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(None, false, true, 120);
+    let content = "short drawer stays whole";
+    insert_drawer(
+        &env.db_path,
+        "drawer-short",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/short.md",
+        None,
+    );
+
+    let json = search_response_json(&env.server(), "whole").await;
+    let result = &json["results"][0];
+
+    assert_eq!(result["content"], content);
+    assert_eq!(result["content_truncated"], false);
+    assert_eq!(
+        result["original_content_bytes"].as_u64(),
+        Some(content.len() as u64)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mempal_read_drawer_returns_raw_full_content() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(None, false, true, 16);
+    let content = "Decision: keep the original raw drawer content intact even when previews are truncated in search.";
+    insert_drawer(
+        &env.db_path,
+        "drawer-read",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/read.md",
+        None,
+    );
+
+    let response = env
+        .server()
+        .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
+            drawer_id: "drawer-read".to_string(),
+        }))
+        .await
+        .expect("read drawer should succeed")
+        .0;
+
+    assert_eq!(response.drawer_id, "drawer-read");
+    assert_eq!(response.content, content);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mempal_read_drawer_respects_project_isolation() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(Some("proj-A"), true, true, 32);
+    insert_drawer(
+        &env.db_path,
+        "drawer-b",
+        "project B content should not leak",
+        "code",
+        Some("preview"),
+        "/tmp/b.md",
+        Some("proj-B"),
+    );
+
+    let result = env
+        .server()
+        .mempal_read_drawer(Parameters(mempal::mcp::ReadDrawerRequest {
+            drawer_id: "drawer-b".to_string(),
+        }))
+        .await;
+    let error = match result {
+        Ok(_) => panic!("cross-project read should fail"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("project"),
+        "expected project isolation error, got: {error}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_progressive_disclosure_hot_reload_applies_without_restart() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(None, false, true, 16);
+    let content = "Decision: the preview cap can change at runtime and the next search must observe the updated value.";
+    insert_drawer(
+        &env.db_path,
+        "drawer-hot",
+        content,
+        "code",
+        Some("preview"),
+        "/tmp/hot.md",
+        None,
+    );
+
+    let before = search_response_json(&env.server(), "preview").await;
+    let before_preview = before["results"][0]["content"]
+        .as_str()
+        .expect("before preview")
+        .to_string();
+    assert!(before_preview.chars().count() <= 17);
+
+    let previous = ConfigHandle::version();
+    write_config_atomic(
+        &env.config_path,
+        &config_text(&env.db_path, None, false, true, 48),
+    );
+    wait_for_config_version_change(&previous);
+
+    let after = search_response_json(&env.server(), "preview").await;
+    let after_preview = after["results"][0]["content"]
+        .as_str()
+        .expect("after preview")
+        .to_string();
+
+    assert!(
+        after_preview.chars().count() > before_preview.chars().count(),
+        "preview cap did not grow after hot reload: before={before_preview:?} after={after_preview:?}"
+    );
+}

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -319,7 +319,7 @@ fn test_ext_v5_migration_adds_project_id_column() {
     let db = Database::open(&db_path).expect("open db");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
 
     let drawer_columns = column_names(db.conn(), "drawers");
     assert!(
@@ -353,7 +353,7 @@ fn test_ext_v5_migration_idempotent() {
     db_fork_ext::apply_fork_ext_migrations(db.conn()).expect("reapply twice");
 
     let version = db_fork_ext::read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 5);
+    assert_eq!(version, 6);
     assert_eq!(before_drawers, column_names(db.conn(), "drawers"));
     assert_eq!(
         before_vectors,

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -262,6 +262,7 @@ async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_js
             project_id: None,
             include_global: None,
             all_projects: None,
+            disable_progressive: None,
         },
     )
     .await
@@ -648,6 +649,7 @@ async fn test_ingest_allows_same_content_in_different_projects() {
             project_id: Some("proj-B".to_string()),
             include_global: None,
             all_projects: None,
+            disable_progressive: None,
         },
     )
     .await;

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -24,7 +24,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 }
 
 #[test]
-fn test_fork_ext_migration_v0_to_v5_preserves_pending_messages_table() {
+fn test_fork_ext_migration_v0_to_v6_preserves_pending_messages_table() {
     let (_tmp, db_path, _store) = new_store();
     let conn = Connection::open(db_path).expect("open sqlite");
 
@@ -35,7 +35,7 @@ fn test_fork_ext_migration_v0_to_v5_preserves_pending_messages_table() {
             |row| row.get::<_, String>(0),
         )
         .expect("read fork_ext_version");
-    assert_eq!(version, "5");
+    assert_eq!(version, "6");
 
     let exists = conn
         .query_row(


### PR DESCRIPTION


### Schema bump (ext_v5 → ext_v6, added in round-2 fix)

The initial "no schema bump" constraint from the prompt had to be relaxed for the round-2 fix because dashboard audit/stats under strict project isolation require persisting `project_id` directly on `gating_audit` and `novelty_audit`. Joining through `drawers` was insufficient: reject/drop/merge candidates do not always land in `drawers`, so the LEFT JOIN could return NULL and the rows would be filtered out. The migration is idempotent and backfills `project_id` from the existing drawer lookup where possible.
