### PR TITLE
feat(fork-ext): P11 phase 3 — mempal_timeline MCP tool

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,5 +8,6 @@ pub mod project;
 pub mod protocol;
 pub mod queue;
 pub mod reindex;
+pub mod timeline;
 pub mod types;
 pub mod utils;

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -47,6 +47,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    — capture the meaning. Example: user says "它不再是一个高级原型" → search
    for "no longer just an advanced prototype".
 
+3b. USE TIMELINE FOR PROJECT OVERVIEW
+   When you want project state overview without a specific question in mind,
+   call mempal_timeline instead of issuing a broad-match mempal_search.
+   Timeline gives you a project-scoped digest ordered by importance and
+   recency, with previews plus original_content_bytes so you can decide which
+   drawers deserve a deeper read.
+
 4. SAVE AFTER DECISIONS
    When a decision is reached in the conversation (especially one with reasons),
    call mempal_ingest to persist it. Include the rationale, not just the
@@ -131,6 +138,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
+  mempal_timeline      — project-scoped overview without a query, ordered by importance+recency
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_ingest        — save a new drawer (wing required, room optional, importance 0-5)
   mempal_delete        — soft-delete a drawer by ID
@@ -188,6 +196,18 @@ mod tests {
         assert!(
             MEMORY_PROTOCOL.contains("mempal_cowork_push"),
             "MEMORY_PROTOCOL must mention mempal_cowork_push in TOOLS list"
+        );
+    }
+
+    #[test]
+    fn contains_timeline_guidance() {
+        assert!(
+            MEMORY_PROTOCOL.contains("mempal_timeline"),
+            "MEMORY_PROTOCOL must mention mempal_timeline"
+        );
+        assert!(
+            MEMORY_PROTOCOL.contains("project state overview without a specific question"),
+            "MEMORY_PROTOCOL must explain when to use mempal_timeline"
         );
     }
 }

