### PR TITLE
test(gating): close PR6 p9-judge-gating-local scenario gaps + legacy audit migration

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub config_hot_reload: ConfigHotReloadConfig,
     pub search: SearchConfig,
     pub hotpatch: HotpatchConfig,
+    #[serde(alias = "gating")]
     pub ingest_gating: IngestGatingConfig,
     pub hooks: HooksConfig,
     pub daemon: DaemonConfig,
@@ -88,6 +89,9 @@ impl Config {
         let mut config: Self = toml::from_str(contents)?;
         if root.get("embed").is_none() && root.get("embedder").is_none() {
             config.embed.backend = "model2vec".to_string();
+        }
+        if has_llm_judge_section(&root) {
+            eprintln!("warning: llm_judge tier ignored: external LLM API disabled by design");
         }
         config.validate()?;
         Ok(config)
@@ -316,6 +320,20 @@ impl Config {
                 level: "warn",
                 source: "privacy",
                 message: "hooks capture is enabled while privacy scrubbing is disabled; captured content may persist secrets. Set [privacy].enabled = true or disable [hooks].enabled.".to_string(),
+            });
+        }
+        if self.hooks.enabled && !self.ingest_gating.enabled {
+            warnings.push(RuntimeWarning {
+                level: "warn",
+                source: "gating",
+                message: "hooks capture is enabled while local gating is disabled; passive captures will bypass memory filtering.".to_string(),
+            });
+        }
+        if self.hooks.enabled && self.ingest_gating.fail_open_active() {
+            warnings.push(RuntimeWarning {
+                level: "warn",
+                source: "gating",
+                message: "hooks capture is enabled while tier-2 gating is fail-open on embedder errors; review warnings before trusting passive captures.".to_string(),
             });
         }
         warnings
@@ -710,6 +728,14 @@ pub struct IngestGatingConfig {
     pub novelty: NoveltyConfig,
 }
 
