### PR TITLE
docs(fork-ext): add P11 claude-mem parity specs (integrations + prime + timeline)

### DIFF
--- a/specs/fork-ext/p11-integrations-layer.spec.md
+++ b/specs/fork-ext/p11-integrations-layer.spec.md
@@ -1,0 +1,183 @@
+spec: task
+name: "P11: Tool-neutral integrations layer (~/.mempal/integrations/ as shared hook/skill asset root)"
+tags: [feature, integration, hooks, cli, distribution]
+estimate: 1.5d
+---
+
+## Intent
+
+为 mempal 建立一个**工具中立**的 integration 资产目录 `~/.mempal/integrations/{claude-code,codex,csa}/`，把 hook scripts + skill manifests 放在 agent 无关的 POSIX 路径上；agent 配置（`~/.claude/settings.json` 等**全局** config）只写 reference，不内嵌逻辑。
+
+**动机**：
+- 用户不想跟踪 repo 内 `./.claude`（现有 `mempal cowork-install-hooks` 往 `./.claude/settings.json` 写 hook，违反此约束）
+- 后续 Codex / CSA 集成应共享同一 source-of-truth，避免在每个工具的 config 内复制 hook 脚本
+- Mempal 二进制升级时，只更新 `~/.mempal/integrations/` 即可，agent configs 指向的 path 不变
+
+**v11 判决依据**：
+- claude-mem 的 skill/hook 资产散落在 `~/.claude/plugins/claude-mem-*` 下，Claude Code 专属；mempal 定位是多 agent backend，资产与 agent 解耦是必然
+- 现有 `p8-hook-passive-capture` spec 里的 `~/.claude/settings.json` 直接 merge 策略已能 work，但不符合"整合点分离"原则；此 spec **不 cutover** 现有 hook，只给新 hook/skill 铺路，后续 spec 再做迁移
+
+## Decisions
+
+- 新建目录树 `~/.mempal/integrations/`：
+  ```
+  ~/.mempal/integrations/
+  ├── claude-code/
+  │   ├── hooks/         # shell scripts that call `mempal prime`, `mempal session-end`, etc.
+  │   ├── skills/        # SKILL.md files (Claude Code format)
+  │   └── settings-snippet.json  # JSON fragment to merge into ~/.claude/settings.json
+  ├── codex/
+  │   ├── hooks/
+  │   ├── skills/
+  │   └── config-snippet.toml
+  ├── csa/
+  │   └── (reserved; trait-only in this spec)
+  └── manifest.toml      # asset inventory: path -> expected_hash, for bootstrap verification
+  ```
+- 新 CLI 子命令组 `mempal integrations`：
+  - `mempal integrations bootstrap` —— 把 mempal 二进制 `include_str!` 打包的资产解压到 `~/.mempal/integrations/`，校验 hash；已存在且 hash 一致则 no-op，不一致则先备份再覆写
+  - `mempal integrations install --tool <tool> [--profile user|global]` —— 把 `<tool>/settings-snippet.*` 合并进 tool 的 **global** 配置（Claude Code 默认 `~/.claude/settings.json`），`hooks` / `mcpServers` 数组**追加**不覆盖
+  - `mempal integrations uninstall --tool <tool>` —— 从 tool 全局 config 移除由 mempal 写入的 entries（用 `"mempal_source": true` marker 识别），其他 entries 原样保留
+  - `mempal integrations status` —— 列每个 tool 的 install 状态 + 资产 hash 是否 drift
+- 资产 vendoring：mempal 二进制编译时 `include_str!` 把 `assets/integrations/**/*` 嵌入，`bootstrap` 时解压
+- Tool-specific installer 走 trait：
+  ```rust
+  trait ToolIntegration {
+      fn name(&self) -> &'static str;
+      fn config_paths(&self) -> Vec<PathBuf>;
+      fn merge_snippet(&self, existing: &str, snippet: &str) -> Result<String>;
+      fn detect_our_entries<'a>(&self, existing: &'a str) -> Vec<MempalMarker<'a>>;
+  }
+  ```
+  Claude Code 实现落地；Codex / CSA 给占位 impl（返回 `not_yet_implemented` error），为后续 spec 预留
+- Installer 写前**备份**：`settings.json.bak.<unix_ts>`
+- 所有整合写操作通过 `flock(~/.mempal/integrations/.lock)` 串行化（防并发 install）
+- 默认 install target 是**全局**（`~/.claude/settings.json`），**禁止** `--profile project` 落到 `./.claude/`（spec 级 forbidden，见 Boundaries）
+
+## Boundaries
+
+### Allowed
+- `integrations/mod.rs`（新 module）
+- `integrations/{claude_code,codex,csa}.rs`（per-tool impl）
+- `src/main.rs`（注册 `integrations` 子命令组）
+- `assets/integrations/**/*`（资产模板；`cargo build` 时通过 `include_dir!` 或 `include_str!` 打包）
+- `Cargo.toml`（引入 `include_dir` / `serde_json` 已有 / `fs2` for flock）
+- `tests/integrations_layer.rs`（新建集成测试）
+- `docs/integrations.md`（使用说明）
+
+### Forbidden
+- 不写入 repo 内 `./.claude/`、`./.codex/`、`./.csa/`、`./CLAUDE.md`（此 spec 覆盖面）
+- 不写 `~/.claude/settings.local.json`（per-project override，与全局约束冲突）
+- 不改 schema / 不 bump `fork_ext_version`
+- 不 cutover 现有 `p8-hook-passive-capture` 的 hook 写入（本 spec 只给新渠道铺路，迁移是后续 spec）
+- 不做 Windows 路径支持（POSIX only；明确 error on Windows detect）
+- 不实现 Codex / CSA 的 actual merge 逻辑（仅 trait + `not_yet_implemented` stub）
+- 不做 asset 自动升级 / 热更新（只 bootstrap 时校验 hash，drift 提示用户手动 rerun）
+- 不探测 tool 是否已有其他 memory backend（不与 claude-mem 竞争同一 hook slot，完全独立 append）
+
+## Out of Scope
+
+- claude-mem 现有 hook / skill 的迁移（cutover 留给独立 spec，用户要求保留 claude-mem 作为兜底）
+- 各 tool 的 skill 内容移植（`p11-session-priming-hook` 和 `p11-mcp-timeline-tool` 提供数据源；skill 文件模板由后续 spec 填充）
+- 资产签名 / 供应链安全（mempal 自举资产信任 release 二进制，不引入 GPG 验证）
+- Windows 支持
+- 跨机器同步 `~/.mempal/integrations/`（用户本地事务，不做 cloud sync）
+
+## Completion Criteria
+
+Scenario: `mempal integrations bootstrap` 首次运行生成完整目录树
+  Test:
+    Filter: test_bootstrap_creates_integrations_tree
+    Level: integration
+    Targets: integrations/mod.rs
+  Given `$HOME/.mempal/integrations/` 不存在
+  When 运行 `mempal integrations bootstrap`
+  Then `~/.mempal/integrations/claude-code/hooks/` 存在且非空
+  And `~/.mempal/integrations/manifest.toml` 存在并列出所有资产 + blake3 hash
+  And 退出码 0
+
+Scenario: bootstrap 二次运行 hash 一致时 no-op
+  Test:
+    Filter: test_bootstrap_idempotent_when_hash_matches
+    Level: integration
+    Targets: integrations/mod.rs
+  Given `bootstrap` 已运行一次
+  And 所有资产文件 hash 未改
+  When 再次运行 `mempal integrations bootstrap`
+  Then 没有文件被重写（mtime 不变）
+  And stdout 包含 "up-to-date"
+  And 退出码 0
+
+Scenario: `mempal integrations install --tool claude-code` append 而非覆盖
+  Test:
+    Filter: test_install_appends_to_existing_settings
+    Level: integration
+    Targets: integrations/claude_code.rs
+  Given `~/.claude/settings.json` 已有 unrelated `hooks.SessionStart` entry
+  When 运行 `mempal integrations install --tool claude-code`
+  Then 原有 entry 保留，byte-for-byte
+  And 新增 entry 带 `"mempal_source": true` marker
+  And `settings.json.bak.<ts>` 备份文件存在
+
+Scenario: 拒绝 repo 内 `./.claude/`
+  Test:
+    Filter: test_install_refuses_local_claude_dir
+    Level: integration
+    Targets: integrations/claude_code.rs
+  Given CWD 含 `./.claude/` 目录
+  When 运行 `mempal integrations install --tool claude-code --profile project`
+  Then 退出码非零
+  And stderr 包含 "project profile disabled by P11 spec; use --profile user"
+  And `./.claude/settings.json` 未被修改
+
+Scenario: `uninstall` 只清自己的 entries
+  Test:
+    Filter: test_uninstall_preserves_unrelated_entries
+    Level: integration
+    Targets: integrations/claude_code.rs
+  Given `~/.claude/settings.json` 含 mempal + 非 mempal 的 hooks 各一条
+  When 运行 `mempal integrations uninstall --tool claude-code`
+  Then 带 `"mempal_source": true` 的 entry 被删
+  And 不带 marker 的 entry 保留
+  And JSON 仍然合法（无悬垂逗号）
+
+Scenario: 并发 install 被 flock 串行
+  Test:
+    Filter: test_concurrent_install_flock_serialized
+    Level: integration
+    Targets: integrations/mod.rs
+  Given 两个 `mempal integrations install --tool claude-code` 进程同时启动
+  When 两者都 run to completion
+  Then 只有一个 backup file 生成（第二个 install 看到已是最新，no-op）
+  And `~/.claude/settings.json` 合法 JSON
+  And 不存在"丢失的 entry"（至少一次 install 成功写入）
+
+Scenario: Codex / CSA 未实现返回 stub error
+  Test:
+    Filter: test_codex_install_returns_not_yet_implemented
+    Level: unit
+    Targets: src/integrations/codex.rs
+  When 运行 `mempal integrations install --tool codex`
+  Then 退出码非零
+  And stderr 含 "not_yet_implemented: codex integration is spec-reserved, see specs/fork-ext/p11-integrations-layer.spec.md"
+
+Scenario: `status` 报告 asset drift
+  Test:
+    Filter: test_status_reports_drift_on_manual_edit
+    Level: integration
+    Targets: integrations/mod.rs
+  Given `bootstrap` 已成功
+  And 用户手动修改了 `~/.mempal/integrations/claude-code/hooks/session-start.sh`
+  When 运行 `mempal integrations status`
+  Then 该 hook 标为 `drifted`（current_hash != manifest_hash）
+  And 退出码非零（drift 视作需要人工介入）
+
+Scenario: Windows 平台 early-error
+  Test:
+    Filter: test_windows_detection_errors_early
+    Level: unit
+    Targets: integrations/mod.rs
+  Given `cfg!(target_os = "windows")` 为 true
+  When 运行 `mempal integrations bootstrap`
+  Then 退出码非零
+  And stderr 含 "integrations layer is POSIX-only; Windows not supported"