--- a/src/core/timeline.rs
+++ b/src/core/timeline.rs
@@ -1,0 +1,282 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::params;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::core::db::Database;
+use crate::core::project::ProjectSearchScope;
+use crate::cowork::peek::{format_rfc3339, parse_rfc3339};
+use crate::search::preview::truncate;
+
+pub const DEFAULT_TIMELINE_SINCE: &str = "30d";
+pub const DEFAULT_TIMELINE_TOP_K: usize = 20;
+pub const MAX_TIMELINE_TOP_K: usize = 100;
+pub const TIMELINE_PREVIEW_CHAR_LIMIT: usize = 200;
+
+#[derive(Debug, Clone)]
+pub struct TimelineQuery {
+    pub project_id: Option<String>,
+    pub scope: ProjectSearchScope,
+    pub since: String,
+    pub until: Option<String>,
+    pub top_k: usize,
+    pub min_importance: u8,
+    pub wing: Option<String>,
+    pub room: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimelineReport {
+    pub project_id: Option<String>,
+    pub generated_at: String,
+    pub window: TimelineWindow,
+    pub entries: Vec<TimelineEntry>,
+    pub stats: TimelineStats,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimelineWindow {
+    pub since: String,
+    pub until: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimelineEntry {
+    pub drawer_id: String,
+    pub added_at: String,
+    pub importance_stars: u8,
+    pub wing: String,
+    pub room: Option<String>,
+    pub preview: String,
+    pub preview_truncated: bool,
+    pub original_content_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimelineStats {
+    pub total_in_window: u64,
+    pub returned: usize,
+    pub top_wings: Vec<TimelineWingCount>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimelineWingCount {
+    pub wing: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum TimelineError {
+    #[error("invalid since value `{value}`")]
+    InvalidSince { value: String },
+    #[error("invalid until value `{value}`")]
+    InvalidUntil { value: String },
+    #[error("failed to prepare timeline query")]
+    Prepare(#[source] rusqlite::Error),
+    #[error("failed to execute timeline query")]
+    Query(#[source] rusqlite::Error),
+}
+
+#[derive(Debug, Clone)]
+struct TimelineRow {
+    id: String,
+    content: String,
+    wing: String,
+    room: Option<String>,
+    added_at: String,
+    importance: i32,
+}
+
+pub fn build_timeline_report(
+    db: &Database,
+    request: TimelineQuery,
+) -> Result<TimelineReport, TimelineError> {
+    let now = now_unix_secs();
+    let since = parse_since_cutoff(&request.since, now)?;
+    let until = parse_until_cutoff(request.until.as_deref(), now)?;
+    let rows = query_scoped_rows(db, &request.scope)?;
+    let filtered = rows
+        .into_iter()
+        .filter(|row| row.importance >= i32::from(request.min_importance))
+        .filter(|row| {
+            request
+                .wing
+                .as_deref()
+                .is_none_or(|wing| row.wing.as_str() == wing)
+        })
+        .filter(|row| {
+            request
+                .room
+                .as_deref()
+                .is_none_or(|room| row.room.as_deref() == Some(room))
+        })
+        .filter(|row| {
+            parse_added_at(&row.added_at)
+                .is_some_and(|added_at| added_at >= since && added_at < until)
+        })
+        .collect::<Vec<_>>();
+
+    let entries = filtered
+        .iter()
+        .take(request.top_k)
+        .map(build_entry)
+        .collect::<Vec<_>>();
+
+    Ok(TimelineReport {
+        project_id: request.project_id,
+        generated_at: format_timestamp(now),
+        window: TimelineWindow {
+            since: format_timestamp(since),
+            until: format_timestamp(until),
+        },
+        stats: TimelineStats {
+            total_in_window: filtered.len() as u64,
+            returned: entries.len(),
+            top_wings: build_top_wings(&filtered),
+        },
+        entries,
+    })
+}
+
+fn query_scoped_rows(
+    db: &Database,
+    scope: &ProjectSearchScope,
+) -> Result<Vec<TimelineRow>, TimelineError> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT id, content, wing, room, added_at, COALESCE(importance, 0) AS importance
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND (
+                  ?1 = 'all'
+                  OR (?1 = 'project' AND project_id = ?2)
+                  OR (?1 = 'project_plus_global' AND (project_id = ?2 OR project_id IS NULL))
+                  OR (?1 = 'null_only' AND project_id IS NULL)
+              )
+            ORDER BY importance DESC, added_at DESC, id DESC
+            "#,
+        )
+        .map_err(TimelineError::Prepare)?;
+
+    statement
+        .query_map(
+            params![scope.mode_param(), scope.project_id.as_deref()],
+            |row| {
+                Ok(TimelineRow {
+                    id: row.get::<_, String>(0)?,
+                    content: row.get::<_, String>(1)?,
+                    wing: row.get::<_, String>(2)?,
+                    room: row.get::<_, Option<String>>(3)?,
+                    added_at: row.get::<_, String>(4)?,
+                    importance: row.get::<_, i32>(5)?,
+                })
+            },
+        )
+        .map_err(TimelineError::Query)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(TimelineError::Query)
+}
+
+fn build_entry(row: &TimelineRow) -> TimelineEntry {
+    let preview_limit = if row.content.chars().count() > TIMELINE_PREVIEW_CHAR_LIMIT {
+        TIMELINE_PREVIEW_CHAR_LIMIT.saturating_sub(1)
+    } else {
+        TIMELINE_PREVIEW_CHAR_LIMIT
+    };
+    let preview = truncate(&row.content, preview_limit.max(1));
+    TimelineEntry {
+        drawer_id: row.id.clone(),
+        added_at: format_display_added_at(&row.added_at),
+        importance_stars: row.importance.clamp(0, 5) as u8,
+        wing: row.wing.clone(),
+        room: row.room.clone(),
+        preview: preview.content,
+        preview_truncated: preview.truncated,
+        original_content_bytes: row.content.len() as u64,
+    }
+}
+
+fn build_top_wings(rows: &[TimelineRow]) -> Vec<TimelineWingCount> {
+    let mut counts = BTreeMap::<String, u64>::new();
+    for row in rows {
+        *counts.entry(row.wing.clone()).or_default() += 1;
+    }
+
+    let mut top_wings = counts
+        .into_iter()
+        .map(|(wing, count)| TimelineWingCount { wing, count })
+        .collect::<Vec<_>>();
+    top_wings.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.wing.cmp(&right.wing))
+    });
+    top_wings.truncate(3);
+    top_wings
+}
+
+fn parse_since_cutoff(raw: &str, now: i64) -> Result<i64, TimelineError> {
+    if let Some(seconds) = parse_relative_duration(raw) {
+        return Ok(now - seconds);
+    }
+
+    parse_absolute_timestamp(raw).ok_or_else(|| TimelineError::InvalidSince {
+        value: raw.to_string(),
+    })
+}
+
+fn parse_until_cutoff(raw: Option<&str>, now: i64) -> Result<i64, TimelineError> {
+    match raw {
+        None => Ok(now),
+        Some(raw) => parse_absolute_timestamp(raw).ok_or_else(|| TimelineError::InvalidUntil {
+            value: raw.to_string(),
+        }),
+    }
+}
+
+fn parse_relative_duration(raw: &str) -> Option<i64> {
+    if raw.len() < 2 {
+        return None;
+    }
+
+    let (digits, unit) = raw.split_at(raw.len() - 1);
+    let value = digits.parse::<i64>().ok()?;
+    let multiplier = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 24 * 60 * 60,
+        _ => return None,
+    };
+    Some(value * multiplier)
+}
+
+fn parse_absolute_timestamp(raw: &str) -> Option<i64> {
+    raw.parse::<i64>().ok().or_else(|| parse_rfc3339(raw))
+}
+
+fn parse_added_at(raw: &str) -> Option<i64> {
+    parse_absolute_timestamp(raw)
+}
+
+fn format_display_added_at(raw: &str) -> String {
+    parse_added_at(raw)
+        .map(format_timestamp)
+        .unwrap_or_else(|| raw.to_string())
+}
+
+fn format_timestamp(secs: i64) -> String {
+    format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs.max(0) as u64))
+}
+
+fn now_unix_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_secs() as i64
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,9 +1,11 @@
 #![warn(clippy::all)]
 
 mod server;
