### PR TITLE
feat(ingest): route MCP and REST ingest through token-aware chunker

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -79,6 +79,14 @@ struct IngestRequest {
 #[derive(Debug, Serialize)]
 struct IngestResponse {
     drawer_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    drawer_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    chunk_count: usize,
+}
+
+fn is_zero(v: &usize) -> bool {
+    *v == 0
 }
 
 #[derive(Debug, Serialize)]
@@ -180,53 +188,76 @@ async fn ingest_handler(
         .build()
         .await
         .map_err(internal_error)?;
-    let vector: Vec<f32> = embedder
-        .embed(&[request.content.as_str()])
-        .await
-        .map_err(internal_error)?
-        .into_iter()
-        .next()
-        .ok_or_else(|| {
-            ApiError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "embedder returned no vector",
-            )
-        })?;
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let config = ConfigHandle::current();
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
-    let (drawer_id, drawer_exists) = db
-        .resolve_ingest_drawer_id(
-            &request.wing,
-            request.room.as_deref(),
-            &request.content,
-            project_id.as_deref(),
-        )
-        .map_err(internal_error)?;
 
-    if !drawer_exists {
-        let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
-        db.insert_drawer_with_project(
-            &Drawer {
-                id: drawer_id.clone(),
-                content: request.content,
-                wing: request.wing,
-                room: request.room,
-                source_file: Some(source_file),
-                source_type: SourceType::Manual,
-                added_at: current_timestamp(),
-                chunk_index: Some(0),
-                importance: 0,
-            },
-            project_id.as_deref(),
-        )
-        .map_err(internal_error)?;
-        db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
-            .map_err(internal_error)?;
+    // Chunk the content using the token-aware chunker (issue #57).
+    let chunks =
+        crate::ingest::prepare_chunks(&request.content, &config.chunker, embedder.as_ref());
+    if chunks.is_empty() {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "content produced no chunks",
+        ));
     }
 
-    Ok((StatusCode::CREATED, Json(IngestResponse { drawer_id })))
+    // Embed all chunks in one batch call.
+    let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
+    let vectors = embedder.embed(&chunk_refs).await.map_err(internal_error)?;
+    if vectors.len() != chunks.len() {
+        return Err(ApiError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "embedder returned wrong number of vectors",
+        ));
+    }
+
+    // Insert each chunk as a separate drawer.
+    let mut drawer_ids: Vec<String> = Vec::with_capacity(chunks.len());
+    for (chunk_idx, (chunk, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
+        let (drawer_id, drawer_exists) = db
+            .resolve_ingest_drawer_id(
+                &request.wing,
+                request.room.as_deref(),
+                chunk,
+                project_id.as_deref(),
+            )
+            .map_err(internal_error)?;
+
+        if !drawer_exists {
+            let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
+            db.insert_drawer_with_project(
+                &Drawer {
+                    id: drawer_id.clone(),
+                    content: chunk.clone(),
+                    wing: request.wing.clone(),
+                    room: request.room.clone(),
+                    source_file: Some(source_file),
+                    source_type: SourceType::Manual,
+                    added_at: current_timestamp(),
+                    chunk_index: Some(chunk_idx as i64),
+                    importance: 0,
+                },
+                project_id.as_deref(),
+            )
+            .map_err(internal_error)?;
+            db.insert_vector_with_project(&drawer_id, vector, project_id.as_deref())
+                .map_err(internal_error)?;
+        }
+        drawer_ids.push(drawer_id);
+    }
+
+    let primary_drawer_id = drawer_ids.first().cloned().unwrap_or_default();
+    let chunk_count = chunks.len();
+    Ok((
+        StatusCode::CREATED,
+        Json(IngestResponse {
+            drawer_id: primary_drawer_id,
+            drawer_ids,
+            chunk_count,
+        }),
+    ))
 }
 
 async fn taxonomy_handler(

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -128,6 +128,23 @@ pub enum IngestError {
     },
 }
 
+/// Chunk content for embedding using the token-aware chunker.
+///
+/// This is the shared entry point for MCP, REST, and any non-file ingest
+/// path that receives pre-processed text. Uses `chunk_text_token_aware`
+/// (plaintext mode) since the caller has already normalized the content.
+///
+/// Returns a `Vec<String>` where each element fits within the embedder's
+/// `max_input_tokens` limit. For short content that fits in a single chunk,
+/// the returned vec has exactly one element.
+pub fn prepare_chunks<E: Embedder + ?Sized>(
+    content: &str,
+    config: &crate::core::config::ChunkerConfig,
+    embedder: &E,
+) -> Vec<String> {
+    chunk_text_token_aware(content, config, embedder, None)
+}
+
 pub async fn ingest_file<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -141,6 +141,85 @@ impl MempalMcpServer {
 
         Ok(None)
     }
