### PR TITLE
fix(ingest): INSERT OR IGNORE for PK-deterministic drawer/vector inserts

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -181,7 +181,7 @@ impl Database {
     ) -> Result<(), DbError> {
         self.conn.execute(
             r#"
-            INSERT INTO drawers (
+            INSERT OR IGNORE INTO drawers (
                 id,
                 content,
                 wing,
@@ -603,7 +603,7 @@ impl Database {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
         self.conn.execute(
-            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+            "INSERT OR IGNORE INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
             params![drawer_id, vector_json.as_str(), project_id],
         )?;
         Ok(())


### PR DESCRIPTION
## Summary
- drawer_id and vector id are `sha256(content)[:8]`-derived, so identical chunk text across different source files in the same wing produces identical primary keys
- Under N=2 parallel ingest of 18k+ file wings, intra-batch collisions hit `UNIQUE constraint failed: drawers.id` (SQLite code 1555) and roll back the whole transaction, failing the wing
- Switch the two base inserts (drawers + drawer_vectors) to `INSERT OR IGNORE`; the merge path at line 394 (DELETE+INSERT in a single transaction) is untouched
- First writer wins, duplicates drop silently; `stats.chunks` slightly over-counts on dupes — cosmetic, acceptable

## Context
During the claude-mem → mempal migration (`drafts/claude-mem/migration-plan/todo.md` Phase 2.4), two large wings FAILed on the same root cause:
- `mandate-monorepo` (18415 files, 328s in)
- `claude-mem` (18432 files, 956s in)

Both surface `Error code 1555: A PRIMARY KEY constraint failed` because multiple files in the same wing contain identical chunk text (e.g., boilerplate headers, short repeated observations) and hash to the same 8-hex drawer_id.

## Test plan
- [x] Unit tests pass in isolation (`test_concurrent_enqueue_does_not_block` is perf-sensitive under SQLite load; ingest workers killed before commit)
- [x] Full lefthook gate pass (just fmt + just clippy + just test, 585s)
- [ ] Post-merge: re-run `mempal ingest` on mandate-monorepo and claude-mem wings to confirm PK-collision wings now complete

## Related
Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)