### PR TITLE
fix(#20+#50): queue id spec + stabilize mcp roots/list_changed flaky test

### DIFF
--- a/specs/fork-ext/p8-pending-message-store.spec.md
+++ b/specs/fork-ext/p8-pending-message-store.spec.md
@@ -19,7 +19,7 @@ estimate: 2d
 - 表结构：
   ```sql
   CREATE TABLE pending_messages (
-      id TEXT PRIMARY KEY,              -- ULID
+      id TEXT PRIMARY KEY,              -- monotonic id: <prefix>-<millis_hex>-<counter_hex>, lex-sortable (enqueue 顺序 = id 顺序)
       kind TEXT NOT NULL,               -- 'hook_event' | 'bulk_import' | etc.
       payload TEXT NOT NULL,            -- JSON 原文
       status TEXT NOT NULL,             -- 'pending' | 'claimed' | 'failed'
@@ -36,7 +36,7 @@ estimate: 2d
   CREATE INDEX idx_pending_heartbeat ON pending_messages(status, heartbeat_at) WHERE status='claimed';
   ```
 - 公共 API：
-  - `enqueue(kind: &str, payload: &str) -> Result<String>` 返回新消息 ULID，写入时 `status='pending'`, `next_attempt_at=now`
+  - `enqueue(kind: &str, payload: &str) -> Result<String>` 返回新消息 id（格式 `<prefix>-<millis_hex>-<counter_hex>`，单调且字典序可排）；写入时 `status='pending'`, `next_attempt_at=now`
   - `claim_next(worker_id: &str, claim_ttl_secs: i64) -> Result<Option<ClaimedMessage>>` 原子更新（SELECT + UPDATE in txn）一条 `status='pending' AND next_attempt_at <= now` 的消息，标为 `claimed`
   - `confirm(id: &str) -> Result<()>` 处理成功，DELETE 该行
   - `mark_failed(id: &str, error: &str) -> Result<()>` 处理失败，`retry_count += 1`，`next_attempt_at = now + backoff(retry_count)`，`status='pending'`（重新可领取）；超过 `max_retries` 时 `status='failed'` 永久保留供审计
@@ -60,7 +60,7 @@ estimate: 2d
 - `crates/mempal-core/src/lib.rs`（`pub mod queue` + re-export）
 - `crates/mempal-core/src/db/schema.rs` 或等价（fork_ext_version `0 → 1` migration + `pending_messages` DDL）
 - `crates/mempal-core/src/db.rs` 或 `db/mod.rs`（`Database::open` 追加 `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL`；启动时调 `reclaim_stale`）
-- `crates/mempal-core/Cargo.toml`（添加 `thiserror`、`ulid` workspace dep，若尚未有）
+- `crates/mempal-core/Cargo.toml`（添加 `thiserror` workspace dep，若尚未有；message id 使用内置 millis+counter 格式，不依赖 `ulid` crate）
 - `crates/mempal-cli/src/main.rs`（`mempal status` 加队列 stats 行）
 - `tests/queue_crash_safety.rs`（新建集成测试文件）
 - `tests/queue_concurrency.rs`（新建）

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -2143,7 +2143,22 @@ async fn test_mcp_roots_list_changed_invalidates_cached_project_id() {
         .await
         .expect("notify roots changed");
 
-    let second = call_mcp_search(&mut client, "root change").await;
+    // MCP `roots/list_changed` is fire-and-forget per protocol: no response is sent
+    // back after the server processes the notification. Under load the server's
+    // cache-invalidation handler may race with the next `tools/call`, so clients
+    // must poll until propagation is observed. See issue #50 for flake history.
+    let second = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let response = call_mcp_search(&mut client, "root change").await;
+            if parse_search_ids(&response) == vec!["drawer-project-b".to_string()] {
+                return response;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("roots change did not reflect in search within 5s");
+
     assert_eq!(
         parse_search_ids(&second),
         vec!["drawer-project-b".to_string()]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "6c5dcc365291a65c489633313a6bba14bca482cd"
+commit = "48fe3c3790fd837721cfd43c12fa05c4f178020c"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- **#20 (item 4)**: Amend `specs/fork-ext/p8-pending-message-store.spec.md` to document the actual `<prefix>-<millis_hex>-<counter_hex>` monotonic-id format (lex-sortable, prefix-typed) instead of ULID. Drops stale `ulid` crate dep reference. Items 1-3 already landed in PR #30.
- **#50**: Wrap the second `call_mcp_search` in `test_mcp_roots_list_changed_invalidates_cached_project_id` with a 5 s poll loop. `roots/list_changed` is fire-and-forget per MCP protocol; clients must tolerate eventual consistency between notification receipt and server-side cache invalidation. Verified stable across 10 consecutive isolated runs.
- Routine `weave.lock` refresh per repo convention.

Closes #20
Closes #50

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `just clippy` passes
- [x] `cargo test --features rest` full suite passes (~165s, 200+ tests)
- [x] `test_mcp_roots_list_changed_invalidates_cached_project_id` passes 10/10 runs (stress validation)

Generated with [Claude Code](https://claude.com/claude-code)