+mod timeline;
 mod tools;
 
 pub use server::MempalMcpServer;
+pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
     ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse, SearchRequest,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,6 +26,7 @@ use rmcp::{
     tool, tool_handler, tool_router,
 };
 
+use super::timeline::{TimelineRequest, TimelineResponse};
 use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DuplicateWarning,
     EmbedStatusDto, FactCheckRequest, FactCheckResponse, IngestRequest, IngestResponse, KgRequest,
@@ -94,13 +95,13 @@ impl MempalMcpServer {
             .context("failed to initialize MCP stdio transport")
     }
 
-    fn open_db(&self) -> std::result::Result<Database, ErrorData> {
+    pub(super) fn open_db(&self) -> std::result::Result<Database, ErrorData> {
         Database::open(&self.db_path).map_err(|error| {
             ErrorData::internal_error(format!("failed to open database: {error}"), None)
         })
     }
 
-    async fn resolve_mcp_project_id(
+    pub(super) async fn resolve_mcp_project_id(
         &self,
         explicit: Option<&str>,
         config: &crate::core::config::Config,
@@ -331,6 +332,17 @@ impl MempalMcpServer {
                 .collect(),
             system_warnings,
         }))
+    }
+
+    #[tool(
+        name = "mempal_timeline",
+        description = "Return a project-scoped narrative overview ordered by importance and recency, without requiring a search query. Prefer this over broad mempal_search when you want project state overview without a specific question in mind."
+    )]
+    pub async fn mempal_timeline(
+        &self,
+        Parameters(request): Parameters<TimelineRequest>,
+    ) -> std::result::Result<Json<TimelineResponse>, ErrorData> {
+        super::timeline::handle(self, request).await
     }
 
     #[tool(
@@ -1384,7 +1396,7 @@ impl ServerHandler for MempalMcpServer {
     }
 }
 
