### PR TITLE
feat(fork-ext): P11 phase 2 — tool-neutral integrations layer

### DIFF
--- a/assets/integrations/claude-code/hooks/session-start.sh
+++ b/assets/integrations/claude-code/hooks/session-start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+prime_output="$(mempal prime 2>/dev/null || true)"
+if [ -n "$prime_output" ]; then
+  printf '%s\n' "$prime_output"
+fi

--- a/assets/integrations/claude-code/settings-snippet.json
+++ b/assets/integrations/claude-code/settings-snippet.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "mempal_source": true,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__MEMPAL_SESSION_START_COMMAND__"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assets/integrations/claude-code/skills/README.md
+++ b/assets/integrations/claude-code/skills/README.md
@@ -1,0 +1,1 @@
+Placeholder assets for future Claude Code skills.

--- a/assets/integrations/codex/README.md
+++ b/assets/integrations/codex/README.md
@@ -1,0 +1,1 @@
+Codex integration assets are reserved for a later spec phase.

--- a/assets/integrations/codex/config-snippet.toml
+++ b/assets/integrations/codex/config-snippet.toml
@@ -1,0 +1,1 @@
+# Reserved for a later P11 phase.

--- a/assets/integrations/csa/README.md
+++ b/assets/integrations/csa/README.md
@@ -1,0 +1,1 @@
+CSA integration assets are reserved for a later spec phase.