--- a/specs/fork-ext/p11-mcp-timeline-tool.spec.md
+++ b/specs/fork-ext/p11-mcp-timeline-tool.spec.md
@@ -1,0 +1,173 @@
+spec: task
+name: "P11: `mempal_timeline` MCP tool (project narrative aggregator)"
+tags: [feature, mcp, narrative, claude-mem-parity]
+estimate: 0.5d
+---
+
+## Intent
+
+为 MCP 层补齐 claude-mem 的 `timeline` 工具语义：agent 在 session 中途调一次 `mempal_timeline` 就能拿到"本 project 按 importance + 时间排序的叙事视图"，不需要构造搜索 query。
+
+**动机**：
+- `mempal prime`（p11-session-priming-hook）是 SessionStart 的一次性快照；session 中途 agent 想"再看一眼最近的项目记忆"得有 MCP 入口
+- `mempal_search` 是 query-driven，`mempal_tail/timeline/stats`（p10-cli-dashboard）是 CLI 操作员视角；agent 通过 MCP 只能走 search，缺 aggregate view
+- claude-mem 有 `timeline` MCP tool；此 spec 做同样语义的 mempal 版本
+
+**与 `mempal prime` 的差异**：
+- `prime` 是 CLI，单向输出 formatted 文本，供 hook 注入 session
+- `mempal_timeline` 是 MCP tool，返回结构化 `TimelineResponse` DTO，agent 在 session 中 on-demand 调用
+
+## Decisions
+
+- 新 MCP tool `mempal_timeline`（第 11 个 MCP 工具），走 `#[tool]` 宏注册到 `MempalMcpServer`
+- Request schema:
+  ```rust
+  #[derive(Deserialize, JsonSchema)]
+  pub struct TimelineRequest {
+      pub project_id: Option<String>,       // absent → infer from client roots
+      pub since: Option<String>,            // ISO8601 or relative ("7d", "24h"); default "30d"
+      pub until: Option<String>,            // ISO8601; default now
+      pub top_k: Option<usize>,             // default 20, max 100
+      pub min_importance: Option<u8>,       // default 1, i.e., 全返回
+      pub wing: Option<String>,             // optional filter
+      pub room: Option<String>,             // optional filter
+  }
+  ```
+- Response schema:
+  ```rust
+  #[derive(Serialize, JsonSchema)]
+  pub struct TimelineResponse {
+      pub project_id: Option<String>,
+      pub generated_at: String,
+      pub window: TimelineWindow { since: String, until: String },
+      pub entries: Vec<TimelineEntry>,
+      pub stats: TimelineStats { total_in_window: u64, returned: usize, top_wings: Vec<WingCount> },
+      pub system_warnings: Vec<SystemWarning>,
+  }
+  pub struct TimelineEntry {
+      pub drawer_id: String,
+      pub added_at: String,
+      pub importance_stars: u8,
+      pub wing: String,
+      pub room: Option<String>,
+      pub preview: String,           // 200-char UTF-8 safe truncation
+      pub preview_truncated: bool,
+      pub original_content_bytes: u64,  // 对齐 p9-progressive-disclosure `content_truncated` 协议
+  }
+  ```
+- 服务端实现：
+  - 走 `ProjectSearchScope::from_request(project_id, include_global=false, all_projects=false, strict=true)` 做 project 硬过滤（贯彻 p10-project-vector-isolation）
+  - SQL: `SELECT ... FROM drawers WHERE project_id = ? AND added_at >= ? AND added_at < ? AND importance >= ? [AND wing = ?] [AND room = ?] ORDER BY importance DESC, added_at DESC LIMIT ?`
+  - preview 截断走已有 `src/search/preview.rs::truncate`（p9 产物）
+  - `original_content_bytes` 填 raw content 字节数，便于 agent 判断是否该 `mempal_read_drawers` 拿全文
+- **不调 embedder**（aggregate view 不需要 query vector，degraded-safe）
+- tunnel resolver **不参与**（timeline 是 single-project 视图；tunnel hints 只在 search 结果里）
+- 协议注入：把 `mempal_timeline` 列入 `MEMORY_PROTOCOL.instructions` 里"11 条规则"的适当位置（新增一条 rule："Use `mempal_timeline` instead of broad-match `mempal_search` when you want project state overview without a specific question in mind."）
+
+## Boundaries
+
+### Allowed
+- `src/mcp/server.rs`（加 `#[tool] mempal_timeline` handler）
+- `src/mcp/timeline.rs`（新 module，handler 主体）
+- `src/core/timeline.rs`（SQL 查询 + DTO 组装；与 `p11-session-priming-hook` 的 `priming.rs` 不 merge——两者 query 相似但消费方不同，硬共享反而 coupling）
+- `tests/mcp_timeline.rs`（新建集成测试）
+- `src/mcp/protocol.rs`（`MEMORY_PROTOCOL` 新增规则 + 把 timeline tool 列入 ServerInfo.tools 描述）
+
+### Forbidden
+- 不改 schema / 不 bump `fork_ext_version`
+- 不做 vector 检索
+- 不调 tunnel resolver
+- 不返回完整 `content`（只 preview + `original_content_bytes`）
+- 不做 AAAK 结构化信号注入（那是 search 结果的特性，p7）
+- 不在 CLI 侧暴露新子命令（`mempal timeline` 已由 p10-cli-dashboard 占据；此 spec 纯 MCP）
+- 不允许 `all_projects=true`（timeline 是 single-project 语义；跨 project 概览是 dashboard 的事）
+- 不缓存（每次全量 SQL；palace.db local 查询成本极低）
+
+## Out of Scope
+
+- `mempal_search` 和 `mempal_timeline` 的合并入口（两者语义独立，agent 自己选用）
+- LLM narrative 生成（只返回 raw entries）
+- 基于 KG triples 的 timeline（现有 `mempal_kg timeline` action 已覆盖 entity-based timeline）
+- 历史 diff / "自上次 timeline 以来的新增"（stateless tool，不维护 client cursor）
+- 配置化字段子集返回（总是返回完整 entry shape）
+
+## Completion Criteria
+
+Scenario: 基本调用返回按 importance + recency 排序
+  Test:
+    Filter: test_timeline_default_ordering
+    Level: integration
+    Targets: src/mcp/timeline.rs
+  Given 10 条 drawer, 混合 importance 1-5, 随机 added_at
+  When 调 `mempal_timeline` 无 args（但 MCP peer 声明了 root）
+  Then `entries[0].importance_stars` == 5
+  And `entries[0].added_at` 是 5 星中最新
+  And `entries.len() == 10`（默认 top_k=20, 但只有 10 条）
+
+Scenario: project scope 硬过滤
+  Test:
+    Filter: test_timeline_enforces_project_scope
+    Level: integration
+    Targets: src/mcp/timeline.rs
+  Given drawer A 属于 project `foo`, drawer B 属于 `bar`
+  And MCP peer root 推导得到 `foo`
+  When 调 `mempal_timeline`
+  Then `entries` 只含 drawer A
+  And `project_id == "foo"`
+
+Scenario: `since: "7d"` 过滤窗口
+  Test:
+    Filter: test_timeline_since_filter_7d
+    Level: integration
+    Targets: src/core/timeline.rs
+  Given 5 条 drawer 在 7 天内, 5 条 30 天前
+  When 调 `mempal_timeline { since: "7d" }`
+  Then `entries.len() == 5`
+  And `stats.total_in_window == 5`
+
+Scenario: preview 截断信号
+  Test:
+    Filter: test_timeline_preview_truncation_signal
+    Level: integration
+    Targets: src/mcp/timeline.rs
+  Given drawer content 长 500 字节
+  When 调 `mempal_timeline`
+  Then `entries[0].preview.len() <= 200`（UTF-8 char 粒度）
+  And `entries[0].preview_truncated == true`
+  And `entries[0].original_content_bytes == 500`
+
+Scenario: degraded embedder 下 timeline 仍工作
+  Test:
+    Filter: test_timeline_degraded_embedder_still_works
+    Level: integration
+    Targets: src/mcp/timeline.rs
+  Given `global_embed_status()` degraded
+  When 调 `mempal_timeline`
+  Then 返回 200 OK + entries
+  And `system_warnings` 含 embedder degraded warning（信息性，不是 error）
+
+Scenario: 参数校验 `top_k` 上限
+  Test:
+    Filter: test_timeline_top_k_upper_bound
+    Level: unit
+    Targets: src/mcp/timeline.rs
+  When 调 `mempal_timeline { top_k: 500 }`
+  Then 返回 `invalid_params` error 含 "top_k exceeds max 100"
+
+Scenario: 拒绝 `all_projects`
+  Test:
+    Filter: test_timeline_rejects_all_projects
+    Level: unit
+    Targets: src/mcp/timeline.rs
+  When 调 `mempal_timeline { all_projects: true }`（即使 request schema 不含此字段，服务端也应在 extra 字段时 ignore + 不意外 cross-project）
+  Then 行为等同不传 —— 仍然 single-project
+  And 不返回其他 project 的 drawer
+
+Scenario: 协议头注入
+  Test:
+    Filter: test_memory_protocol_mentions_timeline
+    Level: unit
+    Targets: src/mcp/protocol.rs
+  When 读 `MempalMcpServer::get_info().instructions`
+  Then 含 "mempal_timeline" 字样
+  And 含 "project state overview without a specific question" 近似表述

