### PR TITLE
fix(ingest): swallow vec0 UNIQUE PK error (PR #61 was ineffective)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -602,11 +602,24 @@ impl Database {
     ) -> Result<(), DbError> {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
-        self.conn.execute(
-            "INSERT OR IGNORE INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+        match self.conn.execute(
+            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
             params![drawer_id, vector_json.as_str(), project_id],
-        )?;
-        Ok(())
+        ) {
+            Ok(_) => Ok(()),
+            // sqlite-vec's vec0 virtual table does not honor INSERT OR IGNORE
+            // or INSERT OR REPLACE — it always raises a UNIQUE primary key
+            // violation on duplicate id, regardless of conflict clause. Match
+            // on the message text (extended_code is SQLITE_ERROR=1, not 1555)
+            // and swallow to preserve first-writer-wins semantics consistent
+            // with drawers table's INSERT OR IGNORE behavior.
+            Err(rusqlite::Error::SqliteFailure(_, Some(ref msg)))
+                if msg.contains("UNIQUE constraint failed on drawer_vectors") =>
+            {
+                Ok(())
+            }
+            Err(e) => Err(DbError::Sqlite(e)),
+        }
     }
 
     pub fn novelty_candidates(

--- a/tests/vec0_duplicate_insert.rs
+++ b/tests/vec0_duplicate_insert.rs
@@ -1,0 +1,56 @@
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use tempfile::TempDir;
+
+fn make_drawer(id: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: "test content".to_string(),
+        wing: "test".to_string(),
+        room: Some("default".to_string()),
+        source_file: Some("test.md".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "2026-04-23T00:00:00Z".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    }
+}
+
+#[test]
+fn insert_vector_duplicate_pk_is_idempotent() {
+    // sqlite-vec's vec0 virtual table does not honor `INSERT OR IGNORE` —
+    // duplicate-key inserts raise SQLITE_CONSTRAINT_PRIMARYKEY (extended
+    // code 1555) unconditionally. The Database layer must swallow that
+    // specific error so that bulk ingest of content that produces identical
+    // chunk hashes across multiple source files does not abort the whole
+    // batch.
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let drawer = make_drawer("drawer-dup-test");
+    db.insert_drawer(&drawer).expect("first drawer insert");
+    db.insert_vector(&drawer.id, &[0.1_f32, 0.2, 0.3, 0.4])
+        .expect("first vector insert");
+
+    db.insert_vector(&drawer.id, &[0.5_f32, 0.6, 0.7, 0.8])
+        .expect("duplicate vector insert should be Ok (swallowed), not error");
+}
+
+#[test]
+fn insert_vector_distinct_ids_coexist() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let a = make_drawer("drawer-a");
+    let b = make_drawer("drawer-b");
+    db.insert_drawer(&a).expect("insert a");
+    db.insert_drawer(&b).expect("insert b");
+    db.insert_vector(&a.id, &[0.1_f32, 0.2, 0.3, 0.4])
+        .expect("insert a vector");
+    db.insert_vector(&b.id, &[0.5_f32, 0.6, 0.7, 0.8])
+        .expect("insert b vector");
+
+    let count: i64 = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| row.get(0))
+        .expect("count vectors");
+    assert_eq!(count, 2, "both distinct-id vectors should persist");
+}


### PR DESCRIPTION
## Summary
- PR #61's `INSERT OR IGNORE INTO drawer_vectors` is a no-op: **sqlite-vec's vec0 virtual table ignores both `OR IGNORE` and `OR REPLACE` conflict clauses** and unconditionally raises `SQLITE_CONSTRAINT_PRIMARYKEY` on duplicate id (surfaces as rusqlite `SqliteFailure` with `extended_code=1`, message "UNIQUE constraint failed on drawer_vectors primary key")
- Reproduced via isolated `sqlite3 -cmd '.load vec0.so'` shell — both `OR IGNORE` and `OR REPLACE` fail identically
- Drop the dead `OR IGNORE` clause and match the specific vec0 PK violation by message text at the rusqlite layer; swallow to preserve first-writer-wins semantics consistent with the `drawers` table
- The `drawers` table `INSERT OR IGNORE` at line 184 is kept — it works correctly against the real SQLite table
- The merge path at `update_drawer_after_merge` (line 394, DELETE+INSERT in a single transaction) is untouched and empirically verified against vec0 — DELETE commits before INSERT within the same transaction, no PK conflict arises

## Context
During the claude-mem → mempal migration, the `claude-mem` wing (18432 files) FAILed at `drawer_claude_mem_default_72a593a5` despite PR #61 having merged. Error trace:
```
error: failed to insert vector for drawer_claude_mem_default_72a593a5
  caused by: UNIQUE constraint failed on drawer_vectors primary key
```
The error propagates from `db.insert_vector_with_project` via `ingest/mod.rs:352`, confirming the base-insert path (line 606), not the merge path (line 394).

## Test plan
- [x] New `tests/vec0_duplicate_insert.rs` with two scenarios:
  - `insert_vector_duplicate_pk_is_idempotent` — fails on pre-fix code with `SqliteFailure(Error { code: Unknown, extended_code: 1 }, ...)`; passes post-fix
  - `insert_vector_distinct_ids_coexist` — sanity check that legitimate distinct-id inserts still persist both rows
- [x] Full lefthook gate pass (`just fmt` + `just clippy` + `just test`, 820s)
- [ ] Post-merge: re-run `mempal ingest` on claude-mem + mandate-monorepo wings to confirm PK-collision wings complete end-to-end

## Related
- Supersedes partial fix in #61 (that PR's `drawers`-table change is still correct; its `drawer_vectors`-table change was ineffective and is reverted here)
- Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)