### PR TITLE
feat(p10 optional): folder CLAUDE.md hotpatch suggestion pool

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -25,6 +25,8 @@ const DEFAULT_DAEMON_LOG_PATH: &str = "~/.mempal/daemon.log";
 const DEFAULT_SESSION_REVIEW_WING: &str = "session-reviews";
 const DEFAULT_SESSION_REVIEW_MIN_LENGTH: usize = 100;
 const DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES: usize = 1;
+const DEFAULT_HOTPATCH_MIN_IMPORTANCE_STARS: i32 = 4;
+const DEFAULT_HOTPATCH_MAX_SUGGESTION_LENGTH: usize = 80;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
@@ -36,6 +38,7 @@ pub struct Config {
     pub privacy: PrivacyConfig,
     pub config_hot_reload: ConfigHotReloadConfig,
     pub search: SearchConfig,
+    pub hotpatch: HotpatchConfig,
     pub ingest_gating: IngestGatingConfig,
     pub hooks: HooksConfig,
     pub daemon: DaemonConfig,
@@ -50,6 +53,7 @@ impl Default for Config {
             privacy: PrivacyConfig::default(),
             config_hot_reload: ConfigHotReloadConfig::default(),
             search: SearchConfig::default(),
+            hotpatch: HotpatchConfig::default(),
             ingest_gating: IngestGatingConfig::default(),
             hooks: HooksConfig::default(),
             daemon: DaemonConfig::default(),
@@ -101,6 +105,21 @@ impl Config {
         if self.search.preview_chars == 0 {
             return Err(ConfigError::InvalidConfig(
                 "search.preview_chars must be greater than 0".to_string(),
+            ));
+        }
+        if !(0..=5).contains(&self.hotpatch.min_importance_stars) {
+            return Err(ConfigError::InvalidConfig(
+                "hotpatch.min_importance_stars must be between 0 and 5".to_string(),
+            ));
+        }
+        if self.hotpatch.max_suggestion_length == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "hotpatch.max_suggestion_length must be greater than 0".to_string(),
+            ));
+        }
+        if self.hotpatch.watch_files.is_empty() {
+            return Err(ConfigError::InvalidConfig(
+                "hotpatch.watch_files must not be empty".to_string(),
             ));
         }
         if self.embed.alert.alert_every_n_failures == 0 {
@@ -596,6 +615,32 @@ impl Default for SearchConfig {
             strict_project_isolation: false,
             progressive_disclosure: false,
             preview_chars: DEFAULT_SEARCH_PREVIEW_CHARS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct HotpatchConfig {
+    pub enabled: bool,
+    pub min_importance_stars: i32,
+    pub watch_files: Vec<String>,
+    pub max_suggestion_length: usize,
+    pub allowed_target_prefixes: Vec<String>,
+}
+
+impl Default for HotpatchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_importance_stars: DEFAULT_HOTPATCH_MIN_IMPORTANCE_STARS,
+            watch_files: vec![
+                "CLAUDE.md".to_string(),
+                "AGENTS.md".to_string(),
+                "GEMINI.md".to_string(),
+            ],
+            max_suggestion_length: DEFAULT_HOTPATCH_MAX_SUGGESTION_LENGTH,
+            allowed_target_prefixes: Vec::new(),
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -26,6 +26,7 @@ use serde_json::{Value, json};
 
 use crate::daemon_bootstrap::DaemonContext;
 use crate::hook::CapturedHookEnvelope;
+use crate::hotpatch::generator::{GenerationOptions, suggest_for_drawer};
 use crate::session_review::{SessionReviewOutcome, extract_session_review};
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
@@ -195,7 +196,17 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
     };
     let mut last_drawer_id = None;
     for record in records {
-        last_drawer_id = Some(ingest_drawer_record(&drawer_context, record).await?);
+        let drawer_id = ingest_drawer_record(&drawer_context, record).await?;
+        if let Err(error) = suggest_for_drawer(
+            db,
+            context.config,
+            context.mempal_home,
+            &drawer_id,
+            GenerationOptions::default(),
+        ) {
+            tracing::warn!(?error, drawer_id, "hotpatch suggestion generation failed");
+        }
+        last_drawer_id = Some(drawer_id);
     }
 
     Ok(last_drawer_id.unwrap_or_else(|| message.id.clone()))

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,6 +8,7 @@ use std::{future::Future, pin::Pin};
 
 use crate::core::{
     db::Database,
+    project::resolve_project_id,
     queue::{ClaimedMessage, PendingMessageStore},
     types::{Drawer, SourceType},
     utils::{current_timestamp, synthetic_source_file},
@@ -264,6 +265,7 @@ struct DrawerRecord {
     content: String,
     importance: i32,
     bypass_novelty: bool,
+    project_id: Option<String>,
 }
 
 fn build_drawer_records(
@@ -290,6 +292,7 @@ fn build_drawer_records(
                 content: config.scrub_content(&review.content),
                 importance: review.importance,
                 bypass_novelty: true,
+                project_id: resolve_hook_project_id(envelope, config)?,
             }),
             SessionReviewOutcome::Skipped(reason) => {
                 tracing::info!(?reason, "session self-review skipped");
@@ -322,6 +325,7 @@ fn build_audit_drawer_record(
     config: &crate::core::config::Config,
     mempal_home: &Path,
 ) -> Result<DrawerRecord> {
+    let project_id = resolve_hook_project_id(envelope, config)?;
     if envelope.truncated {
         let preview = config.scrub_content(envelope.payload_preview.as_deref().unwrap_or_default());
         let content = serde_json::to_string(&json!({
@@ -346,6 +350,7 @@ fn build_audit_drawer_record(
             content,
             importance: 0,
             bypass_novelty: false,
+            project_id,
         });
     }
 
@@ -373,7 +378,16 @@ fn build_audit_drawer_record(
         content,
         importance: 0,
         bypass_novelty: false,
+        project_id,
     })
+}
+
+fn resolve_hook_project_id(
+    envelope: &CapturedHookEnvelope,
+    config: &crate::core::config::Config,
+) -> Result<Option<String>> {
+    resolve_project_id(None, config, Some(Path::new(&envelope.claude_cwd)))
+        .map_err(anyhow::Error::from)
 }
 
 fn audit_target_for_event(
@@ -425,7 +439,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             &record.wing,
             Some(record.room.as_str()),
             &record.content,
-            None,
+            record.project_id.as_deref(),
         )
         .with_context(|| {
             format!(
@@ -451,7 +465,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     {
         context
             .db
-            .record_gating_audit(&drawer_id, decision, None)
+            .record_gating_audit(&drawer_id, decision, record.project_id.as_deref())
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         return Ok(drawer_id);
     }
@@ -484,7 +498,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         );
         context
             .db
-            .record_gating_audit(&drawer_id, &decision, None)
+            .record_gating_audit(&drawer_id, &decision, record.project_id.as_deref())
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         gating_audit_recorded = true;
         if decision.is_rejected() {
@@ -496,7 +510,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
         context
             .db
-            .record_gating_audit(&drawer_id, decision, None)
+            .record_gating_audit(&drawer_id, decision, record.project_id.as_deref())
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
     }
 
@@ -531,7 +545,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
-                        None,
+                        record.project_id.as_deref(),
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
             }
@@ -548,7 +562,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         novelty.near_drawer_id.as_deref(),
                         novelty.cosine,
                         novelty.audit_decision,
-                        None,
+                        record.project_id.as_deref(),
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
             }
@@ -604,7 +618,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         Some(target_id.as_str()),
                         novelty.cosine,
                         Some("insert_due_to_merge_cap"),
-                        None,
+                        record.project_id.as_deref(),
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
                 insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
@@ -621,7 +635,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         Some(target_id.as_str()),
                         novelty.cosine,
                         novelty.audit_decision,
-                        None,
+                        record.project_id.as_deref(),
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
                 let mut db_for_merge = Database::open(context.db.path())
@@ -664,9 +678,9 @@ fn insert_drawer_with_vector(
         chunk_index: Some(0),
         importance: record.importance,
     };
-    db.insert_drawer(&drawer)
+    db.insert_drawer_with_project(&drawer, record.project_id.as_deref())
         .with_context(|| format!("failed to insert hook drawer {}", drawer.id))?;
-    db.insert_vector(&drawer.id, vector)
+    db.insert_vector_with_project(&drawer.id, vector, record.project_id.as_deref())
         .with_context(|| format!("failed to insert hook vector {}", drawer.id))?;
     Ok(())
 }

--- a/src/hotpatch/generator.rs
+++ b/src/hotpatch/generator.rs
@@ -1,0 +1,399 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::core::{
+    config::Config,
+    db::Database,
+    project::{ProjectSearchScope, resolve_project_id},
+};
+use crate::hotpatch::{FileLock, short_drawer_id};
+use crate::search::preview;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GenerationOptions {
+    pub all_projects: bool,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GenerationOutcome {
+    pub appended: usize,
+    pub skipped: usize,
+}
+
+pub fn suggest_for_drawer(
+    db: &Database,
+    config: &Config,
+    mempal_home: &Path,
+    drawer_id: &str,
+    options: GenerationOptions,
+) -> Result<GenerationOutcome> {
+    if !config.hotpatch.enabled {
+        return Ok(GenerationOutcome::default());
+    }
+
+    let details = match db
+        .get_drawer_details(drawer_id)
+        .with_context(|| format!("failed to load drawer {drawer_id}"))?
+    {
+        Some(details) => details,
+        None => return Ok(GenerationOutcome::default()),
+    };
+
+    let resolved_project = resolve_generation_project(config, &details.drawer.content)?;
+    let scope = ProjectSearchScope::from_request(
+        resolved_project,
+        false,
+        options.all_projects,
+        config.search.strict_project_isolation,
+    );
+    if !scope.allows_row(details.project_id.as_deref()) {
+        return Ok(GenerationOutcome {
+            appended: 0,
+            skipped: 1,
+        });
+    }
+
+    let (summary_source, flags, relative_base) = summary_inputs(&details.drawer.content)?;
+    if !is_eligible(
+        details.drawer.importance,
+        &flags,
+        summary_source
+            .as_deref()
+            .unwrap_or(details.drawer.content.as_str()),
+        config.hotpatch.min_importance_stars,
+    ) {
+        return Ok(GenerationOutcome {
+            appended: 0,
+            skipped: 1,
+        });
+    }
+
+    let source_file = details
+        .drawer
+        .source_file
+        .as_deref()
+        .map(PathBuf::from)
+        .filter(|path| path.exists());
+    let payload_paths = extract_candidate_paths(
+        source_file.as_deref(),
+        summary_source.as_deref(),
+        relative_base.as_deref(),
+    )?;
+    if payload_paths.is_empty() {
+        return Ok(GenerationOutcome {
+            appended: 0,
+            skipped: 1,
+        });
+    }
+
+    let mut appended = 0usize;
+    let mut skipped = 0usize;
+    let summary = summarize(
+        summary_source
+            .as_deref()
+            .unwrap_or(details.drawer.content.as_str()),
+        config.hotpatch.max_suggestion_length,
+    );
+    let topic = classify_topic(
+        &flags,
+        summary_source.as_deref().unwrap_or(&details.drawer.content),
+    );
+    let line = format!(
+        "- {} {}: {} [drawer:{}]",
+        stars(
+            details
+                .drawer
+                .importance
+                .max(config.hotpatch.min_importance_stars)
+        ),
+        topic,
+        summary,
+        short_drawer_id(&details.drawer.id)
+    );
+
+    for path in payload_paths {
+        let watched_dir = match find_watched_dir(&path, &config.hotpatch.watch_files) {
+            Ok(Some(dir)) => dir,
+            Ok(None) => {
+                skipped += 1;
+                continue;
+            }
+            Err(error) => {
+                tracing::warn!(?error, path = %path.display(), "hotpatch watched-dir resolution failed");
+                skipped += 1;
+                continue;
+            }
+        };
+        let suggestion_path = suggestion_file_path(mempal_home, &watched_dir)?;
+        fs::create_dir_all(
+            suggestion_path
+                .parent()
+                .context("hotpatch suggestion file missing parent")?,
+        )
+        .with_context(|| format!("failed to create {}", suggestion_path.display()))?;
+        let changed =
+            append_suggestion_line(&suggestion_path, &watched_dir, &details.drawer.id, &line)?;
+        if changed {
+            appended += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    Ok(GenerationOutcome { appended, skipped })
+}
+
+fn resolve_generation_project(config: &Config, drawer_content: &str) -> Result<Option<String>> {
+    let cwd = serde_json::from_str::<Value>(drawer_content)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("claude_cwd")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+        });
+    resolve_project_id(None, config, cwd.as_deref()).map_err(anyhow::Error::from)
+}
+
+fn summary_inputs(drawer_content: &str) -> Result<(Option<String>, Vec<String>, Option<PathBuf>)> {
+    let parsed = match serde_json::from_str::<Value>(drawer_content) {
+        Ok(value) => value,
+        Err(_) => return Ok((Some(drawer_content.to_string()), Vec::new(), None)),
+    };
+    let summary_source = parsed
+        .get("preview")
+        .and_then(Value::as_str)
+        .or_else(|| parsed.get("payload_preview").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            parsed
+                .get("content")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        });
+    let flags = parsed
+        .get("flags")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|value| value.to_ascii_uppercase())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let relative_base = parsed
+        .get("claude_cwd")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    Ok((summary_source, flags, relative_base))
+}
+
+fn is_eligible(importance: i32, flags: &[String], summary_source: &str, threshold: i32) -> bool {
+    if importance >= threshold {
+        return true;
+    }
+    if flags
+        .iter()
+        .any(|flag| flag == "DECISION" || flag == "PIVOT")
+    {
+        return true;
+    }
+    let lower = summary_source.to_ascii_lowercase();
+    lower.contains("decision") || lower.contains("pivot")
+}
+
+fn extract_candidate_paths(
+    source_file: Option<&Path>,
+    summary_source: Option<&str>,
+    relative_base: Option<&Path>,
+) -> Result<Vec<PathBuf>> {
+    let mut paths = BTreeSet::new();
+    if let Some(source_file) = source_file {
+        let raw = fs::read_to_string(source_file)
+            .with_context(|| format!("failed to read hook payload {}", source_file.display()))?;
+        if let Ok(value) = serde_json::from_str::<Value>(&raw) {
+            collect_paths_from_value(&value, &mut paths);
+        }
+    }
+    if paths.is_empty()
+        && let Some(summary_source) = summary_source
+        && let Ok(value) = serde_json::from_str::<Value>(summary_source)
+    {
+        collect_paths_from_value(&value, &mut paths);
+    }
+    let mut resolved = Vec::new();
+    for path in paths {
+        resolved.push(resolve_candidate_path(&path, relative_base)?);
+    }
+    Ok(resolved)
+}
+
+fn collect_paths_from_value(value: &Value, out: &mut BTreeSet<PathBuf>) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                if matches!(key.as_str(), "file_path" | "path")
+                    && let Some(value) = nested.as_str()
+                {
+                    out.insert(PathBuf::from(value));
+                }
+                if key == "files" {
+                    match nested {
+                        Value::Array(items) => {
+                            for item in items {
+                                match item {
+                                    Value::String(path) => {
+                                        out.insert(PathBuf::from(path));
+                                    }
+                                    Value::Object(inner) => {
+                                        for inner_key in ["file_path", "path"] {
+                                            if let Some(path) =
+                                                inner.get(inner_key).and_then(Value::as_str)
+                                            {
+                                                out.insert(PathBuf::from(path));
+                                            }
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        Value::String(path) => {
+                            out.insert(PathBuf::from(path));
+                        }
+                        _ => {}
+                    }
+                }
+                collect_paths_from_value(nested, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_paths_from_value(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn resolve_candidate_path(path: &Path, relative_base: Option<&Path>) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf());
+    }
+    let base = relative_base
+        .context("hotpatch payload contained relative path without claude_cwd base")?;
+    Ok(base.join(path))
+}
+
+fn find_watched_dir(path: &Path, watch_files: &[String]) -> Result<Option<PathBuf>> {
+    let mut current = if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent()
+            .map(Path::to_path_buf)
+            .context("candidate path missing parent directory")?
+    };
+    loop {
+        if watch_files.iter().any(|watch| current.join(watch).exists()) {
+            return Ok(Some(current));
+        }
+        if !current.pop() {
+            return Ok(None);
+        }
+    }
+}
+
+pub(crate) fn suggestion_file_path(mempal_home: &Path, dir: &Path) -> Result<PathBuf> {
+    let canonical = dir
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", dir.display()))?;
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    Ok(mempal_home
+        .join("hotpatch")
+        .join(format!("CLAUDE-{}.md", &hash[..12])))
+}
+
+pub(crate) fn append_suggestion_line(
+    suggestion_path: &Path,
+    canonical_dir: &Path,
+    drawer_id: &str,
+    line: &str,
+) -> Result<bool> {
+    let mut lock = FileLock::open_exclusive(suggestion_path)?;
+    let file = lock.file_mut();
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to seek {}", suggestion_path.display()))?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .with_context(|| format!("failed to read {}", suggestion_path.display()))?;
+    let marker = format!("[drawer:{}]", short_drawer_id(drawer_id));
+    if content.contains(&marker) {
+        return Ok(false);
+    }
+
+    if content.trim().is_empty() {
+        content = format!(
+            "# mempal hotpatch suggestions for {}\n\n<!-- managed by mempal, safe to edit — apply via `mempal hotpatch apply --dir {}` -->\n\n",
+            canonical_dir.display(),
+            canonical_dir.display()
+        );
+    } else if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push_str(line);
+    content.push('\n');
+
+    file.set_len(0)
+        .with_context(|| format!("failed to truncate {}", suggestion_path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to rewind {}", suggestion_path.display()))?;
+    file.write_all(content.as_bytes())
+        .with_context(|| format!("failed to write {}", suggestion_path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", suggestion_path.display()))?;
+    Ok(true)
+}
+
+fn summarize(source: &str, max_chars: usize) -> String {
+    let first_line = source
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or(source);
+    let trimmed = first_line
+        .trim()
+        .trim_start_matches('#')
+        .trim()
+        .trim_start_matches("Decision:")
+        .trim_start_matches("decision:")
+        .trim_start_matches("Pivot:")
+        .trim_start_matches("pivot:")
+        .trim();
+    let preview = preview::truncate(trimmed, max_chars);
+    preview.content
+}
+
+fn classify_topic(flags: &[String], source: &str) -> &'static str {
+    if flags.iter().any(|flag| flag == "PIVOT") || source.to_ascii_lowercase().contains("pivot") {
+        return "pivot";
+    }
+    if flags.iter().any(|flag| flag == "DECISION")
+        || source.to_ascii_lowercase().contains("decision")
+    {
+        return "decision";
+    }
+    "note"
+}
+
+fn stars(importance: i32) -> String {
+    let clamped = importance.clamp(1, 5) as usize;
+    "★".repeat(clamped)
+}

--- a/src/hotpatch/manager.rs
+++ b/src/hotpatch/manager.rs
@@ -1,0 +1,499 @@
+use std::env;
+use std::fs;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result, bail};
+
+use crate::core::{config::Config, utils::current_timestamp};
+use crate::hotpatch::FileLock;
+
+use super::generator::suggestion_file_path;
+
+#[derive(Debug, Clone)]
+pub struct ReviewOptions {
+    pub dir: Option<PathBuf>,
+    pub include_applied: bool,
+    pub include_dismissed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApplyOptions {
+    pub dir: PathBuf,
+    pub confirm: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct DismissOptions {
+    pub dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct CleanOptions {
+    pub older_than: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReviewReport {
+    pub pending_count: usize,
+    pub entries: Vec<SuggestionEntry>,
+    pub stdout: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ApplyReport {
+    pub applied_count: usize,
+    pub stdout: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct DismissReport {
+    pub dismissed_count: usize,
+    pub stdout: String,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CleanReport {
+    pub removed_files: usize,
+    pub stdout: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuggestionEntry {
+    pub dir: PathBuf,
+    pub suggestion_file: PathBuf,
+    pub line: String,
+    pub marker: SuggestionMarker,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SuggestionMarker {
+    Pending,
+    Applied,
+    Dismissed,
+}
+
+pub fn review(config: &Config, mempal_home: &Path, options: ReviewOptions) -> Result<ReviewReport> {
+    let filter_dir = options
+        .dir
+        .as_deref()
+        .map(|dir| dir.canonicalize())
+        .transpose()
+        .with_context(|| {
+            options
+                .dir
+                .as_ref()
+                .map(|dir| format!("failed to canonicalize {}", dir.display()))
+                .unwrap_or_else(|| "failed to canonicalize review directory".to_string())
+        })?;
+    let mut entries = load_entries(mempal_home)?;
+    if let Some(filter_dir) = filter_dir.as_deref() {
+        entries.retain(|entry| entry.dir == filter_dir);
+    }
+    entries.retain(|entry| match entry.marker {
+        SuggestionMarker::Pending => true,
+        SuggestionMarker::Applied => options.include_applied,
+        SuggestionMarker::Dismissed => options.include_dismissed,
+    });
+    let pending_count = entries
+        .iter()
+        .filter(|entry| entry.marker == SuggestionMarker::Pending)
+        .count();
+
+    let mut stdout = String::new();
+    if entries.is_empty() {
+        stdout.push_str("no hotpatch suggestions\n");
+    } else {
+        for entry in &entries {
+            stdout.push_str(&format!(
+                "{}\n  suggestion_file: {}\n  {}\n",
+                entry.dir.display(),
+                entry.suggestion_file.display(),
+                entry.line
+            ));
+        }
+        stdout.push_str(&format!("pending={pending_count}\n"));
+    }
+
+    let _ = config;
+    Ok(ReviewReport {
+        pending_count,
+        entries,
+        stdout,
+    })
+}
+
+pub fn apply(config: &Config, mempal_home: &Path, options: ApplyOptions) -> Result<ApplyReport> {
+    let canonical_dir = options
+        .dir
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", options.dir.display()))?;
+    let suggestion_path = suggestion_file_path(mempal_home, &canonical_dir)?;
+    if !suggestion_path.exists() {
+        return Ok(ApplyReport {
+            applied_count: 0,
+            stdout: format!("no suggestion file for {}\n", canonical_dir.display()),
+        });
+    }
+
+    let mut suggestion_lock = FileLock::open_exclusive(&suggestion_path)?;
+    let suggestion_file = suggestion_lock.file_mut();
+    suggestion_file
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to seek {}", suggestion_path.display()))?;
+    let mut suggestion_content = String::new();
+    suggestion_file
+        .read_to_string(&mut suggestion_content)
+        .with_context(|| format!("failed to read {}", suggestion_path.display()))?;
+    let parsed = parse_suggestion_file(&suggestion_path, &suggestion_content)?;
+    let pending = parsed
+        .entries
+        .iter()
+        .filter(|entry| entry.marker == SuggestionMarker::Pending)
+        .cloned()
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(ApplyReport {
+            applied_count: 0,
+            stdout: format!("no pending suggestions for {}\n", canonical_dir.display()),
+        });
+    }
+    if pending.len() > 10 {
+        bail!(
+            "refusing to append {} lines into {}: split the content per rule 034 before applying",
+            pending.len(),
+            canonical_dir.display()
+        );
+    }
+
+    let target_path = resolve_target_file(config, &canonical_dir)?;
+    let mut target_lock = FileLock::open_exclusive(&target_path)?;
+    let target_file = target_lock.file_mut();
+    target_file
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to seek {}", target_path.display()))?;
+    let mut original = String::new();
+    target_file
+        .read_to_string(&mut original)
+        .with_context(|| format!("failed to read {}", target_path.display()))?;
+
+    let to_append = pending
+        .iter()
+        .filter(|entry| !original.contains(&entry.line))
+        .map(|entry| entry.line.clone())
+        .collect::<Vec<_>>();
+
+    if !options.confirm {
+        let mut stdout = format!("dry-run for {}\n", target_path.display());
+        for line in &to_append {
+            stdout.push_str("+ ");
+            stdout.push_str(line);
+            stdout.push('\n');
+        }
+        return Ok(ApplyReport {
+            applied_count: 0,
+            stdout,
+        });
+    }
+
+    if !to_append.is_empty() {
+        target_file
+            .seek(SeekFrom::End(0))
+            .with_context(|| format!("failed to seek end of {}", target_path.display()))?;
+        if !original.is_empty() && !original.ends_with('\n') {
+            target_file
+                .write_all(b"\n")
+                .with_context(|| format!("failed to write newline to {}", target_path.display()))?;
+        }
+        for line in &to_append {
+            target_file
+                .write_all(line.as_bytes())
+                .with_context(|| format!("failed to append {}", target_path.display()))?;
+            target_file.write_all(b"\n").with_context(|| {
+                format!("failed to append newline to {}", target_path.display())
+            })?;
+        }
+        target_file
+            .flush()
+            .with_context(|| format!("failed to flush {}", target_path.display()))?;
+    }
+
+    let marked = mark_entries(&suggestion_content, &pending, "applied")?;
+    suggestion_file
+        .set_len(0)
+        .with_context(|| format!("failed to truncate {}", suggestion_path.display()))?;
+    suggestion_file
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to rewind {}", suggestion_path.display()))?;
+    suggestion_file
+        .write_all(marked.as_bytes())
+        .with_context(|| format!("failed to update {}", suggestion_path.display()))?;
+    suggestion_file
+        .flush()
+        .with_context(|| format!("failed to flush {}", suggestion_path.display()))?;
+
+    Ok(ApplyReport {
+        applied_count: pending.len(),
+        stdout: format!(
+            "applied {} suggestion(s) to {}\n",
+            pending.len(),
+            target_path.display()
+        ),
+    })
+}
+
+pub fn dismiss(
+    _config: &Config,
+    mempal_home: &Path,
+    options: DismissOptions,
+) -> Result<DismissReport> {
+    let canonical_dir = options
+        .dir
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", options.dir.display()))?;
+    let suggestion_path = suggestion_file_path(mempal_home, &canonical_dir)?;
+    let mut suggestion_lock = FileLock::open_exclusive(&suggestion_path)?;
+    let suggestion_file = suggestion_lock.file_mut();
+    suggestion_file
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to seek {}", suggestion_path.display()))?;
+    let mut content = String::new();
+    suggestion_file
+        .read_to_string(&mut content)
+        .with_context(|| format!("failed to read {}", suggestion_path.display()))?;
+    let parsed = parse_suggestion_file(&suggestion_path, &content)?;
+    let pending = parsed
+        .entries
+        .iter()
+        .filter(|entry| entry.marker == SuggestionMarker::Pending)
+        .cloned()
+        .collect::<Vec<_>>();
+    if pending.is_empty() {
+        return Ok(DismissReport {
+            dismissed_count: 0,
+            stdout: format!("no pending suggestions for {}\n", canonical_dir.display()),
+        });
+    }
+    let marked = mark_entries(&content, &pending, "dismissed")?;
+    suggestion_file
+        .set_len(0)
+        .with_context(|| format!("failed to truncate {}", suggestion_path.display()))?;
+    suggestion_file
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to rewind {}", suggestion_path.display()))?;
+    suggestion_file
+        .write_all(marked.as_bytes())
+        .with_context(|| format!("failed to write {}", suggestion_path.display()))?;
+    suggestion_file
+        .flush()
+        .with_context(|| format!("failed to flush {}", suggestion_path.display()))?;
+    Ok(DismissReport {
+        dismissed_count: pending.len(),
+        stdout: format!("dismissed {} suggestion(s)\n", pending.len()),
+    })
+}
+
+pub fn clean(_config: &Config, mempal_home: &Path, options: CleanOptions) -> Result<CleanReport> {
+    let threshold = parse_older_than(&options.older_than)?;
+    let hotpatch_dir = mempal_home.join("hotpatch");
+    if !hotpatch_dir.exists() {
+        return Ok(CleanReport {
+            removed_files: 0,
+            stdout: "removed 0 hotpatch files\n".to_string(),
+        });
+    }
+    let mut removed_files = 0usize;
+    for entry in fs::read_dir(&hotpatch_dir)
+        .with_context(|| format!("failed to read {}", hotpatch_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let parsed = parse_suggestion_file(&path, &content)?;
+        if parsed
+            .entries
+            .iter()
+            .all(|entry| entry.marker != SuggestionMarker::Pending)
+        {
+            let modified = fs::metadata(&path)
+                .and_then(|meta| meta.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            if modified.elapsed().unwrap_or(Duration::ZERO) >= threshold {
+                fs::remove_file(&path)
+                    .with_context(|| format!("failed to remove {}", path.display()))?;
+                removed_files += 1;
+            }
+        }
+    }
+    Ok(CleanReport {
+        removed_files,
+        stdout: format!("removed {removed_files} hotpatch files\n"),
+    })
+}
+
+struct SuggestionFile {
+    entries: Vec<SuggestionEntry>,
+}
+
+fn load_entries(mempal_home: &Path) -> Result<Vec<SuggestionEntry>> {
+    let hotpatch_dir = mempal_home.join("hotpatch");
+    if !hotpatch_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut all = Vec::new();
+    for entry in fs::read_dir(&hotpatch_dir)
+        .with_context(|| format!("failed to read {}", hotpatch_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let parsed = parse_suggestion_file(&path, &content)?;
+        all.extend(parsed.entries);
+    }
+    Ok(all)
+}
+
+fn parse_suggestion_file(path: &Path, content: &str) -> Result<SuggestionFile> {
+    let header = content
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .context("suggestion file missing header")?;
+    let dir = PathBuf::from(
+        header
+            .strip_prefix("# mempal hotpatch suggestions for ")
+            .context("invalid suggestion header")?,
+    );
+    let canonical_dir = dir
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", dir.display()))?;
+    let mut entries = Vec::new();
+    for line in content.lines().filter(|line| line.starts_with("- ")) {
+        let marker = if line.contains("<!-- applied ") {
+            SuggestionMarker::Applied
+        } else if line.contains("<!-- dismissed ") {
+            SuggestionMarker::Dismissed
+        } else {
+            SuggestionMarker::Pending
+        };
+        entries.push(SuggestionEntry {
+            dir: canonical_dir.clone(),
+            suggestion_file: path.to_path_buf(),
+            line: strip_marker(line),
+            marker,
+        });
+    }
+    Ok(SuggestionFile { entries })
+}
+
+fn strip_marker(line: &str) -> String {
+    line.split(" <!-- ")
+        .next()
+        .unwrap_or(line)
+        .trim_end()
+        .to_string()
+}
+
+fn resolve_target_file(config: &Config, canonical_dir: &Path) -> Result<PathBuf> {
+    let candidate = config
+        .hotpatch
+        .watch_files
+        .iter()
+        .map(|watch| canonical_dir.join(watch))
+        .find(|path| path.exists())
+        .with_context(|| {
+            format!(
+                "no watched CLAUDE/AGENTS/GEMINI file found in {}",
+                canonical_dir.display()
+            )
+        })?;
+    let resolved_target = fs::canonicalize(&candidate)
+        .with_context(|| format!("failed to canonicalize {}", candidate.display()))?;
+    ensure_allowed_target(config, &resolved_target)?;
+    Ok(resolved_target)
+}
+
+fn ensure_allowed_target(config: &Config, resolved_target: &Path) -> Result<()> {
+    let prefixes = allowed_prefixes(config)?;
+    if prefixes
+        .iter()
+        .any(|prefix| resolved_target.starts_with(prefix))
+    {
+        return Ok(());
+    }
+    bail!(
+        "refusing to write {} because it escapes hotpatch.allowed_target_prefixes",
+        resolved_target.display()
+    );
+}
+
+fn allowed_prefixes(config: &Config) -> Result<Vec<PathBuf>> {
+    if !config.hotpatch.allowed_target_prefixes.is_empty() {
+        return config
+            .hotpatch
+            .allowed_target_prefixes
+            .iter()
+            .map(|value| canonicalize_prefix(value))
+            .collect();
+    }
+    let mut defaults = Vec::new();
+    defaults.push(env::current_dir().context("failed to resolve current directory")?);
+    if let Some(home) = env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        defaults.push(home.join("drafts"));
+        defaults.push(home.join("s/llm"));
+    }
+    Ok(defaults
+        .into_iter()
+        .filter(|path| path.exists())
+        .map(|path| path.canonicalize().unwrap_or(path))
+        .collect())
+}
+
+fn canonicalize_prefix(value: &str) -> Result<PathBuf> {
+    let expanded = if let Some(rest) = value.strip_prefix("~/") {
+        PathBuf::from(env::var_os("HOME").context("HOME missing while expanding hotpatch prefix")?)
+            .join(rest)
+    } else {
+        PathBuf::from(value)
+    };
+    Ok(expanded.canonicalize().unwrap_or(expanded))
+}
+
+fn mark_entries(content: &str, entries: &[SuggestionEntry], marker: &str) -> Result<String> {
+    let timestamp = current_timestamp();
+    let targets = entries
+        .iter()
+        .map(|entry| entry.line.as_str())
+        .collect::<Vec<_>>();
+    let mut lines = Vec::new();
+    for line in content.lines() {
+        if targets.contains(&line) {
+            lines.push(format!("{line} <!-- {marker} {timestamp} -->"));
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+    let mut output = lines.join("\n");
+    if content.ends_with('\n') {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn parse_older_than(raw: &str) -> Result<Duration> {
+    let days = raw
+        .strip_suffix('d')
+        .context("hotpatch clean --older-than currently supports only <days>d")?
+        .parse::<u64>()
+        .context("failed to parse clean --older-than days")?;
+    Ok(Duration::from_secs(days * 24 * 60 * 60))
+}

--- a/src/hotpatch/mod.rs
+++ b/src/hotpatch/mod.rs
@@ -1,0 +1,125 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+
+use crate::core::config::Config;
+
+pub mod generator;
+pub mod manager;
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum HotpatchCommands {
+    Review {
+        #[arg(long)]
+        dir: Option<PathBuf>,
+        #[arg(long, default_value_t = false)]
+        include_applied: bool,
+        #[arg(long, default_value_t = false)]
+        include_dismissed: bool,
+    },
+    Apply {
+        #[arg(long)]
+        dir: PathBuf,
+        #[arg(long, default_value_t = false)]
+        confirm: bool,
+    },
+    Dismiss {
+        #[arg(long)]
+        dir: PathBuf,
+    },
+    Clean {
+        #[arg(long, default_value = "30d")]
+        older_than: String,
+    },
+}
+
+pub fn run_command(config: &Config, mempal_home: &Path, command: HotpatchCommands) -> Result<()> {
+    match command {
+        HotpatchCommands::Review {
+            dir,
+            include_applied,
+            include_dismissed,
+        } => {
+            let report = manager::review(
+                config,
+                mempal_home,
+                manager::ReviewOptions {
+                    dir,
+                    include_applied,
+                    include_dismissed,
+                },
+            )?;
+            print!("{}", report.stdout);
+        }
+        HotpatchCommands::Apply { dir, confirm } => {
+            let report =
+                manager::apply(config, mempal_home, manager::ApplyOptions { dir, confirm })?;
+            print!("{}", report.stdout);
+        }
+        HotpatchCommands::Dismiss { dir } => {
+            let report = manager::dismiss(config, mempal_home, manager::DismissOptions { dir })?;
+            print!("{}", report.stdout);
+        }
+        HotpatchCommands::Clean { older_than } => {
+            let report = manager::clean(config, mempal_home, manager::CleanOptions { older_than })?;
+            print!("{}", report.stdout);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn short_drawer_id(drawer_id: &str) -> &str {
+    let len = drawer_id
+        .char_indices()
+        .nth(8)
+        .map(|(idx, _)| idx)
+        .unwrap_or(drawer_id.len());
+    &drawer_id[..len]
+}
+
+pub(crate) struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    pub(crate) fn open_exclusive(path: &Path) -> Result<Self> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            // SAFETY: flock operates on the valid file descriptor owned by this
+            // File and does not outlive it.
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if rc != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .with_context(|| format!("failed to lock {}", path.display()));
+            }
+        }
+        Ok(Self { file })
+    }
+
+    pub(crate) fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            // SAFETY: unlocks the same valid descriptor previously locked.
+            let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}

--- a/src/hotpatch/mod.rs
+++ b/src/hotpatch/mod.rs
@@ -71,12 +71,19 @@ pub fn run_command(config: &Config, mempal_home: &Path, command: HotpatchCommand
 }
 
 pub(crate) fn short_drawer_id(drawer_id: &str) -> &str {
-    let len = drawer_id
-        .char_indices()
-        .nth(8)
-        .map(|(idx, _)| idx)
-        .unwrap_or(drawer_id.len());
-    &drawer_id[..len]
+    drawer_id
+        .rsplit_once('_')
+        .map(|(_, suffix)| suffix)
+        .or_else(|| {
+            let start = drawer_id
+                .char_indices()
+                .rev()
+                .nth(7)
+                .map(|(idx, _)| idx)
+                .unwrap_or(0);
+            drawer_id.get(start..)
+        })
+        .unwrap_or(drawer_id)
 }
 
 pub(crate) struct FileLock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod embed;
 pub mod factcheck;
 pub mod hook;
 pub mod hook_install;
+pub mod hotpatch;
 pub mod ingest;
 pub mod mcp;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,10 @@ enum Commands {
         #[command(subcommand)]
         command: mempal::hook::HookCommands,
     },
+    Hotpatch {
+        #[command(subcommand)]
+        command: mempal::hotpatch::HotpatchCommands,
+    },
     Daemon {
         #[arg(long, default_value_t = false)]
         foreground: bool,
@@ -302,6 +306,7 @@ fn main() {
 
 fn run() -> Result<()> {
     let cli = Cli::parse();
+    let config_path = default_config_path();
 
     // Cowork commands must graceful-degrade without requiring palace.db
     // or config to exist. Dispatch them BEFORE Config::load / Database::open
@@ -324,6 +329,16 @@ fn run() -> Result<()> {
         Commands::Hook { command } => {
             return mempal::hook::run_command(command);
         }
+        Commands::Hotpatch { command } => {
+            let config = Config::load_from(&config_path)
+                .with_context(|| format!("failed to load config {}", config_path.display()))?;
+            let db_path = expand_home(&config.db_path);
+            let mempal_home = db_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."));
+            return mempal::hotpatch::run_command(&config, &mempal_home, command);
+        }
         Commands::Daemon { foreground } => {
             return mempal::daemon::run_command(default_config_path(), foreground);
         }
@@ -331,7 +346,6 @@ fn run() -> Result<()> {
         _ => {}
     }
 
-    let config_path = default_config_path();
     ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
     let config = ConfigHandle::current();
     let db = Database::open(&expand_home(&config.db_path)).context("failed to open database")?;
@@ -443,6 +457,7 @@ fn run() -> Result<()> {
         | Commands::CoworkStatus { .. }
         | Commands::CoworkInstallHooks { .. }
         | Commands::Hook { .. }
+        | Commands::Hotpatch { .. }
         | Commands::Daemon { .. } => unreachable!(),
     }
 }

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -43,6 +43,16 @@ impl Embedder for EventuallyOkEmbedder {
     }
 }
 
+fn hotpatch_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    if !dir.exists() {
+        return Vec::new();
+    }
+    fs::read_dir(dir)
+        .expect("read hotpatch dir")
+        .map(|entry| entry.expect("dir entry").path())
+        .collect()
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_daemon_heartbeat_fires_during_embed_retry() {
     let tmp = TempDir::new().expect("tempdir");
@@ -123,4 +133,108 @@ async fn test_daemon_heartbeat_fires_during_embed_retry() {
         heartbeat_at.unwrap_or_default() > claimed_at.unwrap_or_default(),
         "heartbeat must be refreshed during retry loop"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_hotpatch_preserves_project_scope_for_post_tool_use() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let mempal_home = tmp.path().join(".mempal");
+    let project_dir = tmp.path().join("workspace/project-alpha");
+    fs::create_dir_all(project_dir.join("src")).expect("create project src");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    fs::write(project_dir.join("CLAUDE.md"), "# Project\n").expect("write claude");
+    fs::write(project_dir.join("src/lib.rs"), "pub fn demo() {}\n").expect("write source");
+    Database::open(&db_path).expect("open db");
+
+    let store = PendingMessageStore::new(&db_path).expect("store");
+    let hook_payload = serde_json::json!({
+        "tool_name": "Edit",
+        "input": "edit src/lib.rs",
+        "tool_input": {
+            "file_path": project_dir.join("src/lib.rs").display().to_string()
+        },
+        "output": "ok",
+        "exit_code": 0
+    });
+    let envelope = CapturedHookEnvelope {
+        event: HookEvent::PostToolUse.display_name().to_string(),
+        kind: HookEvent::PostToolUse.queue_kind().to_string(),
+        agent: "claude".to_string(),
+        captured_at: "123".to_string(),
+        claude_cwd: project_dir.display().to_string(),
+        payload: Some(hook_payload.to_string()),
+        payload_path: None,
+        payload_preview: None,
+        original_size_bytes: hook_payload.to_string().len(),
+        truncated: false,
+    };
+    let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+    let id = store
+        .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+        .expect("enqueue");
+    let claimed = store
+        .claim_next("worker-hotpatch-project", 120)
+        .expect("claim")
+        .expect("message");
+    assert_eq!(claimed.id, id);
+
+    let config = mempal::core::config::Config::parse(&format!(
+        r#"
+db_path = "{}"
+
+[project]
+id = "project-alpha"
+
+[search]
+strict_project_isolation = true
+
+[hotpatch]
+enabled = true
+min_importance_stars = 0
+watch_files = ["CLAUDE.md"]
+max_suggestion_length = 80
+allowed_target_prefixes = ["{}"]
+
+[hooks]
+enabled = true
+"#,
+        db_path.display(),
+        project_dir.parent().expect("workspace root").display(),
+    ))
+    .expect("parse config");
+    let embedder = EventuallyOkEmbedder {
+        attempts: Arc::new(AtomicUsize::new(0)),
+        fail_before_success: 0,
+    };
+
+    let drawer_id = process_claimed_message_with_embedder(
+        &Database::open(&db_path).expect("reopen db"),
+        &store,
+        "worker-hotpatch-project",
+        &claimed,
+        &embedder,
+        DaemonIngestContext {
+            prototype_classifier: None,
+            config: &config,
+            mempal_home: &mempal_home,
+        },
+    )
+    .await
+    .expect("process message");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    let project_id: Option<String> = conn
+        .query_row(
+            "SELECT project_id FROM drawers WHERE id = ?1",
+            [&drawer_id],
+            |row| row.get(0),
+        )
+        .expect("query drawer project");
+    assert_eq!(project_id.as_deref(), Some("project-alpha"));
+
+    let files = hotpatch_files(&mempal_home.join("hotpatch"));
+    assert_eq!(files.len(), 1, "expected one hotpatch suggestion file");
+    let content = fs::read_to_string(&files[0]).expect("read hotpatch file");
+    assert!(content.contains("tool=Edit"));
 }

--- a/tests/hotpatch_apply.rs
+++ b/tests/hotpatch_apply.rs
@@ -1,0 +1,306 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use mempal::core::config::Config;
+use mempal::hotpatch::manager::{
+    ApplyOptions, DismissOptions, ReviewOptions, apply, dismiss, review,
+};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+struct ApplyEnv {
+    _tmp: TempDir,
+    mempal_home: PathBuf,
+    project_dir: PathBuf,
+    drafts_dir: PathBuf,
+}
+
+impl ApplyEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let mempal_home = home.join(".mempal");
+        let project_dir = tmp.path().join("workspace/project-alpha");
+        let drafts_dir = home.join("drafts/project-alpha");
+        fs::create_dir_all(mempal_home.join("hotpatch")).expect("create hotpatch dir");
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        fs::create_dir_all(&drafts_dir).expect("create drafts dir");
+        Self {
+            _tmp: tmp,
+            mempal_home,
+            project_dir,
+            drafts_dir,
+        }
+    }
+
+    fn config(&self) -> Config {
+        let config_text = format!(
+            r#"
+[hotpatch]
+enabled = true
+watch_files = ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]
+max_suggestion_length = 80
+allowed_target_prefixes = ["{}", "{}"]
+"#,
+            self.project_dir.parent().expect("workspace").display(),
+            self.drafts_dir.parent().expect("drafts root").display()
+        );
+        Config::parse(&config_text).expect("parse config")
+    }
+
+    fn suggestion_file(&self) -> PathBuf {
+        let canonical = self
+            .project_dir
+            .canonicalize()
+            .expect("canonical project dir");
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let hash = format!("{:x}", hasher.finalize());
+        self.mempal_home
+            .join("hotpatch")
+            .join(format!("CLAUDE-{}.md", &hash[..12]))
+    }
+
+    fn write_target_claude(&self, contents: &str) -> PathBuf {
+        let target = self.project_dir.join("CLAUDE.md");
+        fs::write(&target, contents).expect("write claude");
+        target
+    }
+
+    fn write_suggestion_file(&self, dir: &Path, lines: &[&str]) {
+        let content = format!(
+            "# mempal hotpatch suggestions for {}\n\n<!-- managed by mempal -->\n\n{}\n",
+            dir.canonicalize().expect("canonical dir").display(),
+            lines.join("\n")
+        );
+        fs::write(self.suggestion_file(), content).expect("write suggestion file");
+    }
+}
+
+#[test]
+fn test_suggestion_pool_default_shows_pending_not_applied() {
+    let env = ApplyEnv::new();
+    env.write_target_claude("# Project\n");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &[
+            "- ★★★★★ decision: pending one [drawer:pending1]",
+            "- ★★★★ decision: already applied [drawer:applied1] <!-- applied 1713000000 -->",
+            "- ★★★★ decision: already dismissed [drawer:dismiss1] <!-- dismissed 1713000001 -->",
+        ],
+    );
+
+    let report = review(
+        &env.config(),
+        &env.mempal_home,
+        ReviewOptions {
+            dir: None,
+            include_applied: false,
+            include_dismissed: false,
+        },
+    )
+    .expect("review");
+
+    assert_eq!(report.pending_count, 1);
+    assert_eq!(report.entries.len(), 1);
+    assert!(report.stdout.contains("pending1"));
+    assert!(!report.stdout.contains("applied1"));
+    assert!(!report.stdout.contains("dismiss1"));
+}
+
+#[test]
+fn test_claudemd_apply_requires_confirm_flag() {
+    let env = ApplyEnv::new();
+    let target = env.write_target_claude("# Project\n");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: use Arc<Mutex<>> [drawer:applyreq]"],
+    );
+
+    let outcome = apply(
+        &env.config(),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: false,
+        },
+    )
+    .expect("apply dry run");
+
+    assert!(outcome.stdout.contains("dry-run"));
+    assert!(
+        outcome
+            .stdout
+            .contains("+ - ★★★★★ decision: use Arc<Mutex<>> [drawer:applyreq]")
+    );
+    assert_eq!(
+        fs::read_to_string(&target).expect("read target"),
+        "# Project\n"
+    );
+    let suggestion = fs::read_to_string(env.suggestion_file()).expect("read suggestion");
+    assert!(!suggestion.contains("<!-- applied"));
+}
+
+#[test]
+fn test_claudemd_apply_with_confirm_writes_and_locks() {
+    let env = ApplyEnv::new();
+    env.write_target_claude("# Project\n");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: one-time patch [drawer:locktest]"],
+    );
+    let config = env.config();
+    let barrier = Arc::new(Barrier::new(2));
+    let mempal_home = env.mempal_home.clone();
+    let dir = env.project_dir.clone();
+
+    let first_barrier = barrier.clone();
+    let first_home = mempal_home.clone();
+    let first_dir = dir.clone();
+    let first_config = config.clone();
+    let first = thread::spawn(move || {
+        first_barrier.wait();
+        apply(
+            &first_config,
+            &first_home,
+            ApplyOptions {
+                dir: first_dir,
+                confirm: true,
+            },
+        )
+        .expect("first apply")
+    });
+
+    let second_barrier = barrier.clone();
+    let second_home = mempal_home.clone();
+    let second_dir = dir.clone();
+    let second_config = config.clone();
+    let second = thread::spawn(move || {
+        second_barrier.wait();
+        apply(
+            &second_config,
+            &second_home,
+            ApplyOptions {
+                dir: second_dir,
+                confirm: true,
+            },
+        )
+        .expect("second apply")
+    });
+
+    let first = first.join().expect("join first");
+    let second = second.join().expect("join second");
+    let target = fs::read_to_string(env.project_dir.join("CLAUDE.md")).expect("read target");
+    let suggestion = fs::read_to_string(env.suggestion_file()).expect("read suggestion");
+
+    assert_eq!(
+        target.matches("one-time patch").count(),
+        1,
+        "target must contain one patch"
+    );
+    assert_eq!(
+        suggestion.matches("<!-- applied ").count(),
+        1,
+        "suggestion file must contain one applied marker"
+    );
+    assert_eq!(first.applied_count + second.applied_count, 1);
+}
+
+#[test]
+fn test_claudemd_apply_preserves_existing_file_content() {
+    let env = ApplyEnv::new();
+    let original = "# Project\n## Rules\n- do X\n- do Y\n";
+    let target = env.write_target_claude(original);
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: append only [drawer:preserve]"],
+    );
+
+    apply(
+        &env.config(),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: true,
+        },
+    )
+    .expect("apply");
+
+    let after = fs::read_to_string(&target).expect("read target");
+    assert!(after.starts_with(original));
+    assert!(after.contains("- ★★★★★ decision: append only [drawer:preserve]"));
+}
+
+#[test]
+fn test_claudemd_dismiss_removes_from_pool_without_writing() {
+    let env = ApplyEnv::new();
+    let target = env.write_target_claude("# Project\n");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: dismiss me [drawer:dismissme]"],
+    );
+
+    let dismissed = dismiss(
+        &env.config(),
+        &env.mempal_home,
+        DismissOptions {
+            dir: env.project_dir.clone(),
+        },
+    )
+    .expect("dismiss");
+    let review_report = review(
+        &env.config(),
+        &env.mempal_home,
+        ReviewOptions {
+            dir: Some(env.project_dir.clone()),
+            include_applied: false,
+            include_dismissed: false,
+        },
+    )
+    .expect("review");
+    let suggestion = fs::read_to_string(env.suggestion_file()).expect("read suggestion");
+
+    assert_eq!(dismissed.dismissed_count, 1);
+    assert_eq!(
+        fs::read_to_string(target).expect("read target"),
+        "# Project\n"
+    );
+    assert_eq!(review_report.pending_count, 0);
+    assert!(suggestion.contains("<!-- dismissed "));
+}
+
+#[test]
+fn test_apply_works_on_gitignored_claudemd() {
+    let env = ApplyEnv::new();
+    let target = env.drafts_dir.join("CLAUDE.md");
+    fs::write(&target, "# Draft Rules\n").expect("write drafts target");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&target, env.project_dir.join("CLAUDE.md")).expect("symlink");
+    #[cfg(not(unix))]
+    fs::copy(&target, env.project_dir.join("CLAUDE.md")).expect("copy fallback");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: write symlink target [drawer:symlink1]"],
+    );
+
+    apply(
+        &env.config(),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: true,
+        },
+    )
+    .expect("apply");
+
+    let link_meta = fs::symlink_metadata(env.project_dir.join("CLAUDE.md")).expect("link metadata");
+    let target_contents = fs::read_to_string(&target).expect("read target");
+    assert!(target_contents.contains("write symlink target"));
+    #[cfg(unix)]
+    assert!(
+        link_meta.file_type().is_symlink(),
+        "CLAUDE link must stay a symlink"
+    );
+}

--- a/tests/hotpatch_generator.rs
+++ b/tests/hotpatch_generator.rs
@@ -107,6 +107,22 @@ allowed_target_prefixes = ["{}"]
     }
 }
 
+fn expected_short_drawer_id(drawer_id: &str) -> String {
+    drawer_id
+        .rsplit_once('_')
+        .map(|(_, suffix)| suffix.to_string())
+        .unwrap_or_else(|| {
+            drawer_id
+                .chars()
+                .rev()
+                .take(8)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect()
+        })
+}
+
 fn drawer_hash(db_path: &Path, drawer_id: &str) -> String {
     let db = Database::open(db_path).expect("open db");
     let details = db
@@ -186,7 +202,10 @@ fn test_high_importance_drawer_generates_suggestion() {
     assert_eq!(entries.len(), 1);
     let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
     assert!(content.contains("mempal hotpatch suggestions for"));
-    assert!(content.contains("[drawer:drawer-h]"));
+    assert!(content.contains(&format!(
+        "[drawer:{}]",
+        expected_short_drawer_id("drawer-high-0001")
+    )));
     assert!(content.contains("decision: use Arc<Mutex<>>"));
 }
 
@@ -264,7 +283,67 @@ fn test_duplicate_drawer_id_not_re_appended() {
         .expect("collect entries");
     let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
     assert_eq!(outcome.appended, 0);
-    assert_eq!(content.matches("[drawer:drawer-d]").count(), 1);
+    assert_eq!(
+        content
+            .matches(&format!(
+                "[drawer:{}]",
+                expected_short_drawer_id("drawer-dup-0001")
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn test_distinct_drawers_with_shared_prefix_do_not_collide() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("prefix", &file_path);
+    env.insert_drawer(
+        "drawer_hooks_raw_edit_deadbeef",
+        "Decision: first suggestion survives",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+    env.insert_drawer(
+        "drawer_hooks_raw_edit_cafebabe",
+        "Decision: second suggestion must also survive",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    let first = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer_hooks_raw_edit_deadbeef",
+        GenerationOptions::default(),
+    )
+    .expect("first suggest");
+    let second = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer_hooks_raw_edit_cafebabe",
+        GenerationOptions::default(),
+    )
+    .expect("second suggest");
+
+    let entries = fs::read_dir(env.hotpatch_file())
+        .expect("list hotpatch")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect entries");
+    let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
+
+    assert_eq!(first.appended, 1);
+    assert_eq!(second.appended, 1);
+    assert!(content.contains("[drawer:deadbeef]"));
+    assert!(content.contains("[drawer:cafebabe]"));
 }
 
 #[test]

--- a/tests/hotpatch_generator.rs
+++ b/tests/hotpatch_generator.rs
@@ -1,0 +1,407 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mempal::core::config::Config;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::hotpatch::generator::{GenerationOptions, suggest_for_drawer};
+use rusqlite::params;
+use tempfile::TempDir;
+
+struct HotpatchEnv {
+    _tmp: TempDir,
+    mempal_home: PathBuf,
+    db_path: PathBuf,
+    project_dir: PathBuf,
+}
+
+impl HotpatchEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let mempal_home = home.join(".mempal");
+        let project_dir = tmp.path().join("workspace/project-alpha");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        fs::create_dir_all(project_dir.join("src")).expect("create project src");
+        fs::write(project_dir.join("CLAUDE.md"), "# Project\n").expect("write CLAUDE");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        Self {
+            _tmp: tmp,
+            mempal_home,
+            db_path,
+            project_dir,
+        }
+    }
+
+    fn config(&self, enabled: bool, extra: &str) -> Config {
+        let config_text = format!(
+            r#"
+db_path = "{}"
+
+[project]
+id = "project-alpha"
+
+[search]
+strict_project_isolation = true
+
+[hotpatch]
+enabled = {}
+min_importance_stars = 4
+watch_files = ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]
+max_suggestion_length = 50
+allowed_target_prefixes = ["{}"]
+{}
+"#,
+            self.db_path.display(),
+            enabled,
+            self.project_dir.parent().expect("workspace").display(),
+            extra
+        );
+        Config::parse(&config_text).expect("parse config")
+    }
+
+    fn insert_drawer(
+        &self,
+        drawer_id: &str,
+        content: &str,
+        importance: i32,
+        source_file: &Path,
+        project_id: Option<&str>,
+    ) {
+        let db = Database::open(&self.db_path).expect("open db");
+        db.insert_drawer(&Drawer {
+            id: drawer_id.to_string(),
+            content: content.to_string(),
+            wing: "hooks-raw".to_string(),
+            room: Some("Edit".to_string()),
+            source_file: Some(source_file.display().to_string()),
+            source_type: SourceType::Manual,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance,
+        })
+        .expect("insert drawer");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET project_id = ?2 WHERE id = ?1",
+                params![drawer_id, project_id],
+            )
+            .expect("update drawer project");
+    }
+
+    fn write_hook_payload(&self, name: &str, file_path: &Path) -> PathBuf {
+        let payload_path = self.mempal_home.join(format!("{name}.json"));
+        let payload = serde_json::json!({
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": file_path.display().to_string()
+            }
+        });
+        fs::write(&payload_path, payload.to_string()).expect("write payload");
+        payload_path
+    }
+
+    fn hotpatch_file(&self) -> PathBuf {
+        self.mempal_home.join("hotpatch")
+    }
+}
+
+fn drawer_hash(db_path: &Path, drawer_id: &str) -> String {
+    let db = Database::open(db_path).expect("open db");
+    let details = db
+        .get_drawer_details(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    blake3::hash(details.drawer.content.as_bytes())
+        .to_hex()
+        .to_string()
+}
+
+#[test]
+fn test_disabled_no_suggestion_generated() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("disabled", &file_path);
+    env.insert_drawer(
+        "drawer-disabled-0001",
+        "Decision: use Arc<Mutex<>>",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(false, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    let outcome = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-disabled-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+
+    assert_eq!(outcome.appended, 0);
+    assert!(
+        !env.hotpatch_file().exists()
+            || fs::read_dir(env.hotpatch_file())
+                .expect("list")
+                .next()
+                .is_none()
+    );
+}
+
+#[test]
+fn test_high_importance_drawer_generates_suggestion() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("high", &file_path);
+    env.insert_drawer(
+        "drawer-high-0001",
+        "Decision: use Arc<Mutex<>> over RwLock for low-write path",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    let outcome = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-high-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+
+    assert_eq!(outcome.appended, 1);
+    let entries = fs::read_dir(env.hotpatch_file())
+        .expect("list hotpatch")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect entries");
+    assert_eq!(entries.len(), 1);
+    let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
+    assert!(content.contains("mempal hotpatch suggestions for"));
+    assert!(content.contains("[drawer:drawer-h]"));
+    assert!(content.contains("decision: use Arc<Mutex<>>"));
+}
+
+#[test]
+fn test_low_importance_skipped() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("low", &file_path);
+    env.insert_drawer(
+        "drawer-low-0001",
+        "Routine note: adjusted whitespace",
+        2,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    let outcome = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-low-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+
+    assert_eq!(outcome.appended, 0);
+    assert!(
+        !env.hotpatch_file().exists()
+            || fs::read_dir(env.hotpatch_file())
+                .expect("list")
+                .next()
+                .is_none()
+    );
+}
+
+#[test]
+fn test_duplicate_drawer_id_not_re_appended() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("dup", &file_path);
+    env.insert_drawer(
+        "drawer-dup-0001",
+        "Decision: keep dedup stable",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-dup-0001",
+        GenerationOptions::default(),
+    )
+    .expect("first suggest");
+    let outcome = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-dup-0001",
+        GenerationOptions::default(),
+    )
+    .expect("second suggest");
+
+    let entries = fs::read_dir(env.hotpatch_file())
+        .expect("list hotpatch")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect entries");
+    let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
+    assert_eq!(outcome.appended, 0);
+    assert_eq!(content.matches("[drawer:drawer-d]").count(), 1);
+}
+
+#[test]
+fn test_long_summary_truncated() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("long", &file_path);
+    let long_line = "Decision: this summary is intentionally much longer than fifty characters so it must truncate safely.";
+    env.insert_drawer(
+        "drawer-long-0001",
+        long_line,
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-long-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+
+    let entries = fs::read_dir(env.hotpatch_file())
+        .expect("list hotpatch")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect entries");
+    let content = fs::read_to_string(entries[0].path()).expect("read suggestion file");
+    let line = content
+        .lines()
+        .find(|line| line.starts_with("- "))
+        .expect("suggestion line");
+    let summary = line
+        .split(": ")
+        .nth(1)
+        .expect("topic separator")
+        .split(" [drawer:")
+        .next()
+        .expect("summary");
+    assert!(summary.chars().count() <= 51, "summary too long: {summary}");
+    assert!(
+        summary.ends_with('…'),
+        "summary should end with ellipsis: {summary}"
+    );
+}
+
+#[test]
+fn test_suggestion_generation_uses_local_signals_only() {
+    let generator_src = include_str!("../src/hotpatch/generator.rs");
+    let manager_src = include_str!("../src/hotpatch/manager.rs");
+
+    for forbidden in [
+        "api.openai",
+        "api.anthropic",
+        "generativelanguage",
+        "reqwest",
+        "openai_compat",
+    ] {
+        assert!(
+            !generator_src.contains(forbidden),
+            "generator should stay local-only, found forbidden token {forbidden}"
+        );
+        assert!(
+            !manager_src.contains(forbidden),
+            "manager should stay local-only, found forbidden token {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn test_suggestion_respects_project_isolation() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("scoped", &file_path);
+    env.insert_drawer(
+        "drawer-scoped-0001",
+        "Decision: scoped suggestion",
+        5,
+        &payload_path,
+        Some("project-beta"),
+    );
+
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    let skipped = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-scoped-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+    assert_eq!(skipped.appended, 0);
+
+    let allowed = suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-scoped-0001",
+        GenerationOptions { all_projects: true },
+    )
+    .expect("suggest all projects");
+    assert_eq!(allowed.appended, 1);
+}
+
+#[test]
+fn test_suggestion_source_drawer_ids_remain_raw() {
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload("raw", &file_path);
+    env.insert_drawer(
+        "drawer-raw-0001",
+        "Decision: keep drawers raw verbatim",
+        5,
+        &payload_path,
+        Some("project-alpha"),
+    );
+
+    let before = drawer_hash(&env.db_path, "drawer-raw-0001");
+    let config = env.config(true, "");
+    let db = Database::open(&env.db_path).expect("open db");
+    suggest_for_drawer(
+        &db,
+        &config,
+        &env.mempal_home,
+        "drawer-raw-0001",
+        GenerationOptions::default(),
+    )
+    .expect("suggest");
+    let after = drawer_hash(&env.db_path, "drawer-raw-0001");
+
+    assert_eq!(before, after, "hotpatch generation must not mutate drawers");
+}


### PR DESCRIPTION
## Summary
- implement the optional fork-ext P10 folder CLAUDE.md hotpatch suggestion pool from `specs/fork-ext/p10-folder-claudemd-hotpatch.spec.md`
- generate suggestions from local signals only, store them in `~/.mempal/hotpatch/CLAUDE-<sha256[:12]>.md`, and require explicit CLI confirmation before touching a real CLAUDE/AGENTS/GEMINI file
- append suggestions with `flock`-guarded file access for both pool writes and apply serialization, while preserving raw drawer content and project isolation

## Roadmap Note
This is the capstone optional spec for the fork-ext P9/P10 roadmap. No GitHub issue is closed by this PR.

## Tests Added
- `test_disabled_no_suggestion_generated`
- `test_high_importance_drawer_generates_suggestion`
- `test_low_importance_skipped`
- `test_duplicate_drawer_id_not_re_appended`
- `test_long_summary_truncated`
- `test_suggestion_generation_uses_local_signals_only`
- `test_suggestion_respects_project_isolation`
- `test_suggestion_source_drawer_ids_remain_raw`
- `test_suggestion_pool_default_shows_pending_not_applied`
- `test_claudemd_apply_requires_confirm_flag`
- `test_claudemd_apply_with_confirm_writes_and_locks`
- `test_claudemd_apply_preserves_existing_file_content`
- `test_claudemd_dismiss_removes_from_pool_without_writing`
- `test_apply_works_on_gitignored_claudemd`

## Ambiguity Choices
- No schema bump: followed the spec's explicit "Hotpatch 不触及 drawers 表 / 不加 schema 变更", so `fork_ext_version` remains `6`.
- Suggestion filename: followed the spec verbatim with canonicalized directory hashing via `sha256(dir)[:12]` into `~/.mempal/hotpatch/CLAUDE-<hash>.md`.
- Command shape: kept the spec's `mempal hotpatch review/apply/clean` flow and added `dismiss` as a pool-only marker operation because the task's required scenarios needed a non-write removal path from the pending view.
- Parser robustness: review/apply/clean tolerate leading blank lines before the header so user-edited suggestion files do not become unreadable.

## Verification
- `csa review --diff` -> PASS with no blocking findings
- `just pre-commit`