-fn db_error(error: impl std::fmt::Display) -> ErrorData {
+pub(super) fn db_error(error: impl std::fmt::Display) -> ErrorData {
     ErrorData::internal_error(format!("{error}"), None)
 }
 
@@ -1451,7 +1463,7 @@ fn degraded_write_error() -> ErrorData {
     ErrorData::internal_error(message, data)
 }
 
-fn current_system_warnings() -> Vec<SystemWarning> {
+pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
     let mut warnings = global_embed_status()
         .collect_warnings()
         .into_iter()

--- a/src/mcp/timeline.rs
+++ b/src/mcp/timeline.rs
@@ -1,0 +1,167 @@
+use rmcp::schemars::{self, JsonSchema};
+use rmcp::{ErrorData, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::core::config::ConfigHandle;
+use crate::core::project::ProjectSearchScope;
+use crate::core::timeline::{
+    DEFAULT_TIMELINE_SINCE, DEFAULT_TIMELINE_TOP_K, MAX_TIMELINE_TOP_K, TimelineError,
+    TimelineQuery, TimelineReport, build_timeline_report,
+};
+
+use super::server::{MempalMcpServer, current_system_warnings};
+use super::tools::SystemWarning;
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct TimelineRequest {
+    pub project_id: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub top_k: Option<usize>,
+    pub min_importance: Option<u8>,
+    pub wing: Option<String>,
+    pub room: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TimelineResponse {
+    pub project_id: Option<String>,
+    pub generated_at: String,
+    pub window: TimelineWindow,
+    pub entries: Vec<TimelineEntry>,
+    pub stats: TimelineStats,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TimelineWindow {
+    pub since: String,
+    pub until: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TimelineEntry {
+    pub drawer_id: String,
+    pub added_at: String,
+    pub importance_stars: u8,
+    pub wing: String,
+    pub room: Option<String>,
+    pub preview: String,
+    pub preview_truncated: bool,
+    pub original_content_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TimelineStats {
+    pub total_in_window: u64,
+    pub returned: usize,
+    pub top_wings: Vec<TimelineWingCount>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct TimelineWingCount {
+    pub wing: String,
+    pub count: u64,
+}
+
+pub(super) async fn handle(
+    server: &MempalMcpServer,
+    request: TimelineRequest,
+) -> Result<Json<TimelineResponse>, ErrorData> {
+    let top_k = request.top_k.unwrap_or(DEFAULT_TIMELINE_TOP_K);
+    if top_k > MAX_TIMELINE_TOP_K {
+        return Err(ErrorData::invalid_params(
+            format!("top_k exceeds max {MAX_TIMELINE_TOP_K}"),
+            None,
+        ));
+    }
+
+    let min_importance = request.min_importance.unwrap_or(1);
+    if min_importance > 5 {
+        return Err(ErrorData::invalid_params(
+            "min_importance must be between 0 and 5",
+            None,
+        ));
+    }
+
+    let config = ConfigHandle::current();
+    let project_id = server
+        .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+        .await?;
+    let scope = ProjectSearchScope::from_request(project_id.clone(), false, false, true);
+    let db = server.open_db()?;
+    let report = build_timeline_report(
+        &db,
+        TimelineQuery {
+            project_id,
+            scope,
+            since: request
+                .since
+                .unwrap_or_else(|| DEFAULT_TIMELINE_SINCE.to_string()),
+            until: request.until,
+            top_k,
+            min_importance,
+            wing: request.wing,
+            room: request.room,
+        },
+    )
+    .map_err(timeline_error)?;
+
+    Ok(Json(TimelineResponse::from_report(
+        report,
+        current_system_warnings(),
+    )))
+}
+
+impl TimelineResponse {
+    fn from_report(report: TimelineReport, system_warnings: Vec<SystemWarning>) -> Self {
+        Self {
+            project_id: report.project_id,
+            generated_at: report.generated_at,
+            window: TimelineWindow {
+                since: report.window.since,
+                until: report.window.until,
+            },
+            entries: report
+                .entries
+                .into_iter()
+                .map(|entry| TimelineEntry {
+                    drawer_id: entry.drawer_id,
+                    added_at: entry.added_at,
+                    importance_stars: entry.importance_stars,
+                    wing: entry.wing,
+                    room: entry.room,
+                    preview: entry.preview,
+                    preview_truncated: entry.preview_truncated,
+                    original_content_bytes: entry.original_content_bytes,
+                })
+                .collect(),
+            stats: TimelineStats {
+                total_in_window: report.stats.total_in_window,
+                returned: report.stats.returned,
+                top_wings: report
+                    .stats
+                    .top_wings
+                    .into_iter()
+                    .map(|entry| TimelineWingCount {
+                        wing: entry.wing,
+                        count: entry.count,
+                    })
+                    .collect(),
+            },
+            system_warnings,
+        }
+    }
+}
+
+fn timeline_error(error: TimelineError) -> ErrorData {
+    match error {
+        TimelineError::InvalidSince { .. } | TimelineError::InvalidUntil { .. } => {
+            ErrorData::invalid_params(error.to_string(), None)
+        }
+        TimelineError::Prepare(_) | TimelineError::Query(_) => {
+            ErrorData::internal_error(error.to_string(), None)
+        }
+    }
+}

--- a/tests/mcp_timeline.rs
+++ b/tests/mcp_timeline.rs
@@ -1,0 +1,533 @@
+mod common;
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use common::harness::McpStdio;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::core::project::infer_project_id_from_path;
+use mempal::core::protocol::MEMORY_PROTOCOL;
+use mempal::core::types::{Drawer, SourceType};
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
+use mempal::mcp::{MempalMcpServer, TimelineRequest};
+use rmcp::ServerHandler;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::ErrorCode;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+async fn config_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_secs() as i64
+}
+
+#[derive(Clone)]
+struct PanicEmbedderFactory;
+
+#[async_trait]
+impl EmbedderFactory for PanicEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        panic!("mempal_timeline must not build an embedder");
+    }
+}
+
+struct TimelineEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+}
+
+impl TimelineEnv {
+    fn new(project_id: Option<&str>, degrade_after_failures: u64) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let config_path = mempal_home.join("config.toml");
+        let db_path = mempal_home.join("palace.db");
+        write_config_atomic(
+            &config_path,
+            &timeline_config(&db_path, project_id, degrade_after_failures),
+        );
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        Self { _tmp: tmp, db_path }
+    }
+
+    fn server(&self) -> MempalMcpServer {
+        MempalMcpServer::new_with_factory(self.db_path.clone(), Arc::new(PanicEmbedderFactory))
+    }
+}
+
+fn timeline_config(
+    db_path: &Path,
+    project_id: Option<&str>,
+    degrade_after_failures: u64,
+) -> String {
+    let project_section = project_id
+        .map(|project_id| format!("\n[project]\nid = \"{project_id}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"
+db_path = "{}"
+{}
+[embed]
+backend = "model2vec"
+
+[embed.degradation]
+degrade_after_n_failures = {}
+block_writes_when_degraded = true
+
+[search]
+strict_project_isolation = false
+progressive_disclosure = true
+preview_chars = 200
+"#,
+        db_path.display(),
+        project_section,
+        degrade_after_failures
+    )
+}
+
+fn write_config_atomic(path: &Path, contents: &str) {
+    let tmp_path = path.with_extension("tmp");
+    fs::write(&tmp_path, contents).expect("write temp config");
+    fs::rename(&tmp_path, path).expect("rename config");
+}
+
+struct DrawerSeed<'a> {
+    id: &'a str,
+    content: &'a str,
+    wing: &'a str,
+    room: Option<&'a str>,
+    added_at: i64,
+    importance: i32,
+    project_id: Option<&'a str>,
+}
+
+fn insert_drawer(db_path: &Path, seed: DrawerSeed<'_>) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: seed.id.to_string(),
+            content: seed.content.to_string(),
+            wing: seed.wing.to_string(),
+            room: seed.room.map(ToOwned::to_owned),
+            source_file: Some(format!("/tmp/{}.md", seed.id)),
+            source_type: SourceType::Manual,
+            added_at: seed.added_at.to_string(),
+            chunk_index: Some(0),
+            importance: seed.importance,
+        },
+        seed.project_id,
+    )
+    .expect("insert drawer");
+}
+
+fn expected_project_id(path: &Path) -> String {
+    infer_project_id_from_path(path)
+        .expect("infer project id")
+        .expect("project id present")
+}
+
+async fn call_mcp_timeline(client: &mut McpStdio, arguments: Value) -> Value {
+    let result = match tokio::time::timeout(
+        Duration::from_secs(5),
+        client.call(
+            "tools/call",
+            json!({
+                "name": "mempal_timeline",
+                "arguments": arguments,
+            }),
+        ),
+    )
+    .await
+    {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => {
+            let stderr = client.stderr_lines().await.join("\n");
+            panic!("call mempal_timeline failed: {error}\nstderr:\n{stderr}");
+        }
+        Err(_) => {
+            let stderr = client.stderr_lines().await.join("\n");
+            panic!("call mempal_timeline timed out\nstderr:\n{stderr}");
+        }
+    };
+    result["structuredContent"].clone()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_default_ordering() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    let db_path = mempal_home.join("palace.db");
+    let foo_project = tmp.path().join("workspace").join("foo");
+    fs::create_dir_all(&foo_project).expect("create foo project");
+    Database::open(&db_path).expect("open db");
+
+    let foo_project_id = expected_project_id(&foo_project);
+    let now = now_secs();
+    for index in 0..10usize {
+        let importance = match index {
+            0..=2 => 5,
+            3..=5 => 4,
+            6..=7 => 3,
+            8 => 2,
+            _ => 1,
+        };
+        let drawer_id = format!("drawer-{index}");
+        let content = format!("timeline entry {index}");
+        insert_drawer(
+            &db_path,
+            DrawerSeed {
+                id: &drawer_id,
+                content: &content,
+                wing: "decisions",
+                room: Some("core"),
+                added_at: now - ((index as i64 + 1) * 60),
+                importance,
+                project_id: Some(&foo_project_id),
+            },
+        );
+    }
+
+    let mut client = McpStdio::start(&db_path, HashMap::new())
+        .await
+        .expect("start mcp stdio");
+    let root_uri = format!("file://{}", foo_project.display());
+    client
+        .initialize_with_roots(&[&root_uri])
+        .await
+        .expect("initialize with roots");
+
+    let response = call_mcp_timeline(&mut client, json!({})).await;
+    let entries = response["entries"].as_array().expect("entries array");
+
+    assert_eq!(entries.len(), 10);
+    assert_eq!(
+        entries[0]["drawer_id"].as_str().expect("drawer_id"),
+        "drawer-0"
+    );
+    assert_eq!(
+        entries[0]["importance_stars"]
+            .as_u64()
+            .expect("importance stars"),
+        5
+    );
+    assert_eq!(
+        response["stats"]["returned"].as_u64().expect("returned"),
+        10
+    );
+
+    client.shutdown().await.expect("shutdown client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_enforces_project_scope() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    let db_path = mempal_home.join("palace.db");
+    let foo_project = tmp.path().join("workspace").join("foo");
+    let bar_project = tmp.path().join("workspace").join("bar");
+    fs::create_dir_all(&foo_project).expect("create foo project");
+    fs::create_dir_all(&bar_project).expect("create bar project");
+    Database::open(&db_path).expect("open db");
+
+    let foo_project_id = expected_project_id(&foo_project);
+    let bar_project_id = expected_project_id(&bar_project);
+    let now = now_secs();
+    insert_drawer(
+        &db_path,
+        DrawerSeed {
+            id: "drawer-foo",
+            content: "foo-only timeline entry",
+            wing: "notes",
+            room: Some("scope"),
+            added_at: now - 60,
+            importance: 4,
+            project_id: Some(&foo_project_id),
+        },
+    );
+    insert_drawer(
+        &db_path,
+        DrawerSeed {
+            id: "drawer-bar",
+            content: "bar-only timeline entry",
+            wing: "notes",
+            room: Some("scope"),
+            added_at: now - 30,
+            importance: 5,
+            project_id: Some(&bar_project_id),
+        },
+    );
+
+    let mut client = McpStdio::start(&db_path, HashMap::new())
+        .await
+        .expect("start mcp stdio");
+    let root_uri = format!("file://{}", foo_project.display());
+    client
+        .initialize_with_roots(&[&root_uri])
+        .await
+        .expect("initialize with roots");
+
+    let response = call_mcp_timeline(&mut client, json!({})).await;
+    let entries = response["entries"].as_array().expect("entries array");
+
+    assert_eq!(
+        response["project_id"].as_str(),
+        Some(foo_project_id.as_str())
+    );
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["drawer_id"].as_str(), Some("drawer-foo"));
+
+    client.shutdown().await.expect("shutdown client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_since_filter_7d() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 10);
+    let now = now_secs();
+    for index in 0..5usize {
+        insert_drawer(
+            &env.db_path,
+            DrawerSeed {
+                id: &format!("recent-{index}"),
+                content: &format!("recent timeline entry {index}"),
+                wing: "timeline",
+                room: Some("recent"),
+                added_at: now - ((index as i64 + 1) * 60),
+                importance: 3,
+                project_id: Some("foo"),
+            },
+        );
+        insert_drawer(
+            &env.db_path,
+            DrawerSeed {
+                id: &format!("old-{index}"),
+                content: &format!("old timeline entry {index}"),
+                wing: "timeline",
+                room: Some("archive"),
+                added_at: now - (30 * 24 * 60 * 60) - index as i64,
+                importance: 5,
+                project_id: Some("foo"),
+            },
+        );
+    }
+
+    let response = env
+        .server()
+        .mempal_timeline(Parameters(TimelineRequest {
+            project_id: Some("foo".to_string()),
+            since: Some("7d".to_string()),
+            until: None,
+            top_k: None,
+            min_importance: None,
+            wing: None,
+            room: None,
+        }))
+        .await
+        .expect("timeline should succeed")
+        .0;
+
+    assert_eq!(response.entries.len(), 5);
+    assert_eq!(response.stats.total_in_window, 5);
+    assert_eq!(response.stats.returned, 5);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_preview_truncation_signal() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 10);
+    let content = "signal ".repeat(71) + "tail";
+    assert_eq!(content.len(), 501);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "drawer-long",
+            content: &content,
+            wing: "notes",
+            room: Some("preview"),
+            added_at: now_secs() - 60,
+            importance: 4,
+            project_id: Some("foo"),
+        },
+    );
+
+    let response = env
+        .server()
+        .mempal_timeline(Parameters(TimelineRequest {
+            project_id: Some("foo".to_string()),
+            since: None,
+            until: None,
+            top_k: Some(1),
+            min_importance: None,
+            wing: None,
+            room: None,
+        }))
+        .await
+        .expect("timeline should succeed")
+        .0;
+
+    let entry = &response.entries[0];
+    assert!(entry.preview_truncated);
+    assert!(entry.preview.chars().count() <= 200, "{}", entry.preview);
+    assert_eq!(entry.original_content_bytes, 501);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_degraded_embedder_still_works() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 1);
+    global_embed_status().reset_for_tests();
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "drawer-degraded",
+            content: "timeline still works when embedder is degraded",
+            wing: "notes",
+            room: Some("degraded"),
+            added_at: now_secs() - 60,
+            importance: 4,
+            project_id: Some("foo"),
+        },
+    );
+    global_embed_status().record_failure(&"synthetic degraded failure");
+
+    let response = env
+        .server()
+        .mempal_timeline(Parameters(TimelineRequest {
+            project_id: Some("foo".to_string()),
+            since: None,
+            until: None,
+            top_k: None,
+            min_importance: None,
+            wing: None,
+            room: None,
+        }))
+        .await
+        .expect("timeline should succeed while degraded")
+        .0;
+
+    assert_eq!(response.entries.len(), 1);
+    assert!(response.system_warnings.iter().any(|warning| {
+        warning.source == "embed" && warning.message.contains("embed backend degraded")
+    }));
+
+    global_embed_status().reset_for_tests();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_top_k_upper_bound() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 10);
+
+    let error = match env
+        .server()
+        .mempal_timeline(Parameters(TimelineRequest {
+            project_id: Some("foo".to_string()),
+            since: None,
+            until: None,
+            top_k: Some(500),
+            min_importance: None,
+            wing: None,
+            room: None,
+        }))
+        .await
+    {
+        Ok(_) => panic!("oversized top_k must be rejected"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+    assert!(error.message.contains("top_k exceeds max 100"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_rejects_all_projects() {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    let db_path = mempal_home.join("palace.db");
+    let foo_project = tmp.path().join("workspace").join("foo");
+    let bar_project = tmp.path().join("workspace").join("bar");
+    fs::create_dir_all(&foo_project).expect("create foo project");
+    fs::create_dir_all(&bar_project).expect("create bar project");
+    Database::open(&db_path).expect("open db");
+
+    let foo_project_id = expected_project_id(&foo_project);
+    let bar_project_id = expected_project_id(&bar_project);
+    let now = now_secs();
+    insert_drawer(
+        &db_path,
+        DrawerSeed {
+            id: "drawer-foo-only",
+            content: "foo timeline entry",
+            wing: "notes",
+            room: Some("overview"),
+            added_at: now - 60,
+            importance: 4,
+            project_id: Some(&foo_project_id),
+        },
+    );
+    insert_drawer(
+        &db_path,
+        DrawerSeed {
+            id: "drawer-bar-only",
+            content: "bar timeline entry",
+            wing: "notes",
+            room: Some("overview"),
+            added_at: now - 30,
+            importance: 5,
+            project_id: Some(&bar_project_id),
+        },
+    );
+
+    let mut client = McpStdio::start(&db_path, HashMap::new())
+        .await
+        .expect("start mcp stdio");
+    let root_uri = format!("file://{}", foo_project.display());
+    client
+        .initialize_with_roots(&[&root_uri])
+        .await
+        .expect("initialize with roots");
+
+    let response = call_mcp_timeline(&mut client, json!({ "all_projects": true })).await;
+    let entries = response["entries"].as_array().expect("entries array");
+
+    assert_eq!(
+        response["project_id"].as_str(),
+        Some(foo_project_id.as_str())
+    );
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["drawer_id"].as_str(), Some("drawer-foo-only"));
+
+    client.shutdown().await.expect("shutdown client");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_memory_protocol_mentions_timeline() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 10);
+    let info = <MempalMcpServer as ServerHandler>::get_info(&env.server());
+    let instructions = info.instructions.expect("instructions");
+
+    assert!(MEMORY_PROTOCOL.contains("mempal_timeline"));
+    assert!(MEMORY_PROTOCOL.contains("project state overview without a specific question"));
+    assert!(instructions.contains("mempal_timeline"));
+    assert!(instructions.contains("project state overview without a specific question"));
+}


### PR DESCRIPTION
## Summary
- Implements `specs/fork-ext/p11-mcp-timeline-tool.spec.md` (P11 phase 3, 0.5d estimate — final phase of P11 track)
- New MCP tool `mempal_timeline` (11th MCP tool): project-scoped narrative aggregate view for agents mid-session, no query required
- Enforces single-project scope via existing `ProjectSearchScope::from_request` (strict=true); rejects `all_projects`
- Degraded-safe: NO embedder calls, NO tunnel resolver (aggregate view only)
- Returns preview + `preview_truncated` + `original_content_bytes` per p9 progressive-disclosure parity (NOT full content)
- Injected into MEMORY_PROTOCOL instructions

## Differentiation
- vs `mempal prime` (CLI, phase 1 #53): timeline is MCP on-demand; prime is one-shot SessionStart CLI output
- vs `mempal_search`: search is query-driven; timeline is aggregate view without a specific question
- vs CLI `mempal tail/timeline/stats` (p10 dashboard): those are operator CLI; this is agent-facing MCP

## Implementation
- `src/mcp/timeline.rs` (NEW) — handler body + DTO
- `src/core/timeline.rs` (NEW) — SQL query + DTO assembly (kept separate from `priming.rs` per spec)
- `src/mcp/server.rs` — registered `#[tool] mempal_timeline` handler
- `src/mcp/protocol.rs` — extended MEMORY_PROTOCOL + ServerInfo.tools
- `tests/mcp_timeline.rs` (NEW) — 8 integration scenarios

## DTOs
- `TimelineRequest { project_id, since, until, top_k, min_importance, wing, room }`
- `TimelineResponse { project_id, generated_at, window, entries, stats, system_warnings }`
- `TimelineEntry { drawer_id, added_at, importance_stars, wing, room, preview, preview_truncated, original_content_bytes }`

## Review
- Implementation tool: csa-codex (`01KPVKN8GZWDP0B8S24P0K82QV`)
- Cumulative review: csa-claude (`01KPVNK6PZ42P25HSTK66S85XJ`) — **PASS / CLEAN**, 0 findings
- csa-gemini review fell back due to 401 auth; csa-claude per fork-ext convention
- Quality gates: cargo test, clippy -D warnings, lefthook full suite via commit hook

## Phase context
Phase 3 of 3 in P11 claude-mem parity track — completes the track:
1. ✅ prime (#53 merged) — data layer CLI
2. ✅ integrations-layer (#54 merged) — installer + asset root
3. ✅ **mcp-timeline-tool** (this PR) — MCP-side aggregate view

## Test plan
- [x] Default ordering (importance DESC, recency DESC tiebreak)
- [x] Project scope hard-enforced via ProjectSearchScope
- [x] `since: "7d"` filter window correct
- [x] Preview truncation signal (`preview_truncated`, `original_content_bytes`)
- [x] Degraded embedder still works (no embedder call path)
- [x] top_k upper bound 100 validated
- [x] Rejects `all_projects` override attempt
- [x] MEMORY_PROTOCOL mentions timeline