### PR TITLE
test(fork-ext): close PR5 canonical scenario gaps + dashboard hooks-raw preview strip + project-scope dashboard coverage

### DIFF
--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -179,8 +179,7 @@ pub fn timeline_command(
     match options.format {
         "json" | "ndjson" => {
             for record in records {
-                let signals =
-                    crate::aaak::analyze(crate::session_review::analysis_content(&record.content));
+                let signals = crate::aaak::analyze(visible_content(&record.wing, &record.content));
                 let line = TimelineJsonLine {
                     timestamp: format_timestamp(&record.added_at),
                     drawer_id: record.id,
@@ -192,7 +191,10 @@ pub fn timeline_command(
                         .into_iter()
                         .map(|value| maybe_escape(&value, options.raw))
                         .collect(),
-                    preview: maybe_escape(&preview(&record.content), options.raw),
+                    preview: maybe_escape(
+                        &preview(&record.wing, &record.content, options.raw),
+                        options.raw,
+                    ),
                 };
                 println!(
                     "{}",
@@ -222,7 +224,13 @@ pub fn timeline_command(
             maybe_escape(render_room(record.room.as_deref()), options.raw),
             maybe_escape(&record.id, options.raw)
         );
-        println!("  {}", maybe_escape(&preview(&record.content), options.raw));
+        println!(
+            "  {}",
+            maybe_escape(
+                &preview(&record.wing, &record.content, options.raw),
+                options.raw,
+            )
+        );
     }
     Ok(())
 }
@@ -236,10 +244,12 @@ pub fn stats_command(db: &Database, config: &Config, options: StatsOptions) -> R
     let fork_ext_version =
         read_fork_ext_version(db.conn()).context("failed to read fork_ext_version")?;
     let mut by_scope = std::collections::BTreeMap::<String, usize>::new();
+    let mut by_project = std::collections::BTreeMap::<Option<String>, usize>::new();
     let mut importance_total = 0i64;
     for record in &records {
         let key = format!("{}/{}", record.wing, render_room(record.room.as_deref()));
         *by_scope.entry(key).or_default() += 1;
+        *by_project.entry(record.project_id.clone()).or_default() += 1;
         importance_total += i64::from(record.importance);
     }
     let avg_importance = if records.is_empty() {
@@ -281,6 +291,13 @@ pub fn stats_command(db: &Database, config: &Config, options: StatsOptions) -> R
     println!("drawers by scope:");
     for (scope_key, count) in by_scope {
         println!("  {}: {count}", maybe_escape(&scope_key, options.raw));
+    }
+    println!("drawers by project:");
+    for (project_id, count) in by_project {
+        match project_id {
+            Some(project_id) => println!("  {}: {count}", maybe_escape(&project_id, options.raw)),
+            None => println!("  NULL: {count}"),
+        }
     }
     println!("queue:");
     println!("  pending: {}", queue_stats.pending);
@@ -349,8 +366,8 @@ pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) ->
     if options.raw {
         println!("{}", drawer.content);
     } else {
-        let signals =
-            crate::aaak::analyze(crate::session_review::analysis_content(&drawer.content));
+        let display_content = visible_content(&drawer.wing, &drawer.content);
+        let signals = crate::aaak::analyze(display_content);
         println!(
             "flags: {}",
             signals
@@ -379,7 +396,7 @@ pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) ->
                 .join(", ")
         );
         println!();
-        println!("{}", maybe_escape(&drawer.content, false));
+        println!("{}", maybe_escape(display_content, false));
     }
     Ok(())
 }
@@ -1061,16 +1078,26 @@ fn format_tail_line(record: &DrawerRecord, raw: bool) -> String {
         maybe_escape(&record.wing, raw),
         maybe_escape(render_room(record.room.as_deref()), raw),
         maybe_escape(&record.id, raw),
-        maybe_escape(&preview(&record.content), raw)
+        maybe_escape(&preview(&record.wing, &record.content, raw), raw)
     )
 }
 
-fn preview(content: &str) -> String {
-    crate::search::preview::truncate(
-        crate::session_review::analysis_content(content),
-        PREVIEW_CHARS,
-    )
-    .content
+fn preview(wing: &str, content: &str, raw: bool) -> String {
+    let content = if raw {
+        content
+    } else {
+        visible_content(wing, content)
+    };
+    crate::search::preview::truncate(content, PREVIEW_CHARS).content
+}
+
+fn visible_content<'a>(wing: &str, content: &'a str) -> &'a str {
+    let content = crate::session_review::analysis_content(content);
+    if wing == "hooks-raw" {
+        crate::session_review::split_hooks_raw_metadata(content).0
+    } else {
+        content
+    }
 }
 
 fn render_room(room: Option<&str>) -> &str {

--- a/src/search/filter.rs
+++ b/src/search/filter.rs
@@ -26,7 +26,7 @@ pub fn build_filter_clause(
     )
 }
 