+
+    /// Fallback helper for novelty merge paths that fall back to insert
+    /// (e.g. merge cap reached, re-embed failed). Inserts all chunks as
+    /// separate drawers, mirroring the Insert branch.
+    #[allow(clippy::too_many_arguments)]
+    fn mcp_ingest_insert_fallback(
+        &self,
+        db: &mut Database,
+        primary_drawer_id: &str,
+        _scrubbed_content: &str,
+        request: &IngestRequest,
+        chunks: &[String],
+        vectors: &[Vec<f32>],
+        chunk_drawer_ids: &[(usize, String, bool)],
+        mempal_home: &std::path::Path,
+        project_id: Option<&str>,
+        near_target_id: &str,
+        novelty: &crate::ingest::novelty::NoveltyDecision,
+        audit_decision: Option<&str>,
+        inserted_drawer_ids: &mut Vec<String>,
+    ) -> std::result::Result<(), ErrorData> {
+        db.record_novelty_audit(
+            primary_drawer_id,
+            NoveltyAction::Insert,
+            Some(near_target_id),
+            novelty.cosine,
+            audit_decision,
+            project_id,
+        )
+        .map_err(db_error)?;
+
+        for ((chunk_idx, chunk_did, _), (chunk, vector)) in chunk_drawer_ids
+            .iter()
+            .zip(chunks.iter().zip(vectors.iter()))
+        {
+            let _extra_lock = if *chunk_idx > 0 {
+                Some(
+                    crate::ingest::lock::acquire_source_lock(
+                        mempal_home,
+                        chunk_did,
+                        std::time::Duration::from_secs(5),
+                    )
+                    .map_err(|e| {
+                        ErrorData::internal_error(
+                            format!("ingest lock chunk {chunk_idx}: {e}"),
+                            None,
+                        )
+                    })?,
+                )
+            } else {
+                None
+            };
+            let exists = db.drawer_exists(chunk_did).map_err(db_error)?;
+            if exists {
+                inserted_drawer_ids.push(chunk_did.clone());
+                continue;
+            }
+            let source_file = source_file_or_synthetic(chunk_did, request.source.as_deref());
+            db.insert_drawer_with_project(
+                &Drawer {
+                    id: chunk_did.clone(),
+                    content: chunk.clone(),
+                    wing: request.wing.clone(),
+                    room: request.room.clone(),
+                    source_file: Some(source_file),
+                    source_type: SourceType::Manual,
+                    added_at: current_timestamp(),
+                    chunk_index: Some(*chunk_idx as i64),
+                    importance: request.importance.unwrap_or(0),
+                },
+                project_id,
+            )
+            .map_err(db_error)?;
+            db.insert_vector_with_project(chunk_did, vector, project_id)
+                .map_err(db_error)?;
+            inserted_drawer_ids.push(chunk_did.clone());
+        }
+        Ok(())
+    }
 }
 
 #[tool_router(router = tool_router)]
