### PR TITLE
test(p9+p10): session-self-review + folder-claudemd-hotpatch scenario gaps + cross-session leak guard + symlink escape rejection + runtime no-outbound audit

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,7 +30,12 @@ use tokio::sync::mpsc;
 use crate::daemon_bootstrap::DaemonContext;
 use crate::hook::CapturedHookEnvelope;
 use crate::hotpatch::generator::{GenerationOptions, suggest_for_drawer};
-use crate::session_review::{SessionReviewOutcome, extract_session_review};
+use crate::session_review::{
+    SessionReviewOutcome, analysis_content, append_hooks_raw_metadata, extract_session_review,
+    split_session_metadata, validate_linked_drawer_ids,
+};
+
+const SESSION_REVIEW_REJECTED_TOTAL_KEY: &str = "session_review.rejected.total";
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     run_command_with_bootstrap_events(config_path, foreground, None)
@@ -197,7 +202,7 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
 ) -> Result<String> {
     let envelope: CapturedHookEnvelope =
         serde_json::from_str(&message.payload).context("failed to decode queued hook envelope")?;
-    let records = build_drawer_records(&envelope, context.config, context.mempal_home)?;
+    let records = build_drawer_records(db, &envelope, context.config, context.mempal_home)?;
     let drawer_context = DrawerIngestContext {
         db,
         store,
@@ -247,7 +252,7 @@ fn build_gating_candidate(
     }
 
     IngestCandidate {
-        content: record.content.clone(),
+        content: analysis_content(&record.content).to_string(),
         tool_name,
         exit_code,
     }
@@ -281,6 +286,7 @@ struct DrawerRecord {
 }
 
 fn build_drawer_records(
+    db: &Database,
     envelope: &CapturedHookEnvelope,
     config: &crate::core::config::Config,
     mempal_home: &Path,
@@ -292,27 +298,81 @@ fn build_drawer_records(
         } else {
             None
         };
-        match extract_session_review(
-            session_review_payload.as_deref(),
-            &envelope.agent,
-            &config.hooks.session_end,
-        )? {
-            SessionReviewOutcome::Review(review) => records.push(DrawerRecord {
-                wing: review.wing,
-                room: review.room,
-                source_file: review.source_file,
-                content: config.scrub_content(&review.content),
-                importance: review.importance,
-                bypass_novelty: true,
-                project_id: resolve_hook_project_id(envelope, config)?,
-            }),
-            SessionReviewOutcome::Skipped(reason) => {
-                tracing::info!(?reason, "session self-review skipped");
+        let review_record = (|| -> Result<Option<DrawerRecord>> {
+            match extract_session_review(
+                session_review_payload.as_deref(),
+                &envelope.agent,
+                &config.hooks.session_end,
+            )? {
+                SessionReviewOutcome::Review(review) => {
+                    let project_id = resolve_hook_project_id(envelope, config)?;
+                    let (_, metadata) = split_session_metadata(&review.content);
+                    if let Some(session_id) = metadata.session_id.as_deref() {
+                        validate_linked_drawer_ids(
+                            db.conn(),
+                            session_id,
+                            project_id.as_deref(),
+                            &metadata.linked_drawer_ids,
+                        )
+                        .with_context(|| {
+                            format!(
+                                "session-review linked_drawer_ids rejected for source_file={}",
+                                review.source_file
+                            )
+                        })?;
+                    }
+                    Ok(Some(DrawerRecord {
+                        wing: review.wing,
+                        room: review.room,
+                        source_file: review.source_file,
+                        content: config.scrub_content(&review.content),
+                        importance: review.importance,
+                        bypass_novelty: true,
+                        project_id,
+                    }))
+                }
+                SessionReviewOutcome::Skipped(reason) => {
+                    tracing::info!(?reason, "session self-review skipped");
+                    Ok(None)
+                }
+            }
+        })();
+
+        match review_record {
+            Ok(Some(record)) => records.push(record),
+            Ok(None) => {}
+            Err(error) => {
+                record_session_review_rejection(db);
+                tracing::warn!(
+                    ?error,
+                    event = %envelope.event,
+                    agent = %envelope.agent,
+                    claude_cwd = %envelope.claude_cwd,
+                    "session self-review rejected; hooks-raw audit will still persist"
+                );
             }
         }
     }
 
     Ok(records)
+}
+
+fn record_session_review_rejection(db: &Database) {
+    if let Err(error) = db.conn().execute(
+        r#"
+        INSERT INTO fork_ext_meta (key, value)
+        VALUES (?1, '1')
+        ON CONFLICT(key) DO UPDATE
+        SET value = CAST(CAST(COALESCE(fork_ext_meta.value, '0') AS INTEGER) + 1 AS TEXT)
+        "#,
+        [SESSION_REVIEW_REJECTED_TOTAL_KEY],
+    ) {
+        tracing::warn!(
+            ?error,
+            key = SESSION_REVIEW_REJECTED_TOTAL_KEY,
+            "failed to record session-review rejection counter"
+        );
+    }
 }
 
 fn load_session_review_payload(envelope: &CapturedHookEnvelope) -> Result<Option<String>> {
@@ -387,6 +447,11 @@ fn build_audit_drawer_record(
         }
     }))
     .context("failed to serialize hook diary drawer")?;
+    let content = append_hooks_raw_metadata(
+        &content,
+        hook_payload_session_id(raw_payload).as_deref(),
+        Some(envelope.captured_at.as_str()),
+    );
     let (wing, room) = audit_target_for_event(&envelope.event, raw_payload, config);
 
     Ok(DrawerRecord {
@@ -506,8 +571,12 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if gating_decision.is_none()
         && let Some(classifier) = context.daemon.prototype_classifier
     {
-        let candidate_vector =
-            embed_text_with_heartbeat(context.embedder, &record.content, Some(&heartbeat)).await?;
+        let candidate_vector = embed_text_with_heartbeat(
+            context.embedder,
+            analysis_content(&record.content),
+            Some(&heartbeat),
+        )
+        .await?;
         let decision = classifier.decide(
             &candidate_vector,
             context
@@ -538,7 +607,12 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     let vector = match vector {
         Some(vector) => vector,
         None => {
-            embed_text_with_heartbeat(context.embedder, &record.content, Some(&heartbeat)).await?
+            embed_text_with_heartbeat(
+                context.embedder,
+                analysis_content(&record.content),
+                Some(&heartbeat),
+            )
+            .await?
         }
     };
     if record.bypass_novelty {
@@ -724,7 +798,7 @@ fn insert_drawer_with_vector(
         wing: record.wing.clone(),
         room: Some(record.room.clone()),
         source_file: Some(record.source_file.clone()),
-        source_type: SourceType::Manual,
+        source_type: SourceType::Conversation,
         added_at: current_timestamp(),
         chunk_index: Some(0),
         importance: record.importance,
@@ -775,6 +849,19 @@ fn preview_for_event(event: &str, raw_payload: &str) -> String {
             .unwrap_or_else(|| raw_payload.to_string()),
         _ => raw_payload.to_string(),
     }
+}
+
+fn hook_payload_session_id(raw_payload: &str) -> Option<String> {
+    serde_json::from_str::<Value>(raw_payload)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("session_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn persist_raw_payload(raw_payload: &str, mempal_home: &Path) -> Result<String> {

--- a/src/hotpatch/generator.rs
+++ b/src/hotpatch/generator.rs
@@ -12,8 +12,10 @@ use crate::core::{
     db::Database,
     project::{ProjectSearchScope, resolve_project_id},
 };
+use crate::hotpatch::manager::ensure_allowed_target;
 use crate::hotpatch::{FileLock, short_drawer_id};
 use crate::search::preview;
+use crate::session_review::hooks_raw_content;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct GenerationOptions {
@@ -118,6 +120,10 @@ pub fn suggest_for_drawer(
     );
 
     for path in payload_paths {
+        let canonical_source = path.canonicalize().with_context(|| {
+            format!("failed to canonicalize hotpatch source {}", path.display())
+        })?;
+        ensure_allowed_target(config, &canonical_source, "source path scan")?;
         let watched_dir = match find_watched_dir(&path, &config.hotpatch.watch_files) {
             Ok(Some(dir)) => dir,
             Ok(None) => {
@@ -130,6 +136,13 @@ pub fn suggest_for_drawer(
                 continue;
             }
         };
+        let canonical_watched_dir = watched_dir.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize hotpatch watched dir {}",
+                watched_dir.display()
+            )
+        })?;
+        ensure_allowed_target(config, &canonical_watched_dir, "watched dir scan")?;
         let suggestion_path = suggestion_file_path(mempal_home, &watched_dir)?;
         fs::create_dir_all(
             suggestion_path
@@ -137,8 +150,12 @@ pub fn suggest_for_drawer(
                 .context("hotpatch suggestion file missing parent")?,
         )
         .with_context(|| format!("failed to create {}", suggestion_path.display()))?;
-        let changed =
-            append_suggestion_line(&suggestion_path, &watched_dir, &details.drawer.id, &line)?;
+        let changed = append_suggestion_line(
+            &suggestion_path,
+            &canonical_watched_dir,
+            &details.drawer.id,
+            &line,
+        )?;
         if changed {
             appended += 1;
         } else {
@@ -150,7 +167,7 @@ pub fn suggest_for_drawer(
 }
 
 fn resolve_generation_project(config: &Config, drawer_content: &str) -> Result<Option<String>> {
-    let cwd = serde_json::from_str::<Value>(drawer_content)
+    let cwd = serde_json::from_str::<Value>(hooks_raw_content(drawer_content))
         .ok()
         .and_then(|value| {
             value
@@ -162,7 +179,7 @@ fn resolve_generation_project(config: &Config, drawer_content: &str) -> Result<O
 }
 
 fn summary_inputs(drawer_content: &str) -> Result<(Option<String>, Vec<String>, Option<PathBuf>)> {
-    let parsed = match serde_json::from_str::<Value>(drawer_content) {
+    let parsed = match serde_json::from_str::<Value>(hooks_raw_content(drawer_content)) {
         Ok(value) => value,
         Err(_) => return Ok((Some(drawer_content.to_string()), Vec::new(), None)),
     };

--- a/src/hotpatch/manager.rs
+++ b/src/hotpatch/manager.rs
@@ -108,9 +108,9 @@ pub fn review(config: &Config, mempal_home: &Path, options: ReviewOptions) -> Re
         for entry in &entries {
             stdout.push_str(&format!(
                 "{}\n  suggestion_file: {}\n  {}\n",
-                entry.dir.display(),
-                entry.suggestion_file.display(),
-                entry.line
+                escape_for_terminal(&entry.dir.display().to_string()),
+                escape_for_terminal(&entry.suggestion_file.display().to_string()),
+                escape_for_terminal(&entry.line)
             ));
         }
         stdout.push_str(&format!("pending={pending_count}\n"));
@@ -133,7 +133,10 @@ pub fn apply(config: &Config, mempal_home: &Path, options: ApplyOptions) -> Resu
     if !suggestion_path.exists() {
         return Ok(ApplyReport {
             applied_count: 0,
-            stdout: format!("no suggestion file for {}\n", canonical_dir.display()),
+            stdout: format!(
+                "no suggestion file for {}\n",
+                escape_for_terminal(&canonical_dir.display().to_string())
+            ),
         });
     }
 
@@ -185,10 +188,13 @@ pub fn apply(config: &Config, mempal_home: &Path, options: ApplyOptions) -> Resu
         .collect::<Vec<_>>();
 
     if !options.confirm {
-        let mut stdout = format!("dry-run for {}\n", target_path.display());
+        let mut stdout = format!(
+            "dry-run for {}\n",
+            escape_for_terminal(&target_path.display().to_string())
+        );
         for line in &to_append {
             stdout.push_str("+ ");
-            stdout.push_str(line);
+            stdout.push_str(&escape_for_terminal(line));
             stdout.push('\n');
         }
         return Ok(ApplyReport {
@@ -238,7 +244,7 @@ pub fn apply(config: &Config, mempal_home: &Path, options: ApplyOptions) -> Resu
         stdout: format!(
             "applied {} suggestion(s) to {}\n",
             pending.len(),
-            target_path.display()
+            escape_for_terminal(&target_path.display().to_string())
         ),
     })
 }
@@ -417,11 +423,15 @@ fn resolve_target_file(config: &Config, canonical_dir: &Path) -> Result<PathBuf>
         })?;
     let resolved_target = fs::canonicalize(&candidate)
         .with_context(|| format!("failed to canonicalize {}", candidate.display()))?;
-    ensure_allowed_target(config, &resolved_target)?;
+    ensure_allowed_target(config, &resolved_target, "write target")?;
     Ok(resolved_target)
 }
 
-fn ensure_allowed_target(config: &Config, resolved_target: &Path) -> Result<()> {
+pub(crate) fn ensure_allowed_target(
+    config: &Config,
+    resolved_target: &Path,
+    purpose: &str,
+) -> Result<()> {
     let prefixes = allowed_prefixes(config)?;
     if prefixes
         .iter()
@@ -430,12 +440,12 @@ fn ensure_allowed_target(config: &Config, resolved_target: &Path) -> Result<()> 
         return Ok(());
     }
     bail!(
-        "refusing to write {} because it escapes hotpatch.allowed_target_prefixes",
+        "refusing hotpatch {purpose} {} because canonical path escapes hotpatch.allowed_target_prefixes (symlink escape / outside project root)",
         resolved_target.display()
     );
 }
 
-fn allowed_prefixes(config: &Config) -> Result<Vec<PathBuf>> {
+pub(crate) fn allowed_prefixes(config: &Config) -> Result<Vec<PathBuf>> {
     if !config.hotpatch.allowed_target_prefixes.is_empty() {
         return config
             .hotpatch
@@ -466,6 +476,10 @@ fn canonicalize_prefix(value: &str) -> Result<PathBuf> {
         PathBuf::from(value)
     };
     Ok(expanded.canonicalize().unwrap_or(expanded))
+}
+
+fn escape_for_terminal(value: &str) -> String {
+    crate::observability::escape_terminal_text(value)
 }
 
 fn mark_entries(content: &str, entries: &[SuggestionEntry], marker: &str) -> Result<String> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -497,13 +497,14 @@ impl SearchResultDto {
             route,
             tunnel_hints,
         } = value;
-        let signals = crate::aaak::analyze(&content);
+        let analyzed_content = crate::session_review::analysis_content(&content);
+        let signals = crate::aaak::analyze(analyzed_content);
         let original_content_bytes = content.len() as u64;
         let preview = if progressive_disclosure {
-            crate::search::preview::truncate(&content, preview_chars)
+            crate::search::preview::truncate(analyzed_content, preview_chars)
         } else {
             crate::search::preview::PreviewText {
-                content,
+                content: content.clone(),
                 truncated: false,
             }
         };

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -179,7 +179,8 @@ pub fn timeline_command(
     match options.format {
         "json" | "ndjson" => {
             for record in records {
-                let signals = crate::aaak::analyze(&record.content);
+                let signals =
+                    crate::aaak::analyze(crate::session_review::analysis_content(&record.content));
                 let line = TimelineJsonLine {
                     timestamp: format_timestamp(&record.added_at),
                     drawer_id: record.id,
@@ -348,7 +349,8 @@ pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) ->
     if options.raw {
         println!("{}", drawer.content);
     } else {
-        let signals = crate::aaak::analyze(&drawer.content);
+        let signals =
+            crate::aaak::analyze(crate::session_review::analysis_content(&drawer.content));
         println!(
             "flags: {}",
             signals
@@ -1064,7 +1066,11 @@ fn format_tail_line(record: &DrawerRecord, raw: bool) -> String {
 }
 
 fn preview(content: &str) -> String {
-    crate::search::preview::truncate(content, PREVIEW_CHARS).content
+    crate::search::preview::truncate(
+        crate::session_review::analysis_content(content),
+        PREVIEW_CHARS,
+    )
+    .content
 }
 
 fn render_room(room: Option<&str>) -> &str {
@@ -1206,7 +1212,7 @@ fn maybe_escape(value: &str, raw: bool) -> String {
     }
 }
 
-fn escape_terminal_text(value: &str) -> String {
+pub fn escape_terminal_text(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
         if ch.is_control() {

--- a/src/session_review.rs
+++ b/src/session_review.rs
@@ -1,14 +1,24 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
+use rusqlite::{Connection, OptionalExtension};
 use serde::Deserialize;
 
 use crate::core::config::HooksSessionEndConfig;
 
-const SESSION_METADATA_SENTINEL: &str = "\n\n--- session_metadata ---\n";
+const SESSION_METADATA_SENTINEL: &str = "\n\n<!-- mempal:session-review -->\n";
+const LEGACY_SESSION_METADATA_SENTINEL: &str = "\n\n--- session_metadata ---\n";
+const HOOKS_RAW_METADATA_PREFIX: &str = "<!-- mempal:hooks-raw -->\n";
+const HOOKS_RAW_METADATA_SUFFIX: &str = "<!-- /mempal:hooks-raw -->\n";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SessionMetadata {
     pub session_id: Option<String>,
     pub linked_drawer_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HooksRawMetadata {
+    pub session_id: Option<String>,
+    pub captured_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,8 +143,8 @@ pub fn extract_session_review(
     let content = append_session_metadata(
         &raw_content,
         &SessionMetadata {
-            session_id: Some(session_id.to_string()),
             linked_drawer_ids,
+            session_id: Some(session_id.to_string()),
         },
     );
 
@@ -149,11 +159,11 @@ pub fn extract_session_review(
 }
 
 pub fn split_session_metadata(content: &str) -> (&str, SessionMetadata) {
-    let Some(index) = content.rfind(SESSION_METADATA_SENTINEL) else {
+    let Some((index, sentinel)) = latest_metadata_sentinel(content) else {
         return (content, SessionMetadata::default());
     };
 
-    let metadata_start = index + SESSION_METADATA_SENTINEL.len();
+    let metadata_start = index + sentinel.len();
     let Some(metadata) = parse_metadata_block(&content[metadata_start..]) else {
         return (content, SessionMetadata::default());
     };
@@ -161,21 +171,124 @@ pub fn split_session_metadata(content: &str) -> (&str, SessionMetadata) {
     (&content[..index], metadata)
 }
 
+pub fn analysis_content(content: &str) -> &str {
+    split_session_metadata(content).0
+}
+
+pub fn append_hooks_raw_metadata(
+    content: &str,
+    session_id: Option<&str>,
+    captured_at: Option<&str>,
+) -> String {
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return content.to_string();
+    };
+
+    let mut lines = vec![format!("session_id: {:?}", session_id)];
+    if let Some(captured_at) = captured_at.map(str::trim).filter(|value| !value.is_empty()) {
+        lines.push(format!("captured_at: {:?}", captured_at));
+    }
+
+    format!(
+        "{HOOKS_RAW_METADATA_PREFIX}{}\n{HOOKS_RAW_METADATA_SUFFIX}{content}",
+        lines.join("\n")
+    )
+}
+
+pub fn split_hooks_raw_metadata(content: &str) -> (&str, HooksRawMetadata) {
+    if !content.starts_with(HOOKS_RAW_METADATA_PREFIX) {
+        return (content, HooksRawMetadata::default());
+    }
+
+    let metadata_and_body = &content[HOOKS_RAW_METADATA_PREFIX.len()..];
+    let Some(end_index) = metadata_and_body.find(HOOKS_RAW_METADATA_SUFFIX) else {
+        return (content, HooksRawMetadata::default());
+    };
+
+    let metadata_block = &metadata_and_body[..end_index];
+    let Some(metadata) = parse_hooks_raw_metadata_block(metadata_block) else {
+        return (content, HooksRawMetadata::default());
+    };
+    let body_start = HOOKS_RAW_METADATA_PREFIX.len() + end_index + HOOKS_RAW_METADATA_SUFFIX.len();
+    (&content[body_start..], metadata)
+}
+
+pub fn hooks_raw_content(content: &str) -> &str {
+    split_hooks_raw_metadata(content).0
+}
+
+pub fn validate_linked_drawer_ids(
+    conn: &Connection,
+    session_id: &str,
+    project_id: Option<&str>,
+    linked_drawer_ids: &[String],
+) -> Result<()> {
+    if linked_drawer_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut violations = 0usize;
+    for drawer_id in linked_drawer_ids {
+        let row = conn
+            .query_row(
+                r#"
+                SELECT wing, room, content, source_file, project_id, source_type
+                FROM drawers
+                WHERE id = ?1 AND deleted_at IS NULL
+                "#,
+                [drawer_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, String>(5)?,
+                    ))
+                },
+            )
+            .optional()
+            .with_context(|| format!("failed to validate linked drawer {drawer_id}"))?;
+
+        let Some((wing, _room, content, _source_file, linked_project_id, source_type)) = row else {
+            violations += 1;
+            continue;
+        };
+
+        let linked_session_id = linked_session_id(&wing, &source_type, &content);
+        let same_session = linked_session_id.as_deref() == Some(session_id);
+        let same_project = linked_project_id.as_deref() == project_id;
+        if !same_session || !same_project {
+            violations += 1;
+        }
+    }
+
+    if violations > 0 {
+        bail!(
+            "linked_drawer_ids validation failed: {violations} id(s) crossed session/project boundary for session {session_id}"
+        );
+    }
+
+    Ok(())
+}
+
 fn append_session_metadata(content: &str, metadata: &SessionMetadata) -> String {
     let mut lines = Vec::new();
+    if !metadata.linked_drawer_ids.is_empty() {
+        lines.push(format!(
+            "linked_drawer_ids: {}",
+            serde_json::to_string(&metadata.linked_drawer_ids)
+                .expect("session-review linked_drawer_ids should serialize")
+        ));
+    }
     if let Some(session_id) = metadata
         .session_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        lines.push(format!("session_id: {session_id}"));
-    }
-    if !metadata.linked_drawer_ids.is_empty() {
-        lines.push(format!(
-            "linked_drawer_ids: {}",
-            metadata.linked_drawer_ids.join(", ")
-        ));
+        lines.push(format!("session_id: {:?}", session_id));
     }
     if lines.is_empty() {
         return content.to_string();
@@ -200,18 +313,104 @@ fn parse_metadata_block(block: &str) -> Option<SessionMetadata> {
         }
         saw_key_value = true;
         match key {
-            "session_id" => metadata.session_id = Some(value.to_string()),
+            "session_id" => metadata.session_id = Some(unquote(value)),
             "linked_drawer_ids" => {
-                metadata.linked_drawer_ids = value
-                    .split(',')
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(ToOwned::to_owned)
-                    .collect();
+                metadata.linked_drawer_ids = parse_linked_drawer_ids(value)?;
             }
             _ => {}
         }
     }
 
     saw_key_value.then_some(metadata)
+}
+
+fn parse_hooks_raw_metadata_block(block: &str) -> Option<HooksRawMetadata> {
+    let mut metadata = HooksRawMetadata::default();
+    let mut saw_key_value = false;
+
+    for line in block.lines() {
+        let (key, value) = line.split_once(": ")?;
+        if key.is_empty()
+            || value.is_empty()
+            || !key
+                .chars()
+                .all(|char| char.is_ascii_lowercase() || char == '_')
+        {
+            return None;
+        }
+        saw_key_value = true;
+        match key {
+            "session_id" => metadata.session_id = Some(unquote(value)),
+            "captured_at" => metadata.captured_at = Some(unquote(value)),
+            _ => {}
+        }
+    }
+
+    saw_key_value.then_some(metadata)
+}
+
+fn latest_metadata_sentinel(content: &str) -> Option<(usize, &'static str)> {
+    let current = content.rfind(SESSION_METADATA_SENTINEL);
+    let legacy = content.rfind(LEGACY_SESSION_METADATA_SENTINEL);
+    match (current, legacy) {
+        (Some(index), Some(legacy_index)) if legacy_index > index => {
+            Some((legacy_index, LEGACY_SESSION_METADATA_SENTINEL))
+        }
+        (Some(index), _) => Some((index, SESSION_METADATA_SENTINEL)),
+        (None, Some(index)) => Some((index, LEGACY_SESSION_METADATA_SENTINEL)),
+        (None, None) => None,
+    }
+}
+
+fn parse_linked_drawer_ids(value: &str) -> Option<Vec<String>> {
+    if let Ok(ids) = serde_json::from_str::<Vec<String>>(value) {
+        return Some(ids);
+    }
+    Some(
+        value
+            .split(',')
+            .map(str::trim)
+            .map(unquote)
+            .filter(|value| !value.is_empty())
+            .collect(),
+    )
+}
+
+fn unquote(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+        trimmed[1..trimmed.len() - 1].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn linked_session_id(wing: &str, source_type: &str, content: &str) -> Option<String> {
+    let metadata = split_session_metadata(content).1;
+    if let Some(session_id) = metadata
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Some(session_id.to_string());
+    }
+
+    if wing != "hooks-raw" {
+        return None;
+    }
+
+    if source_type != "conversation" {
+        return None;
+    }
+
+    // Round-4 security fix: hooks-raw linkage must trust only daemon-persisted
+    // metadata already stored in the drawer, never attacker-chosen disk paths.
+    split_hooks_raw_metadata(content)
+        .1
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }

--- a/tests/folder_claudemd_hotpatch.rs
+++ b/tests/folder_claudemd_hotpatch.rs
@@ -1,0 +1,375 @@
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+use mempal::core::config::Config;
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::hotpatch::generator::{GenerationOptions, suggest_for_drawer};
+use mempal::hotpatch::manager::{ApplyOptions, ReviewOptions, apply, review};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+struct HotpatchEnv {
+    _tmp: TempDir,
+    mempal_home: PathBuf,
+    db_path: PathBuf,
+    project_dir: PathBuf,
+}
+
+impl HotpatchEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join("home/.mempal");
+        let project_dir = tmp.path().join("project");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        fs::create_dir_all(project_dir.join("src")).expect("create src");
+        fs::write(project_dir.join("CLAUDE.md"), "# Project\n").expect("write claude");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        Self {
+            _tmp: tmp,
+            mempal_home,
+            db_path,
+            project_dir,
+        }
+    }
+
+    fn config(&self, extra: &str) -> Config {
+        Config::parse(&format!(
+            r#"
+db_path = "{}"
+
+[project]
+id = "project-alpha"
+
+[search]
+strict_project_isolation = true
+
+[hotpatch]
+enabled = true
+min_importance_stars = 4
+watch_files = ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]
+max_suggestion_length = 80
+allowed_target_prefixes = ["{}"]
+{}
+"#,
+            self.db_path.display(),
+            self.project_dir.display(),
+            extra,
+        ))
+        .expect("parse config")
+    }
+
+    fn suggestion_file_for(&self, dir: &Path) -> PathBuf {
+        let canonical = dir.canonicalize().expect("canonical dir");
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let hash = format!("{:x}", hasher.finalize());
+        self.mempal_home
+            .join("hotpatch")
+            .join(format!("CLAUDE-{}.md", &hash[..12]))
+    }
+
+    fn write_suggestion_file(&self, dir: &Path, lines: &[&str]) -> PathBuf {
+        let suggestion_file = self.suggestion_file_for(dir);
+        fs::create_dir_all(
+            suggestion_file
+                .parent()
+                .expect("suggestion file parent must exist"),
+        )
+        .expect("create hotpatch dir");
+        let content = format!(
+            "# mempal hotpatch suggestions for {}\n\n<!-- managed by mempal -->\n\n{}\n",
+            dir.canonicalize().expect("canonical dir").display(),
+            lines.join("\n")
+        );
+        fs::write(&suggestion_file, content).expect("write suggestion file");
+        suggestion_file
+    }
+
+    fn write_hook_payload(&self, file_path: &Path) -> PathBuf {
+        let payload_path = self.mempal_home.join("hook.json");
+        let payload = serde_json::json!({
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": file_path.display().to_string()
+            }
+        });
+        fs::write(&payload_path, payload.to_string()).expect("write hook payload");
+        payload_path
+    }
+
+    fn insert_drawer(&self, drawer_id: &str, content: &str, source_file: &Path) {
+        let db = Database::open(&self.db_path).expect("open db");
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: drawer_id.to_string(),
+                content: content.to_string(),
+                wing: "hooks-raw".to_string(),
+                room: Some("Edit".to_string()),
+                source_file: Some(source_file.display().to_string()),
+                source_type: SourceType::Manual,
+                added_at: "1713000000".to_string(),
+                chunk_index: Some(0),
+                importance: 5,
+            },
+            Some("project-alpha"),
+        )
+        .expect("insert drawer");
+    }
+}
+
+fn review_default(env: &HotpatchEnv) -> mempal::hotpatch::manager::ReviewReport {
+    review(
+        &env.config(""),
+        &env.mempal_home,
+        ReviewOptions {
+            dir: None,
+            include_applied: false,
+            include_dismissed: false,
+        },
+    )
+    .expect("review")
+}
+
+fn network_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("network guard")
+}
+
+#[test]
+fn test_apply_confirm_merges_to_claudemd() {
+    let env = HotpatchEnv::new();
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: append the new rule [drawer:apply-confirm]"],
+    );
+
+    let outcome = apply(
+        &env.config(""),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: true,
+        },
+    )
+    .expect("apply");
+
+    let target = fs::read_to_string(env.project_dir.join("CLAUDE.md")).expect("read target");
+    let review = review_default(&env);
+    assert_eq!(outcome.applied_count, 1);
+    assert!(target.contains("append the new rule"));
+    assert_eq!(review.pending_count, 0);
+    assert!(!review.stdout.contains("apply-confirm"));
+}
+
+#[test]
+fn test_apply_preserves_existing_content() {
+    let env = HotpatchEnv::new();
+    let original = "EXISTING_CONTENT_MARKER\n## Section A\nKeep this block byte-identical.\n";
+    fs::write(env.project_dir.join("CLAUDE.md"), original).expect("write original claude");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: additive only [drawer:preserve]"],
+    );
+
+    apply(
+        &env.config(""),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: true,
+        },
+    )
+    .expect("apply");
+
+    let updated = fs::read_to_string(env.project_dir.join("CLAUDE.md")).expect("read target");
+    assert!(updated.starts_with(original));
+    assert!(updated.contains("EXISTING_CONTENT_MARKER"));
+    assert!(updated.contains("additive only"));
+}
+
+#[test]
+fn test_apply_without_confirm_is_dry_run() {
+    let env = HotpatchEnv::new();
+    let target_path = env.project_dir.join("CLAUDE.md");
+    let before = fs::read_to_string(&target_path).expect("read target before");
+    env.write_suggestion_file(
+        &env.project_dir,
+        &["- ★★★★★ decision: keep \u{1b}[31mRED\u{1b}[0m preview [drawer:dry-run]"],
+    );
+
+    let outcome = apply(
+        &env.config(""),
+        &env.mempal_home,
+        ApplyOptions {
+            dir: env.project_dir.clone(),
+            confirm: false,
+        },
+    )
+    .expect("apply dry run");
+    let review = review_default(&env);
+    let after = fs::read_to_string(&target_path).expect("read target after");
+
+    assert_eq!(before, after);
+    assert_eq!(review.pending_count, 1);
+    assert!(outcome.stdout.contains("dry-run"));
+    assert!(outcome.stdout.contains("\\u{1b}[31mRED\\u{1b}[0m"));
+    assert!(!outcome.stdout.contains('\u{1b}'));
+}
+
+#[test]
+fn test_hotpatch_no_llm_api_calls() {
+    let _guard = network_guard();
+    let env = HotpatchEnv::new();
+    let file_path = env.project_dir.join("src/lib.rs");
+    fs::write(&file_path, "pub fn demo() {}\n").expect("write source");
+    let payload_path = env.write_hook_payload(&file_path);
+    env.insert_drawer(
+        "drawer-network-audit",
+        "Decision: local hotpatch generation must stay offline.",
+        &payload_path,
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind sentinel listener");
+    listener
+        .set_nonblocking(true)
+        .expect("set nonblocking listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let running = Arc::new(AtomicBool::new(true));
+    let accept_count = Arc::clone(&accepts);
+    let accept_running = Arc::clone(&running);
+    let join = thread::spawn(move || {
+        while accept_running.load(Ordering::SeqCst) {
+            match listener.accept() {
+                Ok((_stream, _addr)) => {
+                    accept_count.fetch_add(1, Ordering::SeqCst);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let proxy = format!("http://{addr}");
+    // SAFETY: guarded by a process-global mutex in this test module.
+    unsafe {
+        std::env::set_var("HTTP_PROXY", &proxy);
+        std::env::set_var("HTTPS_PROXY", &proxy);
+        std::env::set_var("ALL_PROXY", &proxy);
+    }
+
+    let db = Database::open(&env.db_path).expect("open db");
+    let outcome = suggest_for_drawer(
+        &db,
+        &env.config(""),
+        &env.mempal_home,
+        "drawer-network-audit",
+        GenerationOptions::default(),
+    )
+    .expect("generate suggestion");
+
+    running.store(false, Ordering::SeqCst);
+    join.join().expect("join listener thread");
+    // SAFETY: guarded by a process-global mutex in this test module.
+    unsafe {
+        std::env::remove_var("HTTP_PROXY");
+        std::env::remove_var("HTTPS_PROXY");
+        std::env::remove_var("ALL_PROXY");
+    }
+
+    assert_eq!(outcome.appended, 1);
+    assert_eq!(accepts.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn test_review_lists_pending_suggestions() {
+    let env = HotpatchEnv::new();
+    let second_dir = env.project_dir.join("subdir");
+    fs::create_dir_all(&second_dir).expect("create second dir");
+    fs::write(second_dir.join("CLAUDE.md"), "# Subdir\n").expect("write subdir claude");
+
+    env.write_suggestion_file(
+        &env.project_dir,
+        &[
+            "- ★★★★★ decision: alpha [drawer:pending-a]",
+            "- ★★★★ decision: beta \u{1b}[31mwarn\u{1b}[0m [drawer:pending-b]",
+            "- ★★★ decision: already applied [drawer:applied-x] <!-- applied 1713000000 -->",
+        ],
+    );
+    env.write_suggestion_file(&second_dir, &["- ★★★★★ note: gamma [drawer:pending-c]"]);
+
+    let report = review_default(&env);
+
+    assert_eq!(report.pending_count, 3);
+    assert!(report.stdout.contains("pending-a"));
+    assert!(report.stdout.contains("pending-b"));
+    assert!(report.stdout.contains("pending-c"));
+    assert!(report.stdout.contains("\\u{1b}[31mwarn\\u{1b}[0m"));
+    assert!(!report.stdout.contains('\u{1b}'));
+    assert!(!report.stdout.contains("applied-x"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hotpatch_symlink_escape_rejected() {
+    let env = HotpatchEnv::new();
+    let outside_dir = env
+        .project_dir
+        .parent()
+        .expect("project parent")
+        .join("outside-root");
+    fs::create_dir_all(outside_dir.join("src")).expect("create outside dir");
+    fs::write(outside_dir.join("CLAUDE.md"), "# Outside\n").expect("write outside claude");
+    fs::write(outside_dir.join("src/lib.rs"), "pub fn escaped() {}\n")
+        .expect("write outside source");
+    std::os::unix::fs::symlink(&outside_dir, env.project_dir.join("escaped"))
+        .expect("create escape symlink");
+
+    let escaped_file = env.project_dir.join("escaped/src/lib.rs");
+    let payload_path = env.write_hook_payload(&escaped_file);
+    env.insert_drawer(
+        "drawer-symlink-escape",
+        "Decision: reject escaped watched directories.",
+        &payload_path,
+    );
+
+    let db = Database::open(&env.db_path).expect("open db");
+    let error = suggest_for_drawer(
+        &db,
+        &env.config(""),
+        &env.mempal_home,
+        "drawer-symlink-escape",
+        GenerationOptions::default(),
+    )
+    .expect_err("symlink escape must be rejected");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("symlink escape") || message.contains("outside project root"),
+        "unexpected error: {message}"
+    );
+    let hotpatch_dir = env.mempal_home.join("hotpatch");
+    assert!(
+        !hotpatch_dir.exists()
+            || fs::read_dir(&hotpatch_dir)
+                .expect("read hotpatch dir")
+                .next()
+                .is_none()
+    );
+    assert!(
+        !env.project_dir.join("escaped/CLAUDE.md").exists()
+            || outside_dir.join("CLAUDE.md").exists()
+    );
+}

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -13,6 +13,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
 use mempal::daemon_bootstrap::DaemonContext;
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use mempal::session_review::split_hooks_raw_metadata;
 use rusqlite::Connection;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
@@ -345,6 +346,7 @@ async fn test_daemon_processes_hook_post_tool_to_drawer() {
             claude_cwd: tmp.path().display().to_string(),
             payload: Some(
                 serde_json::json!({
+                    "session_id": "sess-hook-post-tool",
                     "tool_name": "Bash",
                     "input": "printf secret",
                     "output": raw_secret,
@@ -378,15 +380,14 @@ async fn test_daemon_processes_hook_post_tool_to_drawer() {
         Path::new(&source_file).exists(),
         "payload path should exist"
     );
-    assert!(content.contains("\"preview\""), "{content}");
+    let (body, metadata) = split_hooks_raw_metadata(&content);
+    assert_eq!(metadata.session_id.as_deref(), Some("sess-hook-post-tool"));
+    assert!(body.contains("\"preview\""), "{body}");
     assert!(
-        content.contains("[REDACTED:openai_key]"),
-        "privacy scrub must affect stored preview: {content}"
+        body.contains("[REDACTED:openai_key]"),
+        "privacy scrub must affect stored preview: {body}"
     );
-    assert!(
-        !content.contains(raw_secret),
-        "raw secret leaked into drawer"
-    );
+    assert!(!body.contains(raw_secret), "raw secret leaked into drawer");
 
     daemon.sigterm();
     let status = daemon.wait().await.expect("wait daemon");

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -280,6 +280,37 @@ async fn test_per_call_disable_progressive() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_non_progressive_returns_raw_bytes_for_session_review_drawer() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 24);
+    let content = concat!(
+        "Decision: keep the full session review drawer verbatim when callers disable preview mode.",
+        "\n\n<!-- mempal:session-review -->\n",
+        "linked_drawer_ids: [\"drawer-a\",\"drawer-b\"]\n",
+        "session_id: \"sess-raw\""
+    );
+    insert_drawer(
+        &env.db_path,
+        "drawer-session-review-raw",
+        content,
+        "sess-raw",
+        true,
+    );
+
+    let response = search(&env.server(), "verbatim", Some(true)).await;
+    let result = response
+        .results
+        .iter()
+        .find(|result| result.drawer_id == "drawer-session-review-raw")
+        .expect("session review result");
+
+    assert_eq!(result.content, content);
+    assert!(result.content.contains("<!-- mempal:session-review -->"));
+    assert_eq!(result.original_content_bytes, content.len() as u64);
+    assert!(!result.content_truncated);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_drawer_not_found() {
     let _guard = config_guard().await;
     let env = TestEnv::new(true, 24);

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -1,30 +1,70 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
-use mempal::core::config::Config;
+use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
 use mempal::core::types::{Drawer, SourceType};
 use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
-use mempal::embed::{EmbedError, Embedder};
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use mempal::mcp::{IngestRequest, MempalMcpServer, SearchRequest};
 use mempal::session_review::{
-    SessionMetadata, SessionReviewOutcome, extract_session_review, split_session_metadata,
+    analysis_content, append_hooks_raw_metadata, split_hooks_raw_metadata, split_session_metadata,
 };
+use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::Connection;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
-async fn test_guard() -> OwnedMutexGuard<()> {
+async fn config_guard() -> OwnedMutexGuard<()> {
     static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
     GUARD
         .get_or_init(|| Arc::new(AsyncMutex::new(())))
         .clone()
         .lock_owned()
         .await
+}
+
+#[derive(Clone)]
+struct LogCapture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for LogCapture {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("log buffer mutex poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn install_log_capture() -> (Arc<Mutex<Vec<u8>>>, tracing::dispatcher::DefaultGuard) {
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let writer_logs = Arc::clone(&logs);
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(move || LogCapture {
+            buffer: Arc::clone(&writer_logs),
+        })
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (logs, guard)
+}
+
+fn captured_logs(logs: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8(logs.lock().expect("log mutex poisoned").clone()).expect("utf8 logs")
 }
 
 #[derive(Clone)]
@@ -56,116 +96,111 @@ impl Embedder for DeterministicEmbedder {
     }
 }
 
+#[derive(Clone)]
+struct StaticEmbedderFactory {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbedderFactory for StaticEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(DeterministicEmbedder {
+            vectors: Arc::new(HashMap::new()),
+            default_vector: self.vector.clone(),
+        }))
+    }
+}
+
 struct TestEnv {
     _tmp: TempDir,
+    config_path: PathBuf,
     db_path: PathBuf,
     mempal_home: PathBuf,
+    project_dir: PathBuf,
     config: Config,
     store: PendingMessageStore,
 }
 
 impl TestEnv {
-    fn new(
-        extra_hooks: &str,
-        extra_privacy: &str,
-        extra_novelty: &str,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let tmp = TempDir::new()?;
+    fn new(extract_self_review: bool, min_length: usize) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
         let mempal_home = tmp.path().join(".mempal");
-        fs::create_dir_all(&mempal_home)?;
+        let project_dir = tmp.path().join("workspace/project-alpha");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        let config_path = mempal_home.join("config.toml");
         let db_path = mempal_home.join("palace.db");
-        Database::open(&db_path)?;
+        Database::open(&db_path).expect("open db");
         let config_text = format!(
             r#"
 db_path = "{}"
+
+[project]
+id = "project-alpha"
 
 [hooks]
 enabled = true
 daemon_poll_interval_ms = 100
 
 [hooks.session_end]
-{}
+extract_self_review = {}
+min_length = {}
 
 [privacy]
-{}
+enabled = false
 
 [ingest_gating]
 enabled = false
 
-[ingest_gating.novelty]
-{}
+[search]
+strict_project_isolation = true
+progressive_disclosure = true
+preview_chars = 48
 "#,
             db_path.display(),
-            extra_hooks,
-            extra_privacy,
-            extra_novelty,
+            extract_self_review,
+            min_length,
         );
-        let config = Config::parse(&config_text)?;
-        let store = PendingMessageStore::new(&db_path)?;
-        Ok(Self {
+        fs::write(&config_path, &config_text).expect("write config");
+        let config = Config::parse(&config_text).expect("parse config");
+        let store = PendingMessageStore::new(&db_path).expect("open store");
+        Self {
             _tmp: tmp,
+            config_path,
             db_path,
             mempal_home,
+            project_dir,
             config,
             store,
-        })
+        }
     }
 
-    fn enqueue_session_end(&self, payload: &str) -> Result<String, Box<dyn std::error::Error>> {
+    fn enqueue_session_end(&self, payload: &str) -> String {
         let envelope = CapturedHookEnvelope {
             event: HookEvent::SessionEnd.display_name().to_string(),
             kind: HookEvent::SessionEnd.queue_kind().to_string(),
             agent: "claude".to_string(),
             captured_at: "1713000000".to_string(),
-            claude_cwd: "/tmp/project".to_string(),
+            claude_cwd: self.project_dir.display().to_string(),
             payload: Some(payload.to_string()),
             payload_path: None,
             payload_preview: None,
             original_size_bytes: payload.len(),
             truncated: false,
         };
-        let payload = serde_json::to_string(&envelope)?;
-        Ok(self
-            .store
-            .enqueue(HookEvent::SessionEnd.queue_kind(), &payload)?)
+        let serialized = serde_json::to_string(&envelope).expect("serialize envelope");
+        self.store
+            .enqueue(HookEvent::SessionEnd.queue_kind(), &serialized)
+            .expect("enqueue session end")
     }
 
-    fn enqueue_truncated_session_end(
-        &self,
-        payload: &str,
-    ) -> Result<String, Box<dyn std::error::Error>> {
-        let oversize_dir = self.mempal_home.join("hook-oversize");
-        fs::create_dir_all(&oversize_dir)?;
-        let payload_path = oversize_dir.join("session-end-oversize.json");
-        fs::write(&payload_path, payload)?;
-        let envelope = CapturedHookEnvelope {
-            event: HookEvent::SessionEnd.display_name().to_string(),
-            kind: HookEvent::SessionEnd.queue_kind().to_string(),
-            agent: "claude".to_string(),
-            captured_at: "1713000000".to_string(),
-            claude_cwd: "/tmp/project".to_string(),
-            payload: None,
-            payload_path: Some(payload_path.to_string_lossy().to_string()),
-            payload_preview: Some(payload.chars().take(64).collect()),
-            original_size_bytes: payload.len(),
-            truncated: true,
-        };
-        let payload = serde_json::to_string(&envelope)?;
-        Ok(self
-            .store
-            .enqueue(HookEvent::SessionEnd.queue_kind(), &payload)?)
-    }
-
-    async fn process_once(
-        &self,
-        embedder: &DeterministicEmbedder,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    async fn process_once(&self, embedder: &DeterministicEmbedder) -> anyhow::Result<String> {
         let claimed = self
             .store
             .claim_next("worker-session-review", 120)?
             .expect("claimed message");
         let db = Database::open(&self.db_path)?;
-        Ok(process_claimed_message_with_embedder(
+        process_claimed_message_with_embedder(
             &db,
             &self.store,
             "worker-session-review",
@@ -177,8 +212,71 @@ enabled = false
                 mempal_home: &self.mempal_home,
             },
         )
-        .await?)
+        .await
     }
+
+    fn insert_hooks_raw_linked_drawer(&self, drawer_id: &str, session_id: &str, project_id: &str) {
+        let db = Database::open(&self.db_path).expect("open db");
+        let payload_path = self
+            .mempal_home
+            .join(format!("{drawer_id}-linked-hooks-raw.json"));
+        let payload = serde_json::json!({
+            "session_id": session_id,
+            "tool_name": "Bash",
+            "input": "ls",
+            "output": "ok",
+            "exit_code": 0,
+            "session_id": session_id,
+        })
+        .to_string();
+        fs::write(&payload_path, &payload).expect("write linked hooks-raw payload");
+        let content = serde_json::json!({
+            "event": HookEvent::PostToolUse.display_name(),
+            "agent": "claude",
+            "captured_at": "1713000100",
+            "claude_cwd": self.project_dir.display().to_string(),
+            "preview": "tool=Bash",
+            "meta": {
+                "hook_payload_path": payload_path.display().to_string(),
+                "original_size_bytes": payload.len(),
+            }
+        })
+        .to_string();
+        let content = append_hooks_raw_metadata(&content, Some(session_id), Some("1713000100"));
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: drawer_id.to_string(),
+                content,
+                wing: "hooks-raw".to_string(),
+                room: Some("Bash".to_string()),
+                source_file: Some(payload_path.display().to_string()),
+                source_type: SourceType::Conversation,
+                added_at: "1713000100".to_string(),
+                chunk_index: Some(0),
+                importance: 0,
+            },
+            Some(project_id),
+        )
+        .expect("insert linked drawer");
+    }
+
+    fn external_source_path(&self, name: &str) -> PathBuf {
+        self.project_dir.join(name)
+    }
+
+    fn server(&self) -> MempalMcpServer {
+        ConfigHandle::bootstrap(&self.config_path).expect("bootstrap config");
+        MempalMcpServer::new_with_factory(
+            self.db_path.clone(),
+            Arc::new(StaticEmbedderFactory {
+                vector: vec![0.9, 0.1, 0.3],
+            }),
+        )
+    }
+}
+
+fn long_assistant_message() -> String {
+    "I decided to keep the session review implementation verbatim because the linked evidence and the search/read split both need a stable summary anchor.".to_string()
 }
 
 fn count_drawers_by_wing(db_path: &Path, wing: &str) -> i64 {
@@ -188,436 +286,460 @@ fn count_drawers_by_wing(db_path: &Path, wing: &str) -> i64 {
         [wing],
         |row| row.get(0),
     )
-    .expect("query drawer count by wing")
+    .expect("count wing")
 }
 
-fn latest_drawer_in_wing(db_path: &Path, wing: &str) -> (String, String, String, i32) {
+fn latest_review(db_path: &Path) -> (String, String, String) {
     let conn = Connection::open(db_path).expect("open sqlite");
     conn.query_row(
         r#"
-        SELECT content, COALESCE(room, ''), COALESCE(source_file, ''), importance
+        SELECT content, COALESCE(room, ''), COALESCE(source_file, '')
         FROM drawers
-        WHERE deleted_at IS NULL AND wing = ?1
+        WHERE deleted_at IS NULL AND wing = 'session-reviews'
         ORDER BY rowid DESC
         LIMIT 1
         "#,
-        [wing],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
     )
-    .expect("query latest drawer")
+    .expect("latest review")
 }
 
-fn novelty_audit_count_for_drawer(db_path: &Path, drawer_id: &str) -> i64 {
+fn latest_hooks_raw(db_path: &Path) -> (String, String, String) {
     let conn = Connection::open(db_path).expect("open sqlite");
     conn.query_row(
-        "SELECT COUNT(*) FROM novelty_audit WHERE candidate_hash = ?1",
-        [drawer_id],
+        r#"
+        SELECT content, COALESCE(room, ''), COALESCE(source_file, '')
+        FROM drawers
+        WHERE deleted_at IS NULL AND wing = 'hooks-raw'
+        ORDER BY rowid DESC
+        LIMIT 1
+        "#,
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .expect("latest hooks-raw")
+}
+
+fn latest_review_project_id(db_path: &Path) -> Option<String> {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        r#"
+        SELECT project_id
+        FROM drawers
+        WHERE deleted_at IS NULL AND wing = 'session-reviews'
+        ORDER BY rowid DESC
+        LIMIT 1
+        "#,
+        [],
         |row| row.get(0),
     )
-    .expect("query novelty audit count")
+    .expect("review project")
 }
 
-fn long_assistant_message(suffix: &str) -> String {
-    format!(
-        "I finished refactor X, decided to keep the payload raw, documented the boundary, and kept the retry path deterministic for auditability. {}",
-        suffix
+fn fork_ext_meta_value(db_path: &Path, key: &str) -> Option<String> {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        "SELECT value FROM fork_ext_meta WHERE key = ?1",
+        [key],
+        |row| row.get(0),
     )
+    .ok()
 }
 
-#[test]
-fn test_session_self_review_disabled_by_default() {
-    let config = Config::default();
-
-    assert!(!config.hooks.session_end.extract_self_review);
-    assert_eq!(config.hooks.session_end.trailing_messages, 1);
-    assert_eq!(config.hooks.session_end.min_length, 100);
-    assert_eq!(config.hooks.session_end.wing, "session-reviews");
-}
-
-#[test]
-fn test_sentinel_false_positive_rejected_by_structure_check() {
-    let content =
-        "assistant body\n--- session_metadata ---\nthis is just an example in prose".to_string();
-
-    let (body, metadata) = split_session_metadata(&content);
-
-    assert_eq!(body, content);
-    assert_eq!(metadata, SessionMetadata::default());
-}
-
-#[test]
-fn test_session_self_review_zero_external_llm_calls() {
-    let session_review_src = include_str!("../src/session_review.rs");
-    let daemon_src = include_str!("../src/daemon.rs");
-
-    for forbidden in [
-        "api.openai",
-        "api.anthropic",
-        "generativelanguage",
-        ".claude/sessions/",
-    ] {
-        assert!(
-            !session_review_src.contains(forbidden),
-            "session_review.rs unexpectedly references {forbidden}"
-        );
-        assert!(
-            !daemon_src.contains(forbidden),
-            "daemon.rs unexpectedly references {forbidden}"
-        );
-    }
-}
-
-#[test]
-fn test_missing_agent_falls_back() {
-    let config = Config::parse(
-        r#"
-[hooks.session_end]
-extract_self_review = true
-min_length = 1
-"#,
-    )
-    .expect("config");
-    let payload = serde_json::json!({
-        "session_id": "missing-agent",
-        "messages": [
-            {"role": "assistant", "content": "summary"}
-        ]
-    });
-
-    let outcome = extract_session_review(Some(&payload.to_string()), "", &config.hooks.session_end)
-        .expect("extract");
-
-    match outcome {
-        SessionReviewOutcome::Review(record) => assert_eq!(record.room, "unknown-agent"),
-        other => panic!("expected review, got {other:?}"),
+fn embedder_for(content: &str) -> DeterministicEmbedder {
+    DeterministicEmbedder {
+        vectors: Arc::new(HashMap::from([(content.to_string(), vec![0.9, 0.1, 0.3])])),
+        default_vector: vec![0.1, 0.2, 0.3],
     }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_session_end_hook_captures_final_assistant_message() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-trailing_messages = 1
-min_length = 100
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let assistant = long_assistant_message("This is the high-signal summary.");
+async fn test_disabled_no_session_review() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(false, 50);
+    let assistant = long_assistant_message();
     let payload = serde_json::json!({
-        "session_id": "S1",
-        "agent": "claude",
-        "messages": [
-            {"role": "user", "content": "go"},
-            {"role": "assistant", "content": assistant}
-        ],
-        "tool_calls": [
-            {"drawer_id": "D1"},
-            {"drawer_id": "D2"}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
-
-    env.process_once(&embedder).await.expect("process");
-
-    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
-    let (content, room, source_file, importance) =
-        latest_drawer_in_wing(&env.db_path, "session-reviews");
-    let (body, metadata) = split_session_metadata(&content);
-    assert_eq!(body, assistant);
-    assert_eq!(room, "claude");
-    assert_eq!(source_file, "S1");
-    assert_eq!(importance, 3);
-    assert_eq!(metadata.session_id.as_deref(), Some("S1"));
-    assert_eq!(metadata.linked_drawer_ids, vec!["D1", "D2"]);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_trailing_messages_concatenation() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-trailing_messages = 2
-min_length = 1
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let payload = serde_json::json!({
-        "session_id": "trail-1",
-        "messages": [
-            {"role": "assistant", "content": "A"},
-            {"role": "assistant", "content": "B"}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
-
-    env.process_once(&embedder).await.expect("process");
-
-    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
-    let (body, metadata) = split_session_metadata(&stored);
-    assert_eq!(body, "A\n---\nB");
-    assert_eq!(metadata.session_id.as_deref(), Some("trail-1"));
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_truncated_session_end_still_creates_session_review() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let assistant = long_assistant_message("oversize payload should still produce a review.");
-    let payload = serde_json::json!({
-        "session_id": "oversize-1",
+        "session_id": "sess-disabled",
         "agent": "claude",
         "messages": [
             {"role": "assistant", "content": assistant}
-        ],
-        "tool_calls": [
-            {"drawer_id": "D-oversize"}
         ]
     });
-    env.enqueue_truncated_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
+    env.enqueue_session_end(&payload.to_string());
 
-    env.process_once(&embedder).await.expect("process");
-
-    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
-    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
-    let (content, room, source_file, importance) =
-        latest_drawer_in_wing(&env.db_path, "session-reviews");
-    let (body, metadata) = split_session_metadata(&content);
-    assert_eq!(body, assistant);
-    assert_eq!(room, "claude");
-    assert_eq!(source_file, "oversize-1");
-    assert_eq!(importance, 3);
-    assert_eq!(metadata.session_id.as_deref(), Some("oversize-1"));
-    assert_eq!(metadata.linked_drawer_ids, vec!["D-oversize"]);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_captured_drawer_is_raw_verbatim() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let assistant = "Line 1\nLine 2\nSymbols: <> [] {}\nUnicode: 你好".to_string();
-    let payload = serde_json::json!({
-        "session_id": "raw-1",
-        "messages": [
-            {"role": "assistant", "content": assistant}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
-
-    env.process_once(&embedder).await.expect("process");
-
-    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
-    let (body, metadata) = split_session_metadata(&stored);
-    assert_eq!(body, "Line 1\nLine 2\nSymbols: <> [] {}\nUnicode: 你好");
-    assert_eq!(metadata.session_id.as_deref(), Some("raw-1"));
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_hooks_raw_audit_drawer_still_written() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let payload = serde_json::json!({
-        "session_id": "audit-1",
-        "messages": [
-            {"role": "assistant", "content": long_assistant_message("audit")}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
-
-    env.process_once(&embedder).await.expect("process");
-
-    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
-    let (_, room, _, _) = latest_drawer_in_wing(&env.db_path, "hooks-raw");
-    assert_eq!(room, "session-lifecycle");
-    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_session_reviews_bypass_novelty_drop() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = false",
-        r#"
-enabled = true
-duplicate_threshold = 0.95
-merge_threshold = 0.80
-wing_scope = "same_wing"
-top_k_candidates = 1
-max_merges_per_drawer = 10
-max_content_bytes_per_drawer = 65536
-"#,
-    )
-    .expect("env");
-    let existing_body = long_assistant_message("existing");
-    let existing_content = format!(
-        "{}\n\n--- session_metadata ---\nsession_id: old-session",
-        existing_body
-    );
-    let db = Database::open(&env.db_path).expect("open db");
-    db.insert_drawer(&Drawer {
-        id: "existing-review".to_string(),
-        content: existing_content.clone(),
-        wing: "session-reviews".to_string(),
-        room: Some("claude".to_string()),
-        source_file: Some("old-session".to_string()),
-        source_type: SourceType::Manual,
-        added_at: "1713000000".to_string(),
-        chunk_index: Some(0),
-        importance: 3,
-    })
-    .expect("insert existing drawer");
-    db.insert_vector("existing-review", &[1.0, 0.0, 0.0])
-        .expect("insert existing vector");
-
-    let candidate_body = long_assistant_message("candidate");
-    let payload = serde_json::json!({
-        "session_id": "new-session",
-        "messages": [
-            {"role": "assistant", "content": candidate_body}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let session_review_content = format!(
-        "{}\n\n--- session_metadata ---\nsession_id: new-session",
-        long_assistant_message("candidate")
-    );
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::from([(
-            session_review_content,
-            vec![1.0, 0.0, 0.0],
-        )])),
-        default_vector: vec![0.0, 1.0, 0.0],
-    };
-
-    let inserted_id = env.process_once(&embedder).await.expect("process");
-
-    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 2);
-    assert_eq!(
-        novelty_audit_count_for_drawer(&env.db_path, &inserted_id),
-        0
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_no_assistant_message_handler_skips() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = false",
-        "enabled = false",
-    )
-    .expect("env");
-    let payload = serde_json::json!({
-        "session_id": "no-assistant",
-        "messages": [
-            {"role": "user", "content": "go"},
-            {"role": "tool", "content": "ls"}
-        ]
-    });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
-
-    env.process_once(&embedder).await.expect("process");
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("process");
 
     assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
     assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_self_review_subject_to_privacy_scrub() {
-    let _guard = test_guard().await;
-    let env = TestEnv::new(
-        r#"
-extract_self_review = true
-min_length = 10
-"#,
-        "enabled = true",
-        "enabled = false",
-    )
-    .expect("env");
+async fn test_enabled_creates_session_review_drawer() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 50);
+    let assistant = long_assistant_message();
     let payload = serde_json::json!({
-        "session_id": "privacy-1",
+        "session_id": "sess-enabled",
+        "agent": "claude",
         "messages": [
-            {"role": "assistant", "content": "I used sk-abcdef1234567890abcdef1234567890abcd in the example and then removed it."}
+            {"role": "user", "content": "ship it"},
+            {"role": "assistant", "content": assistant}
         ]
     });
-    env.enqueue_session_end(&payload.to_string())
-        .expect("enqueue");
-    let embedder = DeterministicEmbedder {
-        vectors: Arc::new(HashMap::new()),
-        default_vector: vec![0.1, 0.2, 0.3],
-    };
+    env.enqueue_session_end(&payload.to_string());
 
-    env.process_once(&embedder).await.expect("process");
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("process");
 
-    let (stored, _, _, _) = latest_drawer_in_wing(&env.db_path, "session-reviews");
-    assert!(stored.contains("[REDACTED:openai_key]"));
-    assert!(!stored.contains("sk-abcdef1234567890abcdef1234567890abcd"));
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+    let (content, room, source_file) = latest_review(&env.db_path);
+    assert!(content.starts_with(&assistant));
+    assert!(content.contains("<!-- mempal:session-review -->"));
+    assert!(content.contains(r#"session_id: "sess-enabled""#));
+    assert_eq!(room, "claude");
+    assert_eq!(source_file, "sess-enabled");
+    assert_eq!(
+        latest_review_project_id(&env.db_path).as_deref(),
+        Some("project-alpha")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_linked_drawer_ids_in_sentinel_section() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 50);
+    env.insert_hooks_raw_linked_drawer("drawer_same_a", "sess-linked", "project-alpha");
+    env.insert_hooks_raw_linked_drawer("drawer_same_b", "sess-linked", "project-alpha");
+    env.insert_hooks_raw_linked_drawer("drawer_other_session", "sess-other", "project-alpha");
+
+    let assistant = format!(
+        "{} Additional evidence references must stay out of previews and embeddings.",
+        long_assistant_message()
+    );
+    let payload = serde_json::json!({
+        "session_id": "sess-linked",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": "drawer_same_a"},
+            {"drawer_id": "drawer_same_b"}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string());
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("process valid linked ids");
+
+    let (content, _, _) = latest_review(&env.db_path);
+    let (body, metadata) = split_session_metadata(&content);
+    assert_eq!(body, assistant);
+    assert_eq!(metadata.session_id.as_deref(), Some("sess-linked"));
+    assert_eq!(
+        metadata.linked_drawer_ids,
+        vec!["drawer_same_a".to_string(), "drawer_same_b".to_string()]
+    );
+    assert!(content.contains("<!-- mempal:session-review -->"));
+    assert!(content.contains(r#"linked_drawer_ids: ["drawer_same_a","drawer_same_b"]"#));
+
+    let search = env
+        .server()
+        .mempal_search(Parameters(SearchRequest {
+            query: "implementation".to_string(),
+            wing: Some("session-reviews".to_string()),
+            room: None,
+            top_k: Some(5),
+            project_id: Some("project-alpha".to_string()),
+            include_global: Some(false),
+            all_projects: Some(false),
+            disable_progressive: None,
+        }))
+        .await
+        .expect("search")
+        .0;
+    let result = search
+        .results
+        .iter()
+        .find(|result| result.drawer_id == stored_review_drawer_id(&env.db_path))
+        .expect("session review search result");
+    assert!(result.content_truncated);
+    assert!(!result.content.contains("linked_drawer_ids"));
+    assert!(!result.content.contains("mempal:session-review"));
+    assert!(result.flags.iter().any(|flag| flag == "DECISION"));
+
+    let embed_text = analysis_content(&content);
+    assert_eq!(embed_text, assistant);
+    assert!(!embed_text.contains("linked_drawer_ids"));
+    assert!(!embed_text.contains("mempal:session-review"));
+
+    let invalid_payload = serde_json::json!({
+        "session_id": "sess-linked",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": format!("{} invalid", long_assistant_message())}
+        ],
+        "tool_calls": [
+            {"drawer_id": "drawer_same_a"},
+            {"drawer_id": "drawer_other_session"}
+        ]
+    });
+    let hooks_raw_before_invalid = count_drawers_by_wing(&env.db_path, "hooks-raw");
+    env.enqueue_session_end(&invalid_payload.to_string());
+    env.process_once(&embedder_for(&format!(
+        "{} invalid",
+        long_assistant_message()
+    )))
+    .await
+    .expect("invalid session review should not block hooks-raw");
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+    assert_eq!(
+        count_drawers_by_wing(&env.db_path, "hooks-raw"),
+        hooks_raw_before_invalid + 1
+    );
+    assert_eq!(
+        fork_ext_meta_value(&env.db_path, "session_review.rejected.total").as_deref(),
+        Some("1")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_invalid_linked_drawer_ids_does_not_block_hooks_raw() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 50);
+    env.insert_hooks_raw_linked_drawer("drawer-cross-session", "sess-other", "project-alpha");
+
+    let assistant = format!(
+        "{} Linked ids from another session must reject only the derived review.",
+        long_assistant_message()
+    );
+    let payload = serde_json::json!({
+        "session_id": "sess-invalid-linked",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": "drawer-cross-session"}
+        ]
+    });
+    let hooks_raw_before = count_drawers_by_wing(&env.db_path, "hooks-raw");
+    env.enqueue_session_end(&payload.to_string());
+
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("hooks-raw should still persist");
+
+    assert_eq!(
+        count_drawers_by_wing(&env.db_path, "hooks-raw"),
+        hooks_raw_before + 1
+    );
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
+    assert_eq!(
+        fork_ext_meta_value(&env.db_path, "session_review.rejected.total").as_deref(),
+        Some("1")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_linked_drawer_ids_accepts_real_hooks_raw_from_same_session() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 50);
+    env.insert_hooks_raw_linked_drawer("drawer-real-hooks-raw", "sess-real", "project-alpha");
+
+    let assistant = format!(
+        "{} Real hooks-raw linked evidence from the same session must pass validation.",
+        long_assistant_message()
+    );
+    let payload = serde_json::json!({
+        "session_id": "sess-real",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": "drawer-real-hooks-raw"}
+        ]
+    });
+    let hooks_raw_before = count_drawers_by_wing(&env.db_path, "hooks-raw");
+    env.enqueue_session_end(&payload.to_string());
+
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("same-session hooks-raw should allow session review");
+
+    let (hooks_raw_content, hooks_raw_room, _) = latest_hooks_raw(&env.db_path);
+    let (hooks_raw_body, hooks_raw_metadata) = split_hooks_raw_metadata(&hooks_raw_content);
+    assert_eq!(hooks_raw_room, "session-lifecycle");
+    assert_eq!(hooks_raw_metadata.session_id.as_deref(), Some("sess-real"));
+    assert!(hooks_raw_body.contains("\"event\":\"SessionEnd\""));
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 1);
+    assert_eq!(
+        count_drawers_by_wing(&env.db_path, "hooks-raw"),
+        hooks_raw_before + 1
+    );
+    assert_eq!(
+        fork_ext_meta_value(&env.db_path, "session_review.rejected.total"),
+        None
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_linked_drawer_ids_rejects_manual_hooks_raw_with_external_source() {
+    let _guard = config_guard().await;
+    let (logs, _log_guard) = install_log_capture();
+    let env = TestEnv::new(true, 50);
+    let forged_path = env.external_source_path("forged-session.json");
+    fs::write(
+        &forged_path,
+        serde_json::json!({
+            "session_id": "sess-forged",
+            "tool_name": "Bash",
+            "input": "cat secret",
+        })
+        .to_string(),
+    )
+    .expect("write forged source");
+
+    let ingested = env
+        .server()
+        .mempal_ingest(Parameters(IngestRequest {
+            content: serde_json::json!({
+                "event": HookEvent::PostToolUse.display_name(),
+                "preview": "tool=Bash"
+            })
+            .to_string(),
+            wing: "hooks-raw".to_string(),
+            room: Some("Bash".to_string()),
+            source: Some(forged_path.display().to_string()),
+            project_id: Some("project-alpha".to_string()),
+            dry_run: None,
+            importance: None,
+        }))
+        .await
+        .expect("manual hooks-raw ingest")
+        .0;
+
+    let assistant = format!(
+        "{} Manual hooks-raw drawers must not be trusted as same-session evidence.",
+        long_assistant_message()
+    );
+    let payload = serde_json::json!({
+        "session_id": "sess-forged",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": ingested.drawer_id}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string());
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("manual hooks-raw should reject only the derived review");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
+    assert_eq!(
+        fork_ext_meta_value(&env.db_path, "session_review.rejected.total").as_deref(),
+        Some("1")
+    );
+    let logs = captured_logs(&logs);
+    assert!(logs.contains("session self-review rejected; hooks-raw audit will still persist"));
+    assert!(logs.contains("linked_drawer_ids validation failed"));
+    assert!(!logs.contains("failed to read hooks-raw payload while resolving linked session"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_linked_drawer_ids_does_not_read_external_filesystem() {
+    let _guard = config_guard().await;
+    let (logs, _log_guard) = install_log_capture();
+    let env = TestEnv::new(true, 50);
+    let missing_path = env.external_source_path("missing-external-source.json");
+
+    let ingested = env
+        .server()
+        .mempal_ingest(Parameters(IngestRequest {
+            content: serde_json::json!({
+                "event": HookEvent::PostToolUse.display_name(),
+                "preview": "tool=Bash"
+            })
+            .to_string(),
+            wing: "hooks-raw".to_string(),
+            room: Some("Bash".to_string()),
+            source: Some(missing_path.display().to_string()),
+            project_id: Some("project-alpha".to_string()),
+            dry_run: None,
+            importance: None,
+        }))
+        .await
+        .expect("manual hooks-raw ingest")
+        .0;
+
+    let assistant = format!(
+        "{} Validation must not open attacker-chosen external files.",
+        long_assistant_message()
+    );
+    let payload = serde_json::json!({
+        "session_id": "sess-no-read",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": assistant}
+        ],
+        "tool_calls": [
+            {"drawer_id": ingested.drawer_id}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string());
+    env.process_once(&embedder_for(&assistant))
+        .await
+        .expect("manual hooks-raw should reject without touching the filesystem");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
+    let logs = captured_logs(&logs);
+    assert!(logs.contains("session self-review rejected; hooks-raw audit will still persist"));
+    assert!(!logs.contains(missing_path.to_string_lossy().as_ref()));
+    assert!(!logs.contains("failed to read hooks-raw payload while resolving linked session"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_short_message_skipped() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(true, 100);
+    let payload = serde_json::json!({
+        "session_id": "sess-short",
+        "agent": "claude",
+        "messages": [
+            {"role": "assistant", "content": "short"}
+        ]
+    });
+    env.enqueue_session_end(&payload.to_string());
+
+    env.process_once(&embedder_for("short"))
+        .await
+        .expect("process");
+
+    assert_eq!(count_drawers_by_wing(&env.db_path, "session-reviews"), 0);
+    assert_eq!(count_drawers_by_wing(&env.db_path, "hooks-raw"), 1);
+}
+
+fn stored_review_drawer_id(db_path: &Path) -> String {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row(
+        r#"
+        SELECT id
+        FROM drawers
+        WHERE deleted_at IS NULL AND wing = 'session-reviews'
+        ORDER BY rowid DESC
+        LIMIT 1
+        "#,
+        [],
+        |row| row.get(0),
+    )
+    .expect("stored review id")
 }


### PR DESCRIPTION
## Summary

PR10 of the fork-ext scenario test gap fill series. Closes the final two scenario buckets (p9-session-self-review + p10-folder-claudemd-hotpatch) into a single PR per the mktd debate consolidation (originally PR10+PR11 → merged PR10).

**Tests added (13)**:
- Session self-review (4): `test_disabled_no_session_review`, `test_enabled_creates_session_review_drawer`, `test_linked_drawer_ids_in_sentinel_section`, `test_short_message_skipped`
- Hotpatch (5): `test_apply_confirm_merges_to_claudemd`, `test_apply_preserves_existing_content`, `test_apply_without_confirm_is_dry_run`, `test_hotpatch_no_llm_api_calls`, `test_review_lists_pending_suggestions`
- Threat-model patches (4): `test_hotpatch_symlink_escape_rejected`, `test_invalid_linked_drawer_ids_does_not_block_hooks_raw`, `test_linked_drawer_ids_rejects_manual_hooks_raw_with_external_source`, `test_linked_drawer_ids_does_not_read_external_filesystem`
- Round-2 byte-identical regression in `tests/progressive_disclosure.rs`: `test_search_non_progressive_returns_raw_bytes_for_session_review_drawer`
- Round-3 happy-path regression: `test_linked_drawer_ids_accepts_real_hooks_raw_from_same_session`

**Threat-model patches honored**:
- `[Security]` linked_drawer_ids cross-session/project rejection (capture-time embedded `session_id` + `source_type=Conversation` trust marker; daemon-only trust boundary)
- `[Security]` Sentinel block excluded from preview / AAAK / vectorization (raw drawer storage retains it)
- `[Security]` Symlink escape rejected by canonical-path allowlist on hotpatch source-scan AND target-apply
- `[Security]` Runtime no-outbound assertion via local TcpListener + HTTP_PROXY/HTTPS_PROXY/ALL_PROXY env capture (NOT source grep)
- `[Security]` Control-char escape on hotpatch review/apply output (reuses PR9's `escape_terminal_text()`)

**Architectural decision** (round-4): trust boundary for linked_drawer_ids hooks-raw provenance is bound to daemon capture path. ONLY drawers with `wing="hooks-raw" + source_type=Conversation + embedded mempal:hooks-raw sentinel` qualify as linked evidence. `mempal_ingest`-written drawers cannot satisfy this regardless of forged content. Old hooks-raw drawers without embedded session_id → rejected as unknown-session linked evidence (Option B migration: no backfill, no filesystem fallback).

## Review provenance

- **Round 1** (csa-codex tier-4-critical, session `01KPSMM5NVHZPJKENT7ZE2CRGZ`): FAIL × 2 HIGH — search over-applied sentinel strip (broke byte-identical contract); validation failure cascaded into hooks-raw loss.
- **Round 2** (`d14704f`): branch-on-mode in mempal_search; local Result containment in daemon. Review (session `01KPSNM3TAF5SXHQ7JH0CC5ND7`): FAIL × 1 HIGH correctness — `linked_session_id()` returned `source_file` filesystem path; tests masked it with fake fixtures.
- **Round 3** (`6d15add`): typed resolution (sentinel for session-review, envelope JSON+payload file for hooks-raw, None reject-by-default); fixtures updated to production shape. Review (session `01KPSPKA0Q1SFDHEWBR24H86XW`): FAIL × 1 HIGH security — envelope JSON path read enables manual-ingest-forged JSON to bypass cross-session guard; arbitrary local file read / FIFO DoS primitive exposed.
- **Round 4** (`e202655`): trust eliminated from filesystem entirely; capture-time embedded session_id + `source_type=Conversation` trust marker; sentinel-only resolution. Review (session `01KPSQYJ9A5SYXPAT8G1CP625E`): **PASS** — all 46 tests across 4 binaries green; all rounds 1-4 contracts preserved; no AGENTS.md violations.

## Cloud bot status

gemini-code-assist quota cooldown until 2026-04-22T03:48:24Z; reviews delegated to csa-codex tier-4-critical per established PR5/PR6/PR7/PR8/PR9 audit-trail pattern.

## Authorization chain

User pre-approved csa-codex tier-4-critical for review/debate during prior PR5 round when gemini-cli auth started failing with 401; pattern persisted across PR6-PR10. SA-mode Layer 0 orchestrator throughout; all implementation delegated to csa-codex tier-3-complex sessions.

## Residual risks (non-blocking)

- `CLAUDE.md` references `skills/rust-skills/SKILL.md` which is not present in this checkout (cleanup item; not introduced by PR10).
- Pre-existing flaky `test_mcp_roots_list_changed_invalidates_cached_project_id` (PR5 origin) flapped once during round-3 manual run, passed on retry and on pre-commit hook re-run; recommend separate stabilization PR.
- Hotpatch CLI surface (`mempal hotpatch review/apply`) is new; suggestion-pool storage and apply UX should accumulate operator feedback in production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)