### PR TITLE
fix(search): bound tunnel_drawers_for_room with SQL LIMIT (#66)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1158,7 +1158,8 @@ impl Database {
             return Ok(Vec::new());
         };
 
-        let sql_limit = limit as i64;
+        let sql_limit =
+            i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
         let mut stmt = self.conn.prepare(
             r#"
             SELECT id, content, wing, room, source_file, source_type, added_at, chunk_index,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1152,11 +1152,13 @@ impl Database {
         room: &str,
         exclude_drawer_id: &str,
         current_project_id: Option<&str>,
+        limit: usize,
     ) -> Result<Vec<TunnelDrawer>, DbError> {
         let Some(current_project_id) = current_project_id else {
             return Ok(Vec::new());
         };
 
+        let sql_limit = limit as i64;
         let mut stmt = self.conn.prepare(
             r#"
             SELECT id, content, wing, room, source_file, source_type, added_at, chunk_index,
@@ -1168,23 +1170,27 @@ impl Database {
               AND project_id IS NOT NULL
               AND project_id != ?3
             ORDER BY CAST(added_at AS INTEGER) DESC, id DESC
+            LIMIT ?4
             "#,
         )?;
         let rows = stmt
-            .query_map([room, exclude_drawer_id, current_project_id], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, String>(2)?,
-                    row.get::<_, Option<String>>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                    row.get::<_, String>(5)?,
-                    row.get::<_, String>(6)?,
-                    row.get::<_, Option<i64>>(7)?,
-                    row.get::<_, i32>(8)?,
-                    row.get::<_, Option<String>>(9)?,
-                ))
-            })?
+            .query_map(
+                rusqlite::params![room, exclude_drawer_id, current_project_id, sql_limit],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, String>(6)?,
+                        row.get::<_, Option<i64>>(7)?,
+                        row.get::<_, i32>(8)?,
+                        row.get::<_, Option<String>>(9)?,
+                    ))
+                },
+            )?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         rows.into_iter()
             .map(

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -229,9 +229,12 @@ pub(crate) fn inject_tunnel_hints_with_cap(
             if fanout_cap == 0 {
                 continue;
             }
-            if let Ok(drawers) =
-                db.tunnel_drawers_for_room(room, &result.drawer_id, scope.project_id.as_deref())
-            {
+            if let Ok(drawers) = db.tunnel_drawers_for_room(
+                room,
+                &result.drawer_id,
+                scope.project_id.as_deref(),
+                fanout_cap.saturating_add(1),
+            ) {
                 let mut added_from_this_result = 0usize;
                 for tunnel in drawers {
                     if added_from_this_result >= fanout_cap {
@@ -744,16 +747,37 @@ mod tests {
         let mut results = vec![make_result(&alpha), make_result(&gamma)];
         inject_tunnel_hints_with_cap(&db, &mut results, &scoped_to_proj_a(), 2);
 
-        // Each of the 2 source results contributes up to 2 tunnel drawers, but
-        // `seen_ids` dedup means the second source result sees the same
-        // beta-{0,1} already inserted → its cap budget still holds 2 fresh rows.
-        // With 10 beta drawers available, we should see 2 (alpha) + 2 (gamma) = 4 tunnel rows
-        // total, plus 2 source rows = 6.
+        // SQL LIMIT = fanout_cap + 1 = 3.  Alpha's query returns 3 beta rows
+        // (beta-9, beta-8, beta-7 DESC order); alpha's Rust cap adds 2 (beta-9,
+        // beta-8).  Gamma's query also returns the same 3 rows; beta-9 and
+        // beta-8 are already in `seen_ids`, so only beta-7 is fresh → 1 tunnel
+        // row from gamma.  Total = 2 source + 2 (alpha) + 1 (gamma) = 5.
         assert_eq!(
             results.len(),
-            6,
-            "expected 2 source + 2 tunnel per source = 6, got {}",
+            5,
+            "expected 2 source + 2 (alpha) + 1 (gamma) = 5, got {}",
             results.len()
+        );
+    }
+
+    #[test]
+    fn tunnel_drawers_for_room_sql_limit_bounds_returned_rows() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+        let source = make_drawer("alpha-1", "alpha", "decision");
+        // Insert 20 beta drawers — well above any reasonable fanout cap.
+        seed_cross_project(&db, &source, 20);
+
+        let limit: usize = 5;
+        let drawers = db
+            .tunnel_drawers_for_room("decision", "alpha-1", Some("proj-a"), limit)
+            .expect("query");
+
+        assert_eq!(
+            drawers.len(),
+            limit,
+            "SQL LIMIT should bound returned rows to {limit}, got {}",
+            drawers.len()
         );
     }
 

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -1869,7 +1869,7 @@ fn test_tunnel_hint_records_target_project_id() {
     );
 
     let tunnels = db
-        .tunnel_drawers_for_room("shared-room", "drawer-a", Some("proj-A"))
+        .tunnel_drawers_for_room("shared-room", "drawer-a", Some("proj-A"), 100)
         .expect("load tunnel drawers");
     assert_eq!(tunnels.len(), 1);
     assert_eq!(tunnels[0].target_project_id.as_deref(), Some("proj-B"));


### PR DESCRIPTION
## Summary

- Add `limit: usize` parameter to `tunnel_drawers_for_room` and append `LIMIT ?` to the SQL query
- Caller passes `fanout_cap.saturating_add(1)` so the DB only reads capped rows from disk instead of every matching drawer across all wings (+1 lets caller detect truncation)
- Application-layer cap in `inject_tunnel_hints_with_cap` remains as defense-in-depth

## Context

Follow-up from #65 (closed #64). The underlying SQL in `tunnel_drawers_for_room` returned every drawer matching a room across all wings — on the 506K-drawer / 56-wing migration corpus that means ~80K rows from disk per top-k hit, all discarded in Rust. PR #65 added the per-result Rust-side cap preventing OOM, this PR pushes the bound to the SQL layer for disk I/O efficiency.

Closes #66

## Test plan

- [x] New test `tunnel_drawers_for_room_sql_limit_bounds_returned_rows` — inserts 20 rows, queries with limit=5, asserts exactly 5 returned
- [x] Updated `tunnel_fanout_cap_applies_per_source_result` — adjusted expected count to reflect SQL LIMIT interaction with `seen_ids` dedup (5 vs previous 6, known trade-off: supplementary tunnel hints may be slightly fewer when multiple source results share a room)
- [x] All 135 unit + 18 integration tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)