### PR TITLE
docs: warn about --git install staleness, recommend --path (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Next session (any agent) → mempal search → finds the decision with source ci
 
 ## Quick Start
 
+> **Caution: `cargo install --git` from a fork is unreliable across schema migrations.**
+> `cargo install --git <fork-url> --branch main --force mempal` may report success while actually
+> skipping the rebuild (cargo's source cache returns a stale ref despite `--force`, which only
+> forces *installation* not *re-fetch*). After a `CURRENT_SCHEMA_VERSION` bump in `src/core/db.rs`,
+> the resulting binary will fail with `database schema version N is newer than supported version N-1`.
+> See [#76](https://github.com/RyderFreeman4Logos/mempal/issues/76).
+>
+> For fork builds, prefer the `--path` route below (clones a fresh checkout, builds locally).
+> A one-liner is provided at [`scripts/install-from-source.sh`](scripts/install-from-source.sh).
+
 ```bash
 cargo install --path crates/mempal-cli --locked
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,16 @@ Before using the CLI, keep four nouns straight:
 
 ## Install
 
+> **Caution: `cargo install --git` from a fork is unreliable across schema migrations.**
+> `cargo install --git <fork-url> --branch main --force mempal` may report success while actually
+> skipping the rebuild (cargo's source cache returns a stale ref despite `--force`, which only
+> forces *installation* not *re-fetch*). After a `CURRENT_SCHEMA_VERSION` bump in `src/core/db.rs`,
+> the resulting binary will fail with `database schema version N is newer than supported version N-1`.
+> See [#76](https://github.com/RyderFreeman4Logos/mempal/issues/76).
+>
+> For fork builds, prefer the `--path` route below (clones a fresh checkout, builds locally).
+> A one-liner is provided at [`scripts/install-from-source.sh`](../scripts/install-from-source.sh).
+
 Install the CLI locally:
 
 ```bash

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install mempal from local source -- safe across schema bumps.
+#
+# Why this script exists: `cargo install --git <fork> --branch main --force mempal`
+# is unreliable. `--force` only forces *installation*, not source re-fetch, so cargo's
+# git source cache can return a stale ref and silently skip the rebuild ("0 deps compiled").
+# After a CURRENT_SCHEMA_VERSION bump, the resulting binary will fail with
+# `database schema version N is newer than supported version N-1`.
+# See https://github.com/RyderFreeman4Logos/mempal/issues/76.
+#
+# This script always pulls fresh source and uses --path, which forces a real rebuild.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+git pull --ff-only origin main
+CARGO_HOME="${CARGO_HOME:-/usr/local}" cargo install --path crates/mempal-cli --force --locked
+
+echo "--- verifying schema match ---"
+"${CARGO_HOME:-/usr/local}/bin/mempal" status | grep -E "schema_version|fork_ext_version"


### PR DESCRIPTION
## Summary

Adds a caveat block above the install instructions in `README.md` and `docs/usage.md` explaining that `cargo install --git --branch main --force mempal` is unreliable across schema migrations — cargo's source cache returns a stale ref despite `--force`, which only forces *installation* not *re-fetch*. Adds `scripts/install-from-source.sh` as the safe local-source install path.

Fixes #76

## Test plan

- [x] `lefthook` quality-gates passed (fmt + clippy + test)
- [x] Documentation-only diff (no code-path changes); test suite continues to pass
- [x] `scripts/install-from-source.sh` is `chmod +x` (mode 100755 in the commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)