--- a/specs/fork-ext/p11-session-priming-hook.spec.md
+++ b/specs/fork-ext/p11-session-priming-hook.spec.md
@@ -1,0 +1,186 @@
+spec: task
+name: "P11: SessionStart semantic priming (`mempal prime` command + agent hook glue)"
+tags: [feature, cli, hooks, priming, claude-code-parity]
+estimate: 1d
+---
+
+## Intent
+
+复现 claude-mem 最有感的 UX：**session 开始时自动喂一段"你过去在这个 repo 做过什么"的高价值摘要**，让 agent 不用主动调 `mempal_search` 就带着项目上下文开工。
+
+本 spec 提供 `mempal prime` 命令 —— agent hook 脚本（`p11-integrations-layer` 铺的路径）调用它拿到 formatted priming 文本，通过各 agent 的 SessionStart 注入协议送给模型。
+
+**动机**：
+- claude-mem SessionStart 注入是观测到最显著的产品感差距；没这个切过去会明显退步（用户亲口认证）
+- Mempal 当前已有 `mempal_status` 能返回协议 + counts，但无 "recent/important drawer narrative" 渲染；`mempal tail/timeline` 是 CLI 操作员视角，不是 agent 摘要视角
+- Prime 要 embedder-free：embedder degraded 时 SessionStart 仍能 fire，不阻塞 agent 启动
+
+**关键决策**：priming **不走向量检索**，纯 SQL `ORDER BY importance DESC, added_at DESC`。理由：(a) 无 query 上下文（session 刚开，不知道用户要做什么），(b) 必须 degraded-safe。
+
+## Decisions
+
+- 新 CLI 子命令 `mempal prime`：
+  - 默认无 args：按 CWD 推导 `project_id`（复用 p10-project-vector-isolation 的 infer 逻辑），按默认 budget 输出 priming 文本
+  - `--project-id <id>`: override CWD 推导
+  - `--format {text|json}`：默认 text（Claude Code / Codex 直接注入），json 用于 CSA 或未来 machine-consumer
+  - `--token-budget <n>`: 输出内容 token 上限（默认 2048，最小 512，最大 8192）
+  - `--include-stats`: 追加统计块（默认 on），`--no-stats` 关
+  - `--since <duration>`: 只考虑最近一段时间的 drawer（默认 `30d`；`all` 表示不限）
+- 输出 text 格式（三块，固定顺序）：
+  1. **Legend header**：单行，说明 icon / importance stars 语义
+  2. **Timeline block**：`<added_at> <importance_stars> <wing>/<room> <id> — <preview[120]>` 逐行，最多 N 条（受 token budget 控制）
+  3. **Stats block** (opt)：drawer 总数 / 最近 7d ingest 数 / top 3 wings + counts / embedder status（`healthy` 或 `degraded`）
+- 排序策略：`ORDER BY importance DESC, added_at DESC`，不分页
+- Token budgeting：
+  - 用 `tiktoken-rs` 或轻量估算器（4 chars ≈ 1 token）
+  - 超限时按 importance 降序截断；保证至少 1 条 entry + stats block 能 fit
+- 空 DB / 无 drawer：输出空字符串 + exit 0（让 SessionStart hook 静默不干扰）
+- DB 不存在：输出空字符串 + exit 0 + stderr 一行 warning（hook 吞掉 stderr）
+- `--format json` schema：
+  ```json
+  {
+    "project_id": "...",
+    "generated_at": "ISO8601",
+    "legend": "...",
+    "drawers": [{"id":"...", "added_at":"...", "importance_stars":N, "wing":"...", "room":"...", "preview":"..."}, ...],
+    "stats": {"total":N, "recent_7d":N, "top_wings":[{"wing":"...","count":N}], "embedder_status":"healthy|degraded"},
+    "budget_used_tokens": N,
+    "truncated": bool
+  }
+  ```
+- 实现在 `cli/prime.rs`（新 module）+ `src/core/priming.rs`（查询 + budgeting）
+- 直连 `palace.db`（不走 MCP stdio，省 fork + IPC），通过 `Database::open(&db_path)` + 预编译 SQL
+- 输出**必须**是纯文本/JSON，无 ANSI 颜色码（下游是 agent 模型而非 TTY）
+
+## Boundaries
+
+### Allowed
+- `cli/prime.rs`（新 module）
+- `main.rs`（注册 `prime` 子命令）
+- `src/core/priming.rs`（查询 + budgeting）
+- `src/core/lib.rs`（re-export priming mod）
+- `Cargo.toml`（引入 `tiktoken-rs` 或 OK 用 4-char 估算）
+- `tests/priming.rs`（新建集成测试）
+- `tests/fixtures/priming/`（已知 drawer 集 + expected output）
+
+### Forbidden
+- 不 embedder call / 不向量检索（degraded-safe 硬约束）
+- 不修改 drawer / 不写 audit（纯读操作）
+- 不触发 session-self-review / auto-ingest（prime 不 side-effect）
+- 不 touch MCP tool（此命令 CLI-only，MCP 暂不暴露 `mempal_prime`；未来可在独立 spec 加）
+- 不读 hook settings / 不知道自己被谁调（prime 是无状态 CLI）
+- 不做 "自动清理陈旧 drawer"（importance + recency 排序，不是 GC 入口）
+- 不改 schema / 不 bump `fork_ext_version`
+- 不依赖 p11-integrations-layer（prime 是数据产物，hook 集成是消费方；本 spec 可独立落地测试）
+
+## Out of Scope
+
+- hook 脚本的实际安装（`p11-integrations-layer` 负责）
+- MCP 工具 `mempal_prime`（保留未来 spec）
+- Query-aware priming（session 中途用户说了什么后再 prime —— 那是 `mempal_search`，不是 prime）
+- 跨 session 增量 priming（每次全量输出；session context 是模型侧的事）
+- Multi-project aggregated priming（当前 scope 死锁在 CWD 推导的单 project；cross-project 场景走 `--all-projects` 是未来需求）
+- LLM 摘要改写（prime 只返回 drawer 片段，不二次生成文字）
+
+## Completion Criteria
+
+Scenario: 有 drawer 的 project, 默认输出三块
+  Test:
+    Filter: test_prime_default_output_has_three_blocks
+    Level: integration
+    Targets: cli/prime.rs
+  Given CWD 是一个已知 project，`palace.db` 含 5 条 drawer, 混合 importance 1-5
+  When 运行 `mempal prime` 无 args
+  Then stdout 按顺序包含：legend 行、timeline 多行、stats 块
+  And timeline 最前一行是 importance 最高的 drawer
+  And exit 0
+
+Scenario: 空 DB 输出空字符串 + exit 0
+  Test:
+    Filter: test_prime_empty_db_silent
+    Level: integration
+    Targets: cli/prime.rs
+  Given `palace.db` 存在但无 drawer
+  When 运行 `mempal prime`
+  Then stdout 为空
+  And stderr 为空
+  And exit 0
+
+Scenario: DB 不存在也 exit 0
+  Test:
+    Filter: test_prime_missing_db_exits_zero
+    Level: integration
+    Targets: cli/prime.rs
+  Given `~/.mempal/palace.db` 不存在
+  When 运行 `mempal prime`
+  Then stdout 为空
+  And stderr 含 "mempal: palace.db not found; skipping priming" 单行
+  And exit 0
+
+Scenario: `--format json` 输出合法 JSON
+  Test:
+    Filter: test_prime_json_format_valid_schema
+    Level: integration
+    Targets: cli/prime.rs
+  Given 非空 DB
+  When 运行 `mempal prime --format json`
+  Then stdout 是合法 JSON
+  And 顶层 keys 包含 `project_id, generated_at, legend, drawers, stats, budget_used_tokens, truncated`
+  And `drawers[].preview` 长度 <= 120 UTF-8 chars
+
+Scenario: Token budget 超限时按 importance 降序截断
+  Test:
+    Filter: test_prime_token_budget_truncates_by_importance
+    Level: integration
+    Targets: src/core/priming.rs
+  Given 50 条 drawer, 含 5 颗星 + 4 颗星 + 3 颗星各若干
+  And 总 preview tokens 远超 512
+  When 运行 `mempal prime --token-budget 512 --format json`
+  Then 返回 `drawers` 全是 >= 4 星（3 星被截断）
+  And `truncated: true`
+  And `budget_used_tokens <= 512`
+
+Scenario: Degraded embedder 不影响 prime
+  Test:
+    Filter: test_prime_runs_when_embedder_degraded
+    Level: integration
+    Targets: cli/prime.rs
+  Given `palace.db` 有 drawer
+  And `global_embed_status()` 处于 `degraded`
+  When 运行 `mempal prime`
+  Then stdout 正常输出 timeline + stats
+  And `stats.embedder_status == "degraded"`（text 或 json 对等信号）
+  And exit 0
+
+Scenario: `--project-id` override CWD 推导
+  Test:
+    Filter: test_prime_project_id_overrides_cwd
+    Level: integration
+    Targets: cli/prime.rs
+  Given CWD 推导得到 project `foo`
+  And DB 里 `foo` 有 1 条 drawer, `bar` 有 3 条
+  When 运行 `mempal prime --project-id bar`
+  Then timeline 只含 `bar` 的 drawer
+  And drawer count == 3
+
+Scenario: `--since 7d` 过滤窗口
+  Test:
+    Filter: test_prime_since_filter
+    Level: integration
+    Targets: src/core/priming.rs
+  Given 10 条 drawer, 5 条在 7 天内, 5 条在 30 天前
+  When 运行 `mempal prime --since 7d`
+  Then timeline 只含最近 7 天的 5 条
+  And `stats.recent_7d == 5`
+
+Scenario: 输出不含 ANSI 颜色码
+  Test:
+    Filter: test_prime_output_no_ansi_escapes
+    Level: integration
+    Targets: cli/prime.rs
+  Given 任意 DB 状态
+  When 运行 `mempal prime`（即使在 TTY 环境下）
+  Then stdout 不含 `\x1b[` 开头的 ANSI escape 序列
+
+stdout 不含 `\x1b[` 开头的 ANSI escape 序列
+

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "48fe3c3790fd837721cfd43c12fa05c4f178020c"
+commit = "f5462c222ac88aed88b9a7e0612ac6f3dd306d67"
 source_kind = "git"