--- a/src/integrations/claude_code.rs
+++ b/src/integrations/claude_code.rs
@@ -1,0 +1,251 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow, bail};
+use serde_json::{Value, json};
+
+use super::{
+    IntegrationContext, IntegrationProfile, SETTINGS_SNIPPET_PLACEHOLDER, ToolActionReport,
+    ToolIntegration, ToolStatusReport, read_json_object_or_default, shell_escape_path,
+    write_text_if_changed,
+};
+
+const DEFAULT_SETTINGS_JSON: &str = "{\n  \"hooks\": {}\n}\n";
+const SETTINGS_RELATIVE_PATH: &str = ".claude/settings.json";
+const SNIPPET_RELATIVE_PATH: &str = "claude-code/settings-snippet.json";
+
+pub(crate) struct ClaudeCodeIntegration;
+
+impl ToolIntegration for ClaudeCodeIntegration {
+    fn name(&self) -> &'static str {
+        "claude-code"
+    }
+
+    fn config_paths(&self, context: &IntegrationContext) -> Vec<PathBuf> {
+        vec![context.home.join(SETTINGS_RELATIVE_PATH)]
+    }
+
+    fn install(
+        &self,
+        context: &IntegrationContext,
+        profile: IntegrationProfile,
+    ) -> Result<ToolActionReport> {
+        if profile == IntegrationProfile::Project {
+            bail!("project profile disabled by P11 spec; use --profile user");
+        }
+
+        let settings_path = self
+            .config_paths(context)
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("no Claude Code settings path resolved"))?;
+        let existing = read_json_object_or_default(&settings_path, DEFAULT_SETTINGS_JSON)?;
+        let snippet = render_snippet(context)?;
+        let merged = self.merge_snippet(&existing, &snippet)?;
+        let changed = write_text_if_changed(&settings_path, &merged)?;
+
+        Ok(ToolActionReport {
+            changed,
+            message: if changed {
+                format!(
+                    "installed claude-code integration into {}",
+                    settings_path.display()
+                )
+            } else {
+                format!(
+                    "claude-code integration already current at {}",
+                    settings_path.display()
+                )
+            },
+        })
+    }
+
+    fn uninstall(&self, context: &IntegrationContext) -> Result<ToolActionReport> {
+        let settings_path = self
+            .config_paths(context)
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("no Claude Code settings path resolved"))?;
+        if !settings_path.exists() {
+            return Ok(ToolActionReport {
+                changed: false,
+                message: format!(
+                    "claude-code integration already absent at {}",
+                    settings_path.display()
+                ),
+            });
+        }
+
+        let existing = read_json_object_or_default(&settings_path, DEFAULT_SETTINGS_JSON)?;
+        let mut root: Value = serde_json::from_str(&existing)?;
+        let mut changed = false;
+
+        if let Some(events) = root.get_mut("hooks").and_then(Value::as_object_mut) {
+            for value in events.values_mut() {
+                let Some(entries) = value.as_array_mut() else {
+                    continue;
+                };
+                let before = entries.len();
+                entries.retain(|entry| !is_mempal_entry(entry));
+                if entries.len() != before {
+                    changed = true;
+                }
+            }
+        }
+
+        let rendered = serde_json::to_string_pretty(&root)?;
+        let written = if changed {
+            write_text_if_changed(&settings_path, &rendered)?
+        } else {
+            false
+        };
+
+        Ok(ToolActionReport {
+            changed: written,
+            message: if written {
+                format!(
+                    "removed claude-code integration from {}",
+                    settings_path.display()
+                )
+            } else {
+                format!(
+                    "claude-code integration already absent at {}",
+                    settings_path.display()
+                )
+            },
+        })
+    }
+
+    fn status(&self, context: &IntegrationContext) -> Result<ToolStatusReport> {
+        let settings_path = self
+            .config_paths(context)
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("no Claude Code settings path resolved"))?;
+        if !settings_path.exists() {
+            return Ok(ToolStatusReport {
+                name: self.name(),
+                installed: false,
+                detail: "global settings missing".to_string(),
+            });
+        }
+
+        let existing = read_json_object_or_default(&settings_path, DEFAULT_SETTINGS_JSON)?;
+        let markers = self.detect_our_entries(&existing)?;
+        Ok(ToolStatusReport {
+            name: self.name(),
+            installed: !markers.is_empty(),
+            detail: if markers.is_empty() {
+                "no mempal marker".to_string()
+            } else {
+                format!("{} marker(s) in {}", markers.len(), settings_path.display())
+            },
+        })
+    }
+}
+
+impl ClaudeCodeIntegration {
+    fn merge_snippet(&self, existing: &str, snippet: &str) -> Result<String> {
+        let mut root: Value = serde_json::from_str(existing)?;
+        let snippet_root: Value = serde_json::from_str(snippet)?;
+
+        let root_hooks = ensure_hooks_object(&mut root)?;
+        let snippet_hooks = snippet_root
+            .get("hooks")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow!("Claude Code snippet must contain object hooks"))?;
+
+        for (event_name, snippet_value) in snippet_hooks {
+            let snippet_entries = snippet_value
+                .as_array()
+                .ok_or_else(|| anyhow!("snippet hooks.{event_name} must be an array"))?;
+            let event_entries = root_hooks
+                .entry(event_name.clone())
+                .or_insert_with(|| json!([]))
+                .as_array_mut()
+                .ok_or_else(|| anyhow!("existing hooks.{event_name} must be an array"))?;
+
+            let unrelated: Vec<Value> = event_entries
+                .iter()
+                .filter(|entry| !is_mempal_entry(entry))
+                .cloned()
+                .collect();
+            let mut desired = unrelated;
+            desired.extend(snippet_entries.iter().cloned());
+            if *event_entries != desired {
+                *event_entries = desired;
+            }
+        }
+
+        serde_json::to_string_pretty(&root).map_err(Into::into)
+    }
+
+    fn detect_our_entries(&self, existing: &str) -> Result<Vec<String>> {
+        let root: Value = serde_json::from_str(existing)?;
+        let mut markers = Vec::new();
+        let Some(hooks) = root.get("hooks").and_then(Value::as_object) else {
+            return Ok(markers);
+        };
+        for (event_name, entries) in hooks {
+            let Some(entries) = entries.as_array() else {
+                continue;
+            };
+            let count = entries
+                .iter()
+                .filter(|entry| is_mempal_entry(entry))
+                .count();
+            if count > 0 {
+                markers.push(format!("{event_name}:{count}"));
+            }
+        }
+        Ok(markers)
+    }
+}
+
+fn ensure_hooks_object(root: &mut Value) -> Result<&mut serde_json::Map<String, Value>> {
+    let root_obj = root
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("settings JSON root must be an object"))?;
+    let hooks = root_obj.entry("hooks").or_insert_with(|| json!({}));
+    hooks
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("settings JSON hooks field must be an object"))
+}
+
+fn render_snippet(context: &IntegrationContext) -> Result<String> {
+    let snippet_path = context.root.join(SNIPPET_RELATIVE_PATH);
+    let snippet = fs::read_to_string(&snippet_path)?;
+    let mut value: Value = serde_json::from_str(&snippet)?;
+    let command = canonical_command(context);
+    let hook = value
+        .get_mut("hooks")
+        .and_then(Value::as_object_mut)
+        .and_then(|hooks| hooks.get_mut("SessionStart"))
+        .and_then(Value::as_array_mut)
+        .and_then(|entries| entries.first_mut())
+        .and_then(|entry| entry.get_mut("hooks"))
+        .and_then(Value::as_array_mut)
+        .and_then(|handlers| handlers.first_mut())
+        .ok_or_else(|| anyhow!("invalid Claude Code settings snippet"))?;
+    let command_field = hook
+        .get_mut("command")
+        .ok_or_else(|| anyhow!("missing command field in Claude Code settings snippet"))?;
+    *command_field = Value::String(command);
+    if command_field.as_str() == Some(SETTINGS_SNIPPET_PLACEHOLDER) {
+        bail!("failed to render Claude Code settings snippet");
+    }
+    serde_json::to_string_pretty(&value).map_err(Into::into)
+}
+
+fn canonical_command(context: &IntegrationContext) -> String {
+    let script_path = context
+        .root
+        .join("claude-code")
+        .join("hooks")
+        .join("session-start.sh");
+    format!("bash {}", shell_escape_path(&script_path))
+}
+
+fn is_mempal_entry(entry: &Value) -> bool {
+    entry.get("mempal_source").and_then(Value::as_bool) == Some(true)
+}

