### PR TITLE
fix(search): clamp KNN k to 4096 to prevent sqlite-vec limit violation

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::core::{
     db::Database,
-    project::{ProjectFilterMode, ProjectSearchScope, SearchResultSource},
+    project::{ProjectSearchScope, SearchResultSource},
     types::{RouteDecision, SearchResult},
     utils::source_file_or_synthetic,
 };
@@ -27,8 +27,6 @@ pub enum SearchError {
     MissingQueryVector,
     #[error("failed to count candidate drawers")]
     CountCandidateDrawers(#[source] rusqlite::Error),
-    #[error("failed to count total drawers")]
-    CountTotalDrawers(#[source] rusqlite::Error),
     #[error("failed to serialize query vector")]
     SerializeQueryVector(#[source] serde_json::Error),
     #[error("top_k does not fit into i64")]
@@ -333,6 +331,20 @@ fn rrf_merge(
     merged
 }
 
+/// Compute the KNN `k` parameter for sqlite-vec, clamped to its hardcoded
+/// limit of 4096. Uses `top_k * 50` as the recall multiplier (allowing
+/// post-filter shrinkage from wing/room/project predicates), floored at
+/// 100 to avoid degenerate single-digit recall on tiny `top_k` values.
+///
+/// When the database grows beyond 4096 drawers the KNN result is an
+/// *approximate* subset — callers that need exact recall on a small
+/// candidate set should use `search_by_vector_scoped_exact` instead.
+pub fn compute_knn_k(top_k: usize) -> i64 {
+    let raw = top_k.saturating_mul(50);
+    let raw_i64 = i64::try_from(raw).unwrap_or(i64::MAX);
+    raw_i64.clamp(100, 4_096)
+}
+
 pub fn search_by_vector(
     db: &Database,
     query_vector: &[f32],
@@ -367,16 +379,11 @@ pub fn search_by_vector(
     if candidate_count == 0 {
         return Ok(Vec::new());
     }
-    let total_count: i64 = db
-        .conn()
-        .query_row(
-            "SELECT COUNT(*) FROM drawers WHERE deleted_at IS NULL",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(SearchError::CountTotalDrawers)?;
 
-    if scope.mode == ProjectFilterMode::ProjectScoped && candidate_count <= 4_096 {
+    // When the candidate set fits within the sqlite-vec KNN limit, use
+    // the exact in-memory path regardless of scope mode — this avoids
+    // approximate recall loss and sidesteps the 4096 KNN cap entirely.
+    if candidate_count <= 4_096 {
         return search_by_vector_scoped_exact(
             db,
             query_vector,
@@ -384,13 +391,14 @@ pub fn search_by_vector(
             applied_wing,
             applied_room,
             top_k,
-            scope.project_id.as_deref(),
+            scope,
         );
     }
 
     let query_json =
         serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
-    let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
+    let top_k_i64 = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
+    let knn_k = compute_knn_k(top_k);
 
     let search_sql = build_vector_search_sql(scope.mode);
 
@@ -402,12 +410,12 @@ pub fn search_by_vector(
         .query_map(
             (
                 query_json.as_str(),
-                total_count,
+                knn_k,
                 scope.mode_param(),
                 scope.project_id.as_deref(),
                 applied_wing,
                 applied_room,
-                top_k,
+                top_k_i64,
             ),
             |row| {
                 let distance: f64 = row.get(6)?;
@@ -441,43 +449,55 @@ fn search_by_vector_scoped_exact(
     applied_wing: Option<&str>,
     applied_room: Option<&str>,
     top_k: usize,
-    project_id: Option<&str>,
+    scope: &ProjectSearchScope,
 ) -> Result<Vec<SearchResult>> {
     let top_k = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
-    let search_sql = r#"
+    // Use the full filter clause so all scope modes (all / project /
+    // project_plus_global / null_only) work correctly through the exact path.
+    let filter = build_filter_clause("d", 1, 2, 3, 4);
+    let search_sql = format!(
+        r#"
         SELECT d.id, d.content, d.wing, d.room, d.source_file, d.project_id, v.embedding
         FROM drawer_vectors v
         JOIN drawers d ON d.id = v.id
-        WHERE d.deleted_at IS NULL
-          AND (?1 IS NULL OR d.wing = ?1)
-          AND (?2 IS NULL OR d.room = ?2)
-          AND (?3 IS NULL OR d.project_id = ?3)
-        "#;
+        {filter}
+        "#
+    );
     let mut statement = db
         .conn()
-        .prepare(search_sql)
+        .prepare(&search_sql)
         .map_err(SearchError::PrepareSearch)?;
     let mut rows = statement
-        .query_map((applied_wing, applied_room, project_id), |row| {
-            let drawer_id: String = row.get(0)?;
-            let source_file = row.get::<_, Option<String>>(4)?;
-            let embedding = row.get::<_, Vec<u8>>(6)?;
-            Ok((
-                drawer_id.clone(),
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, Option<String>>(3)?,
-                source_file_or_synthetic(&drawer_id, source_file.as_deref()),
-                embedding,
-            ))
-        })
+        .query_map(
+            (
+                applied_wing,
+                applied_room,
+                scope.mode_param(),
+                scope.project_id.as_deref(),
+            ),
+            |row| {
+                let drawer_id: String = row.get(0)?;
+                let source_file = row.get::<_, Option<String>>(4)?;
+                let row_project_id = row.get::<_, Option<String>>(5)?;
+                let embedding = row.get::<_, Vec<u8>>(6)?;
+                Ok((
+                    drawer_id.clone(),
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    source_file_or_synthetic(&drawer_id, source_file.as_deref()),
+                    row_project_id,
+                    embedding,
+                ))
+            },
+        )
         .map_err(SearchError::ExecuteSearch)?
         .collect::<std::result::Result<Vec<_>, _>>()
         .map_err(SearchError::CollectSearchRows)?;
 
     rows.sort_by(|a, b| {
-        let a_distance = cosine_distance_from_blob(&a.0, &a.5, query_vector);
-        let b_distance = cosine_distance_from_blob(&b.0, &b.5, query_vector);
+        let a_distance = cosine_distance_from_blob(&a.0, &a.6, query_vector);
+        let b_distance = cosine_distance_from_blob(&b.0, &b.6, query_vector);
         match (a_distance, b_distance) {
             (Ok(left), Ok(right)) => left
                 .partial_cmp(&right)
@@ -491,20 +511,22 @@ fn search_by_vector_scoped_exact(
     let results = rows
         .into_iter()
         .take(top_k as usize)
-        .map(|(drawer_id, content, wing, room, source_file, embedding)| {
-            let distance = cosine_distance_from_blob(&drawer_id, &embedding, query_vector)?;
-            Ok(SearchResult {
-                drawer_id: drawer_id.clone(),
-                content,
-                wing,
-                room,
-                source_file,
-                source: SearchResultSource::Project,
-                similarity: (1.0_f64 - distance) as f32,
-                route: route.clone(),
-                tunnel_hints: vec![],
-            })
-        })
+        .map(
+            |(drawer_id, content, wing, room, source_file, row_project_id, embedding)| {
+                let distance = cosine_distance_from_blob(&drawer_id, &embedding, query_vector)?;
+                Ok(SearchResult {
+                    drawer_id: drawer_id.clone(),
+                    content,
+                    wing,
+                    room,
+                    source_file,
+                    source: scope.classify_row(row_project_id.as_deref()),
+                    similarity: (1.0_f64 - distance) as f32,
+                    route: route.clone(),
+                    tunnel_hints: vec![],
+                })
+            },
+        )
         .collect::<Result<Vec<_>>>()?;
     Ok(results)
 }
@@ -733,5 +755,48 @@ mod tests {
             "expected 2 source + 2 tunnel per source = 6, got {}",
             results.len()
         );
+    }
+
+    // --- compute_knn_k unit tests ---
+
+    #[test]
+    fn compute_knn_k_zero_top_k_returns_floor() {
+        assert_eq!(compute_knn_k(0), 100);
+    }
+
+    #[test]
+    fn compute_knn_k_one_returns_floor() {
+        // 1 * 50 = 50, clamped up to 100
+        assert_eq!(compute_knn_k(1), 100);
+    }
+
+    #[test]
+    fn compute_knn_k_small_top_k() {
+        // 10 * 50 = 500
+        assert_eq!(compute_knn_k(10), 500);
+    }
+
+    #[test]
+    fn compute_knn_k_at_ceiling_boundary() {
+        // 81 * 50 = 4050, still under 4096
+        assert_eq!(compute_knn_k(81), 4050);
+        // 82 * 50 = 4100, clamped to 4096
+        assert_eq!(compute_knn_k(82), 4096);
+    }
+
+    #[test]
+    fn compute_knn_k_large_top_k_clamped() {
+        assert_eq!(compute_knn_k(100), 4096);
+        assert_eq!(compute_knn_k(1_000), 4096);
+        assert_eq!(compute_knn_k(10_000), 4096);
+    }
+
+    #[test]
+    fn compute_knn_k_always_in_bounds() {
+        for top_k in [0, 1, 2, 10, 50, 81, 82, 100, 1_000, 10_000, usize::MAX] {
+            let k = compute_knn_k(top_k);
+            assert!(k >= 100, "k={k} below floor for top_k={top_k}");
+            assert!(k <= 4_096, "k={k} above ceiling for top_k={top_k}");
+        }
     }
 }

--- a/tests/knn_k_bound.rs
+++ b/tests/knn_k_bound.rs
@@ -1,0 +1,121 @@
+//! Integration test for issue #58: sqlite-vec KNN k must not exceed 4096.
+//!
+//! Populates a database with >4096 drawers + vectors, then runs
+//! `search_by_vector` with scope=All to verify no "k value too large" error.
+
+mod common;
+
+use mempal::core::db::Database;
+use mempal::core::project::ProjectSearchScope;
+use mempal::core::types::{Drawer, RouteDecision, SourceType};
+use mempal::search::{compute_knn_k, search_by_vector};
+use tempfile::TempDir;
+
+const DIM: usize = 4;
+const DRAWER_COUNT: usize = 5_000;
+
+fn make_drawer(i: usize) -> Drawer {
+    Drawer {
+        id: format!("d-{i:06}"),
+        content: format!("content for drawer {i}"),
+        wing: "test".to_string(),
+        room: Some("room".to_string()),
+        source_file: None,
+        source_type: SourceType::Manual,
+        added_at: "1700000000".to_string(),
+        chunk_index: None,
+        importance: 0,
+    }
+}
+
+fn random_vector(seed: usize) -> Vec<f32> {
+    // Deterministic pseudo-random vector seeded by drawer index.
+    let mut v = vec![0.0f32; DIM];
+    let mut state = seed as u64 ^ 0xDEAD_BEEF;
+    for value in &mut v {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        *value = ((state >> 33) as f32) / (u32::MAX as f32);
+    }
+    v
+}
+
+#[test]
+fn search_by_vector_succeeds_with_more_than_4096_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("test.db")).expect("open db");
+
+    // Seed drawers + vectors
+    for i in 0..DRAWER_COUNT {
+        let drawer = make_drawer(i);
+        db.insert_drawer_with_project(&drawer, None)
+            .expect("insert drawer");
+        db.insert_vector(&drawer.id, &random_vector(i))
+            .expect("insert vector");
+    }
+
+    let route = RouteDecision {
+        wing: None,
+        room: None,
+        confidence: 0.0,
+        reason: "test".to_string(),
+    };
+    let scope = ProjectSearchScope::from_request(None, true, false, false); // all-projects
+
+    let query_vec = random_vector(42);
+    let results = search_by_vector(&db, &query_vec, route, &scope, 10);
+
+    let results = results.expect("search_by_vector must not fail at drawer_count > 4096");
+    assert!(
+        !results.is_empty(),
+        "expected >0 results from {DRAWER_COUNT} drawers"
+    );
+    assert!(
+        results.len() <= 10,
+        "expected at most 10 results, got {}",
+        results.len()
+    );
+}
+
+#[test]
+fn search_by_vector_succeeds_with_20000_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("test.db")).expect("open db");
+
+    let count = 20_000usize;
+    for i in 0..count {
+        let drawer = make_drawer(i);
+        db.insert_drawer_with_project(&drawer, None)
+            .expect("insert drawer");
+        db.insert_vector(&drawer.id, &random_vector(i))
+            .expect("insert vector");
+    }
+
+    let route = RouteDecision {
+        wing: None,
+        room: None,
+        confidence: 0.0,
+        reason: "test".to_string(),
+    };
+    let scope = ProjectSearchScope::from_request(None, true, false, false);
+
+    let results = search_by_vector(&db, &random_vector(99), route, &scope, 10)
+        .expect("search_by_vector must not fail at drawer_count = 20000");
+    assert!(
+        !results.is_empty(),
+        "expected >0 results from {count} drawers"
+    );
+}
+
+#[test]
+fn compute_knn_k_never_exceeds_sqlite_vec_limit() {
+    for top_k in [0, 1, 10, 100, 1_000, 10_000] {
+        let k = compute_knn_k(top_k);
+        assert!(
+            k <= 4_096,
+            "compute_knn_k({top_k}) = {k}, exceeds 4096 limit"
+        );
+        assert!(k >= 100, "compute_knn_k({top_k}) = {k}, below 100 floor");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #58 — `search_by_vector` binds `total_count` (all non-deleted drawers) as the sqlite-vec KNN `k` parameter. sqlite-vec has a hardcoded limit of **4096**. Any search with `scope.mode != ProjectScoped` fails once the database exceeds 4096 drawers.

### Changes

- **`compute_knn_k(top_k)`**: New helper that clamps KNN k to `[100, 4096]` using a `top_k * 50` recall multiplier, replacing the unbounded `total_count` binding
- **Loosened short-circuit**: Any search with `candidate_count <= 4096` now routes to the exact in-memory path regardless of scope mode (was restricted to `ProjectScoped` only)
- **Generalized `search_by_vector_scoped_exact`**: Accepts full `ProjectSearchScope` for proper `classify_row` across all scope modes
- **Cleanup**: Removed unused `total_count` query and `CountTotalDrawers` error variant

### Tests

- 6 unit tests for `compute_knn_k` edge cases (0, 1, boundary, large, exhaustive bounds)
- Integration tests with 5,000 and 20,000 drawer databases using `scope=All`

### Trade-off

When database exceeds 4096 drawers and `candidate_count > 4096`, KNN recall becomes approximate (capped at 4096 candidates). For databases under 4096 candidates, the exact in-memory sort path provides perfect recall.