-pub fn build_vector_search_sql() -> String {
+pub fn build_vector_search_sql(_mode: ProjectFilterMode) -> String {
     format!(
         r#"
         WITH matches AS (
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_vector_recall_project_filter_pushed_to_sql() {
-        let sql = build_vector_search_sql();
+        let sql = build_vector_search_sql(ProjectFilterMode::ProjectScoped);
         assert!(
             sql.contains("v.project_id = ?4"),
             "vector SQL must push project_id filter into the vector CTE: {sql}"

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::core::{
     db::Database,
-    project::{ProjectSearchScope, SearchResultSource},
+    project::{ProjectFilterMode, ProjectSearchScope, SearchResultSource},
     types::{RouteDecision, SearchResult},
     utils::source_file_or_synthetic,
 };
@@ -39,6 +39,8 @@ pub enum SearchError {
     ExecuteSearch(#[source] rusqlite::Error),
     #[error("failed to collect search rows")]
     CollectSearchRows(#[source] rusqlite::Error),
+    #[error("invalid embedding blob for drawer {drawer_id}")]
+    InvalidEmbeddingBlob { drawer_id: String },
     #[error("failed to load taxonomy entries")]
     LoadTaxonomy(#[source] crate::core::db::DbError),
     #[error("failed to run keyword search")]
@@ -349,11 +351,23 @@ pub fn search_by_vector(
         )
         .map_err(SearchError::CountTotalDrawers)?;
 
+    if scope.mode == ProjectFilterMode::ProjectScoped && candidate_count <= 4_096 {
+        return search_by_vector_scoped_exact(
+            db,
+            query_vector,
+            route.clone(),
+            applied_wing,
+            applied_room,
+            top_k,
+            scope.project_id.as_deref(),
+        );
+    }
+
     let query_json =
         serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
     let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
 
-    let search_sql = build_vector_search_sql();
+    let search_sql = build_vector_search_sql(scope.mode);
 
     let mut statement = db
         .conn()
@@ -393,6 +407,124 @@ pub fn search_by_vector(
         .map_err(SearchError::CollectSearchRows)?;
 
     Ok(results)
+}
+
+fn search_by_vector_scoped_exact(
+    db: &Database,
+    query_vector: &[f32],
+    route: RouteDecision,
+    applied_wing: Option<&str>,
+    applied_room: Option<&str>,
+    top_k: usize,
+    project_id: Option<&str>,
+) -> Result<Vec<SearchResult>> {
+    let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
+    let search_sql = r#"
+        SELECT d.id, d.content, d.wing, d.room, d.source_file, d.project_id, v.embedding
+        FROM drawer_vectors v
+        JOIN drawers d ON d.id = v.id
+        WHERE d.deleted_at IS NULL
+          AND (?1 IS NULL OR d.wing = ?1)
+          AND (?2 IS NULL OR d.room = ?2)
+          AND (?3 IS NULL OR d.project_id = ?3)
+        "#;
+    let mut statement = db
+        .conn()
+        .prepare(search_sql)
+        .map_err(SearchError::PrepareSearch)?;
+    let mut rows = statement
+        .query_map((applied_wing, applied_room, project_id), |row| {
+            let drawer_id: String = row.get(0)?;
+            let source_file = row.get::<_, Option<String>>(4)?;
+            let embedding = row.get::<_, Vec<u8>>(6)?;
+            Ok((
+                drawer_id.clone(),
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                source_file_or_synthetic(&drawer_id, source_file.as_deref()),
+                embedding,
+            ))
+        })
+        .map_err(SearchError::ExecuteSearch)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(SearchError::CollectSearchRows)?;
+
+    rows.sort_by(|a, b| {
+        let a_distance = cosine_distance_from_blob(&a.0, &a.5, query_vector);
+        let b_distance = cosine_distance_from_blob(&b.0, &b.5, query_vector);
+        match (a_distance, b_distance) {
+            (Ok(left), Ok(right)) => left
+                .partial_cmp(&right)
+                .unwrap_or(std::cmp::Ordering::Equal),
+            (Ok(_), Err(_)) => std::cmp::Ordering::Less,
+            (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
+            (Err(_), Err(_)) => a.0.cmp(&b.0),
+        }
+    });
+
+    let results = rows
+        .into_iter()
+        .take(top_k as usize)
+        .map(|(drawer_id, content, wing, room, source_file, embedding)| {
+            let distance = cosine_distance_from_blob(&drawer_id, &embedding, query_vector)?;
+            Ok(SearchResult {
+                drawer_id: drawer_id.clone(),
+                content,
+                wing,
+                room,
+                source_file,
+                source: SearchResultSource::Project,
+                similarity: (1.0_f64 - distance) as f32,
+                route: route.clone(),
+                tunnel_hints: vec![],
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(results)
+}
+
+fn cosine_distance_from_blob(
+    drawer_id: &str,
+    embedding_blob: &[u8],
+    query_vector: &[f32],
+) -> Result<f64> {
+    if embedding_blob.len() % std::mem::size_of::<f32>() != 0 {
+        return Err(SearchError::InvalidEmbeddingBlob {
+            drawer_id: drawer_id.to_string(),
+        });
+    }
+    let embedding = embedding_blob
+        .chunks_exact(std::mem::size_of::<f32>())
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect::<Vec<_>>();
+    if embedding.len() != query_vector.len() {
+        return Err(SearchError::InvalidEmbeddingBlob {
+            drawer_id: drawer_id.to_string(),
+        });
+    }
+
+    let dot = embedding
+        .iter()
+        .zip(query_vector.iter())
+        .map(|(left, right)| f64::from(*left) * f64::from(*right))
+        .sum::<f64>();
+    let left_norm = embedding
+        .iter()
+        .map(|value| f64::from(*value) * f64::from(*value))
+        .sum::<f64>()
+        .sqrt();
+    let right_norm = query_vector
+        .iter()
+        .map(|value| f64::from(*value) * f64::from(*value))
+        .sum::<f64>()
+        .sqrt();
+    let cosine_similarity = if left_norm == 0.0 || right_norm == 0.0 {
+        0.0
+    } else {
+        dot / (left_norm * right_norm)
+    };
+    Ok((1.0 - cosine_similarity).clamp(0.0, 2.0))
 }
 
 pub fn resolve_route(

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -13,6 +13,7 @@ use mempal::core::types::{Drawer, SourceType};
 use mempal::ingest::gating::GatingDecision;
 use mempal::ingest::novelty::NoveltyAction;
 use mempal::observability::{self, TailFollowEvent, TailFollowFilters, TailFollowWake};
+use mempal::session_review::append_hooks_raw_metadata;
 use rusqlite::params;
 use tempfile::TempDir;
 
@@ -34,21 +35,7 @@ impl DashboardEnv {
         fs::create_dir_all(&mempal_home).expect("create mempal home");
         let db_path = mempal_home.join("palace.db");
         Database::open(&db_path).expect("open db");
-        write_config_atomic(
-            &mempal_home.join("config.toml"),
-            &format!(
-                r#"
-db_path = "{}"
-
-[embed]
-backend = "model2vec"
-
-[search]
-strict_project_isolation = false
-"#,
-                db_path.display()
-            ),
-        );
+        write_dashboard_config(&mempal_home.join("config.toml"), &db_path, None, false);
         Self {
             _tmp: tmp,
             home,
@@ -58,6 +45,15 @@ strict_project_isolation = false
 
     fn cwd(&self) -> &Path {
         &self.home
+    }
+
+    fn set_project_scope(&self, project_id: Option<&str>, strict_project_isolation: bool) {
+        write_dashboard_config(
+            &self.home.join(".mempal").join("config.toml"),
+            &self.db_path,
+            project_id,
+            strict_project_isolation,
+        );
     }
 }
 
@@ -90,19 +86,54 @@ fn drawer_seed(
 }
 
 fn insert_drawer(db_path: &Path, seed: &DrawerSeed) {
+    insert_drawer_with_project(db_path, seed, None);
+}
+
+fn insert_drawer_with_project(db_path: &Path, seed: &DrawerSeed, project_id: Option<&str>) {
     let db = Database::open(db_path).expect("open db");
-    db.insert_drawer(&Drawer {
-        id: seed.id.clone(),
-        content: seed.content.clone(),
-        wing: seed.wing.clone(),
-        room: seed.room.clone(),
-        source_file: Some(format!("{}.md", seed.id)),
-        source_type: SourceType::Manual,
-        added_at: seed.added_at.clone(),
-        chunk_index: Some(0),
-        importance: seed.importance,
-    })
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: seed.id.clone(),
+            content: seed.content.clone(),
+            wing: seed.wing.clone(),
+            room: seed.room.clone(),
+            source_file: Some(format!("{}.md", seed.id)),
+            source_type: SourceType::Manual,
+            added_at: seed.added_at.clone(),
+            chunk_index: Some(0),
+            importance: seed.importance,
+        },
+        project_id,
+    )
     .expect("insert drawer");
+}
+
+fn write_dashboard_config(
+    path: &Path,
+    db_path: &Path,
+    project_id: Option<&str>,
+    strict_project_isolation: bool,
+) {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
+    write_config_atomic(
+        path,
+        &format!(
+            r#"
+db_path = "{}"
+{}
+[embed]
+backend = "model2vec"
+
+[search]
+strict_project_isolation = {}
+"#,
+            db_path.display(),
+            project_section,
+            strict_project_isolation
+        ),
+    );
 }
 
 fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool) {
@@ -907,4 +938,231 @@ async fn test_tail_follow_fallback_on_inotify_silence() {
     );
     assert_eq!(batch.lines.len(), 1, "{batch:?}");
     assert!(batch.lines[0].contains("fallback-new"), "{batch:?}");
+}
+
+#[test]
+fn test_tail_strips_hooks_raw_sentinel_from_preview() {
+    let env = DashboardEnv::new();
+    let content = append_hooks_raw_metadata(
+        "hook envelope body remains visible",
+        Some("sess-hook-tail"),
+        Some("1713000100"),
+    );
+    insert_drawer(
+        &env.db_path,
+        &drawer_seed(
+            "hooks-raw-preview",
+            content,
+            "hooks-raw",
+            Some("Bash"),
+            "1713005000",
+            2,
+        ),
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("<!-- mempal:hooks-raw -->"),
+        "non-raw tail leaked hooks metadata:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("session_id:"),
+        "non-raw tail leaked session metadata:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("hook envelope body remains visible"),
+        "{stdout}"
+    );
+
+    let raw_output = run_mempal(&env.home, env.cwd(), &["tail", "--raw"]);
+    assert!(
+        raw_output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&raw_output.stderr)
+    );
+    let raw_stdout = String::from_utf8_lossy(&raw_output.stdout);
+    assert!(
+        raw_stdout.contains("<!-- mempal:hooks-raw -->"),
+        "{raw_stdout}"
+    );
+}
+
+#[test]
+fn test_tail_respects_strict_project_isolation() {
+    let env = DashboardEnv::new();
+    env.set_project_scope(Some("proj-A"), true);
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "tail-proj-a",
+            "project A visible",
+            "default",
+            Some("tail"),
+            "1713006002",
+            2,
+        ),
+        Some("proj-A"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "tail-proj-b",
+            "project B hidden",
+            "default",
+            Some("tail"),
+            "1713006001",
+            2,
+        ),
+        Some("proj-B"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "tail-global",
+            "global hidden",
+            "default",
+            Some("tail"),
+            "1713006000",
+            2,
+        ),
+        None,
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("tail-proj-a"), "{stdout}");
+    assert!(!stdout.contains("tail-proj-b"), "{stdout}");
+    assert!(!stdout.contains("tail-global"), "{stdout}");
+}
+
+#[test]
+fn test_stats_per_project_breakdown() {
+    let env = DashboardEnv::new();
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "stats-proj-a-1",
+            "stats project a one",
+            "default",
+            Some("stats"),
+            "1713007000",
+            1,
+        ),
+        Some("proj-A"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "stats-proj-a-2",
+            "stats project a two",
+            "default",
+            Some("stats"),
+            "1713007001",
+            1,
+        ),
+        Some("proj-A"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "stats-proj-b-1",
+            "stats project b one",
+            "default",
+            Some("stats"),
+            "1713007002",
+            1,
+        ),
+        Some("proj-B"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "stats-global-1",
+            "stats global one",
+            "default",
+            Some("stats"),
+            "1713007003",
+            1,
+        ),
+        None,
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["stats"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("drawers by project:"), "{stdout}");
+    assert!(stdout.contains("  proj-A: 2"), "{stdout}");
+    assert!(stdout.contains("  proj-B: 1"), "{stdout}");
+    assert!(stdout.contains("  NULL: 1"), "{stdout}");
+}
+
+#[test]
+fn test_audit_filters_by_project_when_isolation_strict() {
+    let env = DashboardEnv::new();
+    env.set_project_scope(Some("proj-A"), true);
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "audit-proj-a",
+            "audit project a",
+            "default",
+            Some("audit"),
+            "1713008000",
+            2,
+        ),
+        Some("proj-A"),
+    );
+    insert_drawer_with_project(
+        &env.db_path,
+        &drawer_seed(
+            "audit-proj-b",
+            "audit project b",
+            "default",
+            Some("audit"),
+            "1713008001",
+            2,
+        ),
+        Some("proj-B"),
+    );
+    record_novelty_audit(
+        &env.db_path,
+        "audit-proj-a",
+        NoveltyAction::Insert,
+        now_unix_secs(),
+    );
+    record_novelty_audit(
+        &env.db_path,
+        "audit-proj-b",
+        NoveltyAction::Drop,
+        now_unix_secs(),
+    );
+
+    let output = run_mempal(
+        &env.home,
+        env.cwd(),
+        &["audit", "--kind", "novelty", "--since", "7d"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("audit-proj-a"), "{stdout}");
+    assert!(!stdout.contains("audit-proj-b"), "{stdout}");
 }

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
@@ -18,10 +18,12 @@ use mempal::core::db::{
     Database, apply_fork_ext_migrations_to, read_fork_ext_version, set_fork_ext_version,
 };
 use mempal::core::project::{
-    MAX_PROJECT_ID_BYTES, ProjectError, escape_project_id_for_display, infer_project_id_from_path,
-    infer_project_id_from_root_uri, migrate_null_project_ids, validate_project_id,
+    MAX_PROJECT_ID_BYTES, ProjectError, ProjectFilterMode, escape_project_id_for_display,
+    infer_project_id_from_path, infer_project_id_from_root_uri, migrate_null_project_ids,
+    validate_project_id,
 };
 use mempal::core::types::{Drawer, SourceType};
+use mempal::cowork::{PeekRequest, Tool, peek_partner};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::mcp::{MempalMcpServer, SearchRequest};
 use mempal::search::filter::{build_fts_runtime_sql, build_vector_search_sql};
@@ -147,10 +149,14 @@ strict_project_isolation = {}
     )
 }
 
-fn cli_embed_config(db_path: &Path, base_url: &str) -> String {
+fn cli_embed_config(db_path: &Path, base_url: &str, project_id: Option<&str>) -> String {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
     format!(
         r#"
 db_path = "{}"
+{}
 
 [embed]
 backend = "openai_compat"
@@ -168,6 +174,7 @@ request_timeout_secs = 2
 strict_project_isolation = false
 "#,
         db_path.display(),
+        project_section,
         base_url,
         base_url
     )
@@ -177,6 +184,67 @@ fn write_config_atomic(path: &Path, contents: &str) {
     let tmp = path.with_extension("tmp");
     fs::write(&tmp, contents).expect("write temp config");
     fs::rename(&tmp, path).expect("rename config");
+}
+
+fn init_git_repo(path: &Path) {
+    let output = Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(path)
+        .output()
+        .expect("run git init");
+    assert!(
+        output.status.success(),
+        "git init failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn today_ymd() -> (i64, u32, u32) {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86_400);
+    let d = days + 719_468;
+    let era = if d >= 0 { d } else { d - 146_096 } / 146_097;
+    let doe = (d - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { y + 1 } else { y };
+    (year, month as u32, day as u32)
+}
+
+fn codex_day_dir(home: &Path, year: i64, month: u32, day: u32) -> PathBuf {
+    home.join(format!(".codex/sessions/{year:04}/{month:02}/{day:02}"))
+}
+
+fn build_fake_partner_home(cwd: &Path) -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().to_path_buf();
+    let (year, month, day) = today_ymd();
+    let codex_dir = codex_day_dir(&home, year, month, day);
+    fs::create_dir_all(&codex_dir).expect("create codex day dir");
+    let cwd_str = cwd.to_string_lossy();
+    let stamp = format!("{year:04}-{month:02}-{day:02}T12:00:00Z");
+    let codex_jsonl = format!(
+        r#"{{"timestamp":"{stamp}","type":"session_meta","payload":{{"id":"peek","timestamp":"{stamp}","cwd":"{cwd_str}","originator":"codex-tui"}}}}
+{{"timestamp":"{stamp}","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"partner user msg"}}]}}}}
+{{"timestamp":"{stamp}","type":"response_item","payload":{{"type":"message","role":"assistant","content":[{{"type":"output_text","text":"partner assistant msg"}}]}}}}
+"#
+    );
+    fs::write(
+        codex_dir.join(format!(
+            "rollout-{year:04}-{month:02}-{day:02}T12-00-00-peek.jsonl"
+        )),
+        codex_jsonl,
+    )
+    .expect("write codex session");
+    (tmp, home)
 }
 
 fn column_names(conn: &Connection, table: &str) -> Vec<String> {
@@ -391,7 +459,7 @@ async fn call_mcp_search(client: &mut McpStdio, query: &str) -> Value {
 }
 
 #[test]
-fn test_schema_fork_ext_v5_applies_project_id_column() {
+fn test_fork_ext_migration_v4_to_v5_adds_project_id() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
     insert_projected_drawer(
@@ -441,7 +509,7 @@ fn test_schema_fork_ext_v5_applies_project_id_column() {
 }
 
 #[test]
-fn test_migration_v4_to_v5_preserves_null_project_ids() {
+fn test_v4_to_v5_migration_preserves_vectors_during_recreation() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
     insert_projected_drawer(
@@ -466,11 +534,113 @@ fn test_migration_v4_to_v5_preserves_null_project_ids() {
 
     apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
 
+    let vector_ids = db
+        .conn()
+        .prepare("SELECT id FROM drawer_vectors ORDER BY id")
+        .expect("prepare vector ids")
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query vector ids")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect vector ids");
+    let drawer_payloads = db
+        .conn()
+        .prepare("SELECT id, content FROM drawers ORDER BY id")
+        .expect("prepare drawer payloads")
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .expect("query drawer payloads")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect drawer payloads");
+
+    assert_eq!(
+        vector_ids,
+        vec!["legacy-a".to_string(), "legacy-b".to_string()]
+    );
+    assert_eq!(
+        drawer_payloads,
+        vec![
+            ("legacy-a".to_string(), "legacy content a".to_string()),
+            ("legacy-b".to_string(), "legacy content b".to_string())
+        ]
+    );
     assert_eq!(drawer_project_ids(db.conn(), "drawers"), vec![None, None]);
     assert_eq!(
         drawer_project_ids(db.conn(), "drawer_vectors"),
         vec![None, None]
     );
+}
+
+#[test]
+fn test_v4_to_v5_migration_skips_backup_when_table_absent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    insert_projected_drawer(
+        db.path(),
+        "legacy-drawer",
+        "legacy content",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    downgrade_to_v4(db.conn(), true);
+
+    assert!(
+        sqlite_master_sql(db.conn(), "drawer_vectors").is_none(),
+        "legacy v4 fixture should omit drawer_vectors"
+    );
+
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    assert_eq!(read_fork_ext_version(db.conn()).expect("read version"), 5);
+    assert!(
+        sqlite_master_sql(db.conn(), "drawer_vectors").is_none(),
+        "migration should not recreate missing drawer_vectors eagerly"
+    );
+    assert_eq!(drawer_project_ids(db.conn(), "drawers"), vec![None]);
+}
+
+#[test]
+fn test_lazy_create_after_v5_has_project_id_column() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: "lazy-drawer".to_string(),
+            content: "lazy vector creation".to_string(),
+            wing: "code".to_string(),
+            room: Some("room".to_string()),
+            source_file: Some("lazy.md".to_string()),
+            source_type: SourceType::Manual,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+        },
+        Some("proj-lazy"),
+    )
+    .expect("insert drawer");
+    downgrade_to_v4(db.conn(), true);
+    apply_fork_ext_migrations_to(db.conn(), 5).expect("apply ext v5");
+
+    db.insert_vector_with_project("lazy-drawer", &[0.1, 0.2, 0.3], Some("proj-lazy"))
+        .expect("insert vector");
+
+    let vector_sql = sqlite_master_sql(db.conn(), "drawer_vectors").expect("drawer_vectors sql");
+    let stored = db
+        .conn()
+        .query_row(
+            "SELECT project_id FROM drawer_vectors WHERE id = 'lazy-drawer'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read stored vector project");
+
+    assert!(
+        vector_sql.contains("project_id"),
+        "lazy-created drawer_vectors missing project_id: {vector_sql}"
+    );
+    assert_eq!(stored.as_deref(), Some("proj-lazy"));
 }
 
 #[test]
@@ -1047,7 +1217,7 @@ fn test_validate_project_id_rejects_length_over_limit() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_search_excludes_other_project_vectors() {
+async fn test_search_hard_filters_by_project_id() {
     let _guard = config_guard().await;
     let env = SearchEnv::new(None, false);
     insert_projected_drawer(
@@ -1084,6 +1254,227 @@ async fn test_search_excludes_other_project_vectors() {
     )
     .await;
     assert_eq!(parse_search_ids(&json), vec!["drawer-a".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_include_global_returns_project_and_null() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-project",
+        "shared query text",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-global",
+        "shared query text",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-other",
+        "shared query text",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let mut ids = parse_search_ids(
+        &search_response_json_with_request(
+            &env.server(),
+            SearchRequest {
+                query: "shared".to_string(),
+                wing: None,
+                room: None,
+                top_k: Some(10),
+                project_id: Some("proj-A".to_string()),
+                include_global: Some(true),
+                all_projects: None,
+                disable_progressive: None,
+            },
+        )
+        .await,
+    );
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["drawer-global".to_string(), "drawer-project".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_search_without_project_id_returns_all() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    for (id, project_id) in [
+        ("drawer-null", None),
+        ("drawer-a", Some("proj-A")),
+        ("drawer-b", Some("proj-B")),
+    ] {
+        insert_projected_drawer(
+            &env.db_path,
+            id,
+            "rootless shared query",
+            "code",
+            Some("room"),
+            project_id,
+            &[0.1, 0.2, 0.3],
+        );
+    }
+
+    let mut ids = parse_search_ids(
+        &search_response_json_with_request(
+            &env.server(),
+            SearchRequest {
+                query: "rootless".to_string(),
+                wing: None,
+                room: None,
+                top_k: Some(10),
+                project_id: None,
+                include_global: None,
+                all_projects: None,
+                disable_progressive: None,
+            },
+        )
+        .await,
+    );
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "drawer-a".to_string(),
+            "drawer-b".to_string(),
+            "drawer-null".to_string()
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_strict_isolation_without_project_id_returns_null_only() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, true);
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-null",
+        "strict rootless shared query",
+        "code",
+        Some("room"),
+        None,
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-a",
+        "strict rootless shared query",
+        "code",
+        Some("room"),
+        Some("proj-A"),
+        &[0.1, 0.2, 0.3],
+    );
+    insert_projected_drawer(
+        &env.db_path,
+        "drawer-b",
+        "strict rootless shared query",
+        "code",
+        Some("room"),
+        Some("proj-B"),
+        &[0.1, 0.2, 0.3],
+    );
+
+    let json = search_response_json_with_request(
+        &env.server(),
+        SearchRequest {
+            query: "strict".to_string(),
+            wing: None,
+            room: None,
+            top_k: Some(10),
+            project_id: None,
+            include_global: None,
+            all_projects: None,
+            disable_progressive: None,
+        },
+    )
+    .await;
+    assert_eq!(parse_search_ids(&json), vec!["drawer-null".to_string()]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_large_project_does_not_crowd_out_small() {
+    let _guard = config_guard().await;
+    let env = SearchEnv::new(None, false);
+    let db = Database::open(&env.db_path).expect("open db");
+    for index in 0..100_000 {
+        let id = format!("proj-a-{index:06}");
+        let a_vector = vec![0.1, 0.2, 0.3 + ((index % 17) as f32 / 10_000.0)];
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: id.clone(),
+                content: "vector-only crowd control A".to_string(),
+                wing: "code".to_string(),
+                room: Some("room".to_string()),
+                source_file: Some(format!("{id}.md")),
+                source_type: SourceType::Manual,
+                added_at: "1713000000".to_string(),
+                chunk_index: Some(0),
+                importance: 0,
+            },
+            Some("proj-A"),
+        )
+        .expect("insert proj-A drawer");
+        db.insert_vector_with_project(&id, &a_vector, Some("proj-A"))
+            .expect("insert proj-A vector");
+    }
+    for index in 0..10 {
+        let id = format!("proj-b-{index:02}");
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: id.clone(),
+                content: "vector-only crowd control B".to_string(),
+                wing: "code".to_string(),
+                room: Some("room".to_string()),
+                source_file: Some(format!("{id}.md")),
+                source_type: SourceType::Manual,
+                added_at: format!("{}", 1_713_100_000 + index),
+                chunk_index: Some(0),
+                importance: 0,
+            },
+            Some("proj-B"),
+        )
+        .expect("insert proj-B drawer");
+        db.insert_vector_with_project(&id, &[0.9, 0.8, 0.7], Some("proj-B"))
+            .expect("insert proj-B vector");
+    }
+
+    let ids = parse_search_ids(
+        &search_response_json_with_request(
+            &env.server(),
+            SearchRequest {
+                query: "nonexistent-vector-token".to_string(),
+                wing: None,
+                room: None,
+                top_k: Some(10),
+                project_id: Some("proj-B".to_string()),
+                include_global: None,
+                all_projects: None,
+                disable_progressive: None,
+            },
+        )
+        .await,
+    );
+    assert_eq!(ids.len(), 10, "{ids:?}");
+    assert!(
+        ids.iter().all(|id| id.starts_with("proj-b-")),
+        "small project rows were crowded out: {ids:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1160,7 +1551,7 @@ async fn test_vec_search_excludes_other_project() {
     let db = Database::open(&env.db_path).expect("open db");
     let mut stmt = db
         .conn()
-        .prepare(&build_vector_search_sql())
+        .prepare(&build_vector_search_sql(ProjectFilterMode::ProjectScoped))
         .expect("prepare vector sql");
     let ids = stmt
         .query_map(
@@ -1194,7 +1585,7 @@ async fn test_default_project_matches_current_dir() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), None),
     );
     Database::open(&db_path).expect("open db");
     insert_projected_drawer(
@@ -1236,7 +1627,7 @@ async fn test_explicit_project_override_wins_over_default() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), None),
     );
     Database::open(&db_path).expect("open db");
     insert_projected_drawer(
@@ -1266,6 +1657,148 @@ async fn test_explicit_project_override_wins_over_default() {
     assert_eq!(
         parse_cli_search_ids(&output),
         vec!["drawer-foo".to_string()]
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_project_id_auto_inferred_from_git() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let repo_root = tmp.path().join("workspace").join("repo-root");
+    let subdir = repo_root.join("nested").join("child");
+    fs::create_dir_all(&subdir).expect("create nested repo subdir");
+    init_git_repo(&repo_root);
+    let expected = expected_project_id(&repo_root);
+    let subdir_project_id = expected_project_id(&subdir);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), None),
+    );
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-git-root",
+        "git inferred query",
+        "code",
+        Some("room"),
+        Some(&expected),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-subdir",
+        "git inferred query",
+        "code",
+        Some("room"),
+        Some(subdir_project_id.as_str()),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let output = run_mempal_in_dir(&home, &subdir, &["search", "git", "--json"]);
+    assert_eq!(
+        parse_cli_search_ids(&output),
+        vec!["drawer-git-root".to_string()]
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_config_project_id_overrides_git() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let repo_root = tmp.path().join("workspace").join("repo-root");
+    let subdir = repo_root.join("nested").join("child");
+    fs::create_dir_all(&subdir).expect("create nested repo subdir");
+    init_git_repo(&repo_root);
+    let git_project_id = expected_project_id(&repo_root);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(
+            &db_path,
+            &format!("http://{addr}/v1"),
+            Some("config-project"),
+        ),
+    );
+    Database::open(&db_path).expect("open db");
+    insert_projected_drawer(
+        &db_path,
+        "drawer-config",
+        "config override query",
+        "code",
+        Some("room"),
+        Some("config-project"),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+    insert_projected_drawer(
+        &db_path,
+        "drawer-git-root",
+        "config override query",
+        "code",
+        Some("room"),
+        Some(&git_project_id),
+        &[0.1, 0.2, 0.3, 0.4],
+    );
+
+    let output = run_mempal_in_dir(&home, &subdir, &["search", "config", "--json"]);
+    assert_eq!(
+        parse_cli_search_ids(&output),
+        vec!["drawer-config".to_string()]
+    );
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cli_project_overrides_config() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let repo_root = tmp.path().join("workspace").join("repo-root");
+    let subdir = repo_root.join("nested").join("child");
+    fs::create_dir_all(&subdir).expect("create nested repo subdir");
+    init_git_repo(&repo_root);
+    let git_project_id = expected_project_id(&repo_root);
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_config_atomic(
+        &home.join(".mempal").join("config.toml"),
+        &cli_embed_config(
+            &db_path,
+            &format!("http://{addr}/v1"),
+            Some("config-project"),
+        ),
+    );
+    Database::open(&db_path).expect("open db");
+    for (id, project_id) in [
+        ("drawer-cli", "cli-project"),
+        ("drawer-config", "config-project"),
+        ("drawer-git-root", git_project_id.as_str()),
+    ] {
+        insert_projected_drawer(
+            &db_path,
+            id,
+            "cli override query",
+            "code",
+            Some("room"),
+            Some(project_id),
+            &[0.1, 0.2, 0.3, 0.4],
+        );
+    }
+
+    let output = run_mempal_in_dir(
+        &home,
+        &subdir,
+        &["search", "cli", "--project", "cli-project", "--json"],
+    );
+    assert_eq!(
+        parse_cli_search_ids(&output),
+        vec!["drawer-cli".to_string()]
     );
     handle.shutdown().await;
 }
@@ -1403,7 +1936,7 @@ async fn test_ingest_stores_project_id_from_cwd() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), None),
     );
 
     let output = run_mempal_in_dir(
@@ -1437,7 +1970,7 @@ async fn test_ingest_stores_project_id_from_cwd() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_project_id_override_flag() {
+async fn test_ingest_with_project_id_persists() {
     let tmp = TempDir::new().expect("tempdir");
     let home = install_cli_home(&tmp);
     let db_path = home.join(".mempal").join("palace.db");
@@ -1452,7 +1985,7 @@ async fn test_ingest_project_id_override_flag() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     write_config_atomic(
         &home.join(".mempal").join("config.toml"),
-        &cli_embed_config(&db_path, &format!("http://{addr}/v1")),
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), None),
     );
 
     let output = run_mempal_in_dir(
@@ -1685,6 +2218,26 @@ async fn test_mcp_search_without_project_runs_unscoped_when_not_strict() {
             .any(|warning| warning["message"] == "no project scope resolved, isolation strict"),
         "unexpected warnings: {structured}"
     );
+}
+
+#[test]
+fn test_peek_partner_unaffected_by_project_filter() {
+    let cwd = std::env::current_dir().expect("current dir");
+    let (_tmp, home) = build_fake_partner_home(&cwd);
+    let request = PeekRequest {
+        tool: Tool::Codex,
+        limit: 10,
+        since: None,
+        cwd,
+        caller_tool: Some(Tool::Claude),
+        home_override: Some(home),
+    };
+
+    let response = peek_partner(request).expect("peek partner");
+    assert_eq!(response.partner_tool, Tool::Codex);
+    assert_eq!(response.messages.len(), 2);
+    assert_eq!(response.messages[0].text, "partner user msg");
+    assert_eq!(response.messages[1].text, "partner assistant msg");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

F1 final review (csa-codex tier-4-critical session \`01KPSR9YJZ5BX224T956EKXD53\`) verdict was REJECT for canonical scenario coverage drift (NOT for any security/correctness defect). All 10 fork-ext PRs' implementation, trust boundaries, and cross-PR interactions were clean. Gap was 14 canonical-named PR5 scenarios missing (renames + truly missing) plus 2 dashboard consistency issues.

This PR closes those gaps.

## What changed

**14 PR5 canonical-named tests** in \`tests/project_vector_isolation.rs\`:
- 6 renames: \`test_fork_ext_migration_v4_to_v5_adds_project_id\`, \`test_v4_to_v5_migration_preserves_vectors_during_recreation\`, \`test_v4_to_v5_migration_skips_backup_when_table_absent\`, \`test_lazy_create_after_v5_has_project_id_column\`, \`test_ingest_with_project_id_persists\`, \`test_search_hard_filters_by_project_id\`
- 8 truly new: \`test_search_include_global_returns_project_and_null\`, \`test_search_without_project_id_returns_all\`, \`test_strict_isolation_without_project_id_returns_null_only\`, \`test_large_project_does_not_crowd_out_small\`, \`test_project_id_auto_inferred_from_git\`, \`test_config_project_id_overrides_git\`, \`test_cli_project_overrides_config\`, \`test_peek_partner_unaffected_by_project_filter\`

**Dashboard fixes**:
- \`src/observability/mod.rs\` preview path now calls \`split_hooks_raw_metadata()\` from \`src/session_review.rs\` to strip the PR10-introduced hooks-raw sentinel block from non-raw \`mempal tail/timeline/view\` output (raw passes through unchanged)
- \`src/observability/mod.rs:295\` adds per-project breakdown to \`mempal stats\`
- New tests in \`tests/cli_dashboard.rs\`: \`test_tail_strips_hooks_raw_sentinel_from_preview\`, \`test_tail_respects_strict_project_isolation\`, \`test_stats_per_project_breakdown\`, \`test_audit_filters_by_project_when_isolation_strict\`

**Implementation bonus** (to give \`test_large_project_does_not_crowd_out_small\` real strength):
- \`src/search/mod.rs:354,412,487\` adds project-scoped bounded exact fallback (gated to \`ProjectScoped\` + \`candidate_count <= 4096\`) so vector-recall doesn't crowd out small projects when knn returns insufficient project-scoped rows. Cosine scoring consistent with existing repo similarity handling.

## Review provenance

- F1 final review (csa-codex tier-4-critical, session \`01KPSR9YJZ5BX224T956EKXD53\`): REJECT for coverage; no security/correctness defect.
- F-cleanup implementation internal review (csa, session \`01KPSVC4QJXFJC6NPG8WAHZFCR\`): PASS.
- F-cleanup implementation security audit (session \`01KPSVMV5BZXEYWEHAAQA4NKHM\`): PASS.
- Independent F-cleanup review (csa-codex tier-4-critical, session \`01KPSW0PY3WG5E21M7XF6XB3C8\`): **PASS** — no blocking findings; project-scoped vector fallback verified bounded and cosine-consistent; hooks-raw preview strip verified to bypass via \`--raw\`; AGENTS.md compliance across all touched files.

## Cloud bot status

gemini-code-assist quota cooldown until 2026-04-22T03:48:24Z; reviews via csa-codex tier-4-critical per established PR5-PR10 audit-trail pattern.

## Out of scope (deferred)

- 6 PR3 (embed-qwen3) + 1 PR6 (gating) + 7 PR10 (session-self-review) spec-vs-TODO drift items flagged by F1 — these are spec gaps, not TODO gaps, deferred to future cleanup.
- Pre-existing flaky \`test_mcp_roots_list_changed_invalidates_cached_project_id\` (introduced PR5 commit \`b45013d\`) stabilization — separate task tracked.
- \`CLAUDE.md\` references \`skills/rust-skills/SKILL.md\` (path missing in checkout) — doc cleanup, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)