@@ -503,18 +582,46 @@ impl MempalMcpServer {
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
         let db = self.open_db()?;
-        let (drawer_id, _drawer_exists) = db
-            .resolve_ingest_drawer_id(
-                &request.wing,
-                room,
-                &scrubbed_content,
-                project_id.as_deref(),
-            )
-            .map_err(db_error)?;
+        let dry_run = request.dry_run.unwrap_or(false);
 
-        if request.dry_run.unwrap_or(false) {
+        // Check degraded embed status BEFORE building the embedder so that
+        // non-dry-run writes fail fast with "writes are paused" (issue #57
+        // regression guard).
+        if !dry_run && global_embed_status().should_block_writes() {
+            return Err(degraded_write_error());
+        }
+
+        // --- Chunk the scrubbed content (issue #57) ---
+        // Build embedder early so the chunker can respect max_input_tokens.
+        let embedder = self.embedder_factory.build().await.map_err(|error| {
+            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
+        })?;
+        let chunks =
+            crate::ingest::prepare_chunks(&scrubbed_content, &config.chunker, embedder.as_ref());
+
+        // Resolve drawer_id per chunk. The first chunk's drawer_id is the
+        // primary identifier for backward compatibility.
+        let mut chunk_drawer_ids: Vec<(usize, String, bool)> = Vec::with_capacity(chunks.len());
+        for (idx, chunk) in chunks.iter().enumerate() {
+            let (did, exists) = db
+                .resolve_ingest_drawer_id(&request.wing, room, chunk, project_id.as_deref())
+                .map_err(db_error)?;
+            chunk_drawer_ids.push((idx, did, exists));
+        }
+        let drawer_id = chunk_drawer_ids
+            .first()
+            .map(|(_, id, _)| id.clone())
+            .unwrap_or_default();
+
+        if dry_run {
+            let all_ids: Vec<String> = chunk_drawer_ids
+                .iter()
+                .map(|(_, id, _)| id.clone())
+                .collect();
             return Ok(Json(IngestResponse {
                 drawer_id,
+                drawer_ids: all_ids,
+                chunk_count: chunks.len(),
                 dropped: false,
                 gating_decision: None,
                 novelty_action: None,
@@ -525,10 +632,7 @@ impl MempalMcpServer {
             }));
         }
 
-        if global_embed_status().should_block_writes() {
-            return Err(degraded_write_error());
-        }
-
+        // Tier-1 gating runs on the full content (not per-chunk).
         let candidate = IngestCandidate {
             content: scrubbed_content.clone(),
             tool_name: None,
@@ -541,9 +645,9 @@ impl MempalMcpServer {
             db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
                 .map_err(db_error)?;
             return Ok(Json(IngestResponse {
-                // TODO(spec ambiguity): rejected ingests have no persisted drawer.
-                // Return the candidate-derived drawer_id for audit correlation.
                 drawer_id,
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
                 dropped: true,
                 gating_decision,
                 novelty_action: None,
@@ -556,10 +660,7 @@ impl MempalMcpServer {
 
         let mut db = db;
 
-        // P9-B reordered this path so the same-content lock is acquired
-        // before the expensive embedder call. That keeps concurrent manual
-        // ingests from racing past the dedup gate and writing duplicate
-        // drawers/vectors for identical content.
+        // P9-B: acquire lock on the first chunk's drawer_id before embedding.
         let mempal_home = db
             .path()
             .parent()
@@ -572,14 +673,10 @@ impl MempalMcpServer {
         )
         .map_err(|e| ErrorData::internal_error(format!("ingest lock: {e}"), None))?;
         let lock_wait_ms = Some(lock_guard.wait_duration().as_millis() as u64);
-        // Re-check after waiting: another request may have inserted this drawer
-        // while we were blocked on the same drawer_id lock.
-        let drawer_exists = db.drawer_exists(&drawer_id).map_err(db_error)?;
 
-        let embedder = self.embedder_factory.build().await.map_err(|error| {
-            ErrorData::internal_error(format!("failed to build embedder: {error}"), None)
-        })?;
-        let mut vector = None;
+        // Tier-2 gating: uses the first chunk's embedding as representative.
+        let first_chunk = chunks.first().map(|c| c.as_str()).unwrap_or("");
+        let mut first_vector = None;
         let mut gating_audit_recorded = false;
         if gating_decision.is_none() {
             let tier2_classifier = if config.ingest_gating.enabled
@@ -603,7 +700,7 @@ impl MempalMcpServer {
                 db.record_gating_audit(&drawer_id, &tier2.decision, project_id.as_deref())
                     .map_err(db_error)?;
                 gating_audit_recorded = true;
-                vector = tier2.vector;
+                first_vector = tier2.vector;
                 gating_decision = Some(tier2.decision);
             } else if config.ingest_gating.enabled {
                 gating_decision = Some(GatingDecision::accepted(
@@ -619,6 +716,8 @@ impl MempalMcpServer {
             drop(lock_guard);
             return Ok(Json(IngestResponse {
                 drawer_id,
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
                 dropped: true,
                 gating_decision,
                 novelty_action: None,
@@ -632,22 +731,48 @@ impl MempalMcpServer {
             db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
                 .map_err(db_error)?;
         }
-        let vector = match vector {
-            Some(vector) => vector,
-            None => embedder
-                .embed(&[scrubbed_content.as_str()])
-                .await
-                .map_err(|error| {
-                    ErrorData::internal_error(format!("embedding failed: {error}"), None)
-                })?
-                .into_iter()
-                .next()
-                .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?,
-        };
-        ensure_vector_dim_matches(&db, vector.len())?;
 
-        // Semantic dedup check: find most similar existing drawer
-        let duplicate_warning = check_semantic_duplicate(&db, &vector, &scrubbed_content);
+        // Embed ALL chunks in one batch call. If tier2 already produced a
+        // vector for the first chunk, splice it in.
+        let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
+        let vectors = if first_vector.is_some() && chunks.len() == 1 {
+            // Single-chunk optimization: reuse tier2 vector.
+            vec![first_vector.take().expect("checked Some")]
+        } else if let Some(fv) = first_vector.take() {
+            // Multi-chunk with tier2 vector for first chunk: embed the rest.
+            if chunks.len() > 1 {
+                let rest_refs: Vec<&str> = chunk_refs[1..].to_vec();
+                let mut rest_vecs = embedder.embed(&rest_refs).await.map_err(|error| {
+                    ErrorData::internal_error(format!("embedding failed: {error}"), None)
+                })?;
+                let mut all = vec![fv];
+                all.append(&mut rest_vecs);
+                all
+            } else {
+                vec![fv]
+            }
+        } else {
+            embedder.embed(&chunk_refs).await.map_err(|error| {
+                ErrorData::internal_error(format!("embedding failed: {error}"), None)
+            })?
+        };
+        if vectors.len() != chunks.len() {
+            return Err(ErrorData::internal_error(
+                format!(
+                    "embedder returned {} vectors for {} chunks",
+                    vectors.len(),
+                    chunks.len()
+                ),
+                None,
+            ));
+        }
+        if let Some(v) = vectors.first() {
+            ensure_vector_dim_matches(&db, v.len())?;
+        }
+
+        // Novelty evaluation uses the first chunk's vector as representative.
+        let first_vector_ref = &vectors[0];
+        let duplicate_warning = check_semantic_duplicate(&db, first_vector_ref, first_chunk);
         let novelty_candidate = NoveltyCandidate {
             wing: request.wing.clone(),
             room: request.room.clone(),
@@ -656,11 +781,14 @@ impl MempalMcpServer {
         let novelty = evaluate_novelty(
             &db,
             &novelty_candidate,
-            &vector,
+            first_vector_ref,
             &config.ingest_gating.novelty,
         );
         let mut response_drawer_id = drawer_id.clone();
         let (novelty_action, near_drawer_id);
+
+        // Collect all successfully inserted drawer IDs.
+        let mut inserted_drawer_ids: Vec<String> = Vec::new();
 
         match novelty.action {
             NoveltyAction::Insert => {
@@ -677,26 +805,66 @@ impl MempalMcpServer {
                 }
                 novelty_action = Some(NoveltyAction::Insert);
                 near_drawer_id = novelty.near_drawer_id.clone();
-                if !drawer_exists {
+
+                // Insert ALL chunks as separate drawers.
+                for ((chunk_idx, chunk_did, chunk_exists), (chunk, vector)) in chunk_drawer_ids
+                    .iter()
+                    .zip(chunks.iter().zip(vectors.iter()))
+                {
+                    if *chunk_exists {
+                        inserted_drawer_ids.push(chunk_did.clone());
+                        continue;
+                    }
+                    // Acquire per-chunk lock for chunks beyond the first
+                    // (first chunk already holds lock_guard).
+                    let _extra_lock = if *chunk_idx > 0 {
+                        Some(
+                            crate::ingest::lock::acquire_source_lock(
+                                &mempal_home,
+                                chunk_did,
+                                std::time::Duration::from_secs(5),
+                            )
+                            .map_err(|e| {
+                                ErrorData::internal_error(
+                                    format!("ingest lock chunk {chunk_idx}: {e}"),
+                                    None,
+                                )
+                            })?,
+                        )
+                    } else {
+                        None
+                    };
+                    // Re-check existence after acquiring per-chunk lock.
+                    let exists_after_lock = if *chunk_idx > 0 {
+                        db.drawer_exists(chunk_did).map_err(db_error)?
+                    } else {
+                        // First chunk: re-check after the initial lock.
+                        db.drawer_exists(chunk_did).map_err(db_error)?
+                    };
+                    if exists_after_lock {
+                        inserted_drawer_ids.push(chunk_did.clone());
+                        continue;
+                    }
                     let source_file =
-                        source_file_or_synthetic(&drawer_id, request.source.as_deref());
+                        source_file_or_synthetic(chunk_did, request.source.as_deref());
                     db.insert_drawer_with_project(
                         &Drawer {
-                            id: drawer_id.clone(),
-                            content: scrubbed_content.clone(),
+                            id: chunk_did.clone(),
+                            content: chunk.clone(),
                             wing: request.wing.clone(),
                             room: request.room.clone(),
                             source_file: Some(source_file),
                             source_type: SourceType::Manual,
                             added_at: current_timestamp(),
-                            chunk_index: Some(0),
+                            chunk_index: Some(*chunk_idx as i64),
                             importance: request.importance.unwrap_or(0),
                         },
                         project_id.as_deref(),
                     )
                     .map_err(db_error)?;
-                    db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+                    db.insert_vector_with_project(chunk_did, vector, project_id.as_deref())
                         .map_err(db_error)?;
+                    inserted_drawer_ids.push(chunk_did.clone());
                 }
             }
             NoveltyAction::Drop => {
@@ -716,6 +884,9 @@ impl MempalMcpServer {
                 response_drawer_id = novelty.near_drawer_id.unwrap_or(drawer_id.clone());
             }
             NoveltyAction::Merge => {
+                // Novelty merge operates on the FULL scrubbed content (not
+                // individual chunks). This preserves the existing merge
+                // semantics: the whole content is appended as supplementary.
                 let target_id = novelty.near_drawer_id.clone().ok_or_else(|| {
                     ErrorData::internal_error("novelty merge missing target", None)
                 })?;
@@ -747,42 +918,51 @@ impl MempalMcpServer {
                     || merged_content.len()
                         > config.ingest_gating.novelty.max_content_bytes_per_drawer;
                 if capped {
-                    db.record_novelty_audit(
+                    self.mcp_ingest_insert_fallback(
+                        &mut db,
                         &drawer_id,
-                        NoveltyAction::Insert,
-                        Some(target_id.as_str()),
-                        novelty.cosine,
-                        Some("insert_due_to_merge_cap"),
+                        &scrubbed_content,
+                        &request,
+                        &chunks,
+                        &vectors,
+                        &chunk_drawer_ids,
+                        &mempal_home,
                         project_id.as_deref(),
-                    )
-                    .map_err(db_error)?;
+                        &target_id,
+                        &novelty,
+                        Some("insert_due_to_merge_cap"),
+                        &mut inserted_drawer_ids,
+                    )?;
                     novelty_action = Some(NoveltyAction::Insert);
                     near_drawer_id = Some(target_id);
-                    if !drawer_exists {
-                        let source_file =
-                            source_file_or_synthetic(&drawer_id, request.source.as_deref());
-                        db.insert_drawer_with_project(
-                            &Drawer {
-                                id: drawer_id.clone(),
-                                content: scrubbed_content.clone(),
-                                wing: request.wing.clone(),
-                                room: request.room.clone(),
-                                source_file: Some(source_file),
-                                source_type: SourceType::Manual,
-                                added_at: current_timestamp(),
-                                chunk_index: Some(0),
-                                importance: request.importance.unwrap_or(0),
-                            },
-                            project_id.as_deref(),
-                        )
-                        .map_err(db_error)?;
-                        db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
-                            .map_err(db_error)?;
-                    }
                 } else {
-                    let merged_vector = match embedder.embed(&[merged_content.as_str()]).await {
-                        Ok(vectors) => match vectors.into_iter().next() {
-                            Some(vector) => vector,
+                    // Re-embed the merged content. Note: merged content may
+                    // exceed max_input_tokens — this is intentional (existing
+                    // merge semantics; the merged drawer is a single unit).
+                    match embedder.embed(&[merged_content.as_str()]).await {
+                        Ok(merged_vectors) => match merged_vectors.into_iter().next() {
+                            Some(merged_vector) => {
+                                ensure_vector_dim_matches(&db, merged_vector.len())?;
+                                db.update_drawer_after_merge(
+                                    &target_id,
+                                    &merged_content,
+                                    &merged_at,
+                                    &merged_vector,
+                                )
+                                .map_err(db_error)?;
+                                db.record_novelty_audit(
+                                    &drawer_id,
+                                    NoveltyAction::Merge,
+                                    Some(target_id.as_str()),
+                                    novelty.cosine,
+                                    novelty.audit_decision,
+                                    project_id.as_deref(),
+                                )
+                                .map_err(db_error)?;
+                                novelty_action = Some(NoveltyAction::Merge);
+                                near_drawer_id = Some(target_id.clone());
+                                response_drawer_id = target_id;
+                            }
                             None => {
                                 tracing::warn!(
                                     target_id = %target_id,
@@ -790,142 +970,63 @@ impl MempalMcpServer {
                                     merged_content_bytes = merged_content.len(),
                                     "novelty merge re-embed returned no vector; fail-open insert"
                                 );
-                                db.record_novelty_audit(
+                                self.mcp_ingest_insert_fallback(
+                                    &mut db,
                                     &drawer_id,
-                                    NoveltyAction::Insert,
-                                    Some(target_id.as_str()),
-                                    novelty.cosine,
-                                    Some("insert_due_to_embed_error"),
+                                    &scrubbed_content,
+                                    &request,
+                                    &chunks,
+                                    &vectors,
+                                    &chunk_drawer_ids,
+                                    &mempal_home,
                                     project_id.as_deref(),
-                                )
-                                .map_err(db_error)?;
+                                    &target_id,
+                                    &novelty,
+                                    Some("insert_due_to_embed_error"),
+                                    &mut inserted_drawer_ids,
+                                )?;
                                 novelty_action = Some(NoveltyAction::Insert);
                                 near_drawer_id = Some(target_id);
-                                if !drawer_exists {
-                                    let source_file = source_file_or_synthetic(
-                                        &drawer_id,
-                                        request.source.as_deref(),
-                                    );
-                                    db.insert_drawer_with_project(
-                                        &Drawer {
-                                            id: drawer_id.clone(),
-                                            content: scrubbed_content.clone(),
-                                            wing: request.wing.clone(),
-                                            room: request.room.clone(),
-                                            source_file: Some(source_file),
-                                            source_type: SourceType::Manual,
-                                            added_at: current_timestamp(),
-                                            chunk_index: Some(0),
-                                            importance: request.importance.unwrap_or(0),
-                                        },
-                                        project_id.as_deref(),
-                                    )
-                                    .map_err(db_error)?;
-                                    db.insert_vector_with_project(
-                                        &drawer_id,
-                                        &vector,
-                                        project_id.as_deref(),
-                                    )
-                                    .map_err(db_error)?;
-                                }
-                                drop(lock_guard);
-                                return Ok(Json(IngestResponse {
-                                    drawer_id: response_drawer_id,
-                                    dropped: false,
-                                    gating_decision,
-                                    novelty_action,
-                                    near_drawer_id,
-                                    duplicate_warning,
-                                    lock_wait_ms,
-                                    system_warnings: current_system_warnings(),
-                                }));
                             }
                         },
                         Err(_error) => {
                             tracing::warn!(
-                                target_id = %target_id,
                                 candidate_drawer_id = %drawer_id,
-                                merged_content_bytes = merged_content.len(),
                                 "novelty merge re-embed failed; fail-open insert"
                             );
-                            db.record_novelty_audit(
+                            self.mcp_ingest_insert_fallback(
+                                &mut db,
                                 &drawer_id,
-                                NoveltyAction::Insert,
-                                Some(target_id.as_str()),
-                                novelty.cosine,
-                                Some("insert_due_to_embed_error"),
+                                &scrubbed_content,
+                                &request,
+                                &chunks,
+                                &vectors,
+                                &chunk_drawer_ids,
+                                &mempal_home,
                                 project_id.as_deref(),
-                            )
-                            .map_err(db_error)?;
+                                &target_id,
+                                &novelty,
+                                Some("insert_due_to_embed_error"),
+                                &mut inserted_drawer_ids,
+                            )?;
                             novelty_action = Some(NoveltyAction::Insert);
                             near_drawer_id = Some(target_id);
-                            if !drawer_exists {
-                                let source_file =
-                                    source_file_or_synthetic(&drawer_id, request.source.as_deref());
-                                db.insert_drawer_with_project(
-                                    &Drawer {
-                                        id: drawer_id.clone(),
-                                        content: scrubbed_content.clone(),
-                                        wing: request.wing.clone(),
-                                        room: request.room.clone(),
-                                        source_file: Some(source_file),
-                                        source_type: SourceType::Manual,
-                                        added_at: current_timestamp(),
-                                        chunk_index: Some(0),
-                                        importance: request.importance.unwrap_or(0),
-                                    },
-                                    project_id.as_deref(),
-                                )
-                                .map_err(db_error)?;
-                                db.insert_vector_with_project(
-                                    &drawer_id,
-                                    &vector,
-                                    project_id.as_deref(),
-                                )
-                                .map_err(db_error)?;
-                            }
-                            drop(lock_guard);
-                            return Ok(Json(IngestResponse {
-                                drawer_id: response_drawer_id,
-                                dropped: false,
-                                gating_decision,
-                                novelty_action,
-                                near_drawer_id,
-                                duplicate_warning,
-                                lock_wait_ms,
-                                system_warnings: current_system_warnings(),
-                            }));
                         }
-                    };
-                    ensure_vector_dim_matches(&db, merged_vector.len())?;
-                    db.update_drawer_after_merge(
-                        &target_id,
-                        &merged_content,
-                        &merged_at,
-                        &merged_vector,
-                    )
-                    .map_err(db_error)?;
-                    db.record_novelty_audit(
-                        &drawer_id,
-                        NoveltyAction::Merge,
-                        Some(target_id.as_str()),
-                        novelty.cosine,
-                        novelty.audit_decision,
-                        project_id.as_deref(),
-                    )
-                    .map_err(db_error)?;
-                    novelty_action = Some(NoveltyAction::Merge);
-                    near_drawer_id = Some(target_id.clone());
-                    response_drawer_id = target_id;
+                    }
                 }
             }
         }
 
-        // lock_guard drops here, releasing the advisory lock.
         drop(lock_guard);
+
+        if !inserted_drawer_ids.is_empty() {
+            response_drawer_id = inserted_drawer_ids[0].clone();
+        }
 
         Ok(Json(IngestResponse {
             drawer_id: response_drawer_id,
+            drawer_ids: inserted_drawer_ids,
+            chunk_count: chunks.len(),
             dropped: false,
             gating_decision,
             novelty_action,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -193,7 +193,18 @@ pub struct DeleteResponse {
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IngestResponse {
+    /// ID of the first (or only) drawer created. For backward compatibility,
+    /// callers that only read `drawer_id` continue to work unchanged.
     pub drawer_id: String,
+    /// All drawer IDs created by this ingest (one per chunk). When content
+    /// fits in a single chunk, this contains exactly one element matching
+    /// `drawer_id`. Empty when `dropped` is true.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drawer_ids: Vec<String>,
+    /// Number of chunks the content was split into. Always >= 1 for
+    /// successful ingests; 0 when `dropped` is true.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub chunk_count: usize,
     #[serde(default)]
     pub dropped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,6 +222,10 @@ pub struct IngestResponse {
     pub lock_wait_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+fn is_zero(v: &usize) -> bool {
+    *v == 0
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/tests/ingest_chunker.rs
+++ b/tests/ingest_chunker.rs
@@ -1,0 +1,388 @@
+//! Integration tests for issue #57: MCP and REST ingest must chunk
+//! content through the same token-aware chunker as the CLI pipeline.
+
+mod common;
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+
+/// Embedder with a low `max_input_tokens` to force chunking on moderate content.
+#[derive(Clone)]
+struct SmallLimitEmbedderFactory {
+    dim: usize,
+    max_tokens: usize,
+}
+
+struct SmallLimitEmbedder {
+    dim: usize,
+    max_tokens: usize,
+}
+
+#[async_trait]
+impl EmbedderFactory for SmallLimitEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(SmallLimitEmbedder {
+            dim: self.dim,
+            max_tokens: self.max_tokens,
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for SmallLimitEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| vec![0.1_f32; self.dim]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        "small-limit-test"
+    }
+
+    fn max_input_tokens(&self) -> Option<usize> {
+        Some(self.max_tokens)
+    }
+
+    fn estimate_tokens(&self, text: &str) -> usize {
+        // Simple: 1 token per word (space-separated). This makes it easy
+        // to control chunk boundaries in tests.
+        text.split_whitespace().count()
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+    config_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new(chunker_max_tokens: usize) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        let mempal_home = home.join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let config_path = mempal_home.join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+db_path = "{db_path}"
+
+[config_hot_reload]
+enabled = false
+
+[chunker]
+max_tokens = {chunker_max_tokens}
+target_tokens = {target}
+overlap_tokens = 0
+"#,
+                db_path = db_path.display(),
+                target = chunker_max_tokens / 2,
+            ),
+        )
+        .expect("write config");
+        Self {
+            _tmp: tmp,
+            db_path,
+            config_path,
+        }
+    }
+
+    fn bootstrap_config(&self) -> Config {
+        ConfigHandle::bootstrap(&self.config_path).expect("bootstrap config");
+        Config::load_from(&self.config_path).expect("load config")
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+}
+
+fn drawer_count(db: &Database) -> i64 {
+    db.conn()
+        .query_row("SELECT COUNT(*) FROM drawers", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count drawers")
+}
+
+fn vector_count(db: &Database) -> i64 {
+    db.conn()
+        .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count vectors")
+}
+
+fn drawer_contents(db: &Database) -> Vec<String> {
+    let mut stmt = db
+        .conn()
+        .prepare("SELECT content FROM drawers ORDER BY chunk_index ASC")
+        .expect("prepare");
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .expect("query")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect")
+}
+
+/// Generate content with exactly `n_words` space-separated words.
+fn make_content(n_words: usize) -> String {
+    (0..n_words)
+        .map(|i| format!("word{i}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---- MCP tests ----
+
+#[tokio::test]
+async fn test_mcp_ingest_short_content_single_chunk() {
+    // max_tokens=100, content has 10 words → single chunk
+    let env = TestEnv::new(100);
+    let config = env.bootstrap_config();
+    let factory: Arc<dyn EmbedderFactory> = Arc::new(SmallLimitEmbedderFactory {
+        dim: 4,
+        max_tokens: 100,
+    });
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+
+    let content = make_content(10);
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content,
+            wing: "test".to_string(),
+            room: Some("chunker".to_string()),
+            source: None,
+            project_id: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("mcp ingest")
+        .0;
+
+    assert!(!response.dropped, "should not be dropped");
+    assert_eq!(response.chunk_count, 1, "short content = 1 chunk");
+    assert_eq!(response.drawer_ids.len(), 1, "one drawer ID returned");
+    assert_eq!(response.drawer_id, response.drawer_ids[0]);
+
+    let db = env.db();
+    assert_eq!(drawer_count(&db), 1);
+    assert_eq!(vector_count(&db), 1);
+}
+
+#[tokio::test]
+async fn test_mcp_ingest_large_content_multi_chunk() {
+    // max_tokens=50 (after 32 safety margin → effective=18),
+    // content has 100 words → should produce multiple chunks.
+    let env = TestEnv::new(50);
+    let config = env.bootstrap_config();
+    let factory: Arc<dyn EmbedderFactory> = Arc::new(SmallLimitEmbedderFactory {
+        dim: 4,
+        max_tokens: 50,
+    });
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+
+    let content = make_content(100);
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: content.clone(),
+            wing: "test".to_string(),
+            room: Some("chunker".to_string()),
+            source: None,
+            project_id: None,
+            dry_run: Some(false),
+            importance: None,
+        }))
+        .await
+        .expect("mcp ingest")
+        .0;
+
+    assert!(!response.dropped, "should not be dropped");
+    assert!(
+        response.chunk_count >= 2,
+        "100 words with max_tokens=50 must produce >=2 chunks, got {}",
+        response.chunk_count
+    );
+    assert_eq!(
+        response.drawer_ids.len(),
+        response.chunk_count,
+        "drawer_ids len must match chunk_count"
+    );
+    assert_eq!(response.drawer_id, response.drawer_ids[0]);
+
+    let db = env.db();
+    assert!(
+        drawer_count(&db) >= 2,
+        "must have >=2 drawers, got {}",
+        drawer_count(&db)
+    );
+    assert_eq!(
+        drawer_count(&db),
+        vector_count(&db),
+        "each drawer must have a matching vector"
+    );
+
+    // Verbatim invariant: every word from the original content must appear
+    // in the chunks (in order). The chunker may consume whitespace at chunk
+    // boundaries, so we verify word-level coverage rather than exact string
+    // equality.
+    let contents = drawer_contents(&db);
+    let reconstructed = contents.join(" ");
+    let original_words: Vec<&str> = content.split_whitespace().collect();
+    let reconstructed_words: Vec<&str> = reconstructed.split_whitespace().collect();
+    // All original words must be present (order preserved by chunk_index).
+    for word in &original_words {
+        assert!(
+            reconstructed_words.contains(word),
+            "word {word} missing from reconstructed chunks"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_mcp_ingest_dry_run_returns_chunk_info() {
+    let env = TestEnv::new(50);
+    let config = env.bootstrap_config();
+    let factory: Arc<dyn EmbedderFactory> = Arc::new(SmallLimitEmbedderFactory {
+        dim: 4,
+        max_tokens: 50,
+    });
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+
+    let content = make_content(100);
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content,
+            wing: "test".to_string(),
+            room: Some("chunker".to_string()),
+            source: None,
+            project_id: None,
+            dry_run: Some(true),
+            importance: None,
+        }))
+        .await
+        .expect("mcp ingest dry_run")
+        .0;
+
+    assert!(
+        response.chunk_count >= 2,
+        "dry_run should still report chunk_count"
+    );
+    assert_eq!(response.drawer_ids.len(), response.chunk_count);
+    // No drawers should be written in dry_run.
+    let db = env.db();
+    assert_eq!(drawer_count(&db), 0, "dry_run must not write drawers");
+}
+
+// ---- REST tests ----
+
+#[cfg(feature = "rest")]
+mod rest_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn test_rest_ingest_large_content_multi_chunk() {
+        let env = TestEnv::new(50);
+        let _config = env.bootstrap_config();
+        let factory: Arc<dyn EmbedderFactory> = Arc::new(SmallLimitEmbedderFactory {
+            dim: 4,
+            max_tokens: 50,
+        });
+        let state = mempal::api::ApiState::new(env.db_path.clone(), factory);
+        let app = mempal::api::router(state);
+
+        let content = make_content(100);
+        let body = serde_json::json!({
+            "content": content,
+            "wing": "test",
+            "room": "chunker",
+        });
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/ingest")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let response: axum::http::Response<Body> = app.oneshot(request).await.expect("REST ingest");
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let resp: serde_json::Value = serde_json::from_slice(&body_bytes).expect("parse json");
+
+        let chunk_count = resp["chunk_count"].as_u64().unwrap_or(0);
+        assert!(
+            chunk_count >= 2,
+            "REST ingest must produce >=2 chunks for 100 words with max_tokens=50, got {}",
+            chunk_count
+        );
+
+        let drawer_ids = resp["drawer_ids"].as_array().expect("drawer_ids array");
+        assert_eq!(drawer_ids.len() as u64, chunk_count);
+
+        let db = env.db();
+        assert!(drawer_count(&db) >= 2);
+        assert_eq!(drawer_count(&db), vector_count(&db));
+    }
+
+    #[tokio::test]
+    async fn test_rest_ingest_short_content_single_chunk() {
+        let env = TestEnv::new(100);
+        let _config = env.bootstrap_config();
+        let factory: Arc<dyn EmbedderFactory> = Arc::new(SmallLimitEmbedderFactory {
+            dim: 4,
+            max_tokens: 100,
+        });
+        let state = mempal::api::ApiState::new(env.db_path.clone(), factory);
+        let app = mempal::api::router(state);
+
+        let content = make_content(10);
+        let body = serde_json::json!({
+            "content": content,
+            "wing": "test",
+            "room": "chunker",
+        });
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/ingest")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+
+        let response: axum::http::Response<Body> = app.oneshot(request).await.expect("REST ingest");
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let resp: serde_json::Value = serde_json::from_slice(&body_bytes).expect("parse json");
+
+        let chunk_count = resp["chunk_count"].as_u64().unwrap_or(0);
+        assert_eq!(chunk_count, 1, "short content should produce 1 chunk");
+
+        let db = env.db();
+        assert_eq!(drawer_count(&db), 1);
+        assert_eq!(vector_count(&db), 1);
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "87538e12c2e3cf48a2f517aae5cfef4fa74dc4b2"
+commit = "e30b077fcbc965f15c93edb0f2e8c7fc5bdb483a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- MCP `mempal_ingest` and REST `/api/ingest` now chunk content through the same `chunk_text_token_aware` pipeline as CLI ingest, preventing silent truncation when content exceeds `max_input_tokens`
- Each chunk gets its own drawer and vector; responses include `drawer_ids[]` and `chunk_count` for multi-chunk awareness while keeping `drawer_id` backward-compatible as the first chunk's ID
- Degraded-embed write check moved before embedder construction for fail-fast behavior

## Changes

| File | What |
|------|------|
| `src/ingest/mod.rs` | New `prepare_chunks()` public helper |
| `src/mcp/server.rs` | Rewritten `mempal_ingest` with per-chunk insert, gating on full content, novelty on first chunk |
| `src/mcp/tools.rs` | `IngestResponse` extended with `drawer_ids`, `chunk_count` |
| `src/api/handlers.rs` | Rewritten `ingest_handler` with chunking + batch embed + per-chunk insert |
| `tests/ingest_chunker.rs` | Integration tests: single-chunk, multi-chunk, dry-run for MCP; single/multi-chunk for REST |

## Test plan

- [x] `cargo test` — all 134 unit tests pass
- [x] `cargo test --features rest --test ingest_chunker` — all 13 integration tests pass (3 MCP + 2 REST + 8 harness)
- [x] `cargo clippy --all-features` — clean
- [x] `test_embed_degraded_blocks_writes_when_configured` — regression verified fixed
- [x] Pre-commit hooks (fmt + clippy + test) pass

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)