### PR TITLE
test(project-iso): fill p10 project-vector-isolation scenario gaps (PR5/10, atomic)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "model2vec-rs",
  "notify",
  "ort",
+ "percent-encoding",
  "regex",
  "reqwest",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ libc = "0.2"
 model2vec-rs = { version = "0.1", optional = true }
 notify = "8"
 ort = { version = "2.0.0-rc.9", optional = true }
+percent-encoding = "2"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rmcp = { version = "1.3.0", features = ["client", "server", "macros", "schemars", "transport-async-rw", "transport-io"] }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use super::{
-    types::{Drawer, DrawerDetails, SourceType, TaxonomyEntry, Triple, TripleStats},
+    types::{Drawer, DrawerDetails, SourceType, TaxonomyEntry, Triple, TripleStats, TunnelDrawer},
     utils::{build_drawer_id, build_scoped_drawer_id},
 };
 use crate::ingest::gating::GatingDecision;
@@ -861,7 +861,7 @@ impl Database {
             FROM drawers
             WHERE deleted_at IS NULL
             GROUP BY project_id
-            ORDER BY project_id
+            ORDER BY project_id NULLS LAST
             "#,
         )?;
         let rows = stmt
@@ -872,12 +872,20 @@ impl Database {
         Ok(rows)
     }
 