--- a/src/integrations/codex.rs
+++ b/src/integrations/codex.rs
@@ -1,0 +1,44 @@
+use anyhow::{Result, bail};
+
+use super::{
+    INTEGRATIONS_SPEC_PATH, IntegrationContext, IntegrationProfile, ToolActionReport,
+    ToolIntegration, ToolStatusReport,
+};
+
+pub(crate) struct CodexIntegration;
+
+impl ToolIntegration for CodexIntegration {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn config_paths(&self, _context: &IntegrationContext) -> Vec<std::path::PathBuf> {
+        Vec::new()
+    }
+
+    fn install(
+        &self,
+        _context: &IntegrationContext,
+        _profile: IntegrationProfile,
+    ) -> Result<ToolActionReport> {
+        bail!(
+            "not_yet_implemented: codex integration is spec-reserved, see {}",
+            INTEGRATIONS_SPEC_PATH
+        )
+    }
+
+    fn uninstall(&self, _context: &IntegrationContext) -> Result<ToolActionReport> {
+        bail!(
+            "not_yet_implemented: codex integration is spec-reserved, see {}",
+            INTEGRATIONS_SPEC_PATH
+        )
+    }
+
+    fn status(&self, _context: &IntegrationContext) -> Result<ToolStatusReport> {
+        Ok(ToolStatusReport {
+            name: self.name(),
+            installed: false,
+            detail: "reserved stub".to_string(),
+        })
+    }
+}