### PR DESCRIPTION
## Summary

三份独立可并行的 fork-ext P11 spec，合起来是 mempal 对齐 claude-mem 用户体验的最小路径。数据迁移（p12-claude-mem-import）推迟到这 3 条落地 + dogfood 验证之后再写 spec。

- **`specs/fork-ext/p11-integrations-layer.spec.md`** (1.5d) — 工具中立的 `~/.mempal/integrations/{claude-code,codex,csa}/` 资产根 + `mempal integrations {bootstrap,install,uninstall,status}` 子命令；硬禁 repo 内 `./.claude/` 写入、flock 并发保护、Codex/CSA trait 占位
- **`specs/fork-ext/p11-session-priming-hook.spec.md`** (1d) — `mempal prime [--format text|json] [--token-budget N]` embedder-free 排序（importance DESC, added_at DESC）；degraded-safe；空 DB / 缺 DB exit 0 静默
- **`specs/fork-ext/p11-mcp-timeline-tool.spec.md`** (0.5d) — 新 MCP 工具 `mempal_timeline`（11th tool），贯彻 p10 project 硬过滤 + p9 preview 截断协议；拒绝 `all_projects`、不调 embedder、不用 tunnel resolver

## Review

`csa review --range main...HEAD --tool gemini-cli` (session `01KPV8VN02TSK6V55XSJV12DD1`) → **PASS**

Highlights: 
- `p11-integrations-layer`: flock + POSIX-neutral paths 设计到位
- `p11-session-priming-hook`: exit-0 静默策略 + importance budgeting 稳
- `p11-mcp-timeline-tool`: P9 disclosure + P10 isolation 协议复用一致

## Test plan
- [x] `just fmt` / `just clippy` / `just test` (108 tests) via lefthook pre-commit all passed
- [x] Path drift from workspace-layout convention → single-crate layout corrected in all 3 specs (grep `crates/mempal-` returns 0 matches)
- [x] csa-gemini review PASS

## Next

合并后按依赖顺序实现：integrations-layer → session-priming → mcp-timeline（三者实际可并行，此为建议叙事）。

Generated with [Claude Code](https://claude.com/claude-code)