### PR TITLE
feat(pr0): shared test harness for fork-ext scenario gap filling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,10 +172,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -203,8 +203,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -988,7 +988,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1049,7 +1049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
- "http",
+ "http 1.4.0",
  "indicatif 0.17.11",
  "libc",
  "log",
@@ -1069,6 +1069,17 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1079,12 +1090,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1095,8 +1117,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1114,6 +1136,29 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -1123,8 +1168,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1140,8 +1185,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1161,14 +1206,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1657,6 +1702,7 @@ dependencies = [
  "blake3",
  "clap",
  "daemonize",
+ "hyper 0.14.32",
  "jieba-rs",
  "libc",
  "mockito",
@@ -1726,10 +1772,10 @@ dependencies = [
  "bytes",
  "colored",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -2199,7 +2245,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2236,7 +2282,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2406,10 +2452,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2815,6 +2861,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3058,7 +3114,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3174,8 +3230,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3360,7 +3416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ panic = "abort"        # no unwinding — smaller binary, faster panic
 
 [dev-dependencies]
 axum = "0.8"
+hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
 mockito = "1"
 serde_json = "1"
 tempfile = "3"

--- a/src/bootstrap_events.rs
+++ b/src/bootstrap_events.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapEvent {
+    Daemonize,
+    RuntimeInit,
+    ConfigHandleBootstrap,
+    DbOpen,
+    TracingInit,
+    Ready,
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
@@ -810,6 +811,11 @@ impl ConfigHandle {
 
     pub fn simulate_notify_failure() {
         super::hot_reload::global_hot_reload_state().simulate_notify_failure();
+    }
+
+    #[doc(hidden)]
+    pub fn harness_reload_counter() -> Arc<AtomicUsize> {
+        super::hot_reload::global_hot_reload_state().reload_counter_arc()
     }
 }
 

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1,4 +1,6 @@
 #[rustfmt::skip] #[path = "db_fork_ext.rs"] mod db_fork_ext;
+// harness-point: PR0 — re-export MigrationHook trait + hooked migration runner for tests
+pub use db_fork_ext::{MigrationHook, apply_fork_ext_migrations_with_hook};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -1,5 +1,12 @@
 use rusqlite::{Connection, OptionalExtension, params};
 
+/// Hook injected into the migration runner between `up()` and `COMMIT`.
+/// Returning Err triggers a ROLLBACK, leaving `fork_ext_version` unchanged.
+/// // harness-point: PR0
+pub trait MigrationHook: Send + Sync {
+    fn pre_commit(&self) -> anyhow::Result<()>;
+}
+
 pub const FORK_EXT_META_DDL: &str = r#"
 CREATE TABLE IF NOT EXISTS fork_ext_meta (
     key TEXT PRIMARY KEY,
@@ -320,6 +327,16 @@ fn vector_dimension(conn: &Connection, table_sql: &str) -> rusqlite::Result<usiz
 }
 
 pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    apply_fork_ext_migrations_with_hook(conn, None)
+}
+
+/// Run fork-ext migrations with an optional test hook injected between `up()`
+/// and `COMMIT`. If the hook returns Err the transaction is rolled back.
+// harness-point: PR0
+pub fn apply_fork_ext_migrations_with_hook(
+    conn: &Connection,
+    hook: Option<&dyn MigrationHook>,
+) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_META_DDL)?;
 
     let current_version = read_fork_ext_version(conn)?;
@@ -331,6 +348,16 @@ pub fn apply_fork_ext_migrations(conn: &Connection) -> rusqlite::Result<()> {
 
         let result = (|| {
             (migration.up)(conn)?;
+            // harness-point: PR0 — test hook injection between up() and COMMIT
+            if let Some(hook) = hook {
+                hook.pre_commit().map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(std::io::Error::other(error.to_string())),
+                    )
+                })?;
+            }
             set_fork_ext_version(conn, migration.version)?;
             conn.execute_batch("COMMIT")?;
             Ok(())

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -60,6 +60,8 @@ pub struct HotReloadState {
     runtime: Mutex<Option<RuntimeControl>>,
     event_log: Mutex<VecDeque<String>>,
     parse_attempts: AtomicUsize,
+    // harness-point: PR0 — counts successful reload applications (version changes)
+    reload_count: Arc<AtomicUsize>,
     runtime_prototypes: ArcSwap<Vec<String>>,
 }
 
@@ -73,6 +75,7 @@ impl HotReloadState {
             runtime: Mutex::new(None),
             event_log: Mutex::new(VecDeque::new()),
             parse_attempts: AtomicUsize::new(0),
+            reload_count: Arc::new(AtomicUsize::new(0)),
             runtime_prototypes: ArcSwap::from_pointee(
                 initial.ingest_gating.embedding_classifier.prototypes,
             ),
@@ -132,6 +135,17 @@ impl HotReloadState {
 
     pub fn parse_attempts(&self) -> usize {
         self.parse_attempts.load(Ordering::SeqCst)
+    }
+
+    /// Number of successful reloads (version actually changed).
+    // harness-point: PR0
+    pub fn reload_count(&self) -> usize {
+        self.reload_count.load(Ordering::SeqCst)
+    }
+
+    #[doc(hidden)]
+    pub fn reload_counter_arc(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.reload_count)
     }
 
     pub fn recent_events(&self) -> Vec<String> {
@@ -324,6 +338,8 @@ impl HotReloadState {
             }
         };
         self.snapshot.store(Arc::new(next_snapshot));
+        // harness-point: PR0 — increment reload counter on successful version change
+        self.reload_count.fetch_add(1, Ordering::SeqCst);
         self.push_event(format!(
             "config hot-reload: version changed from {} to {}",
             previous.version, next_version

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::{future::Future, pin::Pin};
 
+use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     db::Database,
     project::resolve_project_id,
@@ -24,6 +25,7 @@ use crate::ingest::gating::{
 use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
+use tokio::sync::mpsc;
 
 use crate::daemon_bootstrap::DaemonContext;
 use crate::hook::CapturedHookEnvelope;
@@ -31,7 +33,16 @@ use crate::hotpatch::generator::{GenerationOptions, suggest_for_drawer};
 use crate::session_review::{SessionReviewOutcome, extract_session_review};
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
-    let context = DaemonContext::bootstrap(config_path, foreground)?;
+    run_command_with_bootstrap_events(config_path, foreground, None)
+}
+
+pub fn run_command_with_bootstrap_events(
+    config_path: PathBuf,
+    foreground: bool,
+    bootstrap_events: Option<mpsc::Sender<BootstrapEvent>>,
+) -> Result<()> {
+    // harness-point: PR0
+    let context = DaemonContext::bootstrap_with_events(config_path, foreground, bootstrap_events)?;
     context.runtime.block_on(run_loop(&context))
 }
 

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -2,21 +2,14 @@ use std::env;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
+use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     config::{Config, ConfigHandle},
     db::Database,
     queue::PendingMessageStore,
 };
 use anyhow::{Context, Result};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Stage {
-    Daemonize,
-    Runtime,
-    ConfigHandleBootstrap,
-    Database,
-    Tracing,
-}
+use tokio::sync::mpsc;
 
 pub struct DaemonContext {
     pub runtime: tokio::runtime::Runtime,
@@ -30,33 +23,22 @@ pub struct DaemonContext {
 
 impl DaemonContext {
     pub fn bootstrap(config_path: PathBuf, foreground: bool) -> Result<Self> {
-        bootstrap_inner(config_path, foreground, BootstrapObserverRef::default())
+        bootstrap_inner(config_path, foreground, None)
     }
 
-    pub fn bootstrap_with_observer(
+    pub fn bootstrap_with_events(
         config_path: PathBuf,
         foreground: bool,
-        observer: &'static dyn BootstrapObserver,
+        bootstrap_events: Option<mpsc::Sender<BootstrapEvent>>,
     ) -> Result<Self> {
-        bootstrap_inner(
-            config_path,
-            foreground,
-            BootstrapObserverRef(Some(observer)),
-        )
+        bootstrap_inner(config_path, foreground, bootstrap_events)
     }
 }
-
-pub trait BootstrapObserver: Send + Sync {
-    fn record(&self, stage: Stage);
-}
-
-#[derive(Clone, Copy, Default)]
-struct BootstrapObserverRef(Option<&'static dyn BootstrapObserver>);
 
 fn bootstrap_inner(
     config_path: PathBuf,
     foreground: bool,
-    observer: BootstrapObserverRef,
+    bootstrap_events: Option<mpsc::Sender<BootstrapEvent>>,
 ) -> Result<DaemonContext> {
     let bootstrap_config =
         Config::load_from(&config_path).context("failed to load daemon config")?;
@@ -70,27 +52,37 @@ fn bootstrap_inner(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    record_stage(observer, Stage::Daemonize);
+    // harness-point: PR0
+    emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::Daemonize);
     perform_daemonize(foreground, &mempal_home, &log_path)?;
 
-    record_stage(observer, Stage::Runtime);
+    // harness-point: PR0
+    emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::RuntimeInit);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("failed to build daemon runtime")?;
 
-    record_stage(observer, Stage::ConfigHandleBootstrap);
+    // harness-point: PR0
+    emit_bootstrap_event(
+        bootstrap_events.as_ref(),
+        BootstrapEvent::ConfigHandleBootstrap,
+    );
     ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
     let config = ConfigHandle::current();
 
-    record_stage(observer, Stage::Database);
+    // harness-point: PR0
+    emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::DbOpen);
     let db = Database::open(&db_path).context("failed to open daemon database")?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
 
-    record_stage(observer, Stage::Tracing);
+    // harness-point: PR0
+    emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::TracingInit);
     init_tracing_subscriber();
 
     let pid_guard = PidFileGuard::create(mempal_home.join("daemon.pid"))?;
+    // harness-point: PR0
+    emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::Ready);
 
     Ok(DaemonContext {
         runtime,
@@ -191,9 +183,12 @@ fn expand_home_path(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn record_stage(observer: BootstrapObserverRef, stage: Stage) {
-    if let Some(observer) = observer.0 {
-        observer.record(stage);
+fn emit_bootstrap_event(
+    bootstrap_events: Option<&mpsc::Sender<BootstrapEvent>>,
+    event: BootstrapEvent,
+) {
+    if let Some(tx) = bootstrap_events {
+        let _ = tx.blocking_send(event);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod aaak;
 #[cfg(feature = "rest")]
 pub mod api;
+pub mod bootstrap_events;
 pub mod core;
 pub mod cowork;
 pub mod daemon;

--- a/tests/common/harness/bootstrap_observer.rs
+++ b/tests/common/harness/bootstrap_observer.rs
@@ -1,0 +1,78 @@
+//! Helpers for asserting daemon bootstrap event ordering via
+//! `tokio::sync::mpsc`.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use mempal::bootstrap_events::BootstrapEvent;
+use tokio::sync::mpsc;
+
+pub struct BootstrapObserver {
+    rx: mpsc::Receiver<BootstrapEvent>,
+    seen: Vec<BootstrapEvent>,
+}
+
+pub fn channel() -> (mpsc::Sender<BootstrapEvent>, BootstrapObserver) {
+    let (tx, rx) = mpsc::channel(16);
+    (
+        tx,
+        BootstrapObserver {
+            rx,
+            seen: Vec::new(),
+        },
+    )
+}
+
+impl BootstrapObserver {
+    pub async fn recv(&mut self) -> Option<BootstrapEvent> {
+        let event = self.rx.recv().await?;
+        self.seen.push(event);
+        Some(event)
+    }
+
+    pub async fn recv_until(
+        &mut self,
+        expected: BootstrapEvent,
+        timeout: Duration,
+    ) -> Result<Vec<BootstrapEvent>> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let event = tokio::time::timeout(remaining, self.recv())
+                .await
+                .context("timed out waiting for bootstrap event")?;
+            match event {
+                Some(event) if event == expected => return Ok(self.seen.clone()),
+                Some(_) => continue,
+                None => bail!("bootstrap event channel closed before {expected:?}"),
+            }
+        }
+
+        bail!("timed out waiting for bootstrap event {expected:?}")
+    }
+
+    pub fn seen(&self) -> &[BootstrapEvent] {
+        &self.seen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn smoke_receives_ready_event() {
+        let (tx, mut observer) = channel();
+        tx.send(BootstrapEvent::Daemonize)
+            .await
+            .expect("send daemonize");
+        tx.send(BootstrapEvent::Ready).await.expect("send ready");
+
+        let seen = observer
+            .recv_until(BootstrapEvent::Ready, Duration::from_secs(1))
+            .await
+            .expect("observe ready");
+
+        assert_eq!(seen, vec![BootstrapEvent::Daemonize, BootstrapEvent::Ready]);
+    }
+}

--- a/tests/common/harness/daemon_supervisor.rs
+++ b/tests/common/harness/daemon_supervisor.rs
@@ -1,0 +1,132 @@
+//! Spawn and supervise `mempal daemon` child processes for integration tests.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+pub struct DaemonSupervisor {
+    child: Child,
+    pid: i32,
+    stdout_lines: Arc<Mutex<Vec<String>>>,
+    stderr_lines: Arc<Mutex<Vec<String>>>,
+    stdout_task: Option<tokio::task::JoinHandle<()>>,
+    stderr_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl DaemonSupervisor {
+    pub async fn spawn(env_vars: HashMap<String, String>, args: Vec<String>) -> Result<Self> {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_mempal"));
+        command.arg("daemon");
+        command.args(args);
+        command.envs(env_vars);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        // harness-point: PR0
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+
+        let mut child = command.spawn()?;
+        let pid = child.id().expect("daemon pid") as i32;
+        let stdout = child.stdout.take().expect("daemon stdout");
+        let stderr = child.stderr.take().expect("daemon stderr");
+        let stdout_lines = Arc::new(Mutex::new(Vec::new()));
+        let stderr_lines = Arc::new(Mutex::new(Vec::new()));
+
+        let stdout_target = Arc::clone(&stdout_lines);
+        let stdout_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                stdout_target.lock().await.push(line);
+            }
+        });
+
+        let stderr_target = Arc::clone(&stderr_lines);
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                stderr_target.lock().await.push(line);
+            }
+        });
+
+        Ok(Self {
+            child,
+            pid,
+            stdout_lines,
+            stderr_lines,
+            stdout_task: Some(stdout_task),
+            stderr_task: Some(stderr_task),
+        })
+    }
+
+    pub async fn wait_ready(&self, timeout: Duration) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            if self
+                .stderr_lines
+                .lock()
+                .await
+                .iter()
+                .any(|line| line.contains("daemon log path:"))
+            {
+                return Ok(());
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        bail!("daemon did not report readiness within {timeout:?}")
+    }
+
+    pub fn sigterm(&self) {
+        unsafe {
+            libc::kill(-self.pid, libc::SIGTERM);
+        }
+    }
+
+    pub fn sigkill(&self) {
+        unsafe {
+            libc::kill(-self.pid, libc::SIGKILL);
+        }
+    }
+
+    pub async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        let status = self.child.wait().await?;
+        if let Some(task) = self.stdout_task.take() {
+            let _ = task.await;
+        }
+        if let Some(task) = self.stderr_task.take() {
+            let _ = task.await;
+        }
+        Ok(status)
+    }
+
+    pub async fn stdout_lines(&self) -> Vec<String> {
+        self.stdout_lines.lock().await.clone()
+    }
+
+    pub async fn stderr_lines(&self) -> Vec<String> {
+        self.stderr_lines.lock().await.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn smoke_binary_path_is_available() {
+        assert!(env!("CARGO_BIN_EXE_mempal").contains("mempal"));
+    }
+}

--- a/tests/common/harness/embed_mock.rs
+++ b/tests/common/harness/embed_mock.rs
@@ -1,0 +1,201 @@
+//! Pauseable loopback HTTP server exposing an OpenAI-compatible
+//! `POST /v1/embeddings` endpoint, implemented with `hyper` + `tokio`.
+
+use std::convert::Infallible;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use anyhow::Result;
+use hyper::body::to_bytes;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use serde_json::{Value, json};
+use tokio::sync::{Mutex, Notify, oneshot};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailMode {
+    Ok,
+    Timeout,
+    Http500,
+    RateLimit429,
+}
+
+struct Inner {
+    dim: AtomicU32,
+    paused: AtomicBool,
+    pause_notify: Notify,
+    fail_mode: Mutex<FailMode>,
+    request_count: AtomicU32,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+#[derive(Clone)]
+pub struct MockEmbedHandle {
+    inner: Arc<Inner>,
+}
+
+impl MockEmbedHandle {
+    pub fn pause(&self) {
+        self.inner.paused.store(true, Ordering::SeqCst);
+    }
+
+    pub fn resume(&self) {
+        self.inner.paused.store(false, Ordering::SeqCst);
+        self.inner.pause_notify.notify_waiters();
+    }
+
+    pub fn set_dim(&self, dim: u32) {
+        self.inner.dim.store(dim, Ordering::SeqCst);
+    }
+
+    pub async fn set_fail_mode(&self, mode: FailMode) {
+        *self.inner.fail_mode.lock().await = mode;
+    }
+
+    pub fn request_count(&self) -> u32 {
+        self.inner.request_count.load(Ordering::SeqCst)
+    }
+
+    pub async fn shutdown(&self) {
+        if let Some(tx) = self.inner.shutdown_tx.lock().await.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+pub async fn start(port: u16) -> Result<(SocketAddr, MockEmbedHandle)> {
+    let inner = Arc::new(Inner {
+        dim: AtomicU32::new(4),
+        paused: AtomicBool::new(false),
+        pause_notify: Notify::new(),
+        fail_mode: Mutex::new(FailMode::Ok),
+        request_count: AtomicU32::new(0),
+        shutdown_tx: Mutex::new(None),
+    });
+
+    let handle = MockEmbedHandle {
+        inner: Arc::clone(&inner),
+    };
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let make_service = make_service_fn(move |_| {
+        let inner = Arc::clone(&inner);
+        async move {
+            Ok::<_, Infallible>(service_fn(move |request| {
+                let inner = Arc::clone(&inner);
+                async move { handle_request(inner, request).await }
+            }))
+        }
+    });
+
+    let server = Server::try_bind(&addr)?;
+    let bind_addr = server.local_addr();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    *handle.inner.shutdown_tx.lock().await = Some(shutdown_tx);
+
+    tokio::spawn(async move {
+        let _ = server
+            .serve(make_service)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await;
+    });
+
+    Ok((bind_addr, handle))
+}
+
+async fn handle_request(
+    inner: Arc<Inner>,
+    request: Request<Body>,
+) -> Result<Response<Body>, Infallible> {
+    inner.request_count.fetch_add(1, Ordering::SeqCst);
+
+    if request.method() != Method::POST || request.uri().path() != "/v1/embeddings" {
+        return Ok(response(
+            StatusCode::NOT_FOUND,
+            json!({"error": "not found"}),
+        ));
+    }
+
+    while inner.paused.load(Ordering::SeqCst) {
+        inner.pause_notify.notified().await;
+    }
+
+    match *inner.fail_mode.lock().await {
+        FailMode::Ok => {}
+        FailMode::Timeout => {
+            std::future::pending::<()>().await;
+            unreachable!();
+        }
+        FailMode::Http500 => {
+            return Ok(response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                json!({"error": "mock 500"}),
+            ));
+        }
+        FailMode::RateLimit429 => {
+            return Ok(response(
+                StatusCode::TOO_MANY_REQUESTS,
+                json!({"error": "mock 429"}),
+            ));
+        }
+    }
+
+    let body = to_bytes(request.into_body()).await.unwrap_or_default();
+    let payload: Value = serde_json::from_slice(&body).unwrap_or_else(|_| json!({}));
+    let count = match payload.get("input") {
+        Some(Value::Array(values)) => values.len(),
+        Some(_) => 1,
+        None => 1,
+    };
+    let dim = inner.dim.load(Ordering::SeqCst) as usize;
+    let embedding = vec![0.0_f32; dim];
+    let data = (0..count)
+        .map(|index| {
+            json!({
+                "index": index,
+                "embedding": embedding,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(response(StatusCode::OK, json!({ "data": data })))
+}
+
+fn response(status: StatusCode, body: Value) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("build mock embed response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn smoke_mock_server_responds() {
+        let (addr, handle) = start(0).await.expect("start mock server");
+        handle.set_dim(6);
+        let response = reqwest::Client::new()
+            .post(format!("http://{addr}/v1/embeddings"))
+            .json(&json!({"input": ["hello"]}))
+            .send()
+            .await
+            .expect("send request");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: Value = response.json().await.expect("parse response body");
+        assert_eq!(
+            body["data"][0]["embedding"]
+                .as_array()
+                .expect("embedding")
+                .len(),
+            6
+        );
+
+        handle.shutdown().await;
+    }
+}

--- a/tests/common/harness/mcp_stdio.rs
+++ b/tests/common/harness/mcp_stdio.rs
@@ -1,0 +1,217 @@
+//! JSON-RPC 2.0 client for `mempal serve --mcp` over stdio.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use rmcp::model::ServerInfo;
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+
+pub struct McpStdio {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    stderr_lines: Arc<Mutex<Vec<String>>>,
+    stderr_task: Option<tokio::task::JoinHandle<()>>,
+    next_id: u64,
+}
+
+impl McpStdio {
+    pub async fn start(db_path: &Path, extra_env: HashMap<String, String>) -> Result<Self> {
+        let mempal_home = db_path
+            .parent()
+            .context("db_path must have a parent mempal home")?;
+        let home = mempal_home.parent().unwrap_or(mempal_home);
+        let config_path = mempal_home.join("config.toml");
+        let embed_base_url = extra_env.get("MEMPAL_TEST_EMBED_BASE_URL").cloned();
+        let config = if let Some(embed_base_url) = embed_base_url {
+            format!(
+                r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+base_url = "{}"
+api_model = "test-embed"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+
+[hooks]
+enabled = true
+
+[daemon]
+log_path = "{}"
+"#,
+                db_path.display(),
+                embed_base_url,
+                embed_base_url,
+                mempal_home.join("daemon.log").display()
+            )
+        } else {
+            format!(
+                r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+
+[hooks]
+enabled = true
+
+[daemon]
+log_path = "{}"
+"#,
+                db_path.display(),
+                mempal_home.join("daemon.log").display()
+            )
+        };
+        tokio::fs::create_dir_all(mempal_home)
+            .await
+            .with_context(|| format!("create {}", mempal_home.display()))?;
+        tokio::fs::write(&config_path, config)
+            .await
+            .with_context(|| format!("write {}", config_path.display()))?;
+
+        let mut command = Command::new(env!("CARGO_BIN_EXE_mempal"));
+        command.args(["serve", "--mcp"]);
+        command.env("HOME", home);
+        command.envs(extra_env);
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let mut child = command.spawn().context("spawn mempal MCP child")?;
+        let stdin = child.stdin.take().context("missing child stdin")?;
+        let stdout = child.stdout.take().context("missing child stdout")?;
+        let stderr = child.stderr.take().context("missing child stderr")?;
+        let stderr_lines = Arc::new(Mutex::new(Vec::new()));
+        let stderr_target = Arc::clone(&stderr_lines);
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                stderr_target.lock().await.push(line);
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            stderr_lines,
+            stderr_task: Some(stderr_task),
+            next_id: 1,
+        })
+    }
+
+    pub async fn initialize(&mut self) -> Result<ServerInfo> {
+        let result = self
+            .call(
+                "initialize",
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "pr0-harness",
+                        "version": "0.0.0"
+                    }
+                }),
+            )
+            .await?;
+        serde_json::from_value(result).context("decode MCP initialize result")
+    }
+
+    pub async fn call(&mut self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .await?;
+        self.read_response(id).await
+    }
+
+    pub async fn shutdown(&mut self) -> Result<()> {
+        let _ = self.call("shutdown", json!({})).await;
+        let _ = self
+            .send(json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/exit"
+            }))
+            .await;
+        let _ = tokio::time::timeout(Duration::from_secs(3), self.child.wait()).await;
+        let _ = self.child.kill().await;
+        if let Some(task) = self.stderr_task.take() {
+            let _ = task.await;
+        }
+        Ok(())
+    }
+
+    pub async fn stderr_lines(&self) -> Vec<String> {
+        self.stderr_lines.lock().await.clone()
+    }
+
+    async fn send(&mut self, message: Value) -> Result<()> {
+        let mut body = serde_json::to_vec(&message).context("serialize JSON-RPC message")?;
+        body.push(b'\n');
+        self.stdin
+            .write_all(&body)
+            .await
+            .context("write JSON-RPC body")?;
+        self.stdin.flush().await.context("flush MCP stdin")?;
+        Ok(())
+    }
+
+    async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
+        loop {
+            let mut line = String::new();
+            let bytes = self
+                .stdout
+                .read_line(&mut line)
+                .await
+                .context("read JSON-RPC line")?;
+            if bytes == 0 {
+                bail!("unexpected EOF while reading JSON-RPC response");
+            }
+            let message: Value =
+                serde_json::from_str(line.trim()).context("parse JSON-RPC response line")?;
+
+            if message.get("id").is_none() {
+                continue;
+            }
+            if message["id"].as_u64() != Some(expected_id) {
+                bail!("unexpected JSON-RPC id: {message}");
+            }
+            if let Some(error) = message.get("error") {
+                bail!("JSON-RPC error: {error}");
+            }
+            return Ok(message["result"].clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn smoke_serializes_jsonrpc_line() {
+        let value = json!({"jsonrpc":"2.0","id":1,"result":{"ok":true}});
+        let mut encoded = serde_json::to_vec(&value).expect("encode");
+        encoded.push(b'\n');
+        assert_eq!(encoded.last(), Some(&b'\n'));
+    }
+}

--- a/tests/common/harness/migration_hook.rs
+++ b/tests/common/harness/migration_hook.rs
@@ -1,0 +1,62 @@
+//! Test doubles for the fork-ext migration hook.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::{Result, anyhow};
+use mempal::core::db::MigrationHook;
+
+pub struct NoopMigrationHook;
+
+impl MigrationHook for NoopMigrationHook {
+    fn pre_commit(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct AlwaysFailMigrationHook;
+
+impl MigrationHook for AlwaysFailMigrationHook {
+    fn pre_commit(&self) -> Result<()> {
+        Err(anyhow!("simulated crash"))
+    }
+}
+
+pub struct CountingMigrationHook {
+    count: AtomicUsize,
+}
+
+impl CountingMigrationHook {
+    pub fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+impl MigrationHook for CountingMigrationHook {
+    fn pre_commit(&self) -> Result<()> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_noop_hook() {
+        let hook = NoopMigrationHook;
+        assert!(hook.pre_commit().is_ok());
+    }
+
+    #[test]
+    fn smoke_failing_hook() {
+        let hook = AlwaysFailMigrationHook;
+        assert!(hook.pre_commit().is_err());
+    }
+}

--- a/tests/common/harness/mod.rs
+++ b/tests/common/harness/mod.rs
@@ -1,0 +1,22 @@
+#[allow(dead_code)]
+pub mod bootstrap_observer;
+#[allow(dead_code)]
+pub mod daemon_supervisor;
+#[allow(dead_code)]
+pub mod embed_mock;
+#[allow(dead_code)]
+pub mod mcp_stdio;
+#[allow(dead_code)]
+pub mod migration_hook;
+#[allow(dead_code)]
+pub mod reload_counter;
+#[allow(dead_code)]
+pub mod vec0_snapshot;
+
+pub use bootstrap_observer::*;
+pub use daemon_supervisor::*;
+pub use embed_mock::*;
+pub use mcp_stdio::*;
+pub use migration_hook::*;
+pub use reload_counter::*;
+pub use vec0_snapshot::*;

--- a/tests/common/harness/reload_counter.rs
+++ b/tests/common/harness/reload_counter.rs
@@ -1,0 +1,45 @@
+//! Shared observation handle for config hot-reload application counts.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use mempal::core::config::ConfigHandle;
+
+#[derive(Debug, Clone)]
+pub struct ReloadCounter(Arc<AtomicUsize>);
+
+impl ReloadCounter {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicUsize::new(0)))
+    }
+
+    pub fn from_hot_reload_state() -> Self {
+        Self(ConfigHandle::harness_reload_counter())
+    }
+
+    pub fn increment(&self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub fn count(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    pub fn reset(&self) {
+        self.0.store(0, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_counter_resets() {
+        let counter = ReloadCounter::new();
+        counter.increment();
+        assert_eq!(counter.count(), 1);
+        counter.reset();
+        assert_eq!(counter.count(), 0);
+    }
+}

--- a/tests/common/harness/vec0_snapshot.rs
+++ b/tests/common/harness/vec0_snapshot.rs
@@ -1,0 +1,115 @@
+//! Snapshot and restore helpers for the `drawer_vectors` vec0 virtual table.
+
+use rusqlite::Connection;
+use rusqlite::types::ValueRef;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Vec0Row {
+    pub drawer_id: String,
+    pub dim: usize,
+    pub raw_blob: Vec<u8>,
+}
+
+pub fn dump(conn: &Connection) -> rusqlite::Result<Vec<Vec0Row>> {
+    let exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'drawer_vectors'",
+        [],
+        |row| row.get(0),
+    )?;
+    if exists == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = match conn.prepare("SELECT rowid, embedding FROM drawer_vectors ORDER BY rowid")
+    {
+        Ok(stmt) => stmt,
+        Err(error) if error.to_string().contains("no such column: rowid") => {
+            conn.prepare("SELECT id, embedding FROM drawer_vectors ORDER BY id")?
+        }
+        Err(error) => return Err(error),
+    };
+    stmt.query_map([], |row| {
+        let drawer_id = match row.get_ref(0)? {
+            ValueRef::Text(text) => String::from_utf8_lossy(text).into_owned(),
+            ValueRef::Integer(value) => value.to_string(),
+            ValueRef::Real(value) => value.to_string(),
+            ValueRef::Blob(blob) => String::from_utf8_lossy(blob).into_owned(),
+            ValueRef::Null => String::new(),
+        };
+        let raw_blob: Vec<u8> = row.get(1)?;
+        Ok(Vec0Row {
+            drawer_id,
+            dim: raw_blob.len() / std::mem::size_of::<f32>(),
+            raw_blob,
+        })
+    })?
+    .collect()
+}
+
+pub fn restore(conn: &Connection, snapshot: &[Vec0Row]) -> rusqlite::Result<()> {
+    if snapshot.is_empty() {
+        return Ok(());
+    }
+
+    let dim = snapshot[0].dim;
+    assert!(
+        snapshot.iter().all(|row| row.dim == dim),
+        "vec0 snapshot dimensions must match"
+    );
+
+    conn.execute_batch(&format!(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]);"
+    ))?;
+    let mut stmt =
+        match conn.prepare("INSERT INTO drawer_vectors (rowid, embedding) VALUES (?1, ?2)") {
+            Ok(stmt) => stmt,
+            Err(error)
+                if error
+                    .to_string()
+                    .contains("table drawer_vectors has no column named rowid") =>
+            {
+                conn.prepare("INSERT INTO drawer_vectors (id, embedding) VALUES (?1, ?2)")?
+            }
+            Err(error) => return Err(error),
+        };
+    for row in snapshot {
+        stmt.execute(rusqlite::params![row.drawer_id, row.raw_blob])?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mempal::core::db::Database;
+    use mempal::core::types::{Drawer, SourceType};
+    use tempfile::TempDir;
+
+    #[test]
+    fn smoke_round_trips_real_vec0_rows() {
+        let tmp = TempDir::new().expect("tempdir");
+        let source = Database::open(&tmp.path().join("source.db")).expect("open source db");
+        let target = Database::open(&tmp.path().join("target.db")).expect("open target db");
+        let drawer = Drawer {
+            id: "drawer-1".to_string(),
+            content: "content".to_string(),
+            wing: "wing".to_string(),
+            room: Some("room".to_string()),
+            source_file: Some("source.txt".to_string()),
+            source_type: SourceType::Manual,
+            added_at: "2026-04-21T00:00:00Z".to_string(),
+            chunk_index: Some(0),
+            importance: 3,
+        };
+        source.insert_drawer(&drawer).expect("insert drawer");
+        source
+            .insert_vector(&drawer.id, &[0.1, 0.2, 0.3, 0.4])
+            .expect("insert vector");
+
+        let snapshot = dump(source.conn()).expect("dump vec0");
+        restore(target.conn(), &snapshot).expect("restore vec0");
+        let restored = dump(target.conn()).expect("dump restored vec0");
+
+        assert_eq!(restored, snapshot);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod harness;

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -1,28 +1,18 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use mempal::bootstrap_events::BootstrapEvent;
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
-use mempal::daemon_bootstrap::{BootstrapObserver, DaemonContext, Stage};
+use mempal::daemon_bootstrap::DaemonContext;
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
 use mockito::Server;
 use tempfile::TempDir;
 
 fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
-}
-
-struct RecordingObserver {
-    stages: Mutex<Vec<Stage>>,
-}
-
-impl BootstrapObserver for RecordingObserver {
-    fn record(&self, stage: Stage) {
-        self.stages.lock().expect("observer mutex").push(stage);
-    }
 }
 
 fn setup_daemon_home() -> (TempDir, PathBuf, PathBuf) {
@@ -59,23 +49,32 @@ log_path = "{}"
 #[test]
 fn test_daemon_context_bootstrap_ordering() {
     let (_tmp, _db_path, config_path) = setup_daemon_home();
-    let observer = Box::leak(Box::new(RecordingObserver {
-        stages: Mutex::new(Vec::new()),
-    }));
+    let runtime = tokio::runtime::Runtime::new().expect("bootstrap runtime");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
-    let context = DaemonContext::bootstrap_with_observer(config_path.clone(), true, observer)
+    let context = DaemonContext::bootstrap_with_events(config_path.clone(), true, Some(tx))
         .expect("bootstrap");
-    let stages = observer.stages.lock().expect("observer mutex").clone();
+    let mut stages = Vec::new();
+    runtime.block_on(async {
+        while let Ok(Some(stage)) = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await
+        {
+            stages.push(stage);
+            if matches!(stages.last(), Some(BootstrapEvent::Ready)) {
+                break;
+            }
+        }
+    });
     let pid_path = context.mempal_home.join("daemon.pid");
 
     assert_eq!(
         stages,
         vec![
-            Stage::Daemonize,
-            Stage::Runtime,
-            Stage::ConfigHandleBootstrap,
-            Stage::Database,
-            Stage::Tracing,
+            BootstrapEvent::Daemonize,
+            BootstrapEvent::RuntimeInit,
+            BootstrapEvent::ConfigHandleBootstrap,
+            BootstrapEvent::DbOpen,
+            BootstrapEvent::TracingInit,
+            BootstrapEvent::Ready,
         ]
     );
     assert!(

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -1,0 +1,249 @@
+mod common;
+
+use std::collections::HashMap;
+use std::fs;
+use std::time::Duration;
+
+use anyhow::Result;
+use common::harness::{
+    AlwaysFailMigrationHook, BootstrapObserver, CountingMigrationHook, DaemonSupervisor, FailMode,
+    McpStdio, NoopMigrationHook, ReloadCounter, dump as dump_vec0, restore as restore_vec0,
+};
+use mempal::bootstrap_events::BootstrapEvent;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::{Database, MigrationHook, apply_fork_ext_migrations_with_hook};
+use mempal::core::queue::PendingMessageStore;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::daemon_bootstrap::DaemonContext;
+use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use tempfile::TempDir;
+
+#[test]
+fn vec0_snapshot_round_trips() {
+    let tmp = TempDir::new().expect("tempdir");
+    let source = Database::open(&tmp.path().join("source.db")).expect("open source db");
+    let target = Database::open(&tmp.path().join("target.db")).expect("open target db");
+    let drawer = Drawer {
+        id: "drawer-1".to_string(),
+        content: "content".to_string(),
+        wing: "wing".to_string(),
+        room: Some("room".to_string()),
+        source_file: Some("source.txt".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "2026-04-21T00:00:00Z".to_string(),
+        chunk_index: Some(0),
+        importance: 3,
+    };
+    source.insert_drawer(&drawer).expect("insert drawer");
+    source
+        .insert_vector(&drawer.id, &[0.1, 0.2, 0.3, 0.4])
+        .expect("insert vector");
+
+    let snapshot = dump_vec0(source.conn()).expect("dump vec0");
+    restore_vec0(target.conn(), &snapshot).expect("restore vec0");
+
+    assert_eq!(
+        dump_vec0(target.conn()).expect("dump restored vec0"),
+        snapshot
+    );
+}
+
+#[test]
+fn migration_hook_smoke() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let counting = CountingMigrationHook::new();
+    apply_fork_ext_migrations_with_hook(db.conn(), Some(&counting))
+        .expect("rerun migrations with counting hook");
+    assert_eq!(counting.count(), 0);
+
+    let noop = NoopMigrationHook;
+    assert!(noop.pre_commit().is_ok());
+    let fail = AlwaysFailMigrationHook;
+    assert!(fail.pre_commit().is_err());
+}
+
+#[tokio::test]
+async fn mcp_stdio_initializes() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path)?;
+    let (addr, handle) = common::harness::start(0).await?;
+
+    let mut client = McpStdio::start(
+        &db_path,
+        HashMap::from([(
+            "MEMPAL_TEST_EMBED_BASE_URL".to_string(),
+            format!("http://{addr}/v1"),
+        )]),
+    )
+    .await?;
+    let server_info = tokio::time::timeout(Duration::from_secs(5), client.initialize()).await??;
+    assert!(!server_info.server_info.name.trim().is_empty());
+    client.shutdown().await?;
+    handle.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn harness_integration_smoke() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+
+    Database::open(&db_path)?;
+    let store = PendingMessageStore::new(&db_path)?;
+    let (addr, mock_handle) = common::harness::start(0).await?;
+    let base_url = format!("http://{addr}/v1");
+    let config = format!(
+        r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+base_url = "{}"
+api_model = "test-embed"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 50
+daemon_claim_ttl_secs = 30
+
+[daemon]
+log_path = "{}"
+"#,
+        db_path.display(),
+        base_url,
+        base_url,
+        mempal_home.join("daemon.log").display()
+    );
+    fs::write(&config_path, config)?;
+    ConfigHandle::bootstrap(&config_path)?;
+
+    let envelope = CapturedHookEnvelope {
+        event: HookEvent::SessionStart.display_name().to_string(),
+        kind: HookEvent::SessionStart.queue_kind().to_string(),
+        agent: "claude".to_string(),
+        captured_at: "123".to_string(),
+        claude_cwd: tmp.path().display().to_string(),
+        payload: Some(r#"{"session_id":"abc","cwd":"/tmp/project"}"#.to_string()),
+        payload_path: None,
+        payload_preview: None,
+        original_size_bytes: 32,
+        truncated: false,
+    };
+    let payload = serde_json::to_string(&envelope)?;
+    store.enqueue(HookEvent::SessionStart.queue_kind(), &payload)?;
+
+    let (tx, mut observer): (_, BootstrapObserver) = common::harness::channel();
+    let bootstrap_config = config_path.clone();
+    let bootstrap_task = tokio::task::spawn_blocking(move || {
+        DaemonContext::bootstrap_with_events(bootstrap_config, true, Some(tx))
+    });
+    let bootstrap_context = tokio::time::timeout(Duration::from_secs(5), bootstrap_task)
+        .await?
+        .expect("join bootstrap task")?;
+    let seen = observer
+        .recv_until(BootstrapEvent::Ready, Duration::from_secs(1))
+        .await?;
+    assert_eq!(
+        seen,
+        vec![
+            BootstrapEvent::Daemonize,
+            BootstrapEvent::RuntimeInit,
+            BootstrapEvent::ConfigHandleBootstrap,
+            BootstrapEvent::DbOpen,
+            BootstrapEvent::TracingInit,
+            BootstrapEvent::Ready,
+        ]
+    );
+    tokio::task::spawn_blocking(move || drop(bootstrap_context))
+        .await
+        .expect("join context drop task");
+
+    let mut supervisor = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await?;
+    supervisor.wait_ready(Duration::from_secs(10)).await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    while tokio::time::Instant::now() < deadline {
+        if mock_handle.request_count() > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        mock_handle.request_count() > 0,
+        "daemon never hit embed mock"
+    );
+
+    supervisor.sigterm();
+    let status = supervisor.wait().await?;
+    assert!(status.success(), "daemon exited with {status:?}");
+    mock_handle.shutdown().await;
+
+    let counter = ReloadCounter::from_hot_reload_state();
+    assert_eq!(counter.count(), 0);
+    counter.reset();
+    Ok(())
+}
+
+#[tokio::test]
+async fn embed_mock_failure_modes() -> Result<()> {
+    let (addr, handle) = common::harness::start(0).await?;
+    handle.set_dim(8);
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/v1/embeddings");
+    let ok = client
+        .post(&url)
+        .json(&serde_json::json!({ "input": ["hello"] }))
+        .send()
+        .await?;
+    assert!(ok.status().is_success());
+
+    handle.set_fail_mode(FailMode::Http500).await;
+    let response = client
+        .post(&url)
+        .json(&serde_json::json!({ "input": ["hello"] }))
+        .send()
+        .await?;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+
+    handle.set_fail_mode(FailMode::RateLimit429).await;
+    let response = client
+        .post(&url)
+        .json(&serde_json::json!({ "input": ["hello"] }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+
+    handle.pause();
+    let paused = client
+        .post(&url)
+        .json(&serde_json::json!({ "input": ["hello"] }))
+        .send();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    handle.resume();
+    let _ = paused.await?;
+
+    handle.shutdown().await;
+    Ok(())
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "582e10a291506dbc004aa225814ce64f6e707465"
+commit = "61e23e12ed1680e1b37d008a30b80400a29f77ba"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add shared fork-ext test harness under `tests/common/harness/` (7 modules + integration smoke)
- Wire minimum prod-side injection points: `BootstrapEvent` mpsc channel, `MigrationHook` DI for rollback, `ReloadCounter` handle for hot-reload observation
- Foundation commit — no runtime behavior change; all 13 harness smoke tests + full `just test` suite pass on this branch

## Test plan
- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --test harness_smoke` — 13/13 pass
- [x] `just fmt` / `just clippy` / `just test` — all pass
- [x] Review: csa-gemini tier-4-critical PASS / CLEAN / 0 findings (session 01KPRGMFJ1MWPG806XAX3NS5PC)

### AI Reviewer Metadata

- **Design Intent**: Provide one stable, test-only harness layer before the fork-ext PR stack lands so later scenario tests (PR1-PR10, ~122 tests) reuse the same infra instead of each PR re-implementing mock servers, process supervision, vec snapshots, and rollback hooks.
- **Key Decisions**:
  - `BootstrapEvent` + `Option<mpsc::Sender<_>>` wiring in daemon bootstrap (replaces trait-object observer; cleaner async, auto-close prevents test deadlocks)
  - Harness-only reload counter handle exposed from hot-reload state via `#[doc(hidden)]` atomic, no behavior change in prod paths
  - Migration rollback injection as optional `MigrationHook` trait; `cfg(test)` DI returns `Err("simulated crash")` before `COMMIT` to assert `fork_ext_version == N-1`
  - Embed mock uses `hyper` (test-only dep); MCP stdio harness follows repo's actual `rmcp` newline-delimited JSON-RPC (not content-length framing) per real transport
- **Reviewer Guidance**:
  - **Timing/Race Scenarios**: daemon bootstrap events preserve order `Daemonize → RuntimeInit → ConfigHandleBootstrap → DbOpen → TracingInit → Ready`; daemon supervisor uses `setsid` + negative-PID kill for process-group cleanup; harness integration covers embed mock + daemon startup without runtime-drop hangs
  - **Boundary Cases**: vec0 snapshot falls back to `id` when `rowid` unavailable; migration hook rollback leaves version unchanged; MCP stdio uses fast local embed config instead of blocking on model bootstrap
  - **Regression Tests Added**: `harness_integration_smoke`, `mcp_stdio_initializes`, `vec0_snapshot_round_trips`, `smoke_round_trips_real_vec0_rows`, `smoke_receives_ready_event`, `test_daemon_context_bootstrap_ordering`

Generated by csa-codex (tier-3-complex), reviewed by csa-gemini (tier-4-critical).