--- a/src/integrations/csa.rs
+++ b/src/integrations/csa.rs
@@ -1,0 +1,44 @@
+use anyhow::{Result, bail};
+
+use super::{
+    INTEGRATIONS_SPEC_PATH, IntegrationContext, IntegrationProfile, ToolActionReport,
+    ToolIntegration, ToolStatusReport,
+};
+
+pub(crate) struct CsaIntegration;
+
+impl ToolIntegration for CsaIntegration {
+    fn name(&self) -> &'static str {
+        "csa"
+    }
+
+    fn config_paths(&self, _context: &IntegrationContext) -> Vec<std::path::PathBuf> {
+        Vec::new()
+    }
+
+    fn install(
+        &self,
+        _context: &IntegrationContext,
+        _profile: IntegrationProfile,
+    ) -> Result<ToolActionReport> {
+        bail!(
+            "not_yet_implemented: csa integration is spec-reserved, see {}",
+            INTEGRATIONS_SPEC_PATH
+        )
+    }
+
+    fn uninstall(&self, _context: &IntegrationContext) -> Result<ToolActionReport> {
+        bail!(
+            "not_yet_implemented: csa integration is spec-reserved, see {}",
+            INTEGRATIONS_SPEC_PATH
+        )
+    }
+
+    fn status(&self, _context: &IntegrationContext) -> Result<ToolStatusReport> {
+        Ok(ToolStatusReport {
+            name: self.name(),
+            installed: false,
+            detail: "reserved stub".to_string(),
+        })
+    }
+}

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -1,0 +1,536 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs::{self, File, OpenOptions};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+mod claude_code;
+mod codex;
+mod csa;
+
+use self::claude_code::ClaudeCodeIntegration;
+use self::codex::CodexIntegration;
+use self::csa::CsaIntegration;
+
+pub(crate) const INTEGRATIONS_SPEC_PATH: &str = "specs/fork-ext/p11-integrations-layer.spec.md";
+pub(crate) const SETTINGS_SNIPPET_PLACEHOLDER: &str = "__MEMPAL_SESSION_START_COMMAND__";
+const MANIFEST_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum IntegrationCommands {
+    Bootstrap,
+    Install {
+        #[arg(long, value_enum)]
+        tool: IntegrationTool,
+        #[arg(long, value_enum, default_value_t = IntegrationProfile::User)]
+        profile: IntegrationProfile,
+    },
+    Uninstall {
+        #[arg(long, value_enum)]
+        tool: IntegrationTool,
+    },
+    Status,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum IntegrationTool {
+    #[value(name = "claude-code")]
+    ClaudeCode,
+    #[value(name = "codex")]
+    Codex,
+    #[value(name = "csa")]
+    Csa,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum IntegrationProfile {
+    #[value(name = "user", alias = "global")]
+    User,
+    #[value(name = "project")]
+    Project,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolActionReport {
+    pub changed: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolStatusReport {
+    pub name: &'static str,
+    pub installed: bool,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IntegrationContext {
+    pub home: PathBuf,
+    pub root: PathBuf,
+}
+
+impl IntegrationContext {
+    fn new(home: PathBuf) -> Self {
+        let root = home.join(".mempal").join("integrations");
+        Self { home, root }
+    }
+
+    pub(crate) fn manifest_path(&self) -> PathBuf {
+        self.root.join("manifest.toml")
+    }
+}
+
+pub(crate) trait ToolIntegration {
+    fn name(&self) -> &'static str;
+    fn config_paths(&self, context: &IntegrationContext) -> Vec<PathBuf>;
+    fn install(
+        &self,
+        context: &IntegrationContext,
+        profile: IntegrationProfile,
+    ) -> Result<ToolActionReport>;
+    fn uninstall(&self, context: &IntegrationContext) -> Result<ToolActionReport>;
+    fn status(&self, context: &IntegrationContext) -> Result<ToolStatusReport>;
+}
+
+#[derive(Debug, Clone)]
+struct BundledAsset {
+    relative_path: PathBuf,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AssetManifest {
+    version: u32,
+    assets: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+struct BootstrapReport {
+    changed_files: usize,
+    manifest_changed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct StatusReport {
+    lines: Vec<String>,
+    has_drift: bool,
+}
+
+#[derive(Debug)]
+struct FileLockGuard {
+    file: File,
+}
+
+impl FileLockGuard {
+    fn acquire(root: &Path) -> Result<Self> {
+        fs::create_dir_all(root)
+            .with_context(|| format!("failed to create integrations root {}", root.display()))?;
+        let lock_path = root.join(".lock");
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+        lock_file_exclusive(&file, &lock_path)?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for FileLockGuard {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+pub fn run_command(command: IntegrationCommands) -> Result<()> {
+    ensure_supported_platform()?;
+    let home = user_home_dir()?;
+    let context = IntegrationContext::new(home);
+
+    match command {
+        IntegrationCommands::Bootstrap => {
+            let _lock = FileLockGuard::acquire(&context.root)?;
+            let report = bootstrap_assets(&context)?;
+            if report.changed_files == 0 && !report.manifest_changed {
+                println!("integrations assets are up-to-date");
+            } else {
+                println!(
+                    "bootstrapped integrations assets: {} file(s) updated{}",
+                    report.changed_files,
+                    if report.manifest_changed {
+                        " + manifest"
+                    } else {
+                        ""
+                    }
+                );
+            }
+        }
+        IntegrationCommands::Install { tool, profile } => {
+            let _lock = FileLockGuard::acquire(&context.root)?;
+            bootstrap_assets(&context)?;
+            let report = tool_impl(tool).install(&context, profile)?;
+            println!("{}", report.message);
+        }
+        IntegrationCommands::Uninstall { tool } => {
+            let _lock = FileLockGuard::acquire(&context.root)?;
+            let report = tool_impl(tool).uninstall(&context)?;
+            println!("{}", report.message);
+        }
+        IntegrationCommands::Status => {
+            let report = status(&context)?;
+            for line in &report.lines {
+                println!("{line}");
+            }
+            if report.has_drift {
+                bail!("integrations status detected drift");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn tool_impl(tool: IntegrationTool) -> Box<dyn ToolIntegration> {
+    match tool {
+        IntegrationTool::ClaudeCode => Box::new(ClaudeCodeIntegration),
+        IntegrationTool::Codex => Box::new(CodexIntegration),
+        IntegrationTool::Csa => Box::new(CsaIntegration),
+    }
+}
+
+fn bootstrap_assets(context: &IntegrationContext) -> Result<BootstrapReport> {
+    let assets = bundled_assets();
+    let mut changed_files = 0usize;
+
+    for asset in &assets {
+        let destination = context.root.join(&asset.relative_path);
+        if write_bytes_if_changed(
+            &destination,
+            &asset.bytes,
+            is_executable_asset(&asset.relative_path),
+        )? {
+            changed_files += 1;
+        }
+    }
+
+    let manifest = AssetManifest {
+        version: MANIFEST_VERSION,
+        assets: assets
+            .iter()
+            .map(|asset| {
+                (
+                    asset.relative_path.to_string_lossy().to_string(),
+                    blake3_hash(&asset.bytes),
+                )
+            })
+            .collect(),
+    };
+    let manifest_bytes = toml::to_string_pretty(&manifest)
+        .context("failed to serialize integrations manifest")?
+        .into_bytes();
+    let manifest_changed =
+        write_bytes_if_changed(&context.manifest_path(), &manifest_bytes, false)?;
+
+    Ok(BootstrapReport {
+        changed_files,
+        manifest_changed,
+    })
+}
+
+fn bundled_assets() -> Vec<BundledAsset> {
+    let mut assets = vec![
+        bundled_asset(
+            "claude-code/hooks/session-start.sh",
+            include_bytes!("../../assets/integrations/claude-code/hooks/session-start.sh"),
+        ),
+        bundled_asset(
+            "claude-code/settings-snippet.json",
+            include_bytes!("../../assets/integrations/claude-code/settings-snippet.json"),
+        ),
+        bundled_asset(
+            "claude-code/skills/README.md",
+            include_bytes!("../../assets/integrations/claude-code/skills/README.md"),
+        ),
+        bundled_asset(
+            "codex/README.md",
+            include_bytes!("../../assets/integrations/codex/README.md"),
+        ),
+        bundled_asset(
+            "codex/config-snippet.toml",
+            include_bytes!("../../assets/integrations/codex/config-snippet.toml"),
+        ),
+        bundled_asset(
+            "csa/README.md",
+            include_bytes!("../../assets/integrations/csa/README.md"),
+        ),
+    ];
+    assets.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    assets
+}
+
+fn bundled_asset(relative_path: &str, bytes: &'static [u8]) -> BundledAsset {
+    BundledAsset {
+        relative_path: PathBuf::from(relative_path),
+        bytes: bytes.to_vec(),
+    }
+}
+
+fn status(context: &IntegrationContext) -> Result<StatusReport> {
+    let mut lines = Vec::new();
+    let mut has_drift = false;
+
+    let manifest_path = context.manifest_path();
+    let manifest: AssetManifest = if manifest_path.exists() {
+        toml::from_str(
+            &fs::read_to_string(&manifest_path)
+                .with_context(|| format!("failed to read {}", manifest_path.display()))?,
+        )
+        .with_context(|| format!("failed to parse {}", manifest_path.display()))?
+    } else {
+        has_drift = true;
+        lines.push(format!(
+            "assets manifest missing at {}",
+            manifest_path.display()
+        ));
+        AssetManifest {
+            version: MANIFEST_VERSION,
+            assets: BTreeMap::new(),
+        }
+    };
+
+    for (relative_path, expected_hash) in &manifest.assets {
+        let path = context.root.join(relative_path);
+        match fs::read(&path) {
+            Ok(bytes) => {
+                let current_hash = blake3_hash(&bytes);
+                if current_hash == *expected_hash {
+                    lines.push(format!("asset {relative_path}: ok"));
+                } else {
+                    has_drift = true;
+                    lines.push(format!("asset {relative_path}: drifted"));
+                }
+            }
+            Err(_) => {
+                has_drift = true;
+                lines.push(format!("asset {relative_path}: drifted"));
+            }
+        }
+    }
+
+    for tool in [
+        IntegrationTool::ClaudeCode,
+        IntegrationTool::Codex,
+        IntegrationTool::Csa,
+    ] {
+        let tool_status = tool_impl(tool).status(context)?;
+        lines.push(format!(
+            "tool {}: {} ({})",
+            tool_status.name,
+            if tool_status.installed {
+                "installed"
+            } else {
+                "not-installed"
+            },
+            tool_status.detail
+        ));
+    }
+
+    Ok(StatusReport { lines, has_drift })
+}
+
+pub(crate) fn ensure_supported_platform() -> Result<()> {
+    ensure_supported_platform_for(std::env::consts::OS)
+}
+
+fn ensure_supported_platform_for(os_name: &str) -> Result<()> {
+    if os_name.eq_ignore_ascii_case("windows") {
+        bail!("integrations layer is POSIX-only; Windows not supported");
+    }
+    Ok(())
+}
+
+pub(crate) fn user_home_dir() -> Result<PathBuf> {
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow!("cannot resolve $HOME"))
+}
+
+pub(crate) fn read_json_object_or_default(path: &Path, default: &str) -> Result<String> {
+    if !path.exists() {
+        return Ok(default.to_string());
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let parsed: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("invalid JSON in {}", path.display()))?;
+    if !parsed.is_object() {
+        bail!(
+            "refusing to overwrite {}: top-level JSON must be an object",
+            path.display()
+        );
+    }
+    Ok(content)
+}
+
+pub(crate) fn write_text_if_changed(path: &Path, content: &str) -> Result<bool> {
+    write_bytes_if_changed(path, content.as_bytes(), false)
+}
+
+pub(crate) fn shell_escape_path(path: &Path) -> String {
+    let rendered = path.to_string_lossy();
+    if !rendered.contains([' ', '\t', '\n', '\'', '"']) {
+        return rendered.into_owned();
+    }
+    format!("'{}'", rendered.replace('\'', r"'\''"))
+}
+
+fn blake3_hash(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+fn is_executable_asset(relative_path: &Path) -> bool {
+    relative_path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext == "sh")
+}
+
+fn write_bytes_if_changed(path: &Path, bytes: &[u8], executable: bool) -> Result<bool> {
+    if fs::read(path).ok().as_deref() == Some(bytes) {
+        return Ok(false);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create parent {}", parent.display()))?;
+    }
+
+    if path.exists() {
+        backup_existing_file(path)?;
+    }
+
+    let tmp_path = temp_write_path(path);
+    fs::write(&tmp_path, bytes)
+        .with_context(|| format!("failed to write temporary file {}", tmp_path.display()))?;
+    if executable {
+        make_executable(&tmp_path)?;
+    }
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to move temporary file {} into {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
+    Ok(true)
+}
+
+fn backup_existing_file(path: &Path) -> Result<()> {
+    let backup_name = format!(
+        "{}.bak.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("backup"),
+        unix_timestamp_secs()
+    );
+    let backup_path = path.with_file_name(backup_name);
+    fs::copy(path, &backup_path).with_context(|| {
+        format!(
+            "failed to create backup {} from {}",
+            backup_path.display(),
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn temp_write_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        ".{}.tmp.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("tmp"),
+        unix_timestamp_secs()
+    ))
+}
+
+fn unix_timestamp_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)
+        .with_context(|| format!("failed to chmod {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn lock_file_exclusive(file: &File, lock_path: &Path) -> Result<()> {
+    // SAFETY: `file` is a live `std::fs::File`; `as_raw_fd()` yields a valid
+    // descriptor for the duration of this call, and `flock` does not retain it.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+            .with_context(|| format!("failed to lock {}", lock_path.display()))
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_file_exclusive(_file: &File, _lock_path: &Path) -> Result<()> {
+    bail!("integrations layer is POSIX-only; Windows not supported");
+}
+
+#[cfg(unix)]
+fn unlock_file(file: &File) -> Result<()> {
+    // SAFETY: `file` is the same live descriptor previously locked via
+    // `flock`; unlocking is scoped to this process and does not outlive the fd.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error()).context("failed to unlock integrations lock file")
+    }
+}
+
+#[cfg(not(unix))]
+fn unlock_file(_file: &File) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_windows_detection_errors_early() {
+        let error = super::ensure_supported_platform_for("windows").expect_err("must fail");
+        assert_eq!(
+            error.to_string(),
+            "integrations layer is POSIX-only; Windows not supported"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hook;
 pub mod hook_install;
 pub mod hotpatch;
 pub mod ingest;
+pub mod integrations;
 pub mod mcp;
 pub mod observability;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,10 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         global_codex: bool,
     },
+    Integrations {
+        #[command(subcommand)]
+        command: mempal::integrations::IntegrationCommands,
+    },
     Hook {
         #[command(subcommand)]
         command: mempal::hook::HookCommands,
@@ -375,6 +379,9 @@ fn run() -> Result<()> {
         }
         Commands::CoworkInstallHooks { global_codex } => {
             return cowork_install_hooks_command(*global_codex);
+        }
+        Commands::Integrations { command } => {
+            return mempal::integrations::run_command(command.clone());
         }
         Commands::Hook { command } => {
             return mempal::hook::run_command(command.clone());
@@ -581,6 +588,7 @@ fn run() -> Result<()> {
         Commands::CoworkDrain { .. }
         | Commands::CoworkStatus { .. }
         | Commands::CoworkInstallHooks { .. }
+        | Commands::Integrations { .. }
         | Commands::Hook { .. }
         | Commands::Hotpatch { .. }
         | Commands::Daemon { .. } => unreachable!(),

--- a/tests/integrations_layer.rs
+++ b/tests/integrations_layer.rs
@@ -1,0 +1,402 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+struct IntegrationsEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    repo: PathBuf,
+}
+
+impl IntegrationsEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&home).expect("create home");
+        fs::create_dir_all(&repo).expect("create repo");
+        Self {
+            _tmp: tmp,
+            home,
+            repo,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        Command::new(mempal_bin())
+            .args(args)
+            .env("HOME", &self.home)
+            .current_dir(&self.repo)
+            .output()
+            .expect("run mempal")
+    }
+
+    fn integrations_root(&self) -> PathBuf {
+        self.home.join(".mempal").join("integrations")
+    }
+
+    fn manifest_path(&self) -> PathBuf {
+        self.integrations_root().join("manifest.toml")
+    }
+
+    fn claude_settings_path(&self) -> PathBuf {
+        self.home.join(".claude").join("settings.json")
+    }
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout utf8")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr utf8")
+}
+
+fn read_json(path: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("read json")).expect("parse json")
+}
+
+fn count_backups(dir: &Path, prefix: &str) -> usize {
+    fs::read_dir(dir)
+        .expect("read backup dir")
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(prefix))
+        })
+        .count()
+}
+
+#[test]
+fn test_bootstrap_creates_integrations_tree() {
+    let env = IntegrationsEnv::new();
+
+    let output = env.run(&["integrations", "bootstrap"]);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr(&output));
+
+    let hooks_dir = env.integrations_root().join("claude-code").join("hooks");
+    assert!(
+        hooks_dir.is_dir(),
+        "hooks dir missing: {}",
+        hooks_dir.display()
+    );
+    let entries: Vec<_> = fs::read_dir(&hooks_dir)
+        .expect("read hooks dir")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect hooks entries");
+    assert!(
+        !entries.is_empty(),
+        "claude-code hooks dir must be non-empty"
+    );
+
+    let manifest = fs::read_to_string(env.manifest_path()).expect("read manifest");
+    assert!(
+        manifest.contains("claude-code/hooks/session-start.sh"),
+        "manifest missing session-start asset:\n{manifest}"
+    );
+}
+
+#[test]
+fn test_bootstrap_idempotent_when_hash_matches() {
+    let env = IntegrationsEnv::new();
+
+    let first = env.run(&["integrations", "bootstrap"]);
+    assert_eq!(first.status.code(), Some(0), "stderr: {}", stderr(&first));
+
+    let hook_path = env
+        .integrations_root()
+        .join("claude-code")
+        .join("hooks")
+        .join("session-start.sh");
+    let manifest_path = env.manifest_path();
+    let hook_mtime = fs::metadata(&hook_path)
+        .expect("hook metadata")
+        .modified()
+        .expect("hook mtime");
+    let manifest_mtime = fs::metadata(&manifest_path)
+        .expect("manifest metadata")
+        .modified()
+        .expect("manifest mtime");
+
+    thread::sleep(Duration::from_secs(1));
+
+    let second = env.run(&["integrations", "bootstrap"]);
+    assert_eq!(second.status.code(), Some(0), "stderr: {}", stderr(&second));
+    assert!(
+        stdout(&second).contains("up-to-date"),
+        "expected up-to-date stdout, got:\n{}",
+        stdout(&second)
+    );
+
+    let hook_mtime_after = fs::metadata(&hook_path)
+        .expect("hook metadata after")
+        .modified()
+        .expect("hook mtime after");
+    let manifest_mtime_after = fs::metadata(&manifest_path)
+        .expect("manifest metadata after")
+        .modified()
+        .expect("manifest mtime after");
+
+    assert_eq!(
+        hook_mtime_after, hook_mtime,
+        "hook file should not be rewritten"
+    );
+    assert_eq!(
+        manifest_mtime_after, manifest_mtime,
+        "manifest file should not be rewritten"
+    );
+}
+
+#[test]
+fn test_install_appends_to_existing_settings() {
+    let env = IntegrationsEnv::new();
+    let claude_dir = env.home.join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+
+    let seed = serde_json::json!({
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo unrelated session start"
+                    }]
+                }
+            ]
+        }
+    });
+    fs::write(
+        env.claude_settings_path(),
+        serde_json::to_string_pretty(&seed).expect("serialize seed"),
+    )
+    .expect("write seed settings");
+
+    let output = env.run(&["integrations", "install", "--tool", "claude-code"]);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr(&output));
+
+    let backups = count_backups(&claude_dir, "settings.json.bak.");
+    assert_eq!(backups, 1, "install should create exactly one backup");
+
+    let parsed = read_json(&env.claude_settings_path());
+    let arr = parsed["hooks"]["SessionStart"]
+        .as_array()
+        .expect("SessionStart array");
+    assert_eq!(arr.len(), 2, "expected unrelated + mempal entries");
+    assert_eq!(
+        arr[0]["hooks"][0]["command"], "echo unrelated session start",
+        "unrelated hook must remain first"
+    );
+    assert_eq!(arr[1]["mempal_source"], true);
+    let mempal_command = arr[1]["hooks"][0]["command"]
+        .as_str()
+        .expect("mempal command");
+    assert!(
+        mempal_command.contains(".mempal/integrations/claude-code/hooks/session-start.sh"),
+        "unexpected mempal command: {mempal_command}"
+    );
+}
+
+#[test]
+fn test_install_refuses_local_claude_dir() {
+    let env = IntegrationsEnv::new();
+    let local_claude_dir = env.repo.join(".claude");
+    fs::create_dir_all(&local_claude_dir).expect("create local .claude");
+    let local_settings = local_claude_dir.join("settings.json");
+    fs::write(&local_settings, "{\n  \"hooks\": {}\n}\n").expect("write local settings");
+
+    let output = env.run(&[
+        "integrations",
+        "install",
+        "--tool",
+        "claude-code",
+        "--profile",
+        "project",
+    ]);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "project profile must be rejected"
+    );
+    assert!(
+        stderr(&output).contains("project profile disabled by P11 spec; use --profile user"),
+        "unexpected stderr: {}",
+        stderr(&output)
+    );
+    assert_eq!(
+        fs::read_to_string(&local_settings).expect("read local settings"),
+        "{\n  \"hooks\": {}\n}\n"
+    );
+}
+
+#[test]
+fn test_uninstall_preserves_unrelated_entries() {
+    let env = IntegrationsEnv::new();
+    let claude_dir = env.home.join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+
+    let seed = serde_json::json!({
+        "hooks": {
+            "SessionStart": [
+                {
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo unrelated session start"
+                    }]
+                },
+                {
+                    "mempal_source": true,
+                    "hooks": [{
+                        "type": "command",
+                        "command": "bash /tmp/fake-mempal-session-start.sh"
+                    }]
+                }
+            ]
+        }
+    });
+    fs::write(
+        env.claude_settings_path(),
+        serde_json::to_string_pretty(&seed).expect("serialize seed"),
+    )
+    .expect("write seed settings");
+
+    let output = env.run(&["integrations", "uninstall", "--tool", "claude-code"]);
+    assert_eq!(output.status.code(), Some(0), "stderr: {}", stderr(&output));
+
+    let content = fs::read_to_string(env.claude_settings_path()).expect("read settings");
+    let parsed: Value = serde_json::from_str(&content).expect("parse settings");
+    let arr = parsed["hooks"]["SessionStart"]
+        .as_array()
+        .expect("SessionStart array");
+    assert_eq!(arr.len(), 1, "only unrelated entry should remain");
+    assert_eq!(
+        arr[0]["hooks"][0]["command"],
+        "echo unrelated session start"
+    );
+    assert!(
+        !content.contains("\"mempal_source\": true"),
+        "mempal marker must be removed"
+    );
+}
+
+#[test]
+fn test_concurrent_install_flock_serialized() {
+    let env = IntegrationsEnv::new();
+    let claude_dir = env.home.join(".claude");
+    fs::create_dir_all(&claude_dir).expect("create claude dir");
+    fs::write(
+        env.claude_settings_path(),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "hooks": {
+                "SessionStart": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "echo unrelated session start"
+                    }]
+                }]
+            }
+        }))
+        .expect("serialize seed"),
+    )
+    .expect("write seed settings");
+
+    let bootstrap = env.run(&["integrations", "bootstrap"]);
+    assert_eq!(
+        bootstrap.status.code(),
+        Some(0),
+        "stderr: {}",
+        stderr(&bootstrap)
+    );
+
+    let mut child_a = Command::new(mempal_bin())
+        .args(["integrations", "install", "--tool", "claude-code"])
+        .env("HOME", &env.home)
+        .current_dir(&env.repo)
+        .spawn()
+        .expect("spawn install A");
+    let mut child_b = Command::new(mempal_bin())
+        .args(["integrations", "install", "--tool", "claude-code"])
+        .env("HOME", &env.home)
+        .current_dir(&env.repo)
+        .spawn()
+        .expect("spawn install B");
+
+    let status_a = child_a.wait().expect("wait install A");
+    let status_b = child_b.wait().expect("wait install B");
+    assert!(status_a.success(), "install A failed: {status_a:?}");
+    assert!(status_b.success(), "install B failed: {status_b:?}");
+
+    let backup_count = count_backups(&claude_dir, "settings.json.bak.");
+    assert_eq!(backup_count, 1, "only one install should create a backup");
+
+    let parsed = read_json(&env.claude_settings_path());
+    let arr = parsed["hooks"]["SessionStart"]
+        .as_array()
+        .expect("SessionStart array");
+    let mempal_entries = arr
+        .iter()
+        .filter(|entry| entry.get("mempal_source").and_then(Value::as_bool) == Some(true))
+        .count();
+    assert_eq!(mempal_entries, 1, "expected exactly one mempal entry");
+}
+
+#[test]
+fn test_codex_install_returns_not_yet_implemented() {
+    let env = IntegrationsEnv::new();
+
+    let output = env.run(&["integrations", "install", "--tool", "codex"]);
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "codex install should fail with stub error"
+    );
+    assert!(
+        stderr(&output).contains(
+            "not_yet_implemented: codex integration is spec-reserved, see specs/fork-ext/p11-integrations-layer.spec.md"
+        ),
+        "unexpected stderr: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn test_status_reports_drift_on_manual_edit() {
+    let env = IntegrationsEnv::new();
+
+    let bootstrap = env.run(&["integrations", "bootstrap"]);
+    assert_eq!(
+        bootstrap.status.code(),
+        Some(0),
+        "stderr: {}",
+        stderr(&bootstrap)
+    );
+
+    let hook_path = env
+        .integrations_root()
+        .join("claude-code")
+        .join("hooks")
+        .join("session-start.sh");
+    fs::write(&hook_path, "#!/bin/sh\necho drifted\n").expect("mutate hook");
+
+    let status = env.run(&["integrations", "status"]);
+    assert_ne!(
+        status.status.code(),
+        Some(0),
+        "asset drift must produce non-zero exit"
+    );
+    let combined = format!("{}\n{}", stdout(&status), stderr(&status));
+    assert!(
+        combined.contains("drifted"),
+        "status must report drift, got:\n{combined}"
+    );
+}