+    pub fn null_project_backfill_pending_count(&self) -> Result<i64, DbError> {
+        Ok(self.conn.query_row(
+            "SELECT COUNT(*) FROM drawers WHERE deleted_at IS NULL AND project_id IS NULL",
+            [],
+            |row| row.get(0),
+        )?)
+    }
+
     pub fn tunnel_drawers_for_room(
         &self,
         room: &str,
         exclude_drawer_id: &str,
         current_project_id: Option<&str>,
-    ) -> Result<Vec<(Drawer, Option<String>)>, DbError> {
+    ) -> Result<Vec<TunnelDrawer>, DbError> {
         let Some(current_project_id) = current_project_id else {
             return Ok(Vec::new());
         };
@@ -925,8 +933,8 @@ impl Database {
                     importance,
                     project_id,
                 )| {
-                    Ok((
-                        Drawer {
+                    Ok(TunnelDrawer {
+                        drawer: Drawer {
                             id,
                             content,
                             wing,
@@ -937,8 +945,8 @@ impl Database {
                             chunk_index,
                             importance,
                         },
-                        project_id,
-                    ))
+                        target_project_id: project_id,
+                    })
                 },
             )
             .collect()

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -189,7 +189,7 @@ fn apply_v4(conn: &Connection) -> rusqlite::Result<()> {
 }
 
 fn apply_v5(conn: &Connection) -> rusqlite::Result<()> {
-    ensure_project_column(conn, "drawers", "TEXT")?;
+    ensure_drawers_project_column(conn)?;
     ensure_project_column(conn, "triples", "TEXT")?;
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_drawers_project_id ON drawers(project_id);",
@@ -229,6 +229,13 @@ fn ensure_project_column(conn: &Connection, table: &str, ty: &str) -> rusqlite::
         return Ok(());
     }
     conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN project_id {ty};"))
+}
+
+fn ensure_drawers_project_column(conn: &Connection) -> rusqlite::Result<()> {
+    if table_has_column(conn, "drawers", "project_id")? {
+        return Ok(());
+    }
+    conn.execute_batch("ALTER TABLE drawers ADD COLUMN project_id TEXT;")
 }
 
 fn table_has_column(conn: &Connection, table: &str, column: &str) -> rusqlite::Result<bool> {

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -1,9 +1,12 @@
 use std::env;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
+use percent_encoding::percent_decode_str;
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -12,6 +15,7 @@ use super::config::Config;
 
 pub const PROJECT_MIGRATION_BATCH_SIZE: usize = 1_000;
 pub const PROJECT_MIGRATION_RETRY_DELAYS_MS: [u64; 3] = [500, 1_000, 2_000];
+pub const MAX_PROJECT_ID_BYTES: usize = 255;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProjectFilterMode {
@@ -129,14 +133,16 @@ pub enum ProjectMigrationEvent {
 
 #[derive(Debug, Error)]
 pub enum ProjectError {
-    #[error("project id cannot be empty")]
+    #[error("project_id is empty")]
     Empty,
-    #[error("project id cannot start or end with whitespace")]
+    #[error("project_id contains surrounding whitespace")]
     SurroundingWhitespace,
-    #[error("project id cannot contain '/'")]
+    #[error("project_id contains '/'")]
     Slash,
-    #[error("project id cannot contain NUL")]
-    Nul,
+    #[error("project_id contains control character")]
+    ControlCharacter,
+    #[error("project_id exceeds {max_bytes} bytes")]
+    TooLong { max_bytes: usize },
     #[error("failed to read current directory")]
     CurrentDir(#[source] std::io::Error),
     #[error("failed to run git to infer project root")]
@@ -172,12 +178,28 @@ pub fn resolve_project_id(
 }
 
 pub fn infer_project_id_from_path(path: &Path) -> Result<Option<String>, ProjectError> {
-    let candidate_root = git_repo_root(path)?.unwrap_or_else(|| path.to_path_buf());
-    match candidate_root.file_name().and_then(|name| name.to_str()) {
-        Some(name) => Ok(Some(validate_project_id(name)?)),
-        None if candidate_root.as_os_str().is_empty() => Ok(None),
-        None => Err(ProjectError::MissingBasename(candidate_root)),
+    if path_contains_nul(path) {
+        return Ok(None);
     }
+    let candidate_root = git_repo_root(path)?.unwrap_or_else(|| path.to_path_buf());
+    let canonical = candidate_root
+        .canonicalize()
+        .unwrap_or_else(|_| candidate_root.clone());
+    if canonical.as_os_str().is_empty() {
+        return Ok(None);
+    }
+    match path_basename(&canonical) {
+        Ok(Some(candidate)) => Ok(validate_project_id(candidate).ok()),
+        Ok(None) | Err(ProjectError::InvalidUtf8Path) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn infer_project_id_from_root_uri(uri: &str) -> Result<Option<String>, ProjectError> {
+    let Some(path) = file_uri_to_path(uri)? else {
+        return Ok(None);
+    };
+    infer_project_id_from_path(&path)
 }
 
 fn git_repo_root(path: &Path) -> Result<Option<PathBuf>, ProjectError> {
@@ -199,6 +221,54 @@ fn git_repo_root(path: &Path) -> Result<Option<PathBuf>, ProjectError> {
     Ok(Some(PathBuf::from(trimmed)))
 }
 
+fn file_uri_to_path(uri: &str) -> Result<Option<PathBuf>, ProjectError> {
+    let Some(rest) = uri.strip_prefix("file://") else {
+        return Ok(None);
+    };
+    if rest.is_empty() {
+        return Ok(None);
+    }
+    let decoded = percent_decode_str(rest)
+        .decode_utf8()
+        .map_err(|_| ProjectError::InvalidUtf8Path)?;
+    #[cfg(unix)]
+    let path = {
+        let decoded = decoded.as_ref();
+        let without_localhost = decoded
+            .strip_prefix("localhost/")
+            .map(|path| format!("/{path}"));
+        let normalized = if decoded.starts_with('/') {
+            decoded.to_string()
+        } else if let Some(path) = without_localhost {
+            path
+        } else {
+            format!("/{decoded}")
+        };
+        PathBuf::from(normalized)
+    };
+    #[cfg(not(unix))]
+    let path = PathBuf::from(decoded.into_owned());
+    Ok(Some(path))
+}
+
+fn path_basename(path: &Path) -> Result<Option<&str>, ProjectError> {
+    match path.file_name() {
+        Some(name) => name.to_str().map(Some).ok_or(ProjectError::InvalidUtf8Path),
+        None => Ok(None),
+    }
+}
+
+fn path_contains_nul(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        path.as_os_str().as_bytes().contains(&b'\0')
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
 pub fn validate_project_id(raw: &str) -> Result<String, ProjectError> {
     if raw.is_empty() {
         return Err(ProjectError::Empty);
@@ -209,10 +279,22 @@ pub fn validate_project_id(raw: &str) -> Result<String, ProjectError> {
     if raw.contains('/') {
         return Err(ProjectError::Slash);
     }
-    if raw.contains('\0') {
-        return Err(ProjectError::Nul);
+    if raw.chars().any(char::is_control) {
+        return Err(ProjectError::ControlCharacter);
+    }
+    if raw.len() > MAX_PROJECT_ID_BYTES {
+        return Err(ProjectError::TooLong {
+            max_bytes: MAX_PROJECT_ID_BYTES,
+        });
     }
     Ok(raw.to_string())
+}
+
+pub fn escape_project_id_for_display(project_id: &str) -> String {
+    project_id
+        .chars()
+        .flat_map(|ch| ch.escape_debug())
+        .collect()
 }
 
 pub fn migrate_null_project_ids<F>(

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -32,6 +32,12 @@ pub struct DrawerDetails {
     pub project_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunnelDrawer {
+    pub drawer: Drawer,
+    pub target_project_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Triple {
     pub id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ use mempal::core::{
     config::{Config, ConfigHandle, default_config_path},
     db::Database,
     project::{
-        ProjectMigrationEvent, ProjectSearchScope, migrate_null_project_ids, resolve_project_id,
+        ProjectMigrationEvent, ProjectSearchScope, escape_project_id_for_display,
+        migrate_null_project_ids, resolve_project_id,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     reindex::ReindexProgressStore,
@@ -1307,6 +1308,12 @@ fn status_command(db: &Database) -> Result<()> {
         .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(0);
     let drawer_count = db.drawer_count().context("failed to count drawers")?;
+    let project_breakdown = db
+        .project_breakdown()
+        .context("failed to count drawers per project")?;
+    let null_project_backfill_pending = db
+        .null_project_backfill_pending_count()
+        .context("failed to count pending project backfill drawers")?;
     let taxonomy_count = db.taxonomy_count().context("failed to count taxonomy")?;
     let db_size_bytes = db
         .database_size_bytes()
@@ -1333,6 +1340,27 @@ fn status_command(db: &Database) -> Result<()> {
     println!("schema_version: {schema_version}");
     println!("fork_ext_version: {fork_ext_version}");
     println!("drawer_count: {drawer_count}");
+    println!("drawers per project:");
+    if project_breakdown.is_empty() {
+        println!("(none)");
+    } else {
+        for (project_id, count) in project_breakdown {
+            match project_id {
+                Some(project_id) => {
+                    let project_id = escape_project_id_for_display(&project_id);
+                    println!("{project_id}={count}");
+                }
+                None => println!("NULL={count}"),
+            }
+        }
+    }
+    println!(
+        "null_project_backfill_pending: {}",
+        null_project_backfill_pending > 0
+    );
+    if null_project_backfill_pending > 0 {
+        println!("null_project_backfill_count: {null_project_backfill_pending}");
+    }
     if deleted_count > 0 {
         println!("deleted_drawers: {deleted_count} (use `mempal purge` to remove)");
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::core::{
     config::ConfigHandle,
     db::Database,
-    project::{ProjectSearchScope, resolve_project_id},
+    project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
     types::{Drawer, SourceType, Triple},
     utils::{build_triple_id, current_timestamp, source_file_or_synthetic},
 };
@@ -21,6 +21,7 @@ use rmcp::{
     ErrorData, Json, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{ServerCapabilities, ServerInfo},
+    service::Peer,
     tool, tool_handler, tool_router,
 };
 
@@ -42,6 +43,8 @@ pub struct MempalMcpServer {
     /// Captured via `initialize` override so `auto` peek mode can infer the
     /// partner from the calling MCP client's self-reported name.
     client_name: Arc<Mutex<Option<String>>>,
+    client_project_id: Arc<Mutex<Option<String>>>,
+    client_peer: Arc<Mutex<Option<Peer<rmcp::RoleServer>>>>,
 }
 
 impl MempalMcpServer {
@@ -72,6 +75,8 @@ impl MempalMcpServer {
             embedder_factory,
             tool_router: Self::tool_router(),
             client_name: Arc::new(Mutex::new(None)),
+            client_project_id: Arc::new(Mutex::new(None)),
+            client_peer: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -91,6 +96,46 @@ impl MempalMcpServer {
         Database::open(&self.db_path).map_err(|error| {
             ErrorData::internal_error(format!("failed to open database: {error}"), None)
         })
+    }
+
+    async fn resolve_mcp_project_id(
+        &self,
+        explicit: Option<&str>,
+        config: &crate::core::config::Config,
+    ) -> std::result::Result<Option<String>, ErrorData> {
+        if let Some(explicit) = explicit {
+            return validate_project_id(explicit).map(Some).map_err(|error| {
+                ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+            });
+        }
+
+        if let Some(configured) = config.project.id.as_deref() {
+            return validate_project_id(configured).map(Some).map_err(|error| {
+                ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+            });
+        }
+
+        if let Ok(guard) = self.client_project_id.lock()
+            && let Some(project_id) = guard.clone()
+        {
+            return Ok(Some(project_id));
+        }
+
+        let peer = self.client_peer.lock().ok().and_then(|guard| guard.clone());
+        if let Some(peer) = peer
+            && let Ok(result) = peer.list_roots().await
+            && let Some(project_id) = result
+                .roots
+                .into_iter()
+                .find_map(|root| infer_project_id_from_root_uri(&root.uri).ok().flatten())
+        {
+            if let Ok(mut guard) = self.client_project_id.lock() {
+                *guard = Some(project_id.clone());
+            }
+            return Ok(Some(project_id));
+        }
+
+        Ok(None)
     }
 }
 
@@ -115,6 +160,8 @@ impl MempalMcpServer {
         let embed_snapshot = global_embed_status().snapshot();
         let schema_version = db.schema_version().map_err(db_error)?;
         let drawer_count = db.drawer_count().map_err(db_error)?;
+        let null_project_backfill_pending =
+            db.null_project_backfill_pending_count().map_err(db_error)?;
         let taxonomy_count = db.taxonomy_count().map_err(db_error)?;
         let db_size_bytes = db.database_size_bytes().map_err(db_error)?;
         let scopes = db
@@ -127,6 +174,16 @@ impl MempalMcpServer {
                 drawer_count,
             })
             .collect();
+        let mut system_warnings = current_system_warnings();
+        if null_project_backfill_pending > 0 {
+            system_warnings.push(SystemWarning {
+                level: "warn".to_string(),
+                message: format!(
+                    "{null_project_backfill_pending} drawers still have NULL project_id; run `mempal project migrate --project <id>` to backfill historical records"
+                ),
+                source: "project_isolation".to_string(),
+            });
+        }
 
         Ok(Json(StatusResponse {
             schema_version,
@@ -160,7 +217,7 @@ impl MempalMcpServer {
                 oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
             },
             scrub_stats: ScrubStatsDto::from(ConfigHandle::scrub_stats()),
-            system_warnings: current_system_warnings(),
+            system_warnings,
         }))
     }
 
@@ -173,10 +230,10 @@ impl MempalMcpServer {
         Parameters(request): Parameters<SearchRequest>,
     ) -> std::result::Result<Json<SearchResponse>, ErrorData> {
         let config = ConfigHandle::current();
-        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
-            .map_err(|error| {
-            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
-        })?;
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await?;
+        let unresolved_scope = project_id.is_none() && !request.all_projects.unwrap_or(false);
         let scope = ProjectSearchScope::from_request(
             project_id,
             request.include_global.unwrap_or(false),
@@ -250,6 +307,13 @@ impl MempalMcpServer {
 
         let mut system_warnings = current_system_warnings();
         system_warnings.extend(extra_warnings);
+        if unresolved_scope && config.search.strict_project_isolation {
+            system_warnings.push(SystemWarning {
+                level: "warn".to_string(),
+                message: "no project scope resolved, isolation strict".to_string(),
+                source: "project_isolation".to_string(),
+            });
+        }
 
         Ok(Json(SearchResponse {
             results: results
@@ -276,10 +340,9 @@ impl MempalMcpServer {
         Parameters(request): Parameters<ReadDrawerRequest>,
     ) -> std::result::Result<Json<ReadDrawerResponse>, ErrorData> {
         let config = ConfigHandle::current();
-        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
-            .map_err(|error| {
-            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
-        })?;
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await?;
         let scope = ProjectSearchScope::from_request(
             project_id,
             request.include_global.unwrap_or(false),
@@ -330,10 +393,9 @@ impl MempalMcpServer {
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
-        let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
-            .map_err(|error| {
-            ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
-        })?;
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await?;
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
@@ -1067,14 +1129,11 @@ impl ServerHandler for MempalMcpServer {
             .with_instructions(instructions)
     }
 
-    fn initialize(
+    async fn initialize(
         &self,
         request: rmcp::model::InitializeRequestParams,
         context: rmcp::service::RequestContext<rmcp::RoleServer>,
-    ) -> impl std::future::Future<
-        Output = std::result::Result<rmcp::model::InitializeResult, ErrorData>,
-    > + Send
-    + '_ {
+    ) -> std::result::Result<rmcp::model::InitializeResult, ErrorData> {
         // Capture the calling client's tool name so `mempal_peek_partner`
         // with `tool: "auto"` can infer which partner to read (e.g.,
         // caller=claude-code ⇒ peek codex; caller=codex-cli ⇒ peek claude).
@@ -1084,9 +1143,26 @@ impl ServerHandler for MempalMcpServer {
         // Preserve rmcp's default behavior: store peer_info so downstream
         // rmcp internals can read client capabilities.
         if context.peer.peer_info().is_none() {
-            context.peer.set_peer_info(request);
+            context.peer.set_peer_info(request.clone());
         }
-        std::future::ready(Ok(self.get_info()))
+
+        if let Ok(mut guard) = self.client_project_id.lock() {
+            *guard = None;
+        }
+        if let Ok(mut guard) = self.client_peer.lock() {
+            *guard = Some(context.peer.clone());
+        }
+
+        Ok(self.get_info())
+    }
+
+    async fn on_roots_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<rmcp::RoleServer>,
+    ) {
+        if let Ok(mut guard) = self.client_project_id.lock() {
+            *guard = None;
+        }
     }
 }
 
@@ -1335,19 +1411,22 @@ mod tests {
         importance: i32,
     ) {
         let db = Database::open(db_path).expect("open db");
-        db.insert_drawer(&Drawer {
-            id: id.to_string(),
-            content: content.to_string(),
-            wing: wing.to_string(),
-            room: room.map(str::to_string),
-            source_file: Some(source_file.to_string()),
-            source_type: SourceType::Manual,
-            added_at: "1713000000".to_string(),
-            chunk_index: Some(0),
-            importance,
-        })
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: id.to_string(),
+                content: content.to_string(),
+                wing: wing.to_string(),
+                room: room.map(str::to_string),
+                source_file: Some(source_file.to_string()),
+                source_type: SourceType::Manual,
+                added_at: "1713000000".to_string(),
+                chunk_index: Some(0),
+                importance,
+            },
+            Some("default"),
+        )
         .expect("insert drawer");
-        db.insert_vector(id, &[0.1, 0.2, 0.3])
+        db.insert_vector_with_project(id, &[0.1, 0.2, 0.3], Some("default"))
             .expect("insert vector");
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -28,8 +28,10 @@ pub struct SearchRequest {
     pub top_k: Option<usize>,
 
     /// Optional explicit project scope. When omitted, mempal resolves the
-    /// current project from config/env/git root and scopes the query there by
-    /// default. Set `all_projects=true` to bypass project scoping.
+    /// current project from `[project]` config or MCP roots and scopes the
+    /// query there by default. If neither resolves, search runs unscoped
+    /// unless strict isolation is enabled. Set `all_projects=true` to bypass
+    /// project scoping.
     pub project_id: Option<String>,
 
     /// Include legacy/global drawers (`project_id IS NULL`) alongside the
@@ -91,8 +93,9 @@ pub struct ReadDrawerRequest {
     pub drawer_id: String,
 
     /// Optional explicit project scope. When omitted, mempal resolves the
-    /// current project from config/env/git root and scopes the read there by
-    /// default. Set `all_projects=true` to bypass project scoping.
+    /// current project from `[project]` config or MCP roots and scopes the
+    /// read there by default. Set `all_projects=true` to bypass project
+    /// scoping.
     pub project_id: Option<String>,
 
     /// Include legacy/global drawers (`project_id IS NULL`) alongside the

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -212,7 +212,8 @@ fn inject_tunnel_hints_and_results(
             if let Ok(drawers) =
                 db.tunnel_drawers_for_room(room, &result.drawer_id, scope.project_id.as_deref())
             {
-                for (drawer, _) in drawers {
+                for tunnel in drawers {
+                    let drawer = tunnel.drawer;
                     if seen_ids.insert(drawer.id.clone()) {
                         tunnel_results.push(SearchResult {
                             drawer_id: drawer.id.clone(),

--- a/tests/common/harness/mcp_stdio.rs
+++ b/tests/common/harness/mcp_stdio.rs
@@ -20,6 +20,7 @@ pub struct McpStdio {
     stderr_lines: Arc<Mutex<Vec<String>>>,
     stderr_task: Option<tokio::task::JoinHandle<()>>,
     next_id: u64,
+    roots: Vec<String>,
 }
 
 impl McpStdio {
@@ -111,16 +112,26 @@ log_path = "{}"
             stderr_lines,
             stderr_task: Some(stderr_task),
             next_id: 1,
+            roots: Vec::new(),
         })
     }
 
     pub async fn initialize(&mut self) -> Result<ServerInfo> {
+        self.initialize_with_roots(&[]).await
+    }
+
+    pub async fn initialize_with_roots(&mut self, roots: &[&str]) -> Result<ServerInfo> {
+        self.roots = roots.iter().map(|root| root.to_string()).collect();
         let result = self
             .call(
                 "initialize",
                 json!({
                     "protocolVersion": "2024-11-05",
-                    "capabilities": {},
+                    "capabilities": if roots.is_empty() {
+                        json!({})
+                    } else {
+                        json!({"roots": {"listChanged": true}})
+                    },
                     "clientInfo": {
                         "name": "pr0-harness",
                         "version": "0.0.0"
@@ -128,7 +139,24 @@ log_path = "{}"
                 }),
             )
             .await?;
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }))
+        .await?;
         serde_json::from_value(result).context("decode MCP initialize result")
+    }
+
+    pub fn set_roots(&mut self, roots: &[&str]) {
+        self.roots = roots.iter().map(|root| root.to_string()).collect();
+    }
+
+    pub async fn notify_roots_list_changed(&mut self) -> Result<()> {
+        self.send(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/roots/list_changed"
+        }))
+        .await
     }
 
     pub async fn call(&mut self, method: &str, params: Value) -> Result<Value> {
@@ -188,6 +216,30 @@ log_path = "{}"
             }
             let message: Value =
                 serde_json::from_str(line.trim()).context("parse JSON-RPC response line")?;
+
+            if let Some(method) = message.get("method").and_then(Value::as_str) {
+                let request_id = message
+                    .get("id")
+                    .and_then(Value::as_u64)
+                    .context("JSON-RPC request missing numeric id")?;
+                match method {
+                    "roots/list" => {
+                        let roots = self
+                            .roots
+                            .iter()
+                            .map(|uri| json!({ "uri": uri }))
+                            .collect::<Vec<_>>();
+                        self.send(json!({
+                            "jsonrpc": "2.0",
+                            "id": request_id,
+                            "result": { "roots": roots },
+                        }))
+                        .await?;
+                        continue;
+                    }
+                    _ => bail!("unexpected JSON-RPC request: {message}"),
+                }
+            }
 
             if message.get("id").is_none() {
                 continue;

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -98,20 +98,24 @@ fn seed_drawers(db_path: &Path, count: usize, vector_dim: usize) {
     let db = Database::open(db_path).expect("open db");
     for index in 0..count {
         let id = format!("drawer-{index:02}");
-        db.insert_drawer(&Drawer {
-            id: id.clone(),
-            content: format!("drawer content {index}"),
-            wing: "test".to_string(),
-            room: Some("reindex".to_string()),
-            source_file: Some("fixtures/source.txt".to_string()),
-            source_type: SourceType::Project,
-            added_at: format!("17130000{index:02}"),
-            chunk_index: Some(index as i64),
-            importance: 0,
-        })
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: id.clone(),
+                content: format!("drawer content {index}"),
+                wing: "test".to_string(),
+                room: Some("reindex".to_string()),
+                source_file: Some("fixtures/source.txt".to_string()),
+                source_type: SourceType::Project,
+                added_at: format!("17130000{index:02}"),
+                chunk_index: Some(index as i64),
+                importance: 0,
+            },
+            Some("default"),
+        )
         .expect("insert drawer");
         let vector = vec![0.1_f32; vector_dim];
-        db.insert_vector(&id, &vector).expect("insert vector");
+        db.insert_vector_with_project(&id, &vector, Some("default"))
+            .expect("insert vector");
     }
 }
 

--- a/tests/embedder_reload.rs
+++ b/tests/embedder_reload.rs
@@ -350,6 +350,7 @@ async fn test_sighup_triggers_reload() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_dim_mismatch_fail_fast() {
     let _guard = test_guard().await;
+    global_embed_status().reset_for_tests();
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     let db = Database::open(&db_path).expect("open db");

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -142,17 +142,20 @@ async fn test_search_deadline_bm25_fallback() {
     );
     let config = Config::load_from(&env.config_path).expect("load config");
     let db = Database::open(&env.db_path).expect("open db");
-    db.insert_drawer(&Drawer {
-        id: "bm25-hit".to_string(),
-        content: "fallback keyword memory".to_string(),
-        wing: "test".to_string(),
-        room: Some("fallback".to_string()),
-        source_file: Some("fixtures/fallback.txt".to_string()),
-        source_type: SourceType::Project,
-        added_at: "1713000000".to_string(),
-        chunk_index: Some(0),
-        importance: 2,
-    })
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: "bm25-hit".to_string(),
+            content: "fallback keyword memory".to_string(),
+            wing: "test".to_string(),
+            room: Some("fallback".to_string()),
+            source_file: Some("fixtures/fallback.txt".to_string()),
+            source_type: SourceType::Project,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 2,
+        },
+        Some("default"),
+    )
     .expect("insert drawer");
 
     let server = MempalMcpServer::new(env.db_path.clone(), config);

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -224,7 +224,7 @@ async fn test_search_result_has_content_truncated_field() {
         "code",
         Some("preview"),
         "/tmp/short.md",
-        None,
+        Some("default"),
     );
 
     let json = search_response_json(&env.server(), "short").await;
@@ -252,7 +252,7 @@ async fn test_search_preview_length_cap_applied() {
         "code",
         Some("preview"),
         "/tmp/long.md",
-        None,
+        Some("default"),
     );
 
     let json = search_response_json(&env.server(), "deterministic").await;
@@ -279,7 +279,7 @@ async fn test_search_short_content_untruncated() {
         "code",
         Some("preview"),
         "/tmp/short.md",
-        None,
+        Some("default"),
     );
 
     let json = search_response_json(&env.server(), "whole").await;
@@ -305,7 +305,7 @@ async fn test_mempal_read_drawer_returns_raw_full_content() {
         "code",
         Some("preview"),
         "/tmp/read.md",
-        None,
+        Some("default"),
     );
 
     let response = env
@@ -469,7 +469,7 @@ async fn test_progressive_disclosure_hot_reload_applies_without_restart() {
         "code",
         Some("preview"),
         "/tmp/hot.md",
-        None,
+        Some("default"),
     );
 
     let before = search_response_json(&env.server(), "preview").await;

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -1,32 +1,35 @@
+mod common;
+
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
 use async_trait::async_trait;
-#[cfg(feature = "rest")]
-use axum::{
-    body::{Body, to_bytes},
-    http::{Request, StatusCode},
-};
-#[cfg(feature = "rest")]
-use mempal::api::{ApiState, router as api_router};
+use common::harness::{McpStdio, dump as dump_vec0, start as start_embed_mock};
 use mempal::core::config::ConfigHandle;
-use mempal::core::db::{Database, apply_fork_ext_migrations, read_fork_ext_version};
+use mempal::core::db::{
+    Database, apply_fork_ext_migrations_to, read_fork_ext_version, set_fork_ext_version,
+};
+use mempal::core::project::{
+    MAX_PROJECT_ID_BYTES, ProjectError, escape_project_id_for_display, infer_project_id_from_path,
+    infer_project_id_from_root_uri, migrate_null_project_ids, validate_project_id,
+};
 use mempal::core::types::{Drawer, SourceType};
-use mempal::core::utils::build_drawer_id;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
-use mempal::mcp::{IngestRequest, MempalMcpServer, SearchRequest};
+use mempal::mcp::{MempalMcpServer, SearchRequest};
+use mempal::search::filter::{build_fts_runtime_sql, build_vector_search_sql};
 use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::{Connection, OptionalExtension, params};
+use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
-#[cfg(feature = "rest")]
-use tower::ServiceExt;
 
 fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
@@ -84,7 +87,6 @@ impl Embedder for StaticEmbedder {
 
 struct SearchEnv {
     _tmp: TempDir,
-    config_path: PathBuf,
     db_path: PathBuf,
 }
 
@@ -95,29 +97,17 @@ impl SearchEnv {
         fs::create_dir_all(&mempal_home).expect("create mempal home");
         let config_path = mempal_home.join("config.toml");
         let db_path = mempal_home.join("palace.db");
-        let config = search_config(&db_path, project_id, strict_project_isolation);
-        write_config_atomic(&config_path, &config);
+        write_config_atomic(
+            &config_path,
+            &search_config(&db_path, project_id, strict_project_isolation),
+        );
         Database::open(&db_path).expect("open db");
         ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
-        Self {
-            _tmp: tmp,
-            config_path,
-            db_path,
-        }
+        Self { _tmp: tmp, db_path }
     }
 
     fn server(&self) -> MempalMcpServer {
         MempalMcpServer::new_with_factory(
-            self.db_path.clone(),
-            Arc::new(StaticEmbedderFactory {
-                vector: vec![0.1, 0.2, 0.3],
-            }),
-        )
-    }
-
-    #[cfg(feature = "rest")]
-    fn api_state(&self) -> ApiState {
-        ApiState::new(
             self.db_path.clone(),
             Arc::new(StaticEmbedderFactory {
                 vector: vec![0.1, 0.2, 0.3],
@@ -157,20 +147,29 @@ strict_project_isolation = {}
     )
 }
 
-fn cli_config(db_path: &Path) -> String {
+fn cli_embed_config(db_path: &Path, base_url: &str) -> String {
     format!(
         r#"
 db_path = "{}"
 
-[embedder]
-backend = "api"
-base_url = "http://127.0.0.1:9/v1/"
-api_model = "test-model"
+[embed]
+backend = "openai_compat"
+base_url = "{}"
+api_model = "test-embed"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
 
 [search]
 strict_project_isolation = false
 "#,
-        db_path.display()
+        db_path.display(),
+        base_url,
+        base_url
     )
 }
 
@@ -178,18 +177,6 @@ fn write_config_atomic(path: &Path, contents: &str) {
     let tmp = path.with_extension("tmp");
     fs::write(&tmp, contents).expect("write temp config");
     fs::rename(&tmp, path).expect("rename config");
-}
-
-fn wait_for_config_version_change(previous: &str) -> String {
-    let deadline = Instant::now() + Duration::from_secs(3);
-    loop {
-        let current = ConfigHandle::version();
-        if current != previous {
-            return current;
-        }
-        assert!(Instant::now() < deadline, "config version did not change");
-        std::thread::sleep(Duration::from_millis(50));
-    }
 }
 
 fn column_names(conn: &Connection, table: &str) -> Vec<String> {
@@ -201,10 +188,10 @@ fn column_names(conn: &Connection, table: &str) -> Vec<String> {
         .expect("collect columns")
 }
 
-fn sqlite_master_sql(conn: &Connection, table: &str) -> Option<String> {
+fn sqlite_master_sql(conn: &Connection, object: &str) -> Option<String> {
     conn.query_row(
         "SELECT sql FROM sqlite_master WHERE type IN ('table', 'index') AND name = ?1",
-        [table],
+        [object],
         |row| row.get::<_, String>(0),
     )
     .optional()
@@ -218,6 +205,7 @@ fn insert_projected_drawer(
     wing: &str,
     room: Option<&str>,
     project_id: Option<&str>,
+    vector: &[f32],
 ) {
     let db = Database::open(db_path).expect("open db");
     db.insert_drawer(&Drawer {
@@ -232,8 +220,7 @@ fn insert_projected_drawer(
         importance: 0,
     })
     .expect("insert drawer");
-    db.insert_vector(id, &[0.1, 0.2, 0.3])
-        .expect("insert vector");
+    db.insert_vector(id, vector).expect("insert vector");
     db.conn()
         .execute(
             "UPDATE drawers SET project_id = ?2 WHERE id = ?1",
@@ -248,60 +235,25 @@ fn insert_projected_drawer(
         .expect("update vector project");
 }
 
-async fn search_response_json(server: &MempalMcpServer, query: &str) -> serde_json::Value {
-    search_response_json_with_request(
-        server,
-        SearchRequest {
-            query: query.to_string(),
-            wing: None,
-            room: None,
-            top_k: Some(10),
-            project_id: None,
-            include_global: None,
-            all_projects: None,
-            disable_progressive: None,
-        },
-    )
-    .await
-}
-
 async fn search_response_json_with_request(
     server: &MempalMcpServer,
     request: SearchRequest,
-) -> serde_json::Value {
+) -> Value {
     let response = server
         .mempal_search(Parameters(request))
         .await
         .expect("search should succeed")
         .0;
-    serde_json::to_value(response).expect("serialize search response")
-}
-
-#[cfg(feature = "rest")]
-async fn rest_json_response(
-    env: &SearchEnv,
-    request: Request<Body>,
-) -> (StatusCode, serde_json::Value) {
-    let response = api_router(env.api_state())
-        .oneshot(request)
-        .await
-        .expect("router request");
-    let status = response.status();
-    let body = to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("read body");
-    let json = serde_json::from_slice(&body).expect("parse json response");
-    (status, json)
+    serde_json::to_value(response).expect("serialize response")
 }
 
 fn install_cli_home(tmp: &TempDir) -> PathBuf {
     let home = tmp.path().join("home");
-    let mempal_home = home.join(".mempal");
-    fs::create_dir_all(&mempal_home).expect("create cli mempal home");
+    fs::create_dir_all(home.join(".mempal")).expect("create cli mempal home");
     home
 }
 
-fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
     Command::new(mempal_bin())
         .args(args)
         .env("HOME", home)
@@ -309,354 +261,423 @@ fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
         .expect("run mempal")
 }
 
-#[test]
-fn test_ext_v5_migration_adds_project_id_column() {
-    let tmp = TempDir::new().expect("tempdir");
-    let db_path = tmp.path().join("palace.db");
-    let db = Database::open(&db_path).expect("open db");
-
-    let version = read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 6);
-
-    let drawer_columns = column_names(db.conn(), "drawers");
-    assert!(
-        drawer_columns.iter().any(|name| name == "project_id"),
-        "drawers columns missing project_id: {drawer_columns:?}"
-    );
-    let triple_columns = column_names(db.conn(), "triples");
-    assert!(
-        triple_columns.iter().any(|name| name == "project_id"),
-        "triples columns missing project_id: {triple_columns:?}"
-    );
-
-    let index_sql =
-        sqlite_master_sql(db.conn(), "idx_drawers_project_id").expect("project index sql");
-    assert!(
-        index_sql.contains("project_id"),
-        "project_id index missing expected SQL: {index_sql}"
-    );
+fn run_mempal_in_dir(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .current_dir(cwd)
+        .output()
+        .expect("run mempal")
 }
 
-#[test]
-fn test_ext_v5_migration_idempotent() {
-    let tmp = TempDir::new().expect("tempdir");
-    let db_path = tmp.path().join("palace.db");
-    let db = Database::open(&db_path).expect("open db");
-
-    let before_drawers = column_names(db.conn(), "drawers");
-    let before_vectors = sqlite_master_sql(db.conn(), "drawer_vectors");
-
-    apply_fork_ext_migrations(db.conn()).expect("reapply once");
-    apply_fork_ext_migrations(db.conn()).expect("reapply twice");
-
-    let version = read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 6);
-    assert_eq!(before_drawers, column_names(db.conn(), "drawers"));
-    assert_eq!(
-        before_vectors,
-        sqlite_master_sql(db.conn(), "drawer_vectors")
-    );
+fn expected_project_id(path: &Path) -> String {
+    expected_project_id_for_path(path).expect("expected project id from path")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_search_excludes_other_projects_by_default() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(Some("proj-A"), false);
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-a",
-        "state lives in proj A",
-        "code",
-        Some("room-a"),
-        Some("proj-A"),
-    );
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-b",
-        "state lives in proj B",
-        "docs",
-        Some("room-b"),
-        Some("proj-B"),
-    );
-
-    let json = search_response_json(&env.server(), "state").await;
-    let results = json["results"].as_array().expect("results array");
-    let ids = results
-        .iter()
-        .map(|value| {
-            value["drawer_id"]
-                .as_str()
-                .expect("drawer_id string")
-                .to_string()
-        })
-        .collect::<Vec<_>>();
-
-    assert!(
-        ids.iter().any(|id| id == "drawer-a"),
-        "missing project-A hit: {ids:?}"
-    );
-    assert!(
-        ids.iter().all(|id| id != "drawer-b"),
-        "project-B hit leaked into scoped search: {ids:?}"
-    );
-    let source = results
-        .iter()
-        .find(|value| value["drawer_id"] == "drawer-a")
-        .and_then(|value| value["source"].as_str())
-        .expect("project result source");
-    assert_eq!(source, "project");
+fn expected_project_id_for_path(path: &Path) -> Option<String> {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_tunnel_resolver_bypasses_project_filter() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(Some("proj-A"), false);
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-a",
-        "anchor query text stays in project A",
-        "code",
-        Some("shared-room"),
-        Some("proj-A"),
-    );
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-b",
-        "cross project docs drawer",
-        "docs",
-        Some("shared-room"),
-        Some("proj-B"),
-    );
-
-    let json = search_response_json(&env.server(), "anchor").await;
-    let results = json["results"].as_array().expect("results array");
-    let ids = results
-        .iter()
-        .map(|value| {
-            value["drawer_id"]
-                .as_str()
-                .expect("drawer_id string")
-                .to_string()
-        })
-        .collect::<Vec<_>>();
-
-    assert!(
-        ids.iter().any(|id| id == "drawer-a"),
-        "missing anchor result: {ids:?}"
-    );
-    assert!(
-        ids.iter().any(|id| id == "drawer-b"),
-        "tunnel did not surface cross-project drawer: {ids:?}"
-    );
-    let tunnel_source = results
-        .iter()
-        .find(|value| value["drawer_id"] == "drawer-b")
-        .and_then(|value| value["source"].as_str())
-        .expect("tunnel result source");
-    assert_eq!(tunnel_source, "tunnel_cross_project");
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_strict_project_isolation_config_hot_reload() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(None, false);
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-a",
-        "reload query from project A",
-        "code",
-        Some("reload"),
-        Some("proj-A"),
-    );
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-global",
-        "reload query from global drawer",
-        "code",
-        Some("reload"),
-        None,
-    );
-
-    let before = search_response_json(&env.server(), "reload").await;
-    let before_ids = before["results"]
-        .as_array()
-        .expect("results array")
-        .iter()
-        .map(|value| value["drawer_id"].as_str().expect("drawer_id").to_string())
-        .collect::<Vec<_>>();
-    assert!(
-        before_ids.iter().any(|id| id == "drawer-a")
-            && before_ids.iter().any(|id| id == "drawer-global"),
-        "strict=false should see project + global drawers: {before_ids:?}"
-    );
-
-    let previous = ConfigHandle::version();
-    write_config_atomic(&env.config_path, &search_config(&env.db_path, None, true));
-    wait_for_config_version_change(&previous);
-
-    let after = search_response_json(&env.server(), "reload").await;
-    let after_ids = after["results"]
-        .as_array()
-        .expect("results array")
-        .iter()
-        .map(|value| value["drawer_id"].as_str().expect("drawer_id").to_string())
-        .collect::<Vec<_>>();
-    assert_eq!(after_ids, vec!["drawer-global".to_string()]);
-}
-
-#[cfg(feature = "rest")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_rest_search_uses_configured_project_scope() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(Some("proj-A"), false);
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-a",
-        "state lives in proj A",
-        "code",
-        Some("room-a"),
-        Some("proj-A"),
-    );
-    insert_projected_drawer(
-        &env.db_path,
-        "drawer-b",
-        "state lives in proj B",
-        "docs",
-        Some("room-b"),
-        Some("proj-B"),
-    );
-
-    let request = Request::builder()
-        .method("GET")
-        .uri("/api/search?q=state")
-        .body(Body::empty())
-        .expect("build search request");
-    let (status, json) = rest_json_response(&env, request).await;
-
-    assert_eq!(status, StatusCode::OK);
-    let results = json.as_array().expect("results array");
-    let ids = results
-        .iter()
-        .map(|value| value["drawer_id"].as_str().expect("drawer id").to_string())
-        .collect::<Vec<_>>();
-    assert!(
-        ids.iter().any(|id| id == "drawer-a"),
-        "missing proj-A hit: {ids:?}"
-    );
-    assert!(
-        ids.iter().all(|id| id != "drawer-b"),
-        "proj-B hit leaked through REST scope: {ids:?}"
-    );
-}
-
-#[cfg(feature = "rest")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_rest_ingest_uses_configured_project_scope() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(Some("proj-A"), false);
-
-    let request = Request::builder()
-        .method("POST")
-        .uri("/api/ingest")
-        .header("content-type", "application/json")
-        .body(Body::from(
-            serde_json::json!({
-                "content": "rest scoped insert",
-                "wing": "code",
-                "room": "api",
-            })
-            .to_string(),
-        ))
-        .expect("build ingest request");
-    let (status, json) = rest_json_response(&env, request).await;
-
-    assert_eq!(status, StatusCode::CREATED);
-    let drawer_id = json["drawer_id"]
-        .as_str()
-        .expect("drawer id in REST ingest response");
-    let db = Database::open(&env.db_path).expect("open db");
-    let stored_project = db
-        .drawer_project_id(drawer_id)
-        .expect("read drawer project id");
-    assert_eq!(stored_project.as_deref(), Some("proj-A"));
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_allows_same_content_in_different_projects() {
-    let _guard = config_guard().await;
-    let env = SearchEnv::new(Some("proj-A"), false);
-    let shared_content = "shared memory across repos";
-    let original_id = build_drawer_id("code", Some("shared"), shared_content);
-    insert_projected_drawer(
-        &env.db_path,
-        &original_id,
-        shared_content,
-        "code",
-        Some("shared"),
-        Some("proj-A"),
-    );
-
-    let response = env
-        .server()
-        .mempal_ingest(Parameters(IngestRequest {
-            content: shared_content.to_string(),
-            wing: "code".to_string(),
-            room: Some("shared".to_string()),
-            source: None,
-            project_id: Some("proj-B".to_string()),
-            dry_run: None,
-            importance: None,
-        }))
-        .await
-        .expect("cross-project ingest should succeed")
-        .0;
-
-    assert_ne!(
-        response.drawer_id, original_id,
-        "cross-project ingest must allocate a distinct drawer id"
-    );
-
-    let conn = Connection::open(&env.db_path).expect("open sqlite");
-    let rows = conn
-        .prepare(
-            r#"
-            SELECT project_id
-            FROM drawers
-            WHERE content = ?1 AND wing = 'code' AND room = 'shared' AND deleted_at IS NULL
-            ORDER BY project_id
-            "#,
-        )
-        .expect("prepare drawer query")
-        .query_map([shared_content], |row| row.get::<_, Option<String>>(0))
-        .expect("query drawers")
+fn drawer_project_ids(conn: &Connection, table: &str) -> Vec<Option<String>> {
+    let sql = format!("SELECT project_id FROM {table} ORDER BY id");
+    let mut stmt = conn.prepare(&sql).expect("prepare project id query");
+    stmt.query_map([], |row| row.get::<_, Option<String>>(0))
+        .expect("query project ids")
         .collect::<Result<Vec<_>, _>>()
-        .expect("collect drawers");
-    assert_eq!(
-        rows,
-        vec![Some("proj-A".to_string()), Some("proj-B".to_string())]
-    );
+        .expect("collect project ids")
+}
 
-    let proj_b_results = search_response_json_with_request(
-        &env.server(),
-        SearchRequest {
-            query: "shared memory".to_string(),
-            wing: None,
-            room: None,
-            top_k: Some(10),
-            project_id: Some("proj-B".to_string()),
-            include_global: None,
-            all_projects: None,
-            disable_progressive: None,
-        },
-    )
-    .await;
-    let ids = proj_b_results["results"]
+fn downgrade_to_v4(conn: &Connection, drop_vector_table: bool) {
+    conn.execute_batch("DROP INDEX IF EXISTS idx_drawers_project_id;")
+        .expect("drop project index");
+    if column_names(conn, "drawers")
+        .iter()
+        .any(|column| column == "project_id")
+    {
+        conn.execute_batch("ALTER TABLE drawers DROP COLUMN project_id;")
+            .expect("drop drawers project_id");
+    }
+    if column_names(conn, "triples")
+        .iter()
+        .any(|column| column == "project_id")
+    {
+        conn.execute_batch("ALTER TABLE triples DROP COLUMN project_id;")
+            .expect("drop triples project_id");
+    }
+
+    if drop_vector_table {
+        conn.execute_batch("DROP TABLE IF EXISTS drawer_vectors;")
+            .expect("drop drawer_vectors");
+    } else if sqlite_master_sql(conn, "drawer_vectors")
+        .as_deref()
+        .is_some_and(|sql| sql.contains("project_id"))
+    {
+        let snapshot = dump_vec0(conn).expect("dump vec0");
+        conn.execute_batch("DROP TABLE drawer_vectors;")
+            .expect("drop vec0 with project_id");
+        if !snapshot.is_empty() {
+            let dim = snapshot[0].dim;
+            conn.execute_batch(&format!(
+                "CREATE VIRTUAL TABLE drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]);"
+            ))
+            .expect("create legacy vec0");
+            for row in snapshot {
+                conn.execute(
+                    "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, ?2)",
+                    params![row.drawer_id, row.raw_blob],
+                )
+                .expect("restore legacy vec0 row");
+            }
+        }
+    }
+
+    set_fork_ext_version(conn, 4).expect("set fork_ext_version=4");
+}
+
+fn parse_search_ids(json: &Value) -> Vec<String> {
+    json["results"]
         .as_array()
         .expect("results array")
         .iter()
         .map(|value| value["drawer_id"].as_str().expect("drawer id").to_string())
-        .collect::<Vec<_>>();
-    assert_eq!(ids, vec![response.drawer_id]);
+        .collect()
+}
+
+fn parse_cli_search_ids(output: &Output) -> Vec<String> {
+    assert!(
+        output.status.success(),
+        "command failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse CLI search JSON");
+    json.as_array()
+        .expect("search array")
+        .iter()
+        .map(|value| value["drawer_id"].as_str().expect("drawer id").to_string())
+        .collect()
+}
+
+async fn call_mcp_search(client: &mut McpStdio, query: &str) -> Value {
+    let result = match tokio::time::timeout(
+        Duration::from_secs(5),
+        client.call(
+            "tools/call",
+            json!({
+                "name": "mempal_search",
+                "arguments": {
+                    "query": query,
+                    "top_k": 10
+                }
+            }),
+        ),
+    )
+    .await
+    {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => {
+            let stderr = client.stderr_lines().await.join("\n");
+            panic!("call mempal_search failed: {error}\nstderr:\n{stderr}");
+        }
+        Err(_) => {
+            let stderr = client.stderr_lines().await.join("\n");
+            panic!("call mempal_search timed out\nstderr:\n{stderr}");
+        }
+    };
+    result["structuredContent"].clone()
+}
+
+#[test]
+fn test_schema_fork_ext_v5_applies_project_id_column() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    insert_projected_drawer(
+        db.path(),
+        "legacy-drawer",
+        "legacy content",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    downgrade_to_v4(db.conn(), false);
+
+    assert_eq!(read_fork_ext_version(db.conn()).expect("read version"), 4);
+
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    assert_eq!(read_fork_ext_version(db.conn()).expect("read version"), 5);
+    assert!(
+        column_names(db.conn(), "drawers")
+            .iter()
+            .any(|name| name == "project_id")
+    );
+    assert!(
+        column_names(db.conn(), "triples")
+            .iter()
+            .any(|name| name == "project_id")
+    );
+    let vector_sql = sqlite_master_sql(db.conn(), "drawer_vectors").expect("drawer_vectors sql");
+    assert!(
+        vector_sql.contains("project_id"),
+        "drawer_vectors missing project_id: {vector_sql}"
+    );
+    let drawer_table_sql = sqlite_master_sql(db.conn(), "drawers").expect("drawers sql");
+    assert!(
+        drawer_table_sql.contains("project_id TEXT"),
+        "drawers project_id column missing: {drawer_table_sql}"
+    );
+    assert!(
+        !drawer_table_sql.contains("DEFAULT 'default'"),
+        "drawers project_id must stay nullable for historical rows: {drawer_table_sql}"
+    );
+    assert!(
+        sqlite_master_sql(db.conn(), "idx_drawers_project_id").is_some(),
+        "idx_drawers_project_id missing from sqlite_master"
+    );
+}
+
+#[test]
+fn test_migration_v4_to_v5_preserves_null_project_ids() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    insert_projected_drawer(
+        db.path(),
+        "legacy-a",
+        "legacy content a",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        db.path(),
+        "legacy-b",
+        "legacy content b",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    downgrade_to_v4(db.conn(), false);
+
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    assert_eq!(drawer_project_ids(db.conn(), "drawers"), vec![None, None]);
+    assert_eq!(
+        drawer_project_ids(db.conn(), "drawer_vectors"),
+        vec![None, None]
+    );
+}
+
+#[test]
+fn test_project_migrate_backfills_null_project_ids_after_v5_migration() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "legacy-a",
+        "legacy content a",
+        "code-memory",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "legacy-b",
+        "legacy content b",
+        "code-memory",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    downgrade_to_v4(db.conn(), false);
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    migrate_null_project_ids(&db_path, "proj-migrated", Some("code-memory"), |_| {})
+        .expect("project migrate after v5");
+
+    assert_eq!(
+        drawer_project_ids(db.conn(), "drawers"),
+        vec![
+            Some("proj-migrated".to_string()),
+            Some("proj-migrated".to_string())
+        ]
+    );
+    assert_eq!(
+        drawer_project_ids(db.conn(), "drawer_vectors"),
+        vec![
+            Some("proj-migrated".to_string()),
+            Some("proj-migrated".to_string())
+        ]
+    );
+}
+
+#[test]
+fn test_status_reports_null_project_backfill_pending_after_v5_migration() {
+    let _guard = home_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &search_config(&db_path, None, false),
+    );
+
+    let db = Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "legacy-status",
+        "legacy status content",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    downgrade_to_v4(db.conn(), false);
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    let output = run_mempal(&home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(
+        stdout.contains("null_project_backfill_pending: true"),
+        "missing pending flag in status output:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("null_project_backfill_count: 1"),
+        "missing pending count in status output:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_status_shows_project_breakdown() {
+    let _guard = home_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &search_config(&db_path, None, false),
+    );
+
+    Database::open(&db_path).expect("open db");
+    for index in 0..3 {
+        insert_projected_drawer(
+            &db_path,
+            &format!("proj-a-{index}"),
+            &format!("proj-A drawer {index}"),
+            "code",
+            Some("room"),
+            Some("proj-A"),
+            &[0.1, 0.2, 0.3],
+        );
+    }
+    for index in 0..2 {
+        insert_projected_drawer(
+            &db_path,
+            &format!("proj-b-{index}"),
+            &format!("proj-B drawer {index}"),
+            "code",
+            Some("room"),
+            Some("proj-B"),
+            &[0.1, 0.2, 0.3],
+        );
+    }
+    insert_projected_drawer(
+        &db_path,
+        "global-0",
+        "global drawer",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+
+    let output = run_mempal(&home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    let lines = stdout.lines().collect::<Vec<_>>();
+    let heading = lines
+        .iter()
+        .position(|line| *line == "drawers per project:")
+        .expect("project breakdown heading");
+    assert_eq!(lines.get(heading + 1), Some(&"proj-A=3"));
+    assert_eq!(lines.get(heading + 2), Some(&"proj-B=2"));
+    assert_eq!(lines.get(heading + 3), Some(&"NULL=1"));
+}
+
+#[test]
+fn test_status_escapes_project_id_with_control_chars() {
+    let _guard = home_guard();
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &search_config(&db_path, None, false),
+    );
+
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "newline-drawer",
+        "newline drawer",
+        "code",
+        Some("room"),
+        Some("safe-newline"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "ansi-drawer",
+        "ansi drawer",
+        "code",
+        Some("room"),
+        Some("safe-ansi"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let newline_project_id = "foo\nWarnings:\n[WARN] fake";
+    let ansi_project_id = "ansi\u{1b}[31mred";
+    let conn = Connection::open(&db_path).expect("open raw db connection");
+    conn.execute(
+        "UPDATE drawers SET project_id = ?1 WHERE id = 'newline-drawer'",
+        params![newline_project_id],
+    )
+    .expect("inject newline project id");
+    conn.execute(
+        "UPDATE drawers SET project_id = ?1 WHERE id = 'ansi-drawer'",
+        params![ansi_project_id],
+    )
+    .expect("inject ansi project id");
+
+    let output = run_mempal(&home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert!(
+        lines
+            .contains(&format!("{}=1", escape_project_id_for_display(newline_project_id)).as_str()),
+        "escaped newline project id missing from status output:\n{stdout}"
+    );
+    assert!(
+        lines.contains(&format!("{}=1", escape_project_id_for_display(ansi_project_id)).as_str()),
+        "escaped ansi project id missing from status output:\n{stdout}"
+    );
+    assert!(
+        !lines.contains(&"Warnings:"),
+        "status output rendered forged line from raw newline:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("\u{1b}[31m"),
+        "status output rendered raw ANSI escape:\n{stdout}"
+    );
 }
 
 #[test]
@@ -667,7 +688,7 @@ fn test_project_migrate_batched_does_not_block_ingest() {
     let db_path = home.join(".mempal").join("palace.db");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_config(&db_path),
+        &search_config(&db_path, None, false),
     );
     Database::open(&db_path).expect("open db");
 
@@ -680,6 +701,7 @@ fn test_project_migrate_batched_does_not_block_ingest() {
             "code-memory",
             Some("migration"),
             None,
+            &[0.1, 0.2, 0.3],
         );
     }
 
@@ -763,6 +785,7 @@ fn test_project_migrate_batched_does_not_block_ingest() {
         "writer saw errors: {:?}",
         errors.lock().expect("errors mutex poisoned")
     );
+
     let latencies = latencies.lock().expect("latencies mutex poisoned");
     assert!(!latencies.is_empty(), "writer never made progress");
     let mut millis = latencies
@@ -802,7 +825,7 @@ fn test_project_migrate_begin_immediate_fails_fast() {
     let db_path = home.join(".mempal").join("palace.db");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_config(&db_path),
+        &search_config(&db_path, None, false),
     );
     Database::open(&db_path).expect("open db");
     insert_projected_drawer(
@@ -812,6 +835,7 @@ fn test_project_migrate_begin_immediate_fails_fast() {
         "code-memory",
         Some("migration"),
         None,
+        &[0.1, 0.2, 0.3],
     );
 
     let (ready_tx, ready_rx) = mpsc::channel();
@@ -844,7 +868,7 @@ fn test_project_migrate_begin_immediate_fails_fast() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn mempal project migrate");
+        .expect("spawn project migrate");
     let stdout = child.stdout.take().expect("stdout pipe");
     let mut reader = BufReader::new(stdout);
 
@@ -880,5 +904,835 @@ fn test_project_migrate_begin_immediate_fails_fast() {
     assert!(
         lines.iter().any(|line| line.contains("batch busy")),
         "missing busy retry output: {lines:?}"
+    );
+}
+
+#[test]
+fn test_root_uri_project_id_decodes_percent_encoded_paths() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path_with_space = tmp.path().join("My Project");
+    let path_with_unicode = tmp.path().join("中文");
+    let path_with_newline = tmp.path().join("line\nbreak");
+    fs::create_dir_all(&path_with_space).expect("create spaced dir");
+    fs::create_dir_all(&path_with_unicode).expect("create unicode dir");
+    fs::create_dir_all(&path_with_newline).expect("create newline dir");
+
+    let spaced_uri = format!("file://{}", path_with_space.display()).replace(' ', "%20");
+    let unicode_uri = format!("file://{}", path_with_unicode.display());
+    let newline_uri = format!("file://{}", path_with_newline.display()).replace('\n', "%0A");
+
+    assert_eq!(
+        infer_project_id_from_root_uri(&spaced_uri).expect("infer from spaced uri"),
+        infer_project_id_from_path(&path_with_space).expect("infer from spaced path")
+    );
+    assert_eq!(
+        infer_project_id_from_root_uri(&unicode_uri).expect("infer from unicode uri"),
+        infer_project_id_from_path(&path_with_unicode).expect("infer from unicode path")
+    );
+    assert_eq!(
+        infer_project_id_from_root_uri(&newline_uri).expect("infer from newline uri"),
+        None
+    );
+}
+
+#[test]
+fn test_project_id_basename_matches_spec_example() {
+    assert_eq!(
+        infer_project_id_from_path(Path::new("/path/to/my-awesome-proj"))
+            .expect("infer project id"),
+        Some("my-awesome-proj".to_string())
+    );
+}
+
+#[test]
+fn test_project_id_inference_returns_none_for_root_path() {
+    assert_eq!(
+        infer_project_id_from_path(Path::new("/")).expect("infer project id"),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_infer_project_id_rejects_invalid_utf8_basename() {
+    let path = PathBuf::from(OsString::from_vec(b"/tmp/mempal-\xFF".to_vec()));
+    assert_eq!(
+        infer_project_id_from_path(&path).expect("invalid utf8 basename should not error"),
+        None
+    );
+}
+
+#[test]
+fn test_infer_project_id_trims_whitespace_and_rejects_empty() {
+    assert_eq!(
+        infer_project_id_from_path(Path::new("/path/to/foo bar/"))
+            .expect("infer project id with internal space"),
+        Some("foo bar".to_string())
+    );
+    assert_eq!(
+        infer_project_id_from_path(Path::new("/path/to/  /"))
+            .expect("blank basename should be rejected"),
+        None
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_infer_project_id_rejects_basename_with_slash_or_null() {
+    assert!(matches!(
+        validate_project_id("foo/bar"),
+        Err(ProjectError::Slash)
+    ));
+    assert!(matches!(
+        validate_project_id("foo\0bar"),
+        Err(ProjectError::ControlCharacter)
+    ));
+
+    let path = PathBuf::from(OsString::from_vec(b"/tmp/foo\0bar".to_vec()));
+    assert_eq!(
+        infer_project_id_from_path(&path).expect("nul basename should not error"),
+        None
+    );
+}
+
+#[test]
+fn test_validate_project_id_rejects_newline() {
+    assert!(matches!(
+        validate_project_id("foo\nbar"),
+        Err(ProjectError::ControlCharacter)
+    ));
+}
+
+#[test]
+fn test_validate_project_id_rejects_ansi_escape() {
+    assert!(matches!(
+        validate_project_id("foo\u{1b}[31mbar"),
+        Err(ProjectError::ControlCharacter)
+    ));
+}
+
+#[test]
+fn test_validate_project_id_rejects_cr_tab_and_other_controls() {
+    for candidate in [
+        "foo\rbar".to_string(),
+        "foo\tbar".to_string(),
+        format!("foo{}bar", '\u{7f}'),
+        format!("foo{}bar", '\u{85}'),
+    ] {
+        assert!(
+            matches!(
+                validate_project_id(&candidate),
+                Err(ProjectError::ControlCharacter)
+            ),
+            "expected control-character rejection for {candidate:?}"
+        );
+    }
+}
+
+#[test]
+fn test_validate_project_id_rejects_length_over_limit() {
+    let within_limit = "a".repeat(MAX_PROJECT_ID_BYTES);
+    assert_eq!(
+        validate_project_id(&within_limit).expect("length limit should be inclusive"),
+        within_limit
+    );
+
+    let over_limit = "a".repeat(MAX_PROJECT_ID_BYTES + 1);
+    assert!(matches!(
+        validate_project_id(&over_limit),
+        Err(ProjectError::TooLong {
+            max_bytes: MAX_PROJECT_ID_BYTES
+        })
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_excludes_other_project_vectors() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "state is scoped to project A",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "state is scoped to project B",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let json = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "state".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: Some("proj-A".to_string()),
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+    assert_eq!(parse_search_ids(&json), vec!["drawer-a".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_excludes_other_project_fts() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "fts query token",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "fts query token",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let db = Database::open(&env.db_path).expect("open db");
+    let mut stmt = db
+        .conn()
+        .prepare(&build_fts_runtime_sql())
+        .expect("prepare fts sql");
+    let ids = stmt
+        .query_map(
+            params![
+                "fts",
+                Option::<String>::None,
+                Option::<String>::None,
+                "project",
+                "proj-A",
+                10_i64
+            ],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("query fts")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect fts ids");
+
+    assert_eq!(ids, vec!["drawer-a".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_vec_search_excludes_other_project() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "vector query token",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "vector query token",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let query_json = serde_json::to_string(&vec![0.1_f32, 0.2, 0.3]).expect("serialize query");
+    let db = Database::open(&env.db_path).expect("open db");
+    let mut stmt = db
+        .conn()
+        .prepare(&build_vector_search_sql())
+        .expect("prepare vector sql");
+    let ids = stmt
+        .query_map(
+            params![
+                query_json,
+                10_i64,
+                "project",
+                "proj-A",
+                Option::<String>::None,
+                Option::<String>::None,
+                10_i64
+            ],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("query vector sql")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect vector ids");
+
+    assert_eq!(ids, vec!["drawer-a".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_default_project_matches_current_dir() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let project_dir = tmp.path().join("workspace").join("alpha");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    let expected = expected_project_id(&project_dir);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+    );
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-cwd",
+        "cwd scoped query",
+        "code",
+        Some("room"),
+        Some(&expected),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-other",
+        "cwd scoped query",
+        "code",
+        Some("room"),
+        Some("other-project"),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let output = run_mempal_in_dir(&home, &project_dir, &["search", "cwd", "--json"]);
+    assert_eq!(
+        parse_cli_search_ids(&output),
+        vec!["drawer-cwd".to_string()]
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_explicit_project_override_wins_over_default() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let project_dir = tmp.path().join("workspace").join("alpha");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    let expected = expected_project_id(&project_dir);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+    );
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-default",
+        "override query",
+        "code",
+        Some("room"),
+        Some(&expected),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-foo",
+        "override query",
+        "code",
+        Some("room"),
+        Some("foo"),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let output = run_mempal_in_dir(
+        &home,
+        &project_dir,
+        &["search", "override", "--project", "foo", "--json"],
+    );
+    assert_eq!(
+        parse_cli_search_ids(&output),
+        vec!["drawer-foo".to_string()]
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tunnel_resolver_bypasses_project_filter() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "anchor query text stays in project A",
+        "code",
+        Some("shared-room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "cross project docs drawer",
+        "docs",
+        Some("shared-room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let json = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "anchor".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+    let ids = parse_search_ids(&json);
+    assert!(ids.iter().any(|id| id == "drawer-a"));
+    assert!(ids.iter().any(|id| id == "drawer-b"));
+}
+
+#[test]
+fn test_tunnel_hint_records_target_project_id() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    insert_projected_drawer(
+        db.path(),
+        "drawer-a",
+        "anchor",
+        "code",
+        Some("shared-room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        db.path(),
+        "drawer-b",
+        "target",
+        "docs",
+        Some("shared-room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let tunnels = db
+        .tunnel_drawers_for_room("shared-room", "drawer-a", Some("proj-A"))
+        .expect("load tunnel drawers");
+    assert_eq!(tunnels.len(), 1);
+    assert_eq!(tunnels[0].target_project_id.as_deref(), Some("proj-B"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tunnel_resolved_drawer_marks_source_cross_project() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(Some("proj-A"), false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "anchor query text stays in project A",
+        "code",
+        Some("shared-room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "cross project docs drawer",
+        "docs",
+        Some("shared-room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let json = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "anchor".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+
+    let tunnel_source = json["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .find(|value| value["drawer_id"] == "drawer-b")
+        .and_then(|value| value["source"].as_str())
+        .expect("tunnel source");
+    assert_eq!(tunnel_source, "tunnel_cross_project");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stores_project_id_from_cwd() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let project_dir = tmp.path().join("workspace").join("beta");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    fs::write(project_dir.join("note.md"), "ingest stores cwd project id").expect("write note");
+    let expected = expected_project_id(&project_dir);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+    );
+
+    let output = run_mempal_in_dir(
+        &home,
+        &project_dir,
+        &[
+            "ingest",
+            project_dir.to_str().expect("project dir str"),
+            "--wing",
+            "code",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "ingest failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let db = Database::open(&db_path).expect("open db");
+    let stored = db
+        .conn()
+        .query_row(
+            "SELECT project_id FROM drawers ORDER BY rowid DESC LIMIT 1",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read stored project");
+    assert_eq!(stored.as_deref(), Some(expected.as_str()));
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_project_id_override_flag() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let project_dir = tmp.path().join("workspace").join("gamma");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    fs::write(
+        project_dir.join("note.md"),
+        "ingest stores explicit project id",
+    )
+    .expect("write note");
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+    );
+
+    let output = run_mempal_in_dir(
+        &home,
+        &project_dir,
+        &[
+            "ingest",
+            project_dir.to_str().expect("project dir str"),
+            "--wing",
+            "code",
+            "--project",
+            "foo",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "ingest failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let db = Database::open(&db_path).expect("open db");
+    let stored = db
+        .conn()
+        .query_row(
+            "SELECT project_id FROM drawers ORDER BY rowid DESC LIMIT 1",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read stored project");
+    assert_eq!(stored.as_deref(), Some("foo"));
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_search_threads_project_id_from_mcp_root() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let project_dir = tmp.path().join("workspace").join("mcp-root");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    let project_id = expected_project_id(&project_dir);
+
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-root",
+        "mcp scoped query",
+        "code",
+        Some("room"),
+        Some(&project_id),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-other",
+        "mcp scoped query",
+        "code",
+        Some("room"),
+        Some("other-project"),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let mut client = McpStdio::start(
+        &db_path,
+        std::collections::HashMap::from([(
+            "MEMPAL_TEST_EMBED_BASE_URL".to_string(),
+            format!("http://{addr}/v1"),
+        )]),
+    )
+    .await
+    .expect("start mcp stdio");
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        client.initialize_with_roots(&[&format!("file://{}", project_dir.display())]),
+    )
+    .await
+    .expect("initialize_with_roots timed out")
+    .expect("initialize with roots");
+
+    let structured = call_mcp_search(&mut client, "mcp").await;
+    assert_eq!(
+        parse_search_ids(&structured),
+        vec!["drawer-root".to_string()]
+    );
+
+    client.shutdown().await.expect("shutdown client");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_roots_list_changed_invalidates_cached_project_id() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    let project_a = tmp.path().join("workspace").join("project a");
+    let project_b = tmp.path().join("workspace").join("project-b");
+    fs::create_dir_all(&project_a).expect("create project a");
+    fs::create_dir_all(&project_b).expect("create project b");
+    let project_a_id = expected_project_id(&project_a);
+    let project_b_id = expected_project_id(&project_b);
+
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-project-a",
+        "root change query",
+        "code",
+        Some("room"),
+        Some(&project_a_id),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-project-b",
+        "root change query",
+        "code",
+        Some("room"),
+        Some(&project_b_id),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let mut client = McpStdio::start(
+        &db_path,
+        std::collections::HashMap::from([(
+            "MEMPAL_TEST_EMBED_BASE_URL".to_string(),
+            format!("http://{addr}/v1"),
+        )]),
+    )
+    .await
+    .expect("start mcp stdio");
+    let root_a_uri = format!("file://{}", project_a.display()).replace(' ', "%20");
+    let root_b_uri = format!("file://{}", project_b.display());
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        client.initialize_with_roots(&[&root_a_uri]),
+    )
+    .await
+    .expect("initialize_with_roots timed out")
+    .expect("initialize with roots");
+
+    let first = call_mcp_search(&mut client, "root change").await;
+    assert_eq!(
+        parse_search_ids(&first),
+        vec!["drawer-project-a".to_string()]
+    );
+
+    client.set_roots(&[&root_b_uri]);
+    client
+        .notify_roots_list_changed()
+        .await
+        .expect("notify roots changed");
+
+    let second = call_mcp_search(&mut client, "root change").await;
+    assert_eq!(
+        parse_search_ids(&second),
+        vec!["drawer-project-b".to_string()]
+    );
+
+    client.shutdown().await.expect("shutdown client");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_search_without_project_runs_unscoped_when_not_strict() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-null",
+        "rootless project query",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-other",
+        "rootless project query",
+        "code",
+        Some("room"),
+        Some("other-project"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-default",
+        "rootless project query",
+        "code",
+        Some("room"),
+        Some("default"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let structured = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "rootless".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+    let mut ids = parse_search_ids(&structured);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "drawer-default".to_string(),
+            "drawer-null".to_string(),
+            "drawer-other".to_string()
+        ]
+    );
+    assert!(
+        !structured
+            .get("system_warnings")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .any(|warning| warning["message"] == "no project scope resolved, isolation strict"),
+        "unexpected warnings: {structured}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_search_without_project_warns_and_returns_empty_when_strict() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, true);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-proj-a",
+        "strict rootless query",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-proj-b",
+        "strict rootless query",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let structured = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "strict".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+    assert_eq!(parse_search_ids(&structured), Vec::<String>::new());
+    let warning_messages = structured["system_warnings"]
+        .as_array()
+        .expect("system warnings array")
+        .iter()
+        .filter_map(|warning| warning["message"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        warning_messages.contains(&"no project scope resolved, isolation strict"),
+        "missing strict isolation warning: {structured}"
     );
 }


### PR DESCRIPTION
## Summary

Fork-ext scenario gap filling **PR5/10** — `p10-project-vector-isolation` (Stage 2 atomic, blocks PR7 novelty-filter).

Implements 16 TODO-mandated scenarios + 24 regression scenarios added across 5 review-fix rounds. Single atomic commit covering schema migration (`fork_ext_v4→v5`), hard-filter recall (vector + FTS), tunnel resolver exemption, CLI/MCP project threading, and project_id validation hardening.

### Scope (40 tests on `tests/project_vector_isolation.rs`)

**Schema + migration (fork_ext_v4→v5)**
- v5 adds `drawers.project_id` as NULLABLE (NULL preserved for historical rows, waits for `mempal project migrate --project <id>` backfill)
- `drawer_vectors.project_id` table recreated with NULL rows matching drawer rows
- Batched migration uses `BEGIN IMMEDIATE` + `LIMIT 1000` so concurrent ingest is not blocked (debate R7)
- `fork_ext_meta(key, value)` K-V axis independent from upstream `PRAGMA user_version`

**Recall filtering**
- FTS5 JOIN + sqlite-vec MATCH both filter on `drawers.project_id`
- `strict_project_isolation=true` + no resolved project → empty result + system_warning (never silent coerce to "default")
- `strict_project_isolation=false` + unresolved project → SearchQuery `project_id: None` branch, full-library recall

**Tunnel exemption (debate cross-spec b)**
- Tunnel rows store `target_project_id`
- Tunnel resolver bypasses project filter
- DTO flags `source: "tunnel_cross_project"` so agent knows hit bypasses isolation

**CLI + ingest + MCP**
- `infer_project_id_from_path()` returns **repo basename** (not hash — spec contract)
- MCP `rootUri` → percent-decoded path → basename → project_id
- `on_roots_list_changed()` invalidates cached `client_project_id`

**project_id validation hardening**
- Rejects empty, leading/trailing whitespace, `/`, NUL, and ALL `is_control()` chars (incl. ANSI escapes)
- 255-byte length bound
- `mempal status` renders project_ids via `char::escape_debug` (defense-in-depth)

**`mempal status` observability**
- `null_project_backfill_pending` counter
- `drawers per project:` breakdown (non-null alpha-sorted, NULL last)
- MCP system_warning when pending backfill exists

### Review history (5 rounds)

| Round | Verdict | Findings |
|-------|---------|----------|
| 1 (`66cf026`) | FAIL | 3: NULL-erasing migration, unencoded file:// URI, no roots/list_changed invalidation |
| 2 (`ddb41ea`) | FAIL | 2: MCP rootless → "default" coercion, blake3 hash vs basename spec |
| 3 (`355d96e`) | FAIL | 2: auto-infer bypasses validate_project_id, missing `drawers per project:` |
| 4 (`d6ba6e5`) | FAIL | 1: control-char terminal injection via project_id render |
| 5 (`b45013d`) | **PASS** | 0 (CLEAN) |

All 40 tests green + full `just test` suite green on final commit.

## Test plan

- [x] `cargo test --test project_vector_isolation` (40/40 pass)
- [x] `just fmt` clean
- [x] `just clippy` clean
- [x] `just test` full suite green
- [x] CSA tier-4-critical review PASS round 5 (session `01KPS2GEGPKX9M5MP3R4SCNM5X`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)