+impl IngestGatingConfig {
+    pub fn fail_open_active(&self) -> bool {
+        self.enabled
+            && self.embedding_classifier.enabled
+            && !self.embedding_classifier.prototypes.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(default)]
 pub struct GatingRuleConfig {
@@ -886,4 +912,11 @@ impl ConfigHandle {
 fn global_scrub_stats() -> &'static Mutex<ScrubStats> {
     static SCRUB_STATS: OnceLock<Mutex<ScrubStats>> = OnceLock::new();
     SCRUB_STATS.get_or_init(|| Mutex::new(ScrubStats::default()))
+}
+
+fn has_llm_judge_section(root: &toml::Value) -> bool {
+    ["ingest_gating", "gating"]
+        .into_iter()
+        .filter_map(|key| root.get(key))
+        .any(|section| section.get("llm_judge").is_some())
 }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1,8 +1,8 @@
 #[rustfmt::skip] #[path = "db_fork_ext.rs"] mod db_fork_ext;
 // harness-point: PR0 — re-export MigrationHook trait + hooked migration runner for tests
 pub use db_fork_ext::{
-    FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL, FORK_EXT_V3_SCHEMA_SQL,
-    MigrationHook, apply_fork_ext_migrations, apply_fork_ext_migrations_to,
+    CURRENT_FORK_EXT_VERSION, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
+    FORK_EXT_V3_SCHEMA_SQL, MigrationHook, apply_fork_ext_migrations, apply_fork_ext_migrations_to,
     apply_fork_ext_migrations_with_hook, read_fork_ext_version, set_fork_ext_version,
 };
 use std::fs;
@@ -22,6 +22,7 @@ use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
 const CURRENT_SCHEMA_VERSION: u32 = 4;
+const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 
 const V1_SCHEMA_SQL: &str = r#"
 PRAGMA foreign_keys = ON;
@@ -97,6 +98,12 @@ pub enum DbError {
 pub struct Database {
     conn: Connection,
     path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatingDropCounts {
+    pub total: Option<u64>,
+    pub by_reason: std::collections::BTreeMap<String, u64>,
 }
 
 #[derive(Clone, Copy)]
@@ -214,6 +221,7 @@ impl Database {
         let created_at = super::utils::current_timestamp()
             .parse::<i64>()
             .unwrap_or_default();
+        let retained_until = created_at + 7 * 24 * 60 * 60;
         let unique_nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_nanos())
@@ -223,19 +231,121 @@ impl Database {
             explain_json
         );
         let id = format!("gating_{}", blake3::hash(id_seed.as_bytes()).to_hex());
+        let audit_decision = if decision.is_rejected() {
+            "skip"
+        } else {
+            "keep"
+        };
+        let drawer_id = (!decision.is_rejected()).then_some(candidate_hash);
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> Result<(), DbError> {
+            self.conn.execute(
+                r#"
+                INSERT INTO gating_audit (
+                    id,
+                    candidate_hash,
+                    drawer_id,
+                    decision,
+                    tier,
+                    label,
+                    reason,
+                    score,
+                    explain_json,
+                    retained_until,
+                    created_at,
+                    project_id
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                "#,
+                params![
+                    id,
+                    candidate_hash,
+                    drawer_id,
+                    audit_decision,
+                    i64::from(decision.tier),
+                    decision.label.as_deref(),
+                    decision.gating_reason.as_deref(),
+                    decision.score,
+                    explain_json,
+                    retained_until,
+                    created_at,
+                    project_id,
+                ],
+            )?;
+            if let Some(reason) = decision.drop_reason() {
+                self.increment_meta_counter(GATING_DROP_TOTAL_KEY)?;
+                self.increment_meta_counter(&format!("gating.dropped.{reason}"))?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    pub fn gating_drop_counts(&self) -> Result<GatingDropCounts, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT key, value
+            FROM fork_ext_meta
+            WHERE key LIKE 'gating.dropped.%'
+            ORDER BY key
+            "#,
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                let key = row.get::<_, String>(0)?;
+                let value = row.get::<_, String>(1)?;
+                Ok((key, value))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let mut total = None;
+        let mut counts = std::collections::BTreeMap::new();
+        for (key, value) in rows {
+            let count = value.parse::<u64>().unwrap_or_default();
+            if key == GATING_DROP_TOTAL_KEY {
+                total = Some(count);
+                continue;
+            }
+            if count == 0 {
+                continue;
+            }
+            if let Some(reason) = key.strip_prefix("gating.dropped.by_reason.") {
+                *counts.entry(reason.to_string()).or_default() += count;
+                continue;
+            }
+
+            let Some(reason) = key.strip_prefix("gating.dropped.") else {
+                continue;
+            };
+            if reason == "total" || reason.starts_with("by_reason.") {
+                continue;
+            }
+            *counts.entry(reason.to_string()).or_default() += count;
+        }
+        Ok(GatingDropCounts {
+            total,
+            by_reason: counts,
+        })
+    }
+
+    fn increment_meta_counter(&self, key: &str) -> Result<(), DbError> {
         self.conn.execute(
             r#"
-            INSERT INTO gating_audit (id, candidate_hash, decision, explain_json, created_at, project_id)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO fork_ext_meta (key, value)
+            VALUES (?1, '1')
+            ON CONFLICT(key) DO UPDATE
+            SET value = CAST(CAST(COALESCE(fork_ext_meta.value, '0') AS INTEGER) + 1 AS TEXT)
             "#,
-            params![
-                id,
-                candidate_hash,
-                decision.decision,
-                explain_json,
-                created_at,
-                project_id,
-            ],
+            [key],
         )?;
         Ok(())
     }

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
+pub const CURRENT_FORK_EXT_VERSION: u32 = 7;
+
 pub const FORK_EXT_V1_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS pending_messages (
     id TEXT PRIMARY KEY,
@@ -54,8 +56,14 @@ pub const FORK_EXT_V3_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS gating_audit (
     id TEXT PRIMARY KEY,
     candidate_hash TEXT NOT NULL,
-    decision TEXT NOT NULL,
+    drawer_id TEXT,
+    decision TEXT NOT NULL CHECK(decision IN ('keep', 'skip')),
+    tier INTEGER NOT NULL,
+    label TEXT,
+    reason TEXT,
+    score REAL,
     explain_json TEXT NOT NULL,
+    retained_until INTEGER NOT NULL,
     created_at INTEGER NOT NULL
 );
 
@@ -95,6 +103,14 @@ AFTER UPDATE OF content ON drawers BEGIN
     INSERT INTO drawers_fts(rowid, content) VALUES (new.rowid, new.content);
 END;
 "#;
+
+const GATING_DROP_COUNTER_KEYS: &[&str] = &[
+    "gating.dropped.too_short",
+    "gating.dropped.boilerplate",
+    "gating.dropped.low_signal",
+    "gating.dropped.prototype_below_threshold",
+];
+const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 
 struct Migration {
     version: u32,
@@ -169,6 +185,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 6,
             up: apply_v6,
         },
+        Migration {
+            version: 7,
+            up: apply_v7,
+        },
     ]
 }
 
@@ -224,11 +244,195 @@ fn apply_v6(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+fn apply_v7(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_gating_audit_columns(conn)?;
+    backfill_gating_audit_from_explain_json(conn)?;
+    for key in GATING_DROP_COUNTER_KEYS {
+        conn.execute(
+            r#"
+            INSERT INTO fork_ext_meta (key, value)
+            VALUES (?1, '0')
+            ON CONFLICT(key) DO NOTHING
+            "#,
+            params![key],
+        )?;
+    }
+    conn.execute(
+        r#"
+        INSERT INTO fork_ext_meta (key, value)
+        VALUES (?1, '0')
+        ON CONFLICT(key) DO NOTHING
+        "#,
+        params![GATING_DROP_TOTAL_KEY],
+    )?;
+    backfill_gating_counter_metadata(conn)?;
+    Ok(())
+}
+
+fn ensure_gating_audit_columns(conn: &Connection) -> rusqlite::Result<()> {
+    if conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?
+        == 0
+    {
+        return Ok(());
+    }
+
+    ensure_nullable_column(conn, "gating_audit", "drawer_id", "TEXT")?;
+    ensure_default_column(conn, "gating_audit", "tier", "INTEGER", "0")?;
+    ensure_nullable_column(conn, "gating_audit", "label", "TEXT")?;
+    ensure_nullable_column(conn, "gating_audit", "reason", "TEXT")?;
+    ensure_nullable_column(conn, "gating_audit", "score", "REAL")?;
+    ensure_default_column(conn, "gating_audit", "retained_until", "INTEGER", "0")?;
+
+    conn.execute_batch(
+        r#"
+        UPDATE gating_audit
+        SET retained_until = created_at + 604800
+        WHERE retained_until IS NULL OR retained_until = 0;
+        "#,
+    )?;
+    Ok(())
+}
+
+fn backfill_gating_audit_from_explain_json(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        r#"
+        UPDATE gating_audit
+        SET
+            drawer_id = CASE
+                WHEN drawer_id IS NULL AND decision IN ('keep', 'accepted') THEN candidate_hash
+                ELSE drawer_id
+            END,
+            tier = CASE
+                WHEN (tier IS NULL OR tier = 0)
+                    AND json_type(explain_json, '$.tier') IN ('integer', 'real', 'text')
+                THEN CAST(json_extract(explain_json, '$.tier') AS INTEGER)
+                ELSE tier
+            END,
+            label = CASE
+                WHEN label IS NULL AND json_type(explain_json, '$.label') = 'text'
+                THEN json_extract(explain_json, '$.label')
+                ELSE label
+            END,
+            reason = CASE
+                WHEN reason IS NULL THEN COALESCE(
+                    CASE
+                        WHEN json_type(explain_json, '$.reason') = 'text'
+                        THEN json_extract(explain_json, '$.reason')
+                    END,
+                    CASE
+                        WHEN json_type(explain_json, '$.gating_reason') = 'text'
+                        THEN json_extract(explain_json, '$.gating_reason')
+                    END,
+                    reason
+                )
+                ELSE reason
+            END,
+            score = CASE
+                WHEN score IS NULL
+                    AND json_type(explain_json, '$.score') IN ('integer', 'real', 'text')
+                THEN CAST(json_extract(explain_json, '$.score') AS REAL)
+                ELSE score
+            END
+        WHERE explain_json IS NOT NULL
+            AND json_valid(explain_json) = 1
+            AND (
+                tier IS NULL
+                OR tier = 0
+                OR label IS NULL
+                OR reason IS NULL
+                OR score IS NULL
+                OR (drawer_id IS NULL AND decision IN ('keep', 'accepted'))
+            );
+
+        UPDATE gating_audit
+        SET decision = CASE
+            WHEN decision = 'accepted' THEN 'keep'
+            WHEN decision = 'rejected' THEN 'skip'
+            ELSE decision
+        END
+        WHERE decision IN ('accepted', 'rejected');
+        "#,
+    )
+}
+
+fn backfill_gating_counter_metadata(conn: &Connection) -> rusqlite::Result<()> {
+    let gating_audit_exists = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if gating_audit_exists == 0 {
+        return Ok(());
+    }
+
+    conn.execute(
+        r#"
+        INSERT INTO fork_ext_meta (key, value)
+        SELECT ?1, CAST(COUNT(*) AS TEXT)
+        FROM gating_audit
+        WHERE decision IN ('skip', 'skipped', 'rejected')
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+        params![GATING_DROP_TOTAL_KEY],
+    )?;
+    conn.execute(
+        "DELETE FROM fork_ext_meta WHERE key LIKE 'gating.dropped.by_reason.%'",
+        [],
+    )?;
+    conn.execute_batch(
+        r#"
+        INSERT INTO fork_ext_meta (key, value)
+        SELECT
+            'gating.dropped.by_reason.' || label,
+            CAST(COUNT(*) AS TEXT)
+        FROM gating_audit
+        WHERE decision IN ('skip', 'skipped', 'rejected')
+            AND label IS NOT NULL
+            AND label != ''
+        GROUP BY label
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+        "#,
+    )?;
+    Ok(())
+}
+
 fn ensure_project_column(conn: &Connection, table: &str, ty: &str) -> rusqlite::Result<()> {
     if table_has_column(conn, table, "project_id")? {
         return Ok(());
     }
     conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN project_id {ty};"))
+}
+
+fn ensure_nullable_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    ty: &str,
+) -> rusqlite::Result<()> {
+    if table_has_column(conn, table, column)? {
+        return Ok(());
+    }
+    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {ty};"))
+}
+
+fn ensure_default_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    ty: &str,
+    default: &str,
+) -> rusqlite::Result<()> {
+    if table_has_column(conn, table, column)? {
+        return Ok(());
+    }
+    conn.execute_batch(&format!(
+        "ALTER TABLE {table} ADD COLUMN {column} {ty} NOT NULL DEFAULT {default};"
+    ))
 }
 
 fn ensure_drawers_project_column(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -471,7 +471,10 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
 
     let candidate = build_gating_candidate(context.envelope, &record);
     let mut gating_decision = evaluate_tier1(&candidate, &context.daemon.config.ingest_gating);
-    if gating_decision.is_none() && !tier2_enabled(&context.daemon.config.ingest_gating) {
+    if gating_decision.is_none()
+        && context.daemon.config.ingest_gating.enabled
+        && !tier2_enabled(&context.daemon.config.ingest_gating)
+    {
         gating_decision = Some(GatingDecision::accepted(
             0,
             Some("tier2_disabled".to_string()),

--- a/src/ingest/gating.rs
+++ b/src/ingest/gating.rs
@@ -3,11 +3,15 @@ use std::sync::Arc;
 use crate::core::config::{
     Config, EmbeddingClassifierConfig, GatingRuleConfig, IngestGatingConfig,
 };
-use crate::embed::{EmbedError, Embedder, EmbedderFactory};
+use crate::embed::{EmbedError, Embedder, EmbedderFactory, build_backend_from_name};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::OnceCell;
+
+const MIN_SIGNAL_BYTES: usize = 12;
+const MAX_PROTOTYPE_COUNT: usize = 64;
+const MAX_PROTOTYPE_LEN_BYTES: usize = 256;
 
 #[derive(Debug, Clone)]
 pub struct IngestCandidate {
@@ -27,6 +31,8 @@ pub struct GatingDecision {
     pub decision: String,
     pub tier: u8,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub gating_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f32>,
@@ -39,16 +45,23 @@ impl GatingDecision {
         Self {
             decision: "accepted".to_string(),
             tier,
+            gating_reason: None,
             label: label.into(),
             score,
             matched_pattern: None,
         }
     }
 
-    pub fn rejected(tier: u8, matched_pattern: Option<String>, score: Option<f32>) -> Self {
+    pub fn rejected(
+        tier: u8,
+        gating_reason: impl Into<Option<String>>,
+        matched_pattern: Option<String>,
+        score: Option<f32>,
+    ) -> Self {
         Self {
             decision: "rejected".to_string(),
             tier,
+            gating_reason: gating_reason.into(),
             label: None,
             score,
             matched_pattern,
@@ -57,6 +70,14 @@ impl GatingDecision {
 
     pub fn is_rejected(&self) -> bool {
         self.decision == "rejected"
+    }
+
+    pub fn drop_reason(&self) -> Option<&str> {
+        if self.is_rejected() {
+            self.gating_reason.as_deref()
+        } else {
+            None
+        }
     }
 }
 
@@ -77,13 +98,30 @@ pub struct PrototypeClassifier {
     prototypes: Vec<EmbeddedPrototype>,
 }
 
+struct Prototypes;
+
 impl PrototypeClassifier {
     pub fn decide(&self, vector: &[f32], threshold: f32) -> GatingDecision {
         let (label, score) = self.classify(vector);
         if score >= threshold {
+            if let Some(label) = label
+                && prototype_reject_reason(label).is_some()
+            {
+                return GatingDecision::rejected(
+                    2,
+                    prototype_reject_reason(label),
+                    None,
+                    Some(score),
+                );
+            }
             GatingDecision::accepted(2, label.map(ToOwned::to_owned), Some(score))
         } else {
-            GatingDecision::rejected(2, None, Some(score))
+            GatingDecision::rejected(
+                2,
+                Some("prototype_below_threshold".to_string()),
+                None,
+                Some(score),
+            )
         }
     }
 
@@ -109,7 +147,17 @@ impl PrototypeClassifier {
 pub enum GatingInitError {
     #[error("failed to build gating embedder")]
     BuildEmbedder(#[source] EmbedError),
-    #[error("gating prototype init failed: label='{label}', reason='{source}'")]
+    #[error("gating prototype init failed: prototype_count={actual} exceeds limit {limit}")]
+    PrototypeCountLimit { actual: usize, limit: usize },
+    #[error(
+        "gating prototype init failed: label='{label}', length={actual_bytes} exceeds limit {limit_bytes}"
+    )]
+    PrototypeTooLong {
+        label: String,
+        actual_bytes: usize,
+        limit_bytes: usize,
+    },
+    #[error("gating prototype init failed: label='{label}', reason='embedder_error'")]
     PrototypeEmbed {
         label: String,
         #[source]
@@ -145,6 +193,12 @@ impl GatingRuntime {
         Ok(())
     }
 
+    pub async fn initialize_from_config(&self) -> Result<(), GatingInitError> {
+        let classifier = compile_classifier_from_config(&self.config).await?;
+        let _ = self.classifier.set(classifier);
+        Ok(())
+    }
+
     pub async fn classifier(&self) -> Result<Option<PrototypeClassifier>, GatingInitError> {
         let classifier = self
             .classifier
@@ -170,9 +224,41 @@ pub fn evaluate_tier1(
     gating: &IngestGatingConfig,
 ) -> Option<GatingDecision> {
     if !gating.enabled {
-        return Some(GatingDecision::accepted(
-            0,
-            Some("gating_disabled".to_string()),
+        return None;
+    }
+
+    if candidate.tool_name.as_deref() == Some("Read") {
+        return Some(GatingDecision::rejected(
+            1,
+            Some("read_tool".to_string()),
+            Some("Read".to_string()),
+            None,
+        ));
+    }
+
+    if is_too_short(candidate) {
+        return Some(GatingDecision::rejected(
+            1,
+            Some("too_short".to_string()),
+            None,
+            None,
+        ));
+    }
+
+    if is_boilerplate(candidate) {
+        return Some(GatingDecision::rejected(
+            1,
+            Some("boilerplate".to_string()),
+            None,
+            None,
+        ));
+    }
+
+    if is_low_signal(candidate) {
+        return Some(GatingDecision::rejected(
+            1,
+            Some("low_signal".to_string()),
+            None,
             None,
         ));
     }
@@ -183,6 +269,7 @@ pub fn evaluate_tier1(
             RuleAction::Reject => {
                 return Some(GatingDecision::rejected(
                     1,
+                    Some(matched_pattern.to_string()),
                     Some(matched_pattern.to_string()),
                     None,
                 ));
@@ -211,6 +298,22 @@ pub async fn compile_classifier_from_embedder<E: Embedder + ?Sized>(
     gating: &IngestGatingConfig,
 ) -> Result<Option<PrototypeClassifier>, GatingInitError> {
     compile_classifier(&gating.embedding_classifier, embedder).await
+}
+
+pub async fn compile_classifier_from_config(
+    config: &Config,
+) -> Result<Option<PrototypeClassifier>, GatingInitError> {
+    if !tier2_enabled(&config.ingest_gating) {
+        return Ok(None);
+    }
+    let embedder = build_backend_from_name(config, config.embed.backend.as_str())
+        .await
+        .map_err(GatingInitError::BuildEmbedder)?;
+    compile_classifier(
+        &config.ingest_gating.embedding_classifier,
+        embedder.as_ref(),
+    )
+    .await
 }
 
 pub async fn evaluate_tier2<E: Embedder + ?Sized>(
@@ -253,36 +356,63 @@ async fn compile_classifier<E: Embedder + ?Sized>(
     config: &EmbeddingClassifierConfig,
     embedder: &E,
 ) -> Result<Option<PrototypeClassifier>, GatingInitError> {
-    if !config.enabled || config.prototypes.is_empty() {
-        return Ok(None);
-    }
+    Prototypes::load(config, embedder).await
+}
 
-    let mut prototypes = Vec::with_capacity(config.prototypes.len());
-    for label in &config.prototypes {
-        let vectors = embedder.embed(&[label.as_str()]).await.map_err(|source| {
-            GatingInitError::PrototypeEmbed {
-                label: label.clone(),
-                source,
-            }
-        })?;
-        if let Some(vector) = vectors.into_iter().next() {
-            let actual = vector.len();
-            let expected = embedder.dimensions();
-            if actual != expected {
-                return Err(GatingInitError::PrototypeDimMismatch {
-                    label: label.clone(),
-                    expected,
-                    actual,
-                });
-            }
-            prototypes.push(EmbeddedPrototype {
-                label: label.clone(),
-                vector,
+impl Prototypes {
+    async fn load<E: Embedder + ?Sized>(
+        config: &EmbeddingClassifierConfig,
+        embedder: &E,
+    ) -> Result<Option<PrototypeClassifier>, GatingInitError> {
+        if !config.enabled || config.prototypes.is_empty() {
+            return Ok(None);
+        }
+
+        if config.prototypes.len() > MAX_PROTOTYPE_COUNT {
+            return Err(GatingInitError::PrototypeCountLimit {
+                actual: config.prototypes.len(),
+                limit: MAX_PROTOTYPE_COUNT,
             });
         }
-    }
 
-    Ok(Some(PrototypeClassifier { prototypes }))
+        let mut prototypes = Vec::with_capacity(config.prototypes.len());
+        for (index, raw_label) in config.prototypes.iter().enumerate() {
+            let label = prototype_display_label(index, raw_label);
+            let actual_bytes = raw_label.len();
+            if actual_bytes > MAX_PROTOTYPE_LEN_BYTES {
+                return Err(GatingInitError::PrototypeTooLong {
+                    label,
+                    actual_bytes,
+                    limit_bytes: MAX_PROTOTYPE_LEN_BYTES,
+                });
+            }
+
+            let vectors = embedder
+                .embed(&[raw_label.as_str()])
+                .await
+                .map_err(|source| GatingInitError::PrototypeEmbed {
+                    label: label.clone(),
+                    source,
+                })?;
+            if let Some(vector) = vectors.into_iter().next() {
+                let actual = vector.len();
+                let expected = embedder.dimensions();
+                if actual != expected {
+                    return Err(GatingInitError::PrototypeDimMismatch {
+                        label,
+                        expected,
+                        actual,
+                    });
+                }
+                prototypes.push(EmbeddedPrototype {
+                    label: raw_label.clone(),
+                    vector,
+                });
+            }
+        }
+
+        Ok(Some(PrototypeClassifier { prototypes }))
+    }
 }
 
 fn match_rule<'a>(candidate: &IngestCandidate, rule: &'a GatingRuleConfig) -> Option<&'a str> {
@@ -360,4 +490,68 @@ fn normalize_rule_action(action: &str) -> RuleAction {
         "accept" | "keep" => RuleAction::Accept,
         _ => RuleAction::Continue,
     }
+}
+
+fn is_too_short(candidate: &IngestCandidate) -> bool {
+    candidate.content.trim().len() < MIN_SIGNAL_BYTES
+}
+
+fn is_boilerplate(candidate: &IngestCandidate) -> bool {
+    let trimmed = candidate.content.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    lower.matches("successfully completed").count() >= 2
+}
+
+fn is_low_signal(candidate: &IngestCandidate) -> bool {
+    let trimmed = candidate.content.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    trimmed.chars().all(|ch| {
+        ch.is_ascii_hexdigit()
+            || matches!(
+                ch,
+                ':' | '-' | '+' | '.' | ',' | 'x' | 'X' | ' ' | '\n' | '\r' | '\t'
+            )
+    }) && trimmed.chars().any(|ch| ch.is_ascii_digit())
+}
+
+fn prototype_reject_reason(label: &str) -> Option<String> {
+    let normalized = normalize_prototype_label(label);
+    let noise_like = ["noise", "boilerplate", "low_signal", "drop", "ignore"];
+    noise_like
+        .iter()
+        .any(|needle| normalized.contains(needle))
+        .then(|| format!("prototype.{normalized}"))
+}
+
+fn normalize_prototype_label(label: &str) -> String {
+    let mut out = String::with_capacity(label.len());
+    let mut last_was_sep = false;
+    for ch in label.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_sep = false;
+        } else if !last_was_sep {
+            out.push('_');
+            last_was_sep = true;
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+fn prototype_display_label(index: usize, raw_label: &str) -> String {
+    let trimmed = raw_label.trim();
+    if !trimmed.is_empty()
+        && trimmed.len() <= 48
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        return trimmed.to_string();
+    }
+    format!("prototype#{}", index + 1)
 }

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -13,11 +13,13 @@ use rusqlite::OptionalExtension;
 
 use crate::core::{
     config::ConfigHandle,
+    config::IngestGatingConfig,
     db::Database,
     types::{Drawer, SourceType},
     utils::{build_drawer_id, current_timestamp, route_room_from_taxonomy},
 };
 use crate::embed::{EmbedError, Embedder};
+use crate::ingest::gating::{PrototypeClassifier, evaluate_tier1, evaluate_tier2};
 use thiserror::Error;
 
 use crate::ingest::{
@@ -46,6 +48,7 @@ pub struct IngestStats {
     pub files: usize,
     pub chunks: usize,
     pub skipped: usize,
+    pub dropped_by_gate: usize,
     /// Time waited acquiring the per-source ingest lock (P9-B). `None`
     /// when the lock was bypassed (e.g. dry-run) or when no wait was
     /// needed and the path took the fast exit before lock acquisition.
@@ -58,6 +61,8 @@ pub struct IngestOptions<'a> {
     pub source_root: Option<&'a Path>,
     pub dry_run: bool,
     pub project_id: Option<&'a str>,
+    pub gating: Option<&'a IngestGatingConfig>,
+    pub prototype_classifier: Option<&'a PrototypeClassifier>,
 }
 
 pub type Result<T> = std::result::Result<T, IngestError>;
@@ -143,6 +148,8 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
             source_root: path.parent(),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -245,6 +252,38 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             continue;
         }
 
+        if let Some(gating) = options.gating {
+            let candidate = gating::IngestCandidate {
+                content: chunk.to_string(),
+                tool_name: None,
+                exit_code: None,
+            };
+            let mut gating_decision = evaluate_tier1(&candidate, gating);
+            if gating_decision.is_none()
+                && let Some(classifier) = options.prototype_classifier
+            {
+                let tier2 = evaluate_tier2(
+                    &candidate,
+                    classifier,
+                    embedder,
+                    gating.embedding_classifier.threshold,
+                )
+                .await;
+                gating_decision = Some(tier2.decision);
+            }
+            if let Some(decision) = gating_decision.as_ref() {
+                db.record_gating_audit(&drawer_id, decision, options.project_id)
+                    .map_err(|source| IngestError::InsertDrawer {
+                        drawer_id: drawer_id.clone(),
+                        source,
+                    })?;
+                if decision.is_rejected() {
+                    stats.dropped_by_gate += 1;
+                    continue;
+                }
+            }
+        }
+
         pending.push((chunk_index, chunk, drawer_id));
     }
 
@@ -338,6 +377,8 @@ pub async fn ingest_dir<E: Embedder + ?Sized>(
             source_root: Some(dir),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -378,6 +419,7 @@ pub async fn ingest_dir_with_options<E: Embedder + ?Sized>(
                 stats.files += file_stats.files;
                 stats.chunks += file_stats.chunks;
                 stats.skipped += file_stats.skipped;
+                stats.dropped_by_gate += file_stats.dropped_by_gate;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use mempal::core::{
 };
 use mempal::embed::build_backend_from_name;
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
+use mempal::ingest::gating::compile_classifier_from_config;
 use mempal::ingest::{IngestOptions, IngestStats, ingest_dir_with_options};
 use mempal::mcp::MempalMcpServer;
 use mempal::search::search;
@@ -53,6 +54,15 @@ struct SearchCommandOptions<'a> {
     json: bool,
 }
 
+struct IngestCommandOptions<'a> {
+    dir: &'a Path,
+    wing: &'a str,
+    format: Option<String>,
+    project: Option<&'a str>,
+    no_gate: bool,
+    dry_run: bool,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     Init {
@@ -68,6 +78,8 @@ enum Commands {
         format: Option<String>,
         #[arg(long)]
         project: Option<String>,
+        #[arg(long, default_value_t = false)]
+        no_gate: bool,
         #[arg(long)]
         dry_run: bool,
     },
@@ -91,6 +103,10 @@ enum Commands {
     Project {
         #[command(subcommand)]
         command: ProjectCommands,
+    },
+    Gating {
+        #[command(subcommand)]
+        command: GatingCommands,
     },
     WakeUp {
         #[arg(long)]
@@ -244,6 +260,14 @@ enum TaxonomyCommands {
 }
 
 #[derive(Subcommand)]
+enum GatingCommands {
+    Stats {
+        #[arg(long)]
+        since: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum KgCommands {
     Add {
         subject: String,
@@ -353,7 +377,32 @@ fn run() -> Result<()> {
 
     ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
     let config = ConfigHandle::current();
-    let db = Database::open(&expand_home(&config.db_path)).context("failed to open database")?;
+    let db_path = expand_home(&config.db_path);
+    let db = match Database::open(&db_path) {
+        Ok(db) => db,
+        Err(_error)
+            if matches!(
+                &cli.command,
+                Commands::Gating {
+                    command: GatingCommands::Stats { .. }
+                }
+            ) && !config_path.exists() =>
+        {
+            eprintln!(
+                "warning: failed to open database {}; reporting empty gating stats",
+                db_path.display()
+            );
+            let since = match &cli.command {
+                Commands::Gating {
+                    command: GatingCommands::Stats { since },
+                } => since.as_deref(),
+                _ => None,
+            };
+            observability::print_empty_gating_stats(since);
+            return Ok(());
+        }
+        Err(error) => return Err(error).context("failed to open database"),
+    };
 
     match cli.command {
         Commands::Init { dir, dry_run } => init_command(&db, &dir, dry_run),
@@ -362,15 +411,19 @@ fn run() -> Result<()> {
             wing,
             format,
             project,
+            no_gate,
             dry_run,
         } => block_on_result(ingest_command(
             &db,
             config.as_ref(),
-            &dir,
-            &wing,
-            format,
-            project.as_deref(),
-            dry_run,
+            IngestCommandOptions {
+                dir: &dir,
+                wing: &wing,
+                format,
+                project: project.as_deref(),
+                no_gate,
+                dry_run,
+            },
         )),
         Commands::Search {
             query,
@@ -425,7 +478,8 @@ fn run() -> Result<()> {
         Commands::Tunnels => tunnels_command(&db),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::Serve { mcp } => block_on_result(serve_command(config.as_ref(), mcp)),
-        Commands::Status => status_command(&db),
+        Commands::Status => status_command(&db, config.as_ref()),
+        Commands::Gating { command } => gating_command(&db, config.as_ref(), command),
         Commands::Tail {
             limit,
             follow,
@@ -559,57 +613,72 @@ fn init_command(db: &Database, dir: &Path, dry_run: bool) -> Result<()> {
 async fn ingest_command(
     db: &Database,
     config: &Config,
-    dir: &Path,
-    wing: &str,
-    format: Option<String>,
-    project: Option<&str>,
-    dry_run: bool,
+    options: IngestCommandOptions<'_>,
 ) -> Result<()> {
-    if let Some(format) = format.as_deref()
+    if let Some(format) = options.format.as_deref()
         && format != "convos"
     {
         bail!("unsupported --format value: {format}");
     }
 
-    let project_id = resolve_project_id(project, config, Some(dir))
+    let project_id = resolve_project_id(options.project, config, Some(options.dir))
         .context("failed to resolve ingest project id")?;
-    let stats = if dry_run {
+    let stats = if options.dry_run {
         ingest_dir_with_options(
             db,
             &NoopEmbedder,
-            dir,
-            wing,
+            options.dir,
+            options.wing,
             IngestOptions {
                 room: None,
-                source_root: Some(dir),
+                source_root: Some(options.dir),
                 dry_run: true,
                 project_id: project_id.as_deref(),
+                gating: None,
+                prototype_classifier: None,
             },
         )
         .await?
     } else {
+        let prototype_classifier = if config.ingest_gating.enabled && !options.no_gate {
+            compile_classifier_from_config(config)
+                .await
+                .map_err(|error| anyhow::anyhow!(error.to_string()))
+                .context("gating prototypes unavailable")?
+        } else {
+            None
+        };
         let embedder = build_embedder(config).await?;
         ingest_dir_with_options(
             db,
             &*embedder,
-            dir,
-            wing,
+            options.dir,
+            options.wing,
             IngestOptions {
                 room: None,
-                source_root: Some(dir),
+                source_root: Some(options.dir),
                 dry_run: false,
                 project_id: project_id.as_deref(),
+                gating: (!options.no_gate).then_some(&config.ingest_gating),
+                prototype_classifier: prototype_classifier.as_ref(),
             },
         )
         .await?
     };
 
-    append_ingest_audit_log(db, dir, wing, format.as_deref(), dry_run, stats)
-        .context("failed to append ingest audit log")?;
+    append_ingest_audit_log(
+        db,
+        options.dir,
+        options.wing,
+        options.format.as_deref(),
+        options.dry_run,
+        stats,
+    )
+    .context("failed to append ingest audit log")?;
 
     println!(
-        "dry_run={} files={} chunks={} skipped={}",
-        dry_run, stats.files, stats.chunks, stats.skipped
+        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={}",
+        options.dry_run, stats.files, stats.chunks, stats.skipped, stats.dropped_by_gate
     );
 
     Ok(())
@@ -664,6 +733,7 @@ fn append_ingest_audit_log(
         "files": stats.files,
         "chunks": stats.chunks,
         "skipped": stats.skipped,
+        "dropped_by_gate": stats.dropped_by_gate,
     });
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
@@ -1285,7 +1355,7 @@ fn fact_check_command(
     Ok(())
 }
 
-fn status_command(db: &Database) -> Result<()> {
+fn status_command(db: &Database, config: &Config) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
     let scrub_stats = ConfigHandle::scrub_stats();
     let runtime_warnings = ConfigHandle::collect_runtime_warnings();
@@ -1315,6 +1385,11 @@ fn status_command(db: &Database) -> Result<()> {
         .null_project_backfill_pending_count()
         .context("failed to count pending project backfill drawers")?;
     let taxonomy_count = db.taxonomy_count().context("failed to count taxonomy")?;
+    let gating_drop_counts = db
+        .gating_drop_counts()
+        .context("failed to read gating counters")?;
+    let gating_stats =
+        observability::gating_stats(db, config, None).context("failed to read gating stats")?;
     let db_size_bytes = db
         .database_size_bytes()
         .context("failed to compute database size")?;
@@ -1418,6 +1493,28 @@ fn status_command(db: &Database) -> Result<()> {
             .join(", ");
         println!("  redactions_per_pattern: {per_pattern}");
     }
+    println!("Gating:");
+    println!("  kept: {}", gating_stats.kept);
+    println!("  skipped: {}", gating_stats.skipped);
+    println!("  tier1_kept: {}", gating_stats.tier1_kept);
+    println!("  tier1_skipped: {}", gating_stats.tier1_skipped);
+    println!("  tier2_kept: {}", gating_stats.tier2_kept);
+    println!("  tier2_skipped: {}", gating_stats.tier2_skipped);
+    println!("  unclassified: {}", gating_stats.unclassified);
+    let nonzero_gating_counts = gating_drop_counts
+        .by_reason
+        .iter()
+        .filter_map(|(reason, count)| (*count > 0).then_some(format!("{reason}={count}")))
+        .collect::<Vec<_>>();
+    let dropped_total = gating_drop_counts
+        .total
+        .unwrap_or_else(|| gating_drop_counts.by_reason.values().copied().sum::<u64>());
+    println!("  dropped_total: {dropped_total}");
+    if nonzero_gating_counts.is_empty() {
+        println!("  dropped_by_reason: none");
+    } else {
+        println!("  dropped_by_reason: {}", nonzero_gating_counts.join(", "));
+    }
     if !runtime_warnings.is_empty() {
         println!("Warnings:");
         for warning in runtime_warnings {
@@ -1442,6 +1539,18 @@ fn status_command(db: &Database) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn gating_command(db: &Database, config: &Config, command: GatingCommands) -> Result<()> {
+    match command {
+        GatingCommands::Stats { since } => observability::gating_stats_command(
+            db,
+            config,
+            observability::GatingStatsOptions {
+                since: since.as_deref(),
+            },
+        ),
+    }
 }
 
 fn read_daemon_pid(db_path: &Path) -> Result<Option<i32>> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -84,7 +84,7 @@ impl MempalMcpServer {
         self,
     ) -> anyhow::Result<rmcp::service::RunningService<rmcp::RoleServer, Self>> {
         self.gating_runtime
-            .initialize()
+            .initialize_from_config()
             .await
             .context("failed to initialize ingest gating")?;
         self.serve(rmcp::transport::stdio())
@@ -412,6 +412,7 @@ impl MempalMcpServer {
         if request.dry_run.unwrap_or(false) {
             return Ok(Json(IngestResponse {
                 drawer_id,
+                dropped: false,
                 gating_decision: None,
                 novelty_action: None,
                 near_drawer_id: None,
@@ -440,6 +441,7 @@ impl MempalMcpServer {
                 // TODO(spec ambiguity): rejected ingests have no persisted drawer.
                 // Return the candidate-derived drawer_id for audit correlation.
                 drawer_id,
+                dropped: true,
                 gating_decision,
                 novelty_action: None,
                 near_drawer_id: None,
@@ -500,7 +502,7 @@ impl MempalMcpServer {
                 gating_audit_recorded = true;
                 vector = tier2.vector;
                 gating_decision = Some(tier2.decision);
-            } else {
+            } else if config.ingest_gating.enabled {
                 gating_decision = Some(GatingDecision::accepted(
                     0,
                     Some("tier2_disabled".to_string()),
@@ -514,6 +516,7 @@ impl MempalMcpServer {
             drop(lock_guard);
             return Ok(Json(IngestResponse {
                 drawer_id,
+                dropped: true,
                 gating_decision,
                 novelty_action: None,
                 near_drawer_id: None,
@@ -713,6 +716,7 @@ impl MempalMcpServer {
 
         Ok(Json(IngestResponse {
             drawer_id: response_drawer_id,
+            dropped: false,
             gating_decision,
             novelty_action,
             near_drawer_id,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -157,6 +157,8 @@ pub struct DeleteResponse {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IngestResponse {
     pub drawer_id: String,
+    #[serde(default)]
+    pub dropped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gating_decision: Option<GatingDecision>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -41,6 +41,10 @@ pub struct AuditOptions<'a> {
     pub since: Option<&'a str>,
 }
 
+pub struct GatingStatsOptions<'a> {
+    pub since: Option<&'a str>,
+}
+
 #[derive(Clone)]
 struct DrawerRecord {
     rowid: i64,
@@ -59,6 +63,37 @@ struct AuditRecord {
     decision: String,
     created_at: i64,
     project_id: Option<String>,
+}
+
+struct GatingAuditDetail {
+    audit_id: String,
+    candidate_hash: String,
+    decision: String,
+    tier: u8,
+    label: Option<String>,
+    reason: Option<String>,
+    created_at: i64,
+    project_id: Option<String>,
+}
+
+struct GatingExplainFields {
+    tier: Option<u8>,
+    label: Option<String>,
+    reason: Option<String>,
+}
+
+#[derive(Default)]
+pub struct GatingStatsSummary {
+    pub total: usize,
+    pub kept: usize,
+    pub skipped: usize,
+    pub tier1_kept: usize,
+    pub tier1_skipped: usize,
+    pub tier2_kept: usize,
+    pub tier2_skipped: usize,
+    pub unclassified: usize,
+    pub kept_by_label: std::collections::BTreeMap<String, usize>,
+    pub skipped_by_reason: std::collections::BTreeMap<String, usize>,
 }
 
 pub fn tail_command(db: &Database, config: &Config, options: TailOptions<'_>) -> Result<()> {
@@ -293,6 +328,31 @@ pub fn audit_command(db: &Database, config: &Config, options: AuditOptions<'_>) 
     Ok(())
 }
 
+pub fn gating_stats(
+    db: &Database,
+    config: &Config,
+    since: Option<&str>,
+) -> Result<GatingStatsSummary> {
+    let scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(since)?;
+    let rows = load_gating_audit_details(db, &scope, since_cutoff)?;
+    Ok(summarize_gating_rows(&rows))
+}
+
+pub fn gating_stats_command(
+    db: &Database,
+    config: &Config,
+    options: GatingStatsOptions<'_>,
+) -> Result<()> {
+    let summary = gating_stats(db, config, options.since)?;
+    print_gating_stats(&summary, options.since);
+    Ok(())
+}
+
+pub fn print_empty_gating_stats(since: Option<&str>) {
+    print_gating_stats(&GatingStatsSummary::default(), since);
+}
+
 fn follow_tail(
     db: &Database,
     scope: &ProjectSearchScope,
@@ -503,16 +563,20 @@ fn load_audit_records(
     scope: &ProjectSearchScope,
     since_cutoff: Option<i64>,
 ) -> Result<Vec<AuditRecord>> {
+    if kind == "gating" {
+        return Ok(load_gating_audit_details(db, scope, since_cutoff)?
+            .into_iter()
+            .map(|row| AuditRecord {
+                audit_id: row.audit_id,
+                candidate_hash: row.candidate_hash,
+                decision: row.decision,
+                created_at: row.created_at,
+                project_id: row.project_id,
+            })
+            .collect());
+    }
+
     let sql = match kind {
-        "gating" => {
-            r#"
-            SELECT a.id, a.candidate_hash, a.decision, a.created_at,
-                   COALESCE(a.project_id, d.project_id)
-            FROM gating_audit a
-            LEFT JOIN drawers d ON d.id = a.candidate_hash
-            ORDER BY a.created_at DESC, a.id DESC
-            "#
-        }
         "novelty" => {
             r#"
             SELECT a.id, a.candidate_hash, a.decision, a.created_at,
@@ -543,6 +607,224 @@ fn load_audit_records(
                 && since_cutoff.is_none_or(|cutoff| row.created_at >= cutoff)
         })
         .collect())
+}
+
+fn load_gating_audit_details(
+    db: &Database,
+    scope: &ProjectSearchScope,
+    since_cutoff: Option<i64>,
+) -> Result<Vec<GatingAuditDetail>> {
+    if db.conn().query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? == 0
+    {
+        return Ok(Vec::new());
+    }
+
+    let columns = table_columns(db, "gating_audit")?;
+    let project_expr = if columns.iter().any(|name| name == "project_id") {
+        "COALESCE(a.project_id, d.project_id)"
+    } else {
+        "d.project_id"
+    };
+    let modern = ["tier", "label", "reason", "drawer_id"]
+        .into_iter()
+        .all(|column| columns.iter().any(|name| name == column));
+
+    let rows = if modern {
+        let sql = format!(
+            r#"
+            SELECT a.id, a.candidate_hash, a.decision, a.tier, a.label, a.reason,
+                   a.explain_json, a.created_at, {project_expr}
+            FROM gating_audit a
+            LEFT JOIN drawers d ON d.id = COALESCE(a.drawer_id, a.candidate_hash)
+            ORDER BY a.created_at DESC, a.id DESC
+            "#
+        );
+        let mut stmt = db.conn().prepare(&sql)?;
+        stmt.query_map([], |row| {
+            let mut tier = row.get::<_, i64>(3)?.clamp(0, i64::from(u8::MAX)) as u8;
+            let mut label = row.get::<_, Option<String>>(4)?;
+            let mut reason = row.get::<_, Option<String>>(5)?;
+            let explain_json = row.get::<_, Option<String>>(6)?;
+            if tier == 0 && label.is_none() && reason.is_none() {
+                if let Some(parsed) = explain_json
+                    .as_deref()
+                    .and_then(parse_gating_explain_fields)
+                {
+                    tier = parsed.tier.unwrap_or(tier);
+                    label = parsed.label.or(label);
+                    reason = parsed.reason.or(reason);
+                }
+            }
+            Ok(GatingAuditDetail {
+                audit_id: row.get::<_, String>(0)?,
+                candidate_hash: row.get::<_, String>(1)?,
+                decision: canonical_gating_decision(row.get::<_, String>(2)?),
+                tier,
+                label,
+                reason,
+                created_at: row.get::<_, i64>(7)?,
+                project_id: row.get::<_, Option<String>>(8)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+    } else {
+        let sql = format!(
+            r#"
+            SELECT a.id, a.candidate_hash, a.decision, a.explain_json, a.created_at, {project_expr}
+            FROM gating_audit a
+            LEFT JOIN drawers d ON d.id = a.candidate_hash
+            ORDER BY a.created_at DESC, a.id DESC
+            "#
+        );
+        let mut stmt = db.conn().prepare(&sql)?;
+        stmt.query_map([], |row| {
+            let explain_json = row.get::<_, String>(3)?;
+            let parsed = parse_gating_explain_fields(&explain_json);
+            Ok(GatingAuditDetail {
+                audit_id: row.get::<_, String>(0)?,
+                candidate_hash: row.get::<_, String>(1)?,
+                decision: canonical_gating_decision(row.get::<_, String>(2)?),
+                tier: parsed
+                    .as_ref()
+                    .and_then(|value| value.tier)
+                    .unwrap_or_default(),
+                label: parsed.as_ref().and_then(|value| value.label.clone()),
+                reason: parsed.and_then(|value| value.reason),
+                created_at: row.get::<_, i64>(4)?,
+                project_id: row.get::<_, Option<String>>(5)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+    };
+
+    Ok(rows
+        .into_iter()
+        .filter(|row| {
+            scope.allows_row(row.project_id.as_deref())
+                && since_cutoff.is_none_or(|cutoff| row.created_at >= cutoff)
+        })
+        .collect())
+}
+
+fn parse_gating_explain_fields(raw: &str) -> Option<GatingExplainFields> {
+    let parsed = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    Some(GatingExplainFields {
+        tier: parsed
+            .get("tier")
+            .and_then(serde_json::Value::as_u64)
+            .map(|value| value.min(u64::from(u8::MAX)) as u8),
+        label: parsed
+            .get("label")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+        reason: parsed
+            .get("reason")
+            .or_else(|| parsed.get("gating_reason"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn summarize_gating_rows(rows: &[GatingAuditDetail]) -> GatingStatsSummary {
+    let mut summary = GatingStatsSummary {
+        total: rows.len(),
+        ..GatingStatsSummary::default()
+    };
+    for row in rows {
+        match (row.decision.as_str(), row.tier) {
+            ("keep", 1) => {
+                summary.kept += 1;
+                summary.tier1_kept += 1;
+            }
+            ("skip", 1) => {
+                summary.skipped += 1;
+                summary.tier1_skipped += 1;
+            }
+            ("keep", 2) => {
+                summary.kept += 1;
+                summary.tier2_kept += 1;
+            }
+            ("skip", 2) => {
+                summary.skipped += 1;
+                summary.tier2_skipped += 1;
+            }
+            ("keep", _) => {
+                summary.kept += 1;
+                summary.unclassified += 1;
+            }
+            ("skip", _) => {
+                summary.skipped += 1;
+                summary.unclassified += 1;
+            }
+            _ => {
+                summary.unclassified += 1;
+            }
+        }
+        if row.decision == "keep" {
+            let key = row.label.clone().unwrap_or_else(|| "unlabeled".to_string());
+            *summary.kept_by_label.entry(key).or_default() += 1;
+        } else if row.decision == "skip" {
+            let key = row.reason.clone().unwrap_or_else(|| "unknown".to_string());
+            *summary.skipped_by_reason.entry(key).or_default() += 1;
+        }
+    }
+    summary
+}
+
+fn render_breakdown(values: &std::collections::BTreeMap<String, usize>) -> String {
+    if values.is_empty() {
+        return "none".to_string();
+    }
+    values
+        .iter()
+        .map(|(key, count)| format!("{key}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn print_gating_stats(summary: &GatingStatsSummary, since: Option<&str>) {
+    println!("Gating stats:");
+    if let Some(since) = since {
+        println!("  window: last {since}");
+    } else {
+        println!("  window: all-time");
+        println!("  all_time_total: {}", summary.total);
+    }
+    println!("  kept: {}", summary.kept);
+    println!("  skipped: {}", summary.skipped);
+    println!("  tier1_kept: {}", summary.tier1_kept);
+    println!("  tier1_skipped: {}", summary.tier1_skipped);
+    println!("  tier2_kept: {}", summary.tier2_kept);
+    println!("  tier2_skipped: {}", summary.tier2_skipped);
+    println!("  unclassified: {}", summary.unclassified);
+    println!(
+        "  kept_by_label: {}",
+        render_breakdown(&summary.kept_by_label)
+    );
+    println!(
+        "  skipped_by_reason: {}",
+        render_breakdown(&summary.skipped_by_reason)
+    );
+}
+
+fn canonical_gating_decision(raw: String) -> String {
+    match raw.as_str() {
+        "accepted" => "keep".to_string(),
+        "rejected" => "skip".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn table_columns(db: &Database, table: &str) -> Result<Vec<String>> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = db.conn().prepare(&pragma)?;
+    Ok(stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?)
 }
 
 fn print_audit_section(kind: &str, rows: &[AuditRecord]) {

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -131,7 +131,7 @@ fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool, project_
     let decision = if accepted {
         GatingDecision::accepted(1, Some("keep".to_string()), Some(0.9))
     } else {
-        GatingDecision::rejected(1, Some("drop".to_string()), None)
+        GatingDecision::rejected(1, Some("drop".to_string()), None, None)
     };
     db.record_gating_audit(drawer_id, &decision, project_id)
         .expect("record gating audit");
@@ -660,5 +660,5 @@ fn test_mempal_stats_counts_project_scoped_audit_rows_without_drawer_rows() {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(stdout.contains("gating:"));
-    assert!(stdout.contains("  rejected: 1"));
+    assert!(stdout.contains("  skip: 1"));
 }

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -541,7 +541,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 6"),
+            .any(|line| line.trim() == "fork_ext_version: 7"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -570,6 +570,8 @@ async fn test_mixed_dim_batch_aborts_before_begin_immediate() {
             source_root: source.parent(),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -1,4 +1,6 @@
-use mempal::core::db::{Database, apply_fork_ext_migrations, read_fork_ext_version};
+use mempal::core::db::{
+    CURRENT_FORK_EXT_VERSION, Database, apply_fork_ext_migrations, read_fork_ext_version,
+};
 use rusqlite::Connection;
 use tempfile::TempDir;
 
@@ -26,12 +28,12 @@ fn current_schema_version() -> u32 {
 }
 
 #[test]
-fn test_fork_ext_version_is_six_after_audit_project_scope_phase() {
+fn test_fork_ext_version_is_current_after_audit_project_scope_phase() {
     let (_tmp, _db_path, db) = new_test_db();
 
     let version = read_fork_ext_version(db.conn()).expect("read fork-ext version");
 
-    assert_eq!(version, 6);
+    assert_eq!(version, CURRENT_FORK_EXT_VERSION);
 }
 
 #[test]
@@ -42,7 +44,7 @@ fn test_fork_ext_migrations_idempotent() {
     apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = read_fork_ext_version(db.conn()).expect("read fork-ext version");
-    assert_eq!(version, 6);
+    assert_eq!(version, CURRENT_FORK_EXT_VERSION);
 }
 
 #[test]

--- a/tests/fork_ext_v2_migration.rs
+++ b/tests/fork_ext_v2_migration.rs
@@ -1,4 +1,6 @@
-use mempal::core::db::{Database, apply_fork_ext_migrations, read_fork_ext_version};
+use mempal::core::db::{
+    CURRENT_FORK_EXT_VERSION, Database, apply_fork_ext_migrations, read_fork_ext_version,
+};
 use tempfile::TempDir;
 
 fn new_test_db() -> (TempDir, Database) {
@@ -13,7 +15,7 @@ fn test_fork_ext_v4_migration() {
     let (_tmp, db) = new_test_db();
 
     let version = read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 6);
+    assert_eq!(version, CURRENT_FORK_EXT_VERSION);
 
     let table_exists = db
         .conn()
@@ -54,5 +56,5 @@ fn test_fork_ext_v4_migration_is_idempotent() {
     apply_fork_ext_migrations(db.conn()).expect("second apply");
 
     let version = read_fork_ext_version(db.conn()).expect("read version");
-    assert_eq!(version, 6);
+    assert_eq!(version, CURRENT_FORK_EXT_VERSION);
 }

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -1,18 +1,44 @@
+mod common;
+
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
-use std::process::{Command, Stdio};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use mempal::core::config::{Config, ConfigHandle};
-use mempal::core::db::Database;
+use common::harness::AlwaysFailMigrationHook;
+use mempal::core::config::{Config, ConfigHandle, GatingRuleConfig};
+use mempal::core::db::{
+    Database, apply_fork_ext_migrations_to, apply_fork_ext_migrations_with_hook,
+    read_fork_ext_version, set_fork_ext_version,
+};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::ingest::gating::{
+    GatingRuntime, IngestCandidate, compile_classifier_from_config,
+    compile_classifier_from_embedder, evaluate_tier1, evaluate_tier2,
+};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use mockito::Server;
 use rmcp::handler::server::wrapper::Parameters;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+/*
+test_embedder_error_fail_open
+test_fork_ext_migration_v2_to_v3_creates_gating_audit
+test_gating_audit_records_decisions
+test_gating_disabled_short_circuits
+test_gating_preserves_vector_dim_consistency
+test_gating_stats_cli_output
+test_llm_judge_section_warns_and_ignores
+test_tier1_skips_read_tool
+test_tier1_skips_short_content
+test_tier2_keeps_above_threshold
+test_tier2_skips_below_threshold
+*/
 
 fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
@@ -27,17 +53,23 @@ async fn test_guard() -> OwnedMutexGuard<()> {
         .await
 }
 
+fn test_guard_blocking() -> OwnedMutexGuard<()> {
+    tokio::runtime::Runtime::new()
+        .expect("runtime")
+        .block_on(test_guard())
+}
+
 #[derive(Clone)]
 struct DeterministicEmbedderFactory {
     vectors: Arc<HashMap<String, Vec<f32>>>,
     default_vector: Vec<f32>,
-    embed_calls: Arc<Mutex<Vec<String>>>,
+    fail_on: Arc<Vec<String>>,
 }
 
 struct DeterministicEmbedder {
     vectors: Arc<HashMap<String, Vec<f32>>>,
     default_vector: Vec<f32>,
-    embed_calls: Arc<Mutex<Vec<String>>>,
+    fail_on: Arc<Vec<String>>,
 }
 
 #[async_trait]
@@ -46,7 +78,7 @@ impl EmbedderFactory for DeterministicEmbedderFactory {
         Ok(Box::new(DeterministicEmbedder {
             vectors: Arc::clone(&self.vectors),
             default_vector: self.default_vector.clone(),
-            embed_calls: Arc::clone(&self.embed_calls),
+            fail_on: Arc::clone(&self.fail_on),
         }))
     }
 }
@@ -54,11 +86,12 @@ impl EmbedderFactory for DeterministicEmbedderFactory {
 #[async_trait]
 impl Embedder for DeterministicEmbedder {
     async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
-        let mut calls = self.embed_calls.lock().expect("embed_calls mutex");
-        for text in texts {
-            calls.push((*text).to_string());
+        if let Some(text) = texts
+            .iter()
+            .find(|text| self.fail_on.iter().any(|candidate| candidate == *text))
+        {
+            return Err(EmbedError::Runtime(format!("forced failure for {text}")));
         }
-        drop(calls);
 
         Ok(texts
             .iter()
@@ -80,11 +113,26 @@ impl Embedder for DeterministicEmbedder {
     }
 }
 
-fn write_config(path: &Path, db_path: &Path, body: &str) {
-    fs::write(
-        path,
-        format!(
-            r#"
+struct TestEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    db_path: PathBuf,
+    config_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new(config_body: &str) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        let mempal_home = home.join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let config_path = mempal_home.join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
 db_path = "{}"
 
 [config_hot_reload]
@@ -92,302 +140,1336 @@ enabled = false
 
 {}
 "#,
-            db_path.display(),
-            body
+                db_path.display(),
+                config_body
+            ),
+        )
+        .expect("write config");
+        Self {
+            _tmp: tmp,
+            home,
+            db_path,
+            config_path,
+        }
+    }
+
+    fn config(&self) -> Config {
+        ConfigHandle::bootstrap(&self.config_path).expect("bootstrap config");
+        Config::load_from(&self.config_path).expect("load config")
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+}
+
+#[derive(Debug)]
+struct GatingAuditRow {
+    drawer_id: Option<String>,
+    decision: String,
+    tier: u8,
+    label: Option<String>,
+    reason: Option<String>,
+    score: Option<f32>,
+}
+
+struct GatingAuditSeed {
+    candidate_hash: String,
+    drawer_id: Option<String>,
+    decision: &'static str,
+    tier: u8,
+    label: Option<String>,
+    reason: Option<String>,
+    score: Option<f32>,
+    created_at: i64,
+}
+
+fn deterministic_factory(
+    vectors: &[(&str, Vec<f32>)],
+    default_vector: Vec<f32>,
+    fail_on: &[&str],
+) -> Arc<dyn EmbedderFactory> {
+    Arc::new(DeterministicEmbedderFactory {
+        vectors: Arc::new(
+            vectors
+                .iter()
+                .map(|(text, vector)| ((*text).to_string(), vector.clone()))
+                .collect(),
         ),
+        default_vector,
+        fail_on: Arc::new(fail_on.iter().map(|text| (*text).to_string()).collect()),
+    })
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
+    std::process::Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .current_dir(home)
+        .output()
+        .expect("run mempal")
+}
+
+async fn ingest_mcp(server: &MempalMcpServer, content: &str) -> mempal::mcp::IngestResponse {
+    server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: content.to_string(),
+            wing: "code-memory".to_string(),
+            room: Some("gating".to_string()),
+            source: None,
+            project_id: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("mcp ingest")
+        .0
+}
+
+fn gating_rows(db: &Database) -> Vec<GatingAuditRow> {
+    let mut stmt = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT candidate_hash, drawer_id, decision, tier, label, reason, score
+            FROM gating_audit
+            ORDER BY created_at ASC, id ASC
+            "#,
+        )
+        .expect("prepare gating rows");
+    stmt.query_map([], |row| {
+        Ok(GatingAuditRow {
+            drawer_id: row.get::<_, Option<String>>(1)?,
+            decision: row.get::<_, String>(2)?,
+            tier: row.get::<_, i64>(3)?.clamp(0, i64::from(u8::MAX)) as u8,
+            label: row.get::<_, Option<String>>(4)?,
+            reason: row.get::<_, Option<String>>(5)?,
+            score: row.get::<_, Option<f32>>(6)?,
+        })
+    })
+    .expect("query gating rows")
+    .collect::<Result<Vec<_>, _>>()
+    .expect("collect gating rows")
+}
+
+fn fork_ext_meta_value(db: &Database, key: &str) -> Option<String> {
+    db.conn()
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = ?1",
+            [key],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()
+}
+
+fn gating_row_count(db: &Database) -> i64 {
+    db.conn()
+        .query_row("SELECT COUNT(*) FROM gating_audit", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count gating rows")
+}
+
+fn gating_decision_counts(db: &Database) -> HashMap<String, i64> {
+    let mut stmt = db
+        .conn()
+        .prepare("SELECT decision, COUNT(*) FROM gating_audit GROUP BY decision")
+        .expect("prepare gating decision counts");
+    stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+    })
+    .expect("query decision counts")
+    .collect::<Result<HashMap<_, _>, _>>()
+    .expect("collect decision counts")
+}
+
+fn insert_gating_audit_row(db: &Database, seed: GatingAuditSeed) {
+    let explain_json = serde_json::json!({
+        "decision": if seed.decision == "keep" { "accepted" } else { "rejected" },
+        "tier": seed.tier,
+        "label": seed.label,
+        "gating_reason": seed.reason,
+        "score": seed.score,
+    })
+    .to_string();
+    let id = format!(
+        "seed-{}-{}-{}-{}",
+        seed.candidate_hash, seed.decision, seed.tier, seed.created_at
+    );
+    db.conn()
+        .execute(
+            r#"
+            INSERT INTO gating_audit (
+                id, candidate_hash, drawer_id, decision, tier, label, reason, score,
+                explain_json, retained_until, created_at, project_id
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, NULL)
+            "#,
+            rusqlite::params![
+                id,
+                seed.candidate_hash,
+                seed.drawer_id,
+                seed.decision,
+                i64::from(seed.tier),
+                seed.label,
+                seed.reason,
+                seed.score,
+                explain_json,
+                seed.created_at + 604800,
+                seed.created_at,
+            ],
+        )
+        .expect("insert gating audit row");
+}
+
+fn now_unix_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("unix time")
+        .as_secs() as i64
+}
+
+fn gating_columns(db: &Database) -> Vec<String> {
+    let mut stmt = db
+        .conn()
+        .prepare("PRAGMA table_info(gating_audit)")
+        .expect("prepare table info");
+    stmt.query_map([], |row| row.get::<_, String>(1))
+        .expect("query table info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table info")
+}
+
+fn prepare_v2_database() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    db.conn()
+        .execute_batch("DROP TABLE IF EXISTS gating_audit;")
+        .expect("drop gating_audit");
+    set_fork_ext_version(db.conn(), 2).expect("set fork_ext_version");
+    assert_eq!(
+        read_fork_ext_version(db.conn()).expect("read fork_ext_version"),
+        2
+    );
+    (tmp, db)
+}
+
+fn recreate_legacy_v6_gating_audit_table(db: &Database) {
+    db.conn()
+        .execute_batch(
+            r#"
+            DROP TABLE IF EXISTS gating_audit;
+            CREATE TABLE gating_audit (
+                id TEXT PRIMARY KEY,
+                candidate_hash TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                explain_json TEXT NOT NULL,
+                retained_until INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                project_id TEXT
+            );
+            CREATE INDEX idx_gating_audit_created_at
+                ON gating_audit(created_at);
+            CREATE INDEX idx_gating_audit_candidate_hash
+                ON gating_audit(candidate_hash);
+            "#,
+        )
+        .expect("recreate legacy gating_audit");
+    set_fork_ext_version(db.conn(), 6).expect("set fork_ext_version");
+}
+
+fn insert_legacy_gating_audit_row(
+    db: &Database,
+    id: &str,
+    candidate_hash: &str,
+    decision: &str,
+    explain_json: serde_json::Value,
+    created_at: i64,
+) {
+    db.conn()
+        .execute(
+            r#"
+            INSERT INTO gating_audit (
+                id, candidate_hash, decision, explain_json, retained_until, created_at, project_id
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)
+            "#,
+            rusqlite::params![
+                id,
+                candidate_hash,
+                decision,
+                explain_json.to_string(),
+                created_at + 604800,
+                created_at,
+            ],
+        )
+        .expect("insert legacy gating audit row");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_embedder_error_fail_open() {
+    let _guard = test_guard().await;
+    let config = Config::parse(
+        r#"
+[config_hot_reload]
+enabled = false
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable"]
+"#,
     )
-    .expect("write config");
-}
-
-fn drawer_count(db_path: &Path) -> i64 {
-    Database::open(db_path)
-        .expect("open db")
-        .drawer_count()
-        .expect("drawer count")
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_tier1_rule_reject_short_circuits_tier2() {
-    let _guard = test_guard().await;
-    let tmp = TempDir::new().expect("tempdir");
-    let mempal_home = tmp.path().join(".mempal");
-    fs::create_dir_all(&mempal_home).expect("create mempal home");
-    let db_path = mempal_home.join("palace.db");
-    Database::open(&db_path).expect("open db");
-
-    let config_path = mempal_home.join("config.toml");
-    write_config(
-        &config_path,
-        &db_path,
-        r#"
-[ingest_gating]
-enabled = true
-
-[[ingest_gating.rules]]
-action = "reject"
-content_bytes_lt = 12
-
-[ingest_gating.embedding_classifier]
-enabled = true
-threshold = 0.8
-prototypes = ["accept"]
-"#,
+    .expect("parse config");
+    let factory = deterministic_factory(
+        &[("valuable", vec![1.0, 0.0])],
+        vec![0.2, 0.2],
+        &["candidate triggers embedder failure"],
     );
-
-    let embed_calls = Arc::new(Mutex::new(Vec::new()));
-    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
-    let config = Config::load_from(&config_path).expect("load config");
-    let factory = Arc::new(DeterministicEmbedderFactory {
-        vectors: Arc::new(HashMap::from([("accept".to_string(), vec![1.0, 0.0])])),
-        default_vector: vec![0.0, 1.0],
-        embed_calls: Arc::clone(&embed_calls),
-    });
-    let server =
-        MempalMcpServer::new_with_factory_and_config(db_path.clone(), config.clone(), factory);
-
-    let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "tiny".to_string(),
-            wing: "code-memory".to_string(),
-            room: Some("gating".to_string()),
-            source: None,
-            project_id: None,
-            dry_run: Some(false),
-            importance: None,
-        }))
+    let embedder = factory.build().await.expect("build embedder");
+    let classifier = compile_classifier_from_embedder(embedder.as_ref(), &config.ingest_gating)
         .await
-        .expect("gating request should succeed")
-        .0;
+        .expect("compile classifier")
+        .expect("classifier");
+    let outcome = evaluate_tier2(
+        &IngestCandidate {
+            content: "candidate triggers embedder failure".to_string(),
+            tool_name: None,
+            exit_code: None,
+        },
+        &classifier,
+        embedder.as_ref(),
+        config.ingest_gating.embedding_classifier.threshold,
+    )
+    .await;
 
-    assert!(config.ingest_gating.enabled);
-    assert_eq!(drawer_count(&db_path), 0);
-    assert!(
-        embed_calls.lock().expect("embed_calls mutex").is_empty(),
-        "tier-1 reject must not touch prototype or candidate embedding"
-    );
-    let decision = response.gating_decision.expect("gating decision");
-    assert_eq!(decision.decision, "rejected");
-    assert_eq!(decision.tier, 1);
-    assert_eq!(
-        decision.matched_pattern.as_deref(),
-        Some("content_bytes_lt")
-    );
-    assert_eq!(decision.score, None);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_tier2_prototype_cosine_classifier() {
-    let _guard = test_guard().await;
-    let tmp = TempDir::new().expect("tempdir");
-    let mempal_home = tmp.path().join(".mempal");
-    fs::create_dir_all(&mempal_home).expect("create mempal home");
-    let db_path = mempal_home.join("palace.db");
-    Database::open(&db_path).expect("open db");
-
-    let config_path = mempal_home.join("config.toml");
-    write_config(
-        &config_path,
-        &db_path,
-        r#"
-[ingest_gating]
-enabled = true
-
-[ingest_gating.embedding_classifier]
-enabled = true
-threshold = 0.8
-prototypes = ["accept-prototype"]
-"#,
-    );
-
-    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
-    let config = Config::load_from(&config_path).expect("load config");
-    let factory = Arc::new(DeterministicEmbedderFactory {
-        vectors: Arc::new(HashMap::from([
-            ("accept-prototype".to_string(), vec![1.0, 0.0]),
-            ("candidate-keep".to_string(), vec![1.0, 0.0]),
-            ("candidate-drop".to_string(), vec![0.0, 1.0]),
-        ])),
-        default_vector: vec![0.0, 1.0],
-        embed_calls: Arc::new(Mutex::new(Vec::new())),
-    });
-    let server =
-        MempalMcpServer::new_with_factory_and_config(db_path.clone(), config.clone(), factory);
-
-    let accepted = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "candidate-keep".to_string(),
-            wing: "code-memory".to_string(),
-            room: Some("gating".to_string()),
-            source: None,
-            project_id: None,
-            dry_run: Some(false),
-            importance: None,
-        }))
-        .await
-        .expect("accepted request")
-        .0;
-    let rejected = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "candidate-drop".to_string(),
-            wing: "code-memory".to_string(),
-            room: Some("gating".to_string()),
-            source: None,
-            project_id: None,
-            dry_run: Some(false),
-            importance: None,
-        }))
-        .await
-        .expect("rejected request")
-        .0;
-
-    assert_eq!(config.ingest_gating.embedding_classifier.threshold, 0.8);
-    assert_eq!(
-        accepted
-            .gating_decision
-            .expect("accepted gating decision")
-            .decision,
-        "accepted"
-    );
-    let rejected_decision = rejected.gating_decision.expect("rejected gating decision");
-    assert_eq!(rejected_decision.decision, "rejected");
-    assert_eq!(rejected_decision.tier, 2);
-    assert!(rejected_decision.score.expect("tier-2 score") < 0.8);
+    assert_eq!(outcome.decision.decision, "accepted");
+    assert_eq!(outcome.decision.tier, 0);
+    assert_eq!(outcome.decision.label.as_deref(), Some("embedder_error"));
+    assert!(outcome.vector.is_none());
 }
 
 #[test]
-fn test_prototype_init_failure_fails_fast() {
-    let tmp = TempDir::new().expect("tempdir");
-    let mempal_home = tmp.path().join(".mempal");
-    fs::create_dir_all(&mempal_home).expect("create mempal home");
-    let db_path = mempal_home.join("palace.db");
-    Database::open(&db_path).expect("open db");
+fn test_fork_ext_migration_v2_to_v3_creates_gating_audit() {
+    let _guard = test_guard_blocking();
+    let (_tmp, db) = prepare_v2_database();
 
-    let mut server = Server::new();
-    let _mock = server
-        .mock("POST", "/v1/embeddings")
-        .with_status(500)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{"error":"prototype boom"}"#)
-        .create();
-
-    let config_path = mempal_home.join("config.toml");
-    write_config(
-        &config_path,
-        &db_path,
-        &format!(
-            r#"
-[embed]
-backend = "openai_compat"
-
-[embed.openai_compat]
-base_url = "{}/v1"
-model = "test-embed"
-dim = 3
-request_timeout_secs = 2
-
-[hooks]
-enabled = true
-daemon_poll_interval_ms = 100
-
-[daemon]
-log_path = "{}"
-
-[ingest_gating]
-enabled = true
-
-[ingest_gating.embedding_classifier]
-enabled = true
-threshold = 0.5
-prototypes = ["accept-prototype"]
-"#,
-            server.url(),
-            mempal_home.join("daemon.log").display()
-        ),
-    );
-
-    let output = Command::new(mempal_bin())
-        .args(["daemon", "--foreground"])
-        .env("HOME", tmp.path())
-        .stdin(Stdio::null())
-        .output()
-        .expect("run daemon");
+    apply_fork_ext_migrations_to(db.conn(), 3).expect("apply migrations to v3");
 
     assert!(
-        !output.status.success(),
-        "daemon startup must fail when prototype init fails"
+        db.conn()
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("load gating ddl")
+            .contains("gating_audit"),
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("gating prototype init failed"), "{stderr}");
-    assert!(stderr.contains("accept-prototype"), "{stderr}");
-    assert!(
-        !mempal_home.join("daemon.pid").exists(),
-        "pid file must not survive failed daemon startup"
+    assert_eq!(
+        read_fork_ext_version(db.conn()).expect("read fork_ext_version"),
+        3
+    );
+
+    let columns = gating_columns(&db);
+    for required in [
+        "id",
+        "candidate_hash",
+        "drawer_id",
+        "decision",
+        "tier",
+        "label",
+        "reason",
+        "created_at",
+        "retained_until",
+    ] {
+        assert!(
+            columns.iter().any(|column| column == required),
+            "missing column {required}: {columns:?}"
+        );
+    }
+}
+
+#[test]
+fn test_fork_ext_migration_v2_to_v3_rollback_via_migration_hook() {
+    let _guard = test_guard_blocking();
+    let (_tmp, db) = prepare_v2_database();
+
+    let error = apply_fork_ext_migrations_with_hook(db.conn(), Some(&AlwaysFailMigrationHook))
+        .expect_err("migration must roll back");
+    assert!(error.to_string().contains("simulated crash"), "{error}");
+    assert_eq!(
+        read_fork_ext_version(db.conn()).expect("read fork_ext_version"),
+        2
+    );
+    assert_eq!(
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("query sqlite_master"),
+        0
     );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_gating_decision_explain_field_structured() {
+async fn test_gating_audit_records_decisions() {
     let _guard = test_guard().await;
-    let tmp = TempDir::new().expect("tempdir");
-    let mempal_home = tmp.path().join(".mempal");
-    fs::create_dir_all(&mempal_home).expect("create mempal home");
-    let db_path = mempal_home.join("palace.db");
-    Database::open(&db_path).expect("open db");
-
-    let config_path = mempal_home.join("config.toml");
-    write_config(
-        &config_path,
-        &db_path,
+    let env = TestEnv::new(
         r#"
-[ingest_gating]
+[gating]
 enabled = true
 
-[[ingest_gating.rules]]
-action = "reject"
-content_bytes_lt = 32
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.6
+prototypes = ["valuable", "noise"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(
+            &[
+                ("valuable", vec![1.0, 0.0]),
+                ("noise", vec![0.0, 1.0]),
+                ("valuable candidate one", vec![0.95, 0.05]),
+                ("valuable candidate two", vec![0.9, 0.1]),
+                ("valuable candidate three", vec![0.85, 0.15]),
+                ("valuable candidate four", vec![0.8, 0.2]),
+                ("noise candidate one", vec![0.1, 0.9]),
+                ("noise candidate two", vec![0.05, 0.95]),
+            ],
+            vec![0.2, 0.2],
+            &[],
+        ),
+    );
 
-[ingest_gating.embedding_classifier]
+    for content in [
+        "valuable candidate one",
+        "valuable candidate two",
+        "valuable candidate three",
+        "valuable candidate four",
+        "noise candidate one",
+        "noise candidate two",
+        "tiny-01",
+        "tiny-02",
+        "tiny-03",
+        "tiny-04",
+    ] {
+        let _ = ingest_mcp(&server, content).await;
+    }
+
+    let counts = gating_decision_counts(&env.db());
+    assert_eq!(counts.get("keep"), Some(&4));
+    assert_eq!(counts.get("skip"), Some(&6));
+    assert_eq!(gating_row_count(&env.db()), 10);
+    let drop_counts = env.db().gating_drop_counts().expect("gating drop counts");
+    assert_eq!(drop_counts.total, Some(6));
+    assert_eq!(drop_counts.by_reason.get("too_short"), Some(&4));
+    assert_eq!(drop_counts.by_reason.get("prototype.noise"), Some(&2));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gating_disabled_short_circuits() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[gating]
+enabled = false
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(&[], vec![0.3, 0.3], &["valuable"]),
+    );
+
+    let response = ingest_mcp(&server, "content that bypasses gating entirely").await;
+
+    assert!(!response.dropped);
+    assert!(response.gating_decision.is_none());
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 1);
+    assert_eq!(gating_row_count(&env.db()), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gating_preserves_vector_dim_consistency() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
 enabled = true
 threshold = 0.5
-prototypes = ["accept-prototype"]
+prototypes = ["valuable"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(
+            &[
+                ("valuable", vec![1.0, 0.0, 0.0]),
+                ("vector dim stays consistent", vec![0.95, 0.05, 0.0]),
+            ],
+            vec![0.2, 0.2, 0.2],
+            &[],
+        ),
+    );
+
+    let response = ingest_mcp(&server, "vector dim stays consistent").await;
+    let rows = gating_rows(&env.db());
+
+    assert!(!response.dropped);
+    assert_eq!(env.db().embedding_dim().expect("embedding dim"), Some(3));
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].decision, "keep");
+    assert_eq!(rows[0].tier, 2);
+}
+
+#[test]
+fn test_gating_stats_cli_output() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+
+    for index in 0..4 {
+        insert_gating_audit_row(
+            &db,
+            GatingAuditSeed {
+                candidate_hash: format!("tier1-keep-{index}"),
+                drawer_id: Some(format!("tier1-keep-{index}")),
+                decision: "keep",
+                tier: 1,
+                label: Some("rule_accept".to_string()),
+                reason: None,
+                score: Some(0.91),
+                created_at: now,
+            },
+        );
+    }
+    for index in 0..6 {
+        insert_gating_audit_row(
+            &db,
+            GatingAuditSeed {
+                candidate_hash: format!("tier2-keep-{index}"),
+                drawer_id: Some(format!("tier2-keep-{index}")),
+                decision: "keep",
+                tier: 2,
+                label: Some("architectural-decision".to_string()),
+                reason: None,
+                score: Some(0.87),
+                created_at: now,
+            },
+        );
+    }
+    for index in 0..12 {
+        insert_gating_audit_row(
+            &db,
+            GatingAuditSeed {
+                candidate_hash: format!("tier1-skip-{index}"),
+                drawer_id: None,
+                decision: "skip",
+                tier: 1,
+                label: None,
+                reason: Some("too_short".to_string()),
+                score: None,
+                created_at: now,
+            },
+        );
+    }
+    for index in 0..8 {
+        insert_gating_audit_row(
+            &db,
+            GatingAuditSeed {
+                candidate_hash: format!("tier2-skip-{index}"),
+                drawer_id: None,
+                decision: "skip",
+                tier: 2,
+                label: None,
+                reason: Some("prototype.noise".to_string()),
+                score: Some(0.31),
+                created_at: now,
+            },
+        );
+    }
+    insert_gating_audit_row(
+        &db,
+        GatingAuditSeed {
+            candidate_hash: "old-window-row".to_string(),
+            drawer_id: Some("old-window-row".to_string()),
+            decision: "keep",
+            tier: 2,
+            label: Some("architectural-decision".to_string()),
+            reason: None,
+            score: Some(0.95),
+            created_at: now - 9 * 24 * 60 * 60,
+        },
+    );
+
+    let output = run_mempal(&env.home, &["gating", "stats", "--since", "7d"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.contains("kept: 10"), "{stdout}");
+    assert!(stdout.contains("skipped: 20"), "{stdout}");
+    assert!(stdout.contains("tier1_kept: 4"), "{stdout}");
+    assert!(stdout.contains("tier1_skipped: 12"), "{stdout}");
+    assert!(stdout.contains("tier2_kept: 6"), "{stdout}");
+    assert!(stdout.contains("tier2_skipped: 8"), "{stdout}");
+    assert!(stdout.contains("architectural-decision=6"), "{stdout}");
+    assert!(stdout.contains("prototype.noise=8"), "{stdout}");
+    assert!(!stdout.contains("kept: 11"), "{stdout}");
+}
+
+#[test]
+fn test_v7_migration_backfills_pre_v7_gating_audit_rows() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+    recreate_legacy_v6_gating_audit_table(&db);
+    insert_legacy_gating_audit_row(
+        &db,
+        "legacy-keep",
+        "legacy-keep",
+        "keep",
+        serde_json::json!({
+            "tier": 1,
+            "label": "read_tool",
+            "score": 0.0,
+        }),
+        now,
+    );
+    insert_legacy_gating_audit_row(
+        &db,
+        "legacy-skip",
+        "legacy-skip",
+        "skip",
+        serde_json::json!({
+            "tier": 1,
+            "label": "read_tool",
+            "reason": "skipped_low_signal",
+            "score": 0.0,
+        }),
+        now,
+    );
+
+    apply_fork_ext_migrations_to(db.conn(), 7).expect("apply migrations to v7");
+
+    let mut stmt = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT id, drawer_id, tier, label, reason, score
+            FROM gating_audit
+            ORDER BY id ASC
+            "#,
+        )
+        .expect("prepare migrated gating rows");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<f64>>(5)?,
+            ))
+        })
+        .expect("query migrated gating rows")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect migrated gating rows");
+
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "legacy-keep".to_string(),
+                Some("legacy-keep".to_string()),
+                1,
+                Some("read_tool".to_string()),
+                None,
+                Some(0.0),
+            ),
+            (
+                "legacy-skip".to_string(),
+                None,
+                1,
+                Some("read_tool".to_string()),
+                Some("skipped_low_signal".to_string()),
+                Some(0.0),
+            ),
+        ]
+    );
+
+    let output = run_mempal(&env.home, &["gating", "stats", "--since", "7d"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.contains("kept: 1"), "{stdout}");
+    assert!(stdout.contains("skipped: 1"), "{stdout}");
+    assert!(stdout.contains("tier1_kept: 1"), "{stdout}");
+    assert!(stdout.contains("tier1_skipped: 1"), "{stdout}");
+    assert!(stdout.contains("unclassified: 0"), "{stdout}");
+    assert!(stdout.contains("read_tool=1"), "{stdout}");
+    assert!(stdout.contains("skipped_low_signal=1"), "{stdout}");
+    assert!(!stdout.contains("unknown=1"), "{stdout}");
+    assert!(!stdout.contains("unlabeled=1"), "{stdout}");
+}
+
+#[test]
+fn test_v7_migration_backfills_legacy_accepted_rejected_decisions() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+    recreate_legacy_v6_gating_audit_table(&db);
+    insert_legacy_gating_audit_row(
+        &db,
+        "legacy-accepted",
+        "abc123",
+        "accepted",
+        serde_json::json!({
+            "tier": 1,
+            "label": "read_tool",
+            "reason": "rule_accept",
+        }),
+        now,
+    );
+    insert_legacy_gating_audit_row(
+        &db,
+        "legacy-rejected",
+        "def456",
+        "rejected",
+        serde_json::json!({
+            "tier": 1,
+            "label": "short_content",
+            "reason": "rule_reject",
+        }),
+        now,
+    );
+
+    apply_fork_ext_migrations_to(db.conn(), 7).expect("apply migrations to v7");
+
+    let mut stmt = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT id, decision, drawer_id, tier, label, reason
+            FROM gating_audit
+            ORDER BY id ASC
+            "#,
+        )
+        .expect("prepare migrated legacy decisions");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })
+        .expect("query migrated legacy decisions")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect migrated legacy decisions");
+
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "legacy-accepted".to_string(),
+                "keep".to_string(),
+                Some("abc123".to_string()),
+                1,
+                Some("read_tool".to_string()),
+                Some("rule_accept".to_string()),
+            ),
+            (
+                "legacy-rejected".to_string(),
+                "skip".to_string(),
+                None,
+                1,
+                Some("short_content".to_string()),
+                Some("rule_reject".to_string()),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn test_v7_migration_backfills_dropped_counters_from_legacy_audit() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+    recreate_legacy_v6_gating_audit_table(&db);
+
+    for index in 0..3 {
+        insert_legacy_gating_audit_row(
+            &db,
+            &format!("rejected-short-{index}"),
+            &format!("rejected-short-{index}"),
+            "rejected",
+            serde_json::json!({
+                "tier": 1,
+                "label": "short_content",
+                "reason": "rule_reject",
+            }),
+            now,
+        );
+    }
+    for index in 0..2 {
+        insert_legacy_gating_audit_row(
+            &db,
+            &format!("rejected-read-{index}"),
+            &format!("rejected-read-{index}"),
+            "rejected",
+            serde_json::json!({
+                "tier": 1,
+                "label": "read_tool",
+                "reason": "rule_reject",
+            }),
+            now,
+        );
+    }
+    for index in 0..5 {
+        insert_legacy_gating_audit_row(
+            &db,
+            &format!("accepted-{index}"),
+            &format!("accepted-{index}"),
+            "accepted",
+            serde_json::json!({
+                "tier": 1,
+                "label": "read_tool",
+                "reason": "rule_accept",
+            }),
+            now,
+        );
+    }
+
+    apply_fork_ext_migrations_to(db.conn(), 7).expect("apply migrations to v7");
+
+    assert_eq!(
+        fork_ext_meta_value(&db, "gating.dropped.total"),
+        Some("5".to_string())
+    );
+    assert_eq!(
+        fork_ext_meta_value(&db, "gating.dropped.by_reason.short_content"),
+        Some("3".to_string())
+    );
+    assert_eq!(
+        fork_ext_meta_value(&db, "gating.dropped.by_reason.read_tool"),
+        Some("2".to_string())
+    );
+
+    let output = run_mempal(&env.home, &["status"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.contains("  dropped_total: 5"), "{stdout}");
+    assert!(stdout.contains("read_tool=2"), "{stdout}");
+    assert!(stdout.contains("short_content=3"), "{stdout}");
+}
+
+#[test]
+fn test_status_uses_dedicated_dropped_total_key() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+    recreate_legacy_v6_gating_audit_table(&db);
+
+    for index in 0..5 {
+        insert_legacy_gating_audit_row(
+            &db,
+            &format!("rejected-unlabeled-{index}"),
+            &format!("rejected-unlabeled-{index}"),
+            "rejected",
+            serde_json::json!({
+                "tier": 1,
+                "reason": "rule_reject",
+            }),
+            now,
+        );
+    }
+
+    apply_fork_ext_migrations_to(db.conn(), 7).expect("apply migrations to v7");
+
+    assert_eq!(
+        fork_ext_meta_value(&db, "gating.dropped.total"),
+        Some("5".to_string())
+    );
+    let drop_counts = db.gating_drop_counts().expect("gating drop counts");
+    assert_eq!(drop_counts.total, Some(5));
+    assert!(drop_counts.by_reason.is_empty(), "{drop_counts:?}");
+
+    let output = run_mempal(&env.home, &["status"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.contains("  dropped_total: 5"), "{stdout}");
+    assert!(stdout.contains("  dropped_by_reason: none"), "{stdout}");
+}
+
+#[test]
+fn test_load_gating_audit_falls_back_to_explain_json_for_default_row() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let now = now_unix_secs();
+    let db = env.db();
+
+    db.conn()
+        .execute(
+            r#"
+            INSERT INTO gating_audit (
+                id, candidate_hash, drawer_id, decision, tier, label, reason, score,
+                explain_json, retained_until, created_at, project_id
+            )
+            VALUES (?1, ?2, NULL, 'keep', 0, NULL, NULL, NULL, ?3, ?4, ?5, NULL)
+            "#,
+            rusqlite::params![
+                "defaulted-modern-row",
+                "defaulted-modern-row",
+                serde_json::json!({
+                    "tier": 2,
+                    "label": "architectural-decision",
+                    "gating_reason": "prototype_below_threshold",
+                    "score": 0.88,
+                })
+                .to_string(),
+                now + 604800,
+                now,
+            ],
+        )
+        .expect("insert defaulted modern row");
+
+    let output = run_mempal(&env.home, &["gating", "stats", "--since", "7d"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    assert!(stdout.contains("kept: 1"), "{stdout}");
+    assert!(stdout.contains("tier2_kept: 1"), "{stdout}");
+    assert!(stdout.contains("unclassified: 0"), "{stdout}");
+    assert!(stdout.contains("architectural-decision=1"), "{stdout}");
+    assert!(!stdout.contains("unlabeled=1"), "{stdout}");
+}
+
+#[test]
+fn test_llm_judge_section_warns_and_ignores() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new(
+        r#"
+[ingest_gating.llm_judge]
+enabled = true
+backend = "api"
 "#,
     );
 
-    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
-    let config = Config::load_from(&config_path).expect("load config");
-    let factory = Arc::new(DeterministicEmbedderFactory {
-        vectors: Arc::new(HashMap::from([(
-            "accept-prototype".to_string(),
-            vec![1.0, 0.0],
-        )])),
-        default_vector: vec![0.0, 1.0],
-        embed_calls: Arc::new(Mutex::new(Vec::new())),
-    });
-    let server = MempalMcpServer::new_with_factory_and_config(db_path, config, factory);
+    let config = env.config();
+    assert!(!config.ingest_gating.enabled);
 
-    let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "reject me".to_string(),
-            wing: "code-memory".to_string(),
-            room: Some("gating".to_string()),
-            source: None,
-            project_id: None,
-            dry_run: Some(false),
-            importance: None,
-        }))
+    let output = run_mempal(&env.home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stderr = String::from_utf8(output.stderr).expect("stderr utf8");
+    assert!(
+        stderr.contains("llm_judge tier ignored: external LLM API disabled by design"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn test_tier1_skips_read_tool() {
+    let _guard = test_guard_blocking();
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let mut config = env.config();
+    config.ingest_gating.enabled = true;
+    config.ingest_gating.rules = vec![GatingRuleConfig {
+        action: "reject".to_string(),
+        tool: Some("Read".to_string()),
+        tool_in: None,
+        content_bytes_lt: None,
+        content_bytes_gt: None,
+        exit_code_eq: None,
+    }];
+
+    let decision = evaluate_tier1(
+        &IngestCandidate {
+            content: "long enough content to hit tool rule".to_string(),
+            tool_name: Some("Read".to_string()),
+            exit_code: None,
+        },
+        &config.ingest_gating,
+    )
+    .expect("tier1 decision");
+    env.db()
+        .record_gating_audit("read-tool-candidate", &decision, None)
+        .expect("record gating audit");
+    let rows = gating_rows(&env.db());
+
+    assert_eq!(decision.tier, 1);
+    assert_eq!(decision.gating_reason.as_deref(), Some("read_tool"));
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].decision, "skip");
+    assert_eq!(rows[0].tier, 1);
+    assert_eq!(rows[0].reason.as_deref(), Some("read_tool"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cli_ingest_tier1_only_does_not_init_gating_embedder() {
+    let _guard = test_guard().await;
+    let mut config = Config::parse(
+        r#"
+db_path = "/tmp/mempal-cli-tier1-only.db"
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = false
+threshold = 0.4
+prototypes = []
+
+[embed]
+backend = "unsupported-backend"
+"#,
+    )
+    .expect("parse config");
+    config.ingest_gating.rules = vec![GatingRuleConfig {
+        action: "accept".to_string(),
+        tool: None,
+        tool_in: None,
+        content_bytes_lt: None,
+        content_bytes_gt: Some(1),
+        exit_code_eq: None,
+    }];
+
+    let build_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts = Arc::clone(&build_attempts);
+    let classifier = if config.ingest_gating.enabled {
+        if config.ingest_gating.embedding_classifier.enabled
+            && !config
+                .ingest_gating
+                .embedding_classifier
+                .prototypes
+                .is_empty()
+        {
+            attempts.fetch_add(1, Ordering::SeqCst);
+        }
+        compile_classifier_from_config(&config)
+            .await
+            .map_err(|error| error.to_string())
+            .expect("tier1-only CLI path should skip gating embedder init")
+    } else {
+        None
+    };
+
+    let decision = evaluate_tier1(
+        &IngestCandidate {
+            content: "content that should pass tier1 without tier2".to_string(),
+            tool_name: None,
+            exit_code: None,
+        },
+        &config.ingest_gating,
+    )
+    .expect("tier1 decision");
+
+    assert!(classifier.is_none());
+    assert_eq!(build_attempts.load(Ordering::SeqCst), 0);
+    assert!(!decision.is_rejected());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tier1_skips_short_content() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new("[gating]\nenabled = true\n");
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(&[], vec![0.2, 0.2], &[]),
+    );
+
+    let response = ingest_mcp(&server, "tiny").await;
+    let rows = gating_rows(&env.db());
+
+    assert!(response.dropped);
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 0);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].decision, "skip");
+    assert_eq!(rows[0].tier, 1);
+    assert_eq!(rows[0].reason.as_deref(), Some("too_short"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tier2_keeps_above_threshold() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.8
+prototypes = ["valuable", "noise"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(
+            &[
+                ("valuable", vec![1.0, 0.0]),
+                ("noise", vec![0.0, 1.0]),
+                ("above threshold candidate", vec![0.98, 0.02]),
+            ],
+            vec![0.2, 0.2],
+            &[],
+        ),
+    );
+
+    let response = ingest_mcp(&server, "above threshold candidate").await;
+    let rows = gating_rows(&env.db());
+
+    assert!(!response.dropped);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].decision, "keep");
+    assert_eq!(rows[0].tier, 2);
+    assert_eq!(rows[0].label.as_deref(), Some("valuable"));
+    assert!(rows[0].score.expect("score") >= 0.8);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tier2_skips_below_threshold() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.9
+prototypes = ["valuable", "noise"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(
+            &[
+                ("valuable", vec![1.0, 0.0]),
+                ("noise", vec![0.0, 1.0]),
+                ("below threshold candidate", vec![0.5, 0.5]),
+            ],
+            vec![0.2, 0.2],
+            &[],
+        ),
+    );
+
+    let response = ingest_mcp(&server, "below threshold candidate").await;
+    let rows = gating_rows(&env.db());
+
+    assert!(response.dropped);
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 0);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].decision, "skip");
+    assert_eq!(rows[0].tier, 2);
+    assert_eq!(rows[0].reason.as_deref(), Some("prototype_below_threshold"));
+    assert!(rows[0].drawer_id.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_prototype_count_limit_enforced() {
+    let _guard = test_guard().await;
+    let mut prototypes = Vec::new();
+    for index in 0..65 {
+        prototypes.push(format!("prototype-{index}"));
+    }
+    let config = Config::parse(&format!(
+        r#"
+db_path = "/tmp/mempal-gating-runtime.db"
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = [{}]
+"#,
+        prototypes
+            .iter()
+            .map(|label| format!(r#""{label}""#))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+    .expect("parse config");
+    let runtime = GatingRuntime::new(config, deterministic_factory(&[], vec![0.1, 0.1], &[]));
+
+    let error = runtime
+        .initialize()
         .await
-        .expect("request")
-        .0;
+        .expect_err("prototype count limit must trip");
+    assert!(error.to_string().contains("prototype_count=65"), "{error}");
+}
 
-    let decision = response.gating_decision.expect("gating decision");
-    let json = serde_json::to_value(&decision).expect("serialize gating decision");
-    assert_eq!(json.get("tier").and_then(|value| value.as_u64()), Some(1));
-    assert_eq!(
-        json.get("matched_pattern").and_then(|value| value.as_str()),
-        Some("content_bytes_lt")
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_prototype_init_error_redacts_text() {
+    let _guard = test_guard().await;
+    let sensitive = "sensitive prototype text with spaces";
+    let config = Config::parse(&format!(
+        r#"
+db_path = "/tmp/mempal-gating-runtime.db"
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["{sensitive}"]
+"#
+    ))
+    .expect("parse config");
+    let runtime = GatingRuntime::new(
+        config,
+        deterministic_factory(&[], vec![0.1, 0.1], &[sensitive]),
+    );
+
+    let error = runtime
+        .initialize()
+        .await
+        .expect_err("prototype init must fail");
+    let rendered = error.to_string();
+    assert!(rendered.contains("prototype#1"), "{rendered}");
+    assert!(!rendered.contains(sensitive), "{rendered}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_warns_when_hooks_on_and_gating_off() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[privacy]
+enabled = true
+
+[hooks]
+enabled = true
+
+[gating]
+enabled = false
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(&[], vec![0.2, 0.2], &[]),
+    );
+
+    let mcp_status = server.mempal_status().await.expect("mcp status").0;
+    let output = run_mempal(&env.home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let warning_messages = mcp_status
+        .system_warnings
+        .iter()
+        .map(|warning| warning.message.clone())
+        .collect::<Vec<_>>();
+
+    assert!(
+        stdout.contains("hooks capture is enabled while local gating is disabled"),
+        "{stdout}"
+    );
+    assert!(warning_messages.iter().any(|message| {
+        message.contains("hooks capture is enabled while local gating is disabled")
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_warns_when_gating_fail_open() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[privacy]
+enabled = true
+
+[hooks]
+enabled = true
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable"]
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(&[("valuable", vec![1.0, 0.0])], vec![0.2, 0.2], &[]),
+    );
+
+    let mcp_status = server.mempal_status().await.expect("mcp status").0;
+    let output = run_mempal(&env.home, &["status"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let warning_messages = mcp_status
+        .system_warnings
+        .iter()
+        .map(|warning| warning.message.clone())
+        .collect::<Vec<_>>();
+
+    assert!(
+        stdout.contains("tier-2 gating is fail-open on embedder errors"),
+        "{stdout}"
     );
     assert!(
-        json.get("score").is_none_or(|value| value.is_null()),
-        "tier-1 rule reject should not fabricate a cosine score: {json}"
+        warning_messages
+            .iter()
+            .any(|message| message.contains("tier-2 gating is fail-open on embedder errors"))
     );
 }

--- a/tests/privacy_scrubbing.rs
+++ b/tests/privacy_scrubbing.rs
@@ -411,6 +411,8 @@ async fn test_drawer_content_stores_scrubbed_text() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -442,6 +444,8 @@ async fn test_embedding_receives_scrubbed_text() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -547,6 +551,8 @@ async fn test_privacy_disabled_preserves_content_byte_identical() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -604,6 +610,8 @@ async fn test_scrub_does_not_affect_storage_invariants() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -681,6 +689,8 @@ async fn test_status_command_shows_scrub_stats() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await
@@ -695,6 +705,8 @@ async fn test_status_command_shows_scrub_stats() {
             source_root: Some(&env.mempal_home),
             dry_run: false,
             project_id: None,
+            gating: None,
+            prototype_classifier: None,
         },
     )
     .await


### PR DESCRIPTION
## Summary
- 11 TODO-mandated `p9-judge-gating-local` scenarios + 4 threat-model + 2 round-2 explain_json backfill + 2 round-3 legacy decision/counter backfill + 2 round-4 CLI tier-1-only / dedicated-total reader = 21 named scenarios (30 total tests in the file including helpers; all green).
- v7 `gating_audit` migration backfills `tier`/`label`/`reason`/`score` from legacy `explain_json` (round-2), normalizes legacy `decision='accepted'/'rejected'` → canonical `keep`/`skip` (round-3), and seeds `gating.dropped.total` + `gating.dropped.by_reason.*` counters from historical audit rows (round-3).
- `load_gating_audit_details()` per-row defense-in-depth: falls back to `explain_json` when modern columns are default (tier=0 + label=NULL + explain_json non-NULL).
- CLI `ingest` no longer hard-fails tier-1-only configs by initializing the gating embedder unconditionally — now matches MCP/daemon "tier 2 optional" semantics.
- `gating_drop_counts()` returns `{ total, by_reason }`; `mempal status` reads dedicated `gating.dropped.total` as authoritative (legacy unlabeled skip rows no longer disappear from total).
- Runtime `record_gating_audit()` updates audit row + total + per-reason counters atomically inside `BEGIN IMMEDIATE`/`COMMIT`.
- New `mempal gating stats [--since]` CLI subcommand.

## Review provenance
- Round 1 review (csa-codex tier-4-critical, session `01KPS4X0MW2`): plan-deviation FAIL — invented scenario names instead of TODO-mandated ones.
- Round 1 fix (`9d8aca1`): renamed all tests to TODO names verbatim, added `mempal gating stats` CLI, real v6→v7 migration test, threat-model coverage.
- Round 2 review (csa-codex tier-4-critical, session `01KPS726THX`): HIGH contract — v7 added columns without backfilling pre-v7 `explain_json`; rows became `unclassified/unknown/unlabeled` in stats.
- Round 2 fix (`7fb9417`): SQL `json_extract` backfill in `apply_v7()`, per-row fallback in `load_gating_audit_details()`, 2 regression tests.
- Round 3 review (csa-codex tier-4-critical, session `01KPS8B5HT2`): HIGH — `drawer_id` backfill only matched `decision='keep'`, missed legacy `'accepted'`. MEDIUM — `gating.dropped.*` counters not backfilled.
- Round 3 fix (`9aba9b8`): broadened backfill match + canonical decision normalization (`accepted→keep`, `rejected→skip`); counter backfill SQL; 2 regression tests.
- Round 4 review (csa-codex tier-4-critical, session `01KPS9KFS1`): HIGH — CLI ingest hard-failed tier-1-only configs. MEDIUM — `gating_drop_counts()` dropped dedicated total key, computed via bucket sum.
- Round 4 fix (`b4434cc`): CLI tier-2 guard via `compile_classifier_from_config()`; `gating_drop_counts()` returns `{ total, by_reason }`; atomic counter increments under `BEGIN IMMEDIATE`; 2 regression tests.
- Round 5 review (csa-codex tier-4-critical, session `01KPSANCBPVSEQTNWKFGSWKN87`): no blocking correctness/security/contract findings; `cargo test --test judge_gating` 30 tests green; ready to merge.

## Cloud bot status
- gemini-cli reviewer hit 401 auth failures throughout PR6 review iterations (matches PR5 pattern).
- Gemini Code Assist cloud bot still in quota cooldown until 2026-04-22T03:48:24Z; deferred.
- Authorization chain: per-PR audit trail per pr-bot skill's quota-exhausted merge path; csa-codex tier-4-critical served as primary reviewer for all 5 rounds.

## Debate contracts honored
- Tier 1 zero-compute / Tier 2 optional spec contract (CLI ingest path now matches MCP/daemon).
- v7 migration backfill is idempotent (rerunnable without double-counting or corruption).
- Atomic counter updates preserve invariant `total >= sum(by_reason)`.
- Defense-in-depth: per-row `explain_json` fallback in reader covers schema-rollback / restore edge cases.
- CLI-only / no-LLM-API / raw-verbatim-storage hard constraints unchanged.

## Test plan
- [x] `just fmt` clean
- [x] `just clippy` clean
- [x] `just test` full suite green
- [x] 30 tests in `tests/judge_gating.rs` (21 named scenarios + 9 helpers/harness)
- [x] Spot-checked: `test_v7_migration_backfills_dropped_counters_from_legacy_audit`, `test_cli_ingest_tier1_only_does_not_init_gating_embedder`, `test_load_gating_audit_falls_back_to_explain_json_for_default_row`
- [x] No `weave.lock` mutations from this branch (user's pre-existing unstaged change preserved)