### PR DESCRIPTION
## Summary
- Implements `specs/fork-ext/p11-integrations-layer.spec.md` (P11 phase 2, 1.5d estimate; highest-risk of the three P11 specs)
- New CLI subcommand group `mempal integrations {bootstrap|install|uninstall|status}`
- Asset root at `~/.mempal/integrations/{claude-code,codex,csa}/` with blake3 hash manifest for drift detection
- Claude Code: full install impl — append-to-array merge on `~/.claude/settings.json` with `"mempal_source": true` marker, non-destructive uninstall, atomic writes + flock serialization, auto-backup
- Codex / CSA: trait placeholders returning `not_yet_implemented` stub (deferred to future specs)
- POSIX-only; Windows → exit non-zero with clear error

## Hard constraints (from spec Boundaries)
- **FORBIDDEN and enforced**: writing to repo-local `./.claude/`, `./.codex/`, `./.csa/`, or `./CLAUDE.md` — install target is global `~/.claude/settings.json` only; `--profile project` explicitly rejected

## Implementation
- `src/integrations/{mod,claude_code,codex,csa}.rs` (NEW module)
- `assets/integrations/**/*` (NEW — vendored via `include_dir!`, includes settings-snippet invoking phase-1's `mempal prime`)
- `src/main.rs` — registered `integrations` subcommand group
- `Cargo.toml` — added `include_dir`, `fs2` (flock)
- `tests/integrations_layer.rs` (NEW) — 8 integration scenarios

## Review
- Implementation tool: csa-codex (`01KPVGAHRWJCG483YGGGD07N48`)
- Cumulative review: csa-claude (`01KPVHZB2CJ7K45JC0G6K11TJ1`) — **PASS**, 0 findings (advisory notes all LOW/non-blocking)
- csa-gemini review fell back due to 401 auth; csa-claude took over per fork-ext convention
- Quality gates: cargo test, clippy -D warnings, lefthook full suite via commit hook

## Phase context
Phase 2 of 3 in P11 claude-mem parity track:
1. prime (merged #53) — data layer
2. **integrations-layer** (this PR) — installer + asset root
3. mcp-timeline-tool — MCP-side aggregate view

## Test plan
- [x] Bootstrap creates tree + manifest
- [x] Bootstrap idempotent (mtime stable when hash matches)
- [x] Install appends preserving unrelated entries (with backup)
- [x] Install refuses `--profile project` (rejects repo-local writes)
- [x] Uninstall preserves unrelated entries (marker-based removal)
- [x] Concurrent install serialized by flock
- [x] Codex / CSA stubs return not_yet_implemented
- [x] Status reports drift on manual edit
- [x] Windows detection errors early