### PR TITLE
test(hook): fill p8 passive-capture scenario gaps (PR4/10)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -23,7 +23,7 @@ use crate::ingest::gating::{
     evaluate_tier1, tier2_enabled,
 };
 use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
 
@@ -48,7 +48,8 @@ pub fn run_command_with_bootstrap_events(
 
 async fn run_loop(context: &DaemonContext) -> Result<()> {
     if !context.config.hooks.enabled {
-        bail!("hooks not enabled");
+        eprintln!("hooks not enabled; daemon exiting without starting worker loop");
+        return Ok(());
     }
 
     install_shutdown_handlers()?;
@@ -339,6 +340,12 @@ fn build_audit_drawer_record(
     let project_id = resolve_hook_project_id(envelope, config)?;
     if envelope.truncated {
         let preview = config.scrub_content(envelope.payload_preview.as_deref().unwrap_or_default());
+        tracing::warn!(
+            event = %envelope.event,
+            original_size_bytes = envelope.original_size_bytes,
+            payload_preview = %preview,
+            "processing truncated hook envelope"
+        );
         let content = serde_json::to_string(&json!({
             "_truncated": true,
             "event": envelope.event,

--- a/src/hook_install.rs
+++ b/src/hook_install.rs
@@ -7,12 +7,14 @@ use clap::ValueEnum;
 use serde_json::{Value, json};
 
 const CLAUDE_SETTINGS_RELATIVE: &str = ".claude/settings.json";
+const CLAUDE_SETTINGS_DIR: &str = ".claude";
+const CLAUDE_SETTINGS_FILE: &str = "settings.json";
 const FORBIDDEN_TARGET_NAMES: [&str; 3] = ["AGENTS.md", "CLAUDE.md", "GEMINI.md"];
-const HOOK_COMMANDS: [(&str, &str); 4] = [
-    ("PostToolUse", "mempal hook hook_post_tool"),
-    ("UserPromptSubmit", "mempal hook hook_user_prompt"),
-    ("SessionStart", "mempal hook hook_session_start"),
-    ("SessionEnd", "mempal hook hook_session_end"),
+const HOOK_COMMAND_EVENTS: [(&str, &str); 4] = [
+    ("PostToolUse", "hook_post_tool"),
+    ("UserPromptSubmit", "hook_user_prompt"),
+    ("SessionStart", "hook_session_start"),
+    ("SessionEnd", "hook_session_end"),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -93,11 +95,12 @@ pub fn install_claude_code(
     uninstall: bool,
 ) -> Result<InstallOutcome> {
     let resolved = resolve_claude_settings_path(cwd, home)?;
+    let hook_commands = hook_commands()?;
     let mut root = read_settings_json(&resolved.write_path)?;
     let mut removed_commands = 0usize;
     let mut changed = false;
 
-    for (event_name, command) in HOOK_COMMANDS {
+    for (event_name, command) in &hook_commands {
         let event_array = ensure_hook_event_array(&mut root, event_name)?;
         let before_len = event_array.len();
         event_array.retain(|entry| !entry_contains_command(entry, command));
@@ -160,7 +163,7 @@ fn resolve_claude_settings_path(cwd: &Path, home: &Path) -> Result<ResolvedSetti
     let local_path = cwd.join(CLAUDE_SETTINGS_RELATIVE);
     if local_path.exists() || is_symlink(&local_path)? {
         let write_path = canonicalize_if_symlink(&local_path)?;
-        validate_write_target(&write_path)?;
+        validate_write_target(cwd, home, &write_path)?;
         return Ok(ResolvedSettingsPath {
             display_path: local_path,
             write_path,
@@ -169,7 +172,7 @@ fn resolve_claude_settings_path(cwd: &Path, home: &Path) -> Result<ResolvedSetti
 
     let global_path = home.join(CLAUDE_SETTINGS_RELATIVE);
     let write_path = canonicalize_if_symlink(&global_path)?;
-    validate_write_target(&write_path)?;
+    validate_write_target(cwd, home, &write_path)?;
     Ok(ResolvedSettingsPath {
         display_path: global_path.clone(),
         write_path,
@@ -237,7 +240,7 @@ fn canonicalize_if_symlink(path: &Path) -> Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-fn validate_write_target(path: &Path) -> Result<()> {
+fn validate_write_target(cwd: &Path, home: &Path, path: &Path) -> Result<()> {
     if path
         .file_name()
         .and_then(|name| name.to_str())
@@ -258,5 +261,74 @@ fn validate_write_target(path: &Path) -> Result<()> {
         }
     }
 
+    let parent_name = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str());
+    let file_name = path.file_name().and_then(|name| name.to_str());
+    if parent_name != Some(CLAUDE_SETTINGS_DIR) || file_name != Some(CLAUDE_SETTINGS_FILE) {
+        bail!(
+            "refusing to edit non-canonical Claude settings target {}",
+            path.display()
+        );
+    }
+
+    let allowed_roots = [
+        cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf()),
+        home.canonicalize().unwrap_or_else(|_| home.to_path_buf()),
+    ];
+    if !allowed_roots
+        .iter()
+        .any(|root| path.starts_with(root) || path == root)
+    {
+        bail!(
+            "refusing to edit settings target outside allowed roots {}",
+            path.display()
+        );
+    }
+
     Ok(())
+}
+
+fn hook_commands() -> Result<Vec<(&'static str, String)>> {
+    let binary = shell_escape_path(&resolve_mempal_binary()?);
+    Ok(HOOK_COMMAND_EVENTS
+        .iter()
+        .map(|(event_name, subcommand)| (*event_name, format!("{binary} hook {subcommand}")))
+        .collect())
+}
+
+fn resolve_mempal_binary() -> Result<PathBuf> {
+    if let Some(path) = env::var_os("CARGO_BIN_EXE_mempal") {
+        let path = PathBuf::from(path);
+        return Ok(path.canonicalize().unwrap_or(path));
+    }
+
+    let current = env::current_exe().context("failed to resolve current executable path")?;
+    if current.file_name().and_then(|name| name.to_str()) == Some("mempal") {
+        return current
+            .canonicalize()
+            .context("failed to canonicalize current executable path");
+    }
+
+    if let Some(candidate) = current
+        .parent()
+        .and_then(Path::parent)
+        .map(|dir| dir.join("mempal"))
+        .filter(|candidate| candidate.exists())
+    {
+        return Ok(candidate.canonicalize().unwrap_or(candidate));
+    }
+
+    current
+        .canonicalize()
+        .context("failed to canonicalize current executable path")
+}
+
+fn shell_escape_path(path: &Path) -> String {
+    let rendered = path.to_string_lossy();
+    if !rendered.contains([' ', '\t', '\n', '\'', '"']) {
+        return rendered.into_owned();
+    }
+    format!("'{}'", rendered.replace('\'', r"'\''"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1315,6 +1315,20 @@ fn status_command(db: &Database) -> Result<()> {
     let deleted_count = db
         .deleted_drawer_count()
         .context("failed to count deleted drawers")?;
+    let daemon_pid = read_daemon_pid(db.path())?;
+    let daemon_running = daemon_pid
+        .map(process_is_running)
+        .transpose()
+        .context("failed to probe daemon pid liveness")?
+        .unwrap_or(false);
+    let last_heartbeat = db
+        .conn()
+        .query_row(
+            "SELECT MAX(heartbeat_at) FROM pending_messages WHERE heartbeat_at IS NOT NULL",
+            [],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .context("failed to query daemon heartbeat")?;
 
     println!("schema_version: {schema_version}");
     println!("fork_ext_version: {fork_ext_version}");
@@ -1340,6 +1354,16 @@ fn status_command(db: &Database) -> Result<()> {
     }
     if let Some(last_success_at) = embed_status.last_success_at_unix_ms {
         println!("embed_last_success_at_unix_ms: {last_success_at}");
+    }
+    println!("Daemon:");
+    println!("  running: {daemon_running}");
+    match daemon_pid {
+        Some(pid) => println!("  pid: {pid}"),
+        None => println!("  pid: none"),
+    }
+    match last_heartbeat {
+        Some(heartbeat) => println!("  last_heartbeat_unix_secs: {heartbeat}"),
+        None => println!("  last_heartbeat_unix_secs: none"),
     }
     println!("Queue:");
     println!("  pending: {}", queue_stats.pending);
@@ -1390,6 +1414,45 @@ fn status_command(db: &Database) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn read_daemon_pid(db_path: &Path) -> Result<Option<i32>> {
+    let Some(mempal_home) = db_path.parent() else {
+        return Ok(None);
+    };
+    let pid_path = mempal_home.join("daemon.pid");
+    let content = match std::fs::read_to_string(&pid_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read daemon pid file {}", pid_path.display()));
+        }
+    };
+    let pid = content
+        .trim()
+        .parse::<i32>()
+        .with_context(|| format!("invalid daemon pid in {}", pid_path.display()))?;
+    Ok(Some(pid))
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: i32) -> Result<bool> {
+    let rc = unsafe { libc::kill(pid, 0) };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH) => Ok(false),
+        Some(libc::EPERM) => Ok(true),
+        _ => Err(error).with_context(|| format!("failed to probe process {pid}")),
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: i32) -> Result<bool> {
+    Ok(false)
 }
 
 async fn serve_command(config: &Config, mcp: bool) -> Result<()> {

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -77,6 +77,35 @@ fn test_hook_post_tool_enqueues_to_queue() {
 }
 
 #[test]
+fn test_hook_writes_nothing_to_stdout() {
+    let (home, _db_path) = setup_home();
+    let payload = r#"{"tool_name":"Bash","input":"ls","exit_code":0,"output":"ok"}"#;
+
+    let mut child = Command::new(mempal_bin())
+        .args(["hook", "hook_post_tool"])
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook command");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload.as_bytes())
+        .expect("write payload");
+    let output = child.wait_with_output().expect("wait output");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+#[test]
 fn test_hook_envelopes_oversized_payload() {
     let (home, db_path) = setup_home();
     let mut oversized = String::from("{\"payload\":\"");

--- a/tests/hook_install.rs
+++ b/tests/hook_install.rs
@@ -15,6 +15,11 @@ fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
 }
 
+fn expected_hook_command(alias: &str) -> String {
+    let binary = fs::canonicalize(mempal_bin()).expect("canonical mempal bin");
+    format!("{} hook {alias}", binary.display())
+}
+
 #[test]
 fn test_hook_install_writes_claude_code_settings() {
     let tmp = TempDir::new().expect("tempdir");
@@ -32,11 +37,11 @@ fn test_hook_install_writes_claude_code_settings() {
     assert!(outcome.rendered.contains("hook_post_tool"));
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        "mempal hook hook_post_tool"
+        expected_hook_command("hook_post_tool")
     );
     assert_eq!(
         parsed["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
-        "mempal hook hook_user_prompt"
+        expected_hook_command("hook_user_prompt")
     );
 }
 
@@ -56,10 +61,52 @@ fn test_hook_install_respects_project_local_settings() {
     assert!(outcome.display_path.ends_with(".claude/settings.json"));
     assert!(outcome.rendered.contains("\"theme\": \"dark\""));
     assert_eq!(parsed["theme"], "dark");
+    assert_eq!(
+        parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+        expected_hook_command("hook_post_tool")
+    );
     assert!(
         !home.join(".claude/settings.json").exists(),
         "global settings must remain untouched"
     );
+}
+
+#[test]
+fn test_hook_install_merges_existing_settings() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(cwd.join(".claude")).expect("create local .claude");
+    fs::create_dir_all(&home).expect("create home");
+    fs::write(
+        cwd.join(".claude/settings.json"),
+        r#"{
+          "theme": "dark",
+          "hooks": {
+            "Stop": [{
+              "hooks": [{
+                "type": "command",
+                "command": "existing stop hook"
+              }]
+            }]
+          }
+        }"#,
+    )
+    .expect("write seed settings");
+
+    let outcome = install_claude_code(&cwd, &home, false, false).expect("install");
+    let parsed = parse_json(&outcome.write_path);
+
+    assert_eq!(parsed["theme"], "dark");
+    assert_eq!(
+        parsed["hooks"]["Stop"][0]["hooks"][0]["command"],
+        "existing stop hook"
+    );
+    assert_eq!(
+        parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+        expected_hook_command("hook_post_tool")
+    );
+    assert!(outcome.changed);
 }
 
 #[cfg(unix)]
@@ -68,12 +115,12 @@ fn test_hook_install_follows_symlink_target() {
     let tmp = TempDir::new().expect("tempdir");
     let cwd = tmp.path().join("repo");
     let home = tmp.path().join("home");
-    let target_dir = tmp.path().join("target-settings");
+    let target_dir = cwd.join("shared");
     fs::create_dir_all(cwd.join(".claude")).expect("create local .claude");
     fs::create_dir_all(&home).expect("create home");
-    fs::create_dir_all(&target_dir).expect("create target dir");
+    fs::create_dir_all(target_dir.join(".claude")).expect("create target dir");
 
-    let real_target = target_dir.join("claude-settings.json");
+    let real_target = target_dir.join(".claude/settings.json");
     fs::write(&real_target, r#"{ "theme": "dark" }"#).expect("write target settings");
     let local_link = cwd.join(".claude/settings.json");
     symlink(&real_target, &local_link).expect("create symlink");
@@ -92,7 +139,7 @@ fn test_hook_install_follows_symlink_target() {
     assert!(outcome.rendered.contains("hook_post_tool"));
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        "mempal hook hook_post_tool"
+        expected_hook_command("hook_post_tool")
     );
 }
 
@@ -128,13 +175,14 @@ fn test_hook_install_coexists_with_upstream_cowork_entry() {
         .flat_map(|entry| entry["hooks"].as_array().expect("hook array").iter())
         .filter_map(|hook| hook["command"].as_str())
         .collect();
+    let expected = expected_hook_command("hook_user_prompt");
 
     assert!(commands.contains(&".claude/hooks/user-prompt-submit.sh"));
-    assert!(commands.contains(&"mempal hook hook_user_prompt"));
+    assert!(commands.iter().any(|command| *command == expected));
     assert_eq!(
         commands
             .iter()
-            .filter(|command| **command == "mempal hook hook_user_prompt")
+            .filter(|command| **command == expected)
             .count(),
         1
     );
@@ -151,11 +199,31 @@ fn test_hook_install_coexists_with_upstream_cowork_entry() {
     assert_eq!(
         second_commands
             .iter()
-            .filter(|command| **command == "mempal hook hook_user_prompt")
+            .filter(|command| **command == expected)
             .count(),
         1
     );
     assert!(!second.changed, "second install should be idempotent");
+}
+
+#[test]
+fn test_hook_install_dry_run_does_not_write() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&home).expect("create home");
+
+    let outcome = install_claude_code(&cwd, &home, true, false).expect("dry-run install");
+    assert!(
+        outcome
+            .rendered
+            .contains(&expected_hook_command("hook_post_tool"))
+    );
+    assert!(
+        !home.join(".claude/settings.json").exists(),
+        "dry-run must not write global settings"
+    );
 }
 
 #[cfg(unix)]
@@ -175,6 +243,43 @@ fn test_hook_install_refuses_agent_instruction_targets() {
     let error = install_claude_code(&cwd, &home, false, false).expect_err("must refuse");
     assert!(
         error.to_string().contains("agent-instruction"),
+        "unexpected error: {error}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_install_absolute_path_binary() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&home).expect("create home");
+
+    let outcome = install_claude_code(&cwd, &home, false, false).expect("install");
+    let parsed = parse_json(&outcome.write_path);
+    let command = parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("post-tool command");
+    assert!(
+        command.starts_with('/'),
+        "hook command must use absolute binary path, got {command}"
+    );
+    assert_eq!(command, expected_hook_command("hook_post_tool"));
+
+    let outside = TempDir::new().expect("outside tempdir");
+    let outside_target = outside.path().join(".claude/settings.json");
+    fs::create_dir_all(outside_target.parent().expect("outside parent"))
+        .expect("create outside parent");
+    fs::write(&outside_target, "{}").expect("write outside settings");
+
+    fs::create_dir_all(cwd.join(".claude")).expect("create local .claude");
+    let local_link = cwd.join(".claude/settings.json");
+    symlink(&outside_target, &local_link).expect("create external symlink");
+
+    let error = install_claude_code(&cwd, &home, false, false).expect_err("must reject");
+    assert!(
+        error.to_string().contains("outside allowed roots"),
         "unexpected error: {error}"
     );
 }
@@ -202,6 +307,6 @@ fn test_hook_install_public_wrapper_uses_home_env() {
     let parsed = parse_json(&home.join(".claude/settings.json"));
     assert_eq!(
         parsed["hooks"]["SessionEnd"][0]["hooks"][0]["command"],
-        "mempal hook hook_session_end"
+        expected_hook_command("hook_session_end")
     );
 }

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -1,0 +1,590 @@
+mod common;
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use common::harness::{BootstrapObserver, DaemonSupervisor, start as start_embed_mock};
+use mempal::bootstrap_events::BootstrapEvent;
+use mempal::core::db::Database;
+use mempal::core::queue::PendingMessageStore;
+use mempal::daemon_bootstrap::DaemonContext;
+use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use rusqlite::Connection;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+async fn test_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn setup_home() -> (TempDir, PathBuf, PathBuf, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    let config_path = mempal_home.join("config.toml");
+    (tmp, mempal_home, db_path, config_path)
+}
+
+fn write_config(
+    config_path: &Path,
+    db_path: &Path,
+    enabled: bool,
+    poll_ms: u64,
+    claim_ttl_secs: u64,
+    base_url: Option<&str>,
+) {
+    let embed = match base_url {
+        Some(base_url) => format!(
+            r#"
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "{base_url}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+"#
+        ),
+        None => r#"
+[embed]
+backend = "model2vec"
+"#
+        .to_string(),
+    };
+    fs::write(
+        config_path,
+        format!(
+            r#"
+db_path = "{}"
+{embed}
+[hooks]
+enabled = {enabled}
+daemon_poll_interval_ms = {poll_ms}
+daemon_claim_ttl_secs = {claim_ttl_secs}
+
+[privacy]
+enabled = true
+
+[daemon]
+log_path = "{}"
+"#,
+            db_path.display(),
+            db_path
+                .parent()
+                .expect("mempal home")
+                .join("daemon.log")
+                .display()
+        ),
+    )
+    .expect("write config");
+}
+
+fn queue_store(db_path: &Path) -> PendingMessageStore {
+    PendingMessageStore::new(db_path).expect("pending store")
+}
+
+fn enqueue_envelope(db_path: &Path, envelope: &CapturedHookEnvelope) -> String {
+    let payload = serde_json::to_string(envelope).expect("serialize envelope");
+    queue_store(db_path)
+        .enqueue(&envelope.kind, &payload)
+        .expect("enqueue envelope")
+}
+
+async fn wait_for_condition<F>(timeout: Duration, mut check: F)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if check() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("condition not satisfied within {timeout:?}");
+}
+
+fn drawer_count(db_path: &Path) -> i64 {
+    Database::open(db_path)
+        .expect("open db")
+        .drawer_count()
+        .expect("drawer count")
+}
+
+fn latest_drawer_row(db_path: &Path) -> (String, String, String, String) {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT wing, room, content, source_file FROM drawers ORDER BY added_at DESC, id DESC LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("latest drawer row")
+}
+
+fn message_status(db_path: &Path, id: &str) -> Option<(String, i64)> {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT status, retry_count FROM pending_messages WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_crash_reclaim_stale() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    handle.pause();
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        50,
+        1,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    let message_id = enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                r#"{"tool_name":"Bash","input":"ls","output":"ok","exit_code":0}"#.to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 64,
+            truncated: false,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(5), || handle.request_count() > 0).await;
+    wait_for_condition(Duration::from_secs(5), || {
+        matches!(message_status(&db_path, &message_id), Some((ref status, _)) if status == "claimed")
+    })
+    .await;
+
+    daemon.sigkill();
+    let _ = daemon.wait().await.expect("wait killed daemon");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    handle.resume();
+    let mut restarted = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn restarted daemon");
+    restarted
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait restarted ready");
+    wait_for_condition(Duration::from_secs(10), || drawer_count(&db_path) > 0).await;
+
+    assert!(
+        message_status(&db_path, &message_id).is_none(),
+        "message should be confirmed after reclaim"
+    );
+    restarted.sigterm();
+    let status = restarted.wait().await.expect("wait restarted daemon");
+    assert!(status.success(), "restarted daemon exited with {status:?}");
+    handle.shutdown().await;
+}
+
+#[test]
+fn test_daemon_exits_when_disabled() {
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    write_config(&config_path, &db_path, false, 50, 60, None);
+
+    let output = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run daemon");
+
+    assert!(
+        output.status.success(),
+        "daemon should exit 0 when disabled"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hooks not enabled"),
+        "missing no-op message: {stderr}"
+    );
+    assert!(
+        !tmp.path().join(".mempal/daemon.pid").exists(),
+        "pid file must not be created when hooks are disabled"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_handles_truncated_envelope_without_retry() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        50,
+        60,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    let message_id = enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: None,
+            payload_path: Some("/tmp/truncated.json".to_string()),
+            payload_preview: Some("sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD".to_string()),
+            original_size_bytes: 10_000_001,
+            truncated: true,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(10), || drawer_count(&db_path) > 0).await;
+
+    let (wing, room, content, _) = latest_drawer_row(&db_path);
+    assert_eq!(wing, "hooks-raw");
+    assert_eq!(room, "truncated");
+    assert!(content.contains("\"_truncated\":true"), "{content}");
+    assert!(
+        message_status(&db_path, &message_id).is_none(),
+        "truncated envelope must be confirmed, not retried"
+    );
+    let failed_count: i64 = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'failed'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("failed count");
+    assert_eq!(failed_count, 0);
+
+    daemon.sigterm();
+    let status = daemon.wait().await.expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_processes_hook_post_tool_to_drawer() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        50,
+        60,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    let raw_secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD";
+    enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                serde_json::json!({
+                    "tool_name": "Bash",
+                    "input": "printf secret",
+                    "output": raw_secret,
+                    "exit_code": 0
+                })
+                .to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 128,
+            truncated: false,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(10), || drawer_count(&db_path) > 0).await;
+
+    let (wing, room, content, source_file) = latest_drawer_row(&db_path);
+    assert_eq!(wing, "hooks-raw");
+    assert_eq!(room, "Bash");
+    assert!(
+        Path::new(&source_file).exists(),
+        "payload path should exist"
+    );
+    assert!(content.contains("\"preview\""), "{content}");
+    assert!(
+        content.contains("[REDACTED:openai_key]"),
+        "privacy scrub must affect stored preview: {content}"
+    );
+    assert!(
+        !content.contains(raw_secret),
+        "raw secret leaked into drawer"
+    );
+
+    daemon.sigterm();
+    let status = daemon.wait().await.expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_sigterm_graceful_shutdown() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        50,
+        60,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::SessionStart.display_name().to_string(),
+            kind: HookEvent::SessionStart.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(r#"{"session_id":"abc","cwd":"/tmp/project"}"#.to_string()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 32,
+            truncated: false,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(10), || drawer_count(&db_path) > 0).await;
+
+    daemon.sigterm();
+    let status = tokio::time::timeout(Duration::from_secs(3), daemon.wait())
+        .await
+        .expect("daemon did not stop within deadline")
+        .expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+
+    let claimed: i64 = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'claimed'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("claimed count");
+    assert_eq!(claimed, 0, "no message may remain claimed after SIGTERM");
+    assert!(
+        !tmp.path().join(".mempal/daemon.pid").exists(),
+        "daemon pid file must be removed"
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_status_reports_state_and_queue() {
+    let _guard = test_guard().await;
+    let (tmp, mempal_home, db_path, config_path) = setup_home();
+    write_config(&config_path, &db_path, true, 50, 60, None);
+
+    let store = queue_store(&db_path);
+    store
+        .enqueue("hook_post_tool", r#"{"tool_name":"Bash"}"#)
+        .expect("enqueue pending");
+    store
+        .enqueue("hook_post_tool", r#"{"tool_name":"Edit"}"#)
+        .expect("enqueue claimed");
+    let claimed = store
+        .claim_next("status-worker", 60)
+        .expect("claim")
+        .expect("message");
+    store
+        .refresh_heartbeat(&claimed.id, "status-worker")
+        .expect("refresh heartbeat");
+    fs::write(
+        mempal_home.join("daemon.pid"),
+        std::process::id().to_string(),
+    )
+    .expect("write daemon pid");
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", tmp.path())
+        .output()
+        .expect("run status");
+    assert!(output.status.success(), "status must succeed");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(stdout.contains("Daemon:"), "{stdout}");
+    assert!(stdout.contains("running: true"), "{stdout}");
+    assert!(stdout.contains("Queue:"), "{stdout}");
+    assert!(stdout.contains("pending: 1"), "{stdout}");
+    assert!(stdout.contains("claimed: 1"), "{stdout}");
+    assert!(stdout.contains("last_heartbeat_unix_secs:"), "{stdout}");
+}
+
+#[test]
+fn test_no_sqlite_before_daemonize() {
+    let (_tmp, _mempal_home, db_path, config_path) = setup_home();
+    write_config(&config_path, &db_path, true, 50, 60, None);
+
+    let runtime = tokio::runtime::Runtime::new().expect("bootstrap runtime");
+    let (tx, mut observer): (_, BootstrapObserver) = common::harness::channel();
+    let context = DaemonContext::bootstrap_with_events(config_path, true, Some(tx))
+        .expect("bootstrap context");
+    let seen = runtime
+        .block_on(async {
+            observer
+                .recv_until(BootstrapEvent::Ready, Duration::from_secs(1))
+                .await
+        })
+        .expect("observe bootstrap");
+
+    assert_eq!(
+        seen,
+        vec![
+            BootstrapEvent::Daemonize,
+            BootstrapEvent::RuntimeInit,
+            BootstrapEvent::ConfigHandleBootstrap,
+            BootstrapEvent::DbOpen,
+            BootstrapEvent::TracingInit,
+            BootstrapEvent::Ready,
+        ]
+    );
+    drop(context);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_truncated_envelope_preview_is_scrubbed() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        50,
+        60,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: None,
+            payload_path: Some("/tmp/truncated.json".to_string()),
+            payload_preview: Some("sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890WXYZ".to_string()),
+            original_size_bytes: 10_000_001,
+            truncated: true,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(10), || drawer_count(&db_path) > 0).await;
+
+    let stderr = daemon.stderr_lines().await.join("\n");
+    assert!(
+        stderr.contains("[REDACTED:openai_key]"),
+        "scrubbed preview missing from daemon logs: {stderr}"
+    );
+    assert!(
+        !stderr.contains("sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890WXYZ"),
+        "raw secret leaked into daemon logs: {stderr}"
+    );
+
+    daemon.sigterm();
+    let status = daemon.wait().await.expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+    handle.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Fork-ext scenario gap filling **PR4/10** — `p8-hook-passive-capture` (Stage 2, strict-serial, after PR3).

Implements 12 TODO-mandated scenarios across the hook installer + daemon surface, with minimal implementation adjustments to make the scenarios testable.

### Tests added (12 scenarios)

`tests/hook_passive_capture.rs` (new), plus extensions to `tests/hook_install.rs` and `tests/hook_enqueue.rs`:

- `test_daemon_crash_reclaim_stale`
- `test_daemon_exits_when_disabled`
- `test_daemon_handles_truncated_envelope_without_retry`
- `test_daemon_processes_hook_post_tool_to_drawer`
- `test_daemon_sigterm_graceful_shutdown`
- `test_daemon_status_reports_state_and_queue`
- `test_hook_install_dry_run_does_not_write`
- `test_hook_install_merges_existing_settings`
- `test_hook_writes_nothing_to_stdout`
- `test_no_sqlite_before_daemonize`
- `test_truncated_envelope_preview_is_scrubbed`
- `test_hook_install_absolute_path_binary`

### Source changes (minimal for scenario support)

- `src/daemon.rs`: graceful no-op exit when `[hooks].enabled = false`; scrubbed preview for truncated envelope
- `src/main.rs`: `mempal status` exposes daemon `running/pid/last_heartbeat_unix_secs`
- `src/hook_install.rs`: absolute mempal binary path, canonical target allowlist (PATH-hijack defense), append-to-array merge semantics

### Harness reuse

- `tests/common/harness/bootstrap_observer.rs` (PR0) for test_no_sqlite_before_daemonize verification
- `tests/common/harness/daemon_supervisor.rs` (PR0)
- `tests/common/harness/embed_mock.rs` (PR0)

### Debate patches applied

- **R2** daemonize × tokio startup ordering: no SQLite / tokio / tracing / fd redirection before `DaemonContext::bootstrap()` — enforced via mpsc<BootstrapEvent> observer
- **Cross-spec interaction (a)**: `.claude/settings.json` merge is append-to-array, coexists with upstream `mempal cowork-install-hooks`
- **[Security] canonical target allowlist**: hook install rejects non-canonical targets

## Test plan

- [x] `cargo test --test hook_passive_capture` green
- [x] `cargo test --test hook_install` green
- [x] `cargo test --test hook_enqueue` green
- [x] `just fmt` clean
- [x] `just clippy` clean
- [x] `just test` full suite green
- [x] CSA gemini-cli tier-4-critical review PASS (session `01KPRRKDNDZ39GV6B7608WST9P`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)