### PR TITLE
fix(ingest): add content_hash column for O(1) dedup lookup on restart

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -22,8 +22,14 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-const CURRENT_SCHEMA_VERSION: u32 = 4;
+const CURRENT_SCHEMA_VERSION: u32 = 5;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
+
+const CONTENT_HASH_BACKFILL_BATCH: usize = 1_000;
+
+fn content_hash_hex(content: &str) -> String {
+    blake3::hash(content.as_bytes()).to_hex().to_string()
+}
 
 const V1_SCHEMA_SQL: &str = r#"
 PRAGMA foreign_keys = ON;
@@ -179,6 +185,7 @@ impl Database {
         drawer: &Drawer,
         project_id: Option<&str>,
     ) -> Result<(), DbError> {
+        let content_hash = content_hash_hex(&drawer.content);
         self.conn.execute(
             r#"
             INSERT OR IGNORE INTO drawers (
@@ -191,9 +198,10 @@ impl Database {
                 added_at,
                 chunk_index,
                 importance,
-                project_id
+                project_id,
+                content_hash
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
             "#,
             params![
                 drawer.id,
@@ -206,6 +214,7 @@ impl Database {
                 drawer.chunk_index,
                 drawer.importance,
                 project_id,
+                content_hash,
             ],
         )?;
 
@@ -995,6 +1004,11 @@ impl Database {
         content: &str,
         project_id: Option<&str>,
     ) -> Result<Option<String>, DbError> {
+        // Indexed lookup via idx_drawers_content_hash(wing, content_hash).
+        // blake3 collisions are cryptographically negligible, so the hash
+        // alone determines content-identity; room/project_id/deleted_at are
+        // post-filtered against the (typically single-row) hash bucket.
+        let hash = content_hash_hex(content);
         let value = self
             .conn
             .query_row(
@@ -1003,13 +1017,13 @@ impl Database {
                 FROM drawers
                 WHERE deleted_at IS NULL
                   AND wing = ?1
-                  AND content = ?2
+                  AND content_hash = ?2
                   AND ((room IS NULL AND ?3 IS NULL) OR room = ?3)
                   AND ((project_id IS NULL AND ?4 IS NULL) OR project_id = ?4)
                 ORDER BY id
                 LIMIT 1
                 "#,
-                params![wing, content, room, project_id],
+                params![wing, hash, room, project_id],
                 |row| row.get::<_, String>(0),
             )
             .optional()?;
@@ -1454,10 +1468,70 @@ fn apply_migrations(conn: &Connection) -> Result<(), DbError> {
         .iter()
         .filter(|migration| migration.version > current_version)
     {
+        if migration.version == 5 {
+            // ALTER TABLE ADD COLUMN is not idempotent in SQLite, so guard
+            // it explicitly. The index in the migration SQL already uses
+            // CREATE INDEX IF NOT EXISTS.
+            ensure_drawers_content_hash_column(conn)?;
+        }
         conn.execute_batch(migration.sql)?;
+        if migration.version == 5 {
+            // V5 introduces content_hash for indexed dedup; backfill existing
+            // rows so the new query path can rely on the column being populated
+            // for all live drawers. Batched commits keep the WAL bounded on
+            // installs with hundreds of thousands of drawers.
+            backfill_content_hash(conn)?;
+        }
         set_user_version(conn, migration.version)?;
     }
 
+    Ok(())
+}
+
+fn ensure_drawers_content_hash_column(conn: &Connection) -> Result<(), DbError> {
+    let exists = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('drawers') WHERE name = 'content_hash'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if exists == 0 {
+        conn.execute_batch("ALTER TABLE drawers ADD COLUMN content_hash TEXT;")?;
+    }
+    Ok(())
+}
+
+fn backfill_content_hash(conn: &Connection) -> Result<(), DbError> {
+    loop {
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let updated = (|| -> Result<usize, DbError> {
+            let mut select = conn
+                .prepare("SELECT id, content FROM drawers WHERE content_hash IS NULL LIMIT ?1")?;
+            let rows = select
+                .query_map([CONTENT_HASH_BACKFILL_BATCH as i64], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            drop(select);
+
+            let mut update = conn.prepare("UPDATE drawers SET content_hash = ?1 WHERE id = ?2")?;
+            for (id, content) in &rows {
+                update.execute(params![content_hash_hex(content), id])?;
+            }
+            Ok(rows.len())
+        })();
+        match updated {
+            Ok(count) => {
+                conn.execute_batch("COMMIT")?;
+                if count == 0 {
+                    break;
+                }
+            }
+            Err(err) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(err);
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1521,12 +1595,20 @@ fn migrations() -> &'static [Migration] {
             version: 4,
             sql: V4_MIGRATION_SQL,
         },
+        Migration {
+            version: 5,
+            sql: V5_MIGRATION_SQL,
+        },
     ];
     MIGRATIONS
 }
 
 const V4_MIGRATION_SQL: &str = r#"
 ALTER TABLE drawers ADD COLUMN importance INTEGER DEFAULT 0;
+"#;
+
+const V5_MIGRATION_SQL: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_drawers_content_hash ON drawers(wing, content_hash);
 "#;
 
 struct Migration {

--- a/tests/cowork_inbox.rs
+++ b/tests/cowork_inbox.rs
@@ -92,7 +92,7 @@ async fn push_and_drain_have_no_palace_db_side_effects() {
     let drawers_before = db.drawer_count().expect("drawer count");
     let triples_before = db.triple_count().expect("triple count");
     let schema_before = db.schema_version().expect("schema version");
-    assert_eq!(schema_before, 4, "baseline palace.db should be schema v4");
+    assert_eq!(schema_before, 5, "baseline palace.db should be schema v5");
     drop(db);
 
     let mempal_home = tmp.path().join("home");

--- a/tests/cowork_peek.rs
+++ b/tests/cowork_peek.rs
@@ -269,7 +269,7 @@ fn test_peek_partner_has_no_mempal_side_effects() {
     let drawers_before = db.drawer_count().expect("drawer count");
     let triples_before = db.triple_count().expect("triple count");
     let schema_before = db.schema_version().expect("schema version");
-    assert_eq!(schema_before, 4, "baseline palace.db should be schema v4");
+    assert_eq!(schema_before, 5, "baseline palace.db should be schema v5");
     drop(db);
 
     // Record the DB file mtime as a second-line check: peek_partner must

--- a/tests/db_content_hash_dedup.rs
+++ b/tests/db_content_hash_dedup.rs
@@ -1,0 +1,189 @@
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use rusqlite::params;
+use tempfile::TempDir;
+
+fn make_drawer(id: &str, content: &str, wing: &str, room: Option<&str>) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: wing.to_string(),
+        room: room.map(|s| s.to_string()),
+        source_file: Some("test.md".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "2026-04-25T00:00:00Z".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    }
+}
+
+fn fresh_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn user_version(db: &Database) -> u32 {
+    db.conn()
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .expect("read user_version")
+}
+
+#[test]
+fn v5_schema_adds_content_hash_column_and_index() {
+    let (_tmp, db) = fresh_db();
+    assert!(user_version(&db) >= 5);
+
+    let has_column: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('drawers') WHERE name = 'content_hash'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("pragma table_info");
+    assert_eq!(has_column, 1, "content_hash column must exist after v5");
+
+    let has_index: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_index_list('drawers') WHERE name = 'idx_drawers_content_hash'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("pragma index_list");
+    assert_eq!(has_index, 1, "idx_drawers_content_hash must exist after v5");
+}
+
+#[test]
+fn insert_drawer_populates_content_hash() {
+    let (_tmp, db) = fresh_db();
+    let drawer = make_drawer("d1", "hello world", "test", Some("default"));
+    db.insert_drawer(&drawer).expect("insert drawer");
+
+    let hash: String = db
+        .conn()
+        .query_row(
+            "SELECT content_hash FROM drawers WHERE id = ?1",
+            params!["d1"],
+            |row| row.get(0),
+        )
+        .expect("read content_hash");
+
+    let expected = blake3::hash(b"hello world").to_hex().to_string();
+    assert_eq!(hash, expected);
+}
+
+#[test]
+fn dedup_resolves_existing_drawer_via_content_hash() {
+    let (_tmp, db) = fresh_db();
+    let drawer = make_drawer("d1", "exact same body", "test", Some("default"));
+    db.insert_drawer(&drawer).expect("insert");
+
+    let (resolved, exists) = db
+        .resolve_ingest_drawer_id("test", Some("default"), "exact same body", None)
+        .expect("resolve");
+    assert!(exists);
+    assert_eq!(resolved, "d1");
+}
+
+#[test]
+fn dedup_isolates_per_project() {
+    let (_tmp, db) = fresh_db();
+    let drawer = make_drawer("d_p1", "shared body", "test", Some("default"));
+    db.insert_drawer_with_project(&drawer, Some("project-1"))
+        .expect("insert in project-1");
+
+    let (_, exists_other_project) = db
+        .resolve_ingest_drawer_id("test", Some("default"), "shared body", Some("project-2"))
+        .expect("resolve in project-2");
+    assert!(
+        !exists_other_project,
+        "same content in a different project must not match"
+    );
+
+    let (resolved_same, exists_same) = db
+        .resolve_ingest_drawer_id("test", Some("default"), "shared body", Some("project-1"))
+        .expect("resolve in project-1");
+    assert!(exists_same);
+    assert_eq!(resolved_same, "d_p1");
+}
+
+#[test]
+fn dedup_query_uses_content_hash_index() {
+    let (_tmp, db) = fresh_db();
+    let drawer = make_drawer("d1", "indexed body", "test", Some("default"));
+    db.insert_drawer(&drawer).expect("insert");
+
+    let blake = blake3::hash(b"indexed body").to_hex().to_string();
+    let plan: Vec<String> = db
+        .conn()
+        .prepare(
+            "EXPLAIN QUERY PLAN SELECT id FROM drawers \
+             WHERE deleted_at IS NULL AND wing = ?1 AND content_hash = ?2 \
+             AND ((room IS NULL AND ?3 IS NULL) OR room = ?3) \
+             AND ((project_id IS NULL AND ?4 IS NULL) OR project_id = ?4) \
+             ORDER BY id LIMIT 1",
+        )
+        .expect("prepare explain")
+        .query_map(
+            params!["test", blake, Some("default"), None::<&str>],
+            |row| row.get::<_, String>(3),
+        )
+        .expect("query explain")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect explain");
+
+    let plan_text = plan.join("\n");
+    assert!(
+        plan_text.contains("idx_drawers_content_hash"),
+        "dedup query must use the content_hash index, plan was:\n{plan_text}"
+    );
+}
+
+#[test]
+fn v5_migration_backfills_existing_drawers_on_reopen() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("palace.db");
+
+    {
+        let db = Database::open(&path).expect("open db v5");
+        db.insert_drawer(&make_drawer("a", "alpha", "test", None))
+            .expect("insert a");
+        db.insert_drawer(&make_drawer("b", "beta", "test", None))
+            .expect("insert b");
+        // Simulate an install that was created at v4: drop the content_hash
+        // values and rewind user_version. The next Database::open() should
+        // re-run the v5 migration (idempotent column add) and the backfill.
+        db.conn()
+            .execute("UPDATE drawers SET content_hash = NULL", [])
+            .expect("null out hashes");
+        db.conn()
+            .execute_batch("PRAGMA user_version = 4")
+            .expect("rewind user_version");
+    }
+
+    let db2 = Database::open(&path).expect("reopen db");
+    assert!(user_version(&db2) >= 5);
+
+    let rows: Vec<(String, Option<String>)> = db2
+        .conn()
+        .prepare("SELECT id, content_hash FROM drawers ORDER BY id")
+        .expect("prepare")
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .expect("query")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows[0].1.as_deref(),
+        Some(blake3::hash(b"alpha").to_hex().to_string().as_str())
+    );
+    assert_eq!(
+        rows[1].1.as_deref(),
+        Some(blake3::hash(b"beta").to_hex().to_string().as_str())
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f3a409cbe368155b15dd7998a801e78ef04126e0"
+commit = "87538e12c2e3cf48a2f517aae5cfef4fa74dc4b2"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add `content_hash` column (blake3) to `drawers` table with composite index `idx_drawers_content_hash(wing, content_hash)` — schema v5
- Rewrite `find_active_drawer_id_by_identity` to query by hash instead of full `content` TEXT, eliminating O(N) per-chunk linear scan on ingest restart
- Idempotent migration: guarded ALTER TABLE + `CREATE INDEX IF NOT EXISTS` + batched 1000-row `BEGIN IMMEDIATE` backfill for existing 506K-drawer installs
- Update baseline schema assertions in `cowork_inbox` and `cowork_peek` tests (v4→v5)

Closes #63

## Context

On the 506K-drawer / 56-wing claude-mem→mempal migration corpus, re-running ingest after restart caused ~83K pread64/sec on palace.db because `find_active_drawer_id_by_identity` did a full content-column linear scan per chunk. With `cap_fanout` from #65 the search side is bounded; this fixes the ingest side. Estimated improvement: ~80h restart → seconds.

## Test plan

- [x] `v5_schema_adds_content_hash_column_and_index` — column and index exist after v5
- [x] `insert_drawer_populates_content_hash` — INSERT writes blake3 hash
- [x] `dedup_resolves_existing_drawer_via_content_hash` — dedup finds existing drawer via hash
- [x] `dedup_isolates_per_project` — same content in different projects does not cross-match
- [x] `dedup_query_uses_content_hash_index` — EXPLAIN QUERY PLAN confirms index usage
- [x] `v5_migration_backfills_existing_drawers_on_reopen` — simulated v4→v5 reopen backfills NULLed hashes
- [x] `just fmt` / `just clippy` / `just test` all pass (lefthook pre-commit gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)