### PR TITLE
fix(cli): accept m/h/d suffix and ISO 8601 for --since (#78)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,12 @@ enum Commands {
         wing: Option<String>,
         #[arg(long)]
         room: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Filter to drawers added after this point. \
+                    Duration: '10s', '15m', '2h', '3d'. \
+                    ISO 8601: '2026-04-25T20:00:00Z' or '2026-04-25T20:00:00+08:00'."
+        )]
         since: Option<String>,
         #[arg(long, default_value_t = false)]
         raw: bool,
@@ -180,7 +185,12 @@ enum Commands {
     Timeline {
         #[arg(long)]
         wing: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Filter to drawers added after this point. \
+                    Duration: '10s', '15m', '2h', '3d'. \
+                    ISO 8601: '2026-04-25T20:00:00Z' or '2026-04-25T20:00:00+08:00'."
+        )]
         since: Option<String>,
         #[arg(long, default_value = "text")]
         format: String,
@@ -199,7 +209,12 @@ enum Commands {
     Audit {
         #[arg(long)]
         kind: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Filter to audit records created after this point. \
+                    Duration: '10s', '15m', '2h', '3d'. \
+                    ISO 8601: '2026-04-25T20:00:00Z' or '2026-04-25T20:00:00+08:00'."
+        )]
         since: Option<String>,
         #[arg(long, default_value_t = false)]
         raw: bool,
@@ -289,7 +304,12 @@ enum TaxonomyCommands {
 #[derive(Subcommand)]
 enum GatingCommands {
     Stats {
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Filter to gating decisions created after this point. \
+                    Duration: '10s', '15m', '2h', '3d'. \
+                    ISO 8601: '2026-04-25T20:00:00Z' or '2026-04-25T20:00:00+08:00'."
+        )]
         since: Option<String>,
     },
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::core::config::{Config, ConfigHandle};
 use crate::core::db::{Database, read_fork_ext_version};
 use crate::core::project::{ProjectSearchScope, resolve_project_id};
-use crate::cowork::peek::format_rfc3339;
+use crate::cowork::peek::{format_rfc3339, parse_rfc3339};
 use anyhow::{Context, Result, bail};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
@@ -1105,27 +1105,51 @@ fn render_room(room: Option<&str>) -> &str {
 }
 
 fn parse_since_cutoff(raw: Option<&str>) -> Result<Option<i64>> {
-    raw.map(parse_duration_spec)
-        .transpose()
-        .map(|seconds| seconds.map(|seconds| now_unix_secs() - seconds))
+    raw.map(|s| parse_since_str(s, now_unix_secs())).transpose()
 }
 
-fn parse_duration_spec(raw: &str) -> Result<i64> {
+/// Parse a `--since` value into an absolute epoch-second cutoff.
+///
+/// Accepts:
+/// - Duration suffix: `10s`, `15m`, `2h`, `3d` → `now - duration`
+/// - ISO 8601 / RFC 3339 absolute timestamp: `2026-04-25T20:00:00Z`,
+///   `2026-04-25T20:00:00+08:00` → exact UTC epoch seconds
+pub(crate) fn parse_since_str(raw: &str, now: i64) -> Result<i64> {
     if raw.is_empty() {
-        bail!("empty duration");
+        bail!(
+            "empty --since value; accepted: duration like '10s', '15m', '2h', '3d' \
+             or ISO 8601 timestamp like '2026-04-25T20:00:00Z'"
+        );
+    }
+    if let Some(secs) = try_parse_duration_secs(raw) {
+        return Ok(now - secs);
+    }
+    if let Some(ts) = parse_rfc3339(raw) {
+        return Ok(ts);
+    }
+    bail!(
+        "invalid --since value {raw:?}; \
+         accepted: duration like '10s', '15m', '2h', '3d' \
+         or ISO 8601 timestamp like '2026-04-25T20:00:00Z'"
+    )
+}
+
+/// Returns the duration in seconds for strings like `10s`, `15m`, `2h`, `3d`.
+/// Returns `None` for unrecognised formats (including ISO timestamps).
+fn try_parse_duration_secs(raw: &str) -> Option<i64> {
+    if raw.is_empty() {
+        return None;
     }
     let (digits, unit) = raw.split_at(raw.len() - 1);
-    let value = digits
-        .parse::<i64>()
-        .with_context(|| format!("invalid duration: {raw}"))?;
+    let value = digits.parse::<i64>().ok()?;
     let multiplier = match unit {
-        "s" => 1,
+        "s" => 1_i64,
         "m" => 60,
-        "h" => 60 * 60,
-        "d" => 60 * 60 * 24,
-        other => bail!("unsupported duration unit: {other}"),
+        "h" => 3600,
+        "d" => 86400,
+        _ => return None,
     };
-    Ok(value * multiplier)
+    Some(value * multiplier)
 }
 
 fn now_unix_secs() -> i64 {
@@ -1249,4 +1273,71 @@ pub fn escape_terminal_text(value: &str) -> String {
         }
     }
     escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXED_NOW: i64 = 1_800_000_000;
+
+    #[test]
+    fn test_parse_since_10_minutes() {
+        let cutoff = parse_since_str("10m", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 600);
+    }
+
+    #[test]
+    fn test_parse_since_1_hour() {
+        let cutoff = parse_since_str("1h", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 3600);
+    }
+
+    #[test]
+    fn test_parse_since_1_day() {
+        let cutoff = parse_since_str("1d", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 86400);
+    }
+
+    #[test]
+    fn test_parse_since_seconds_suffix() {
+        let cutoff = parse_since_str("30s", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 30);
+    }
+
+    #[test]
+    fn test_parse_since_iso_8601_z() {
+        // 2026-04-25T20:00:00Z → absolute UTC epoch, independent of 'now'
+        let cutoff = parse_since_str("2026-04-25T20:00:00Z", FIXED_NOW).unwrap();
+        let expected = parse_rfc3339("2026-04-25T20:00:00Z").expect("valid ISO");
+        assert_eq!(cutoff, expected);
+        // Sanity: result is well before FIXED_NOW (year 2057)
+        assert!(cutoff < FIXED_NOW);
+    }
+
+    #[test]
+    fn test_parse_since_iso_8601_offset() {
+        // +08:00 means 8 hours ahead of UTC → UTC equivalent is 8h earlier
+        let cutoff_z = parse_since_str("2026-04-25T20:00:00Z", FIXED_NOW).unwrap();
+        let cutoff_plus8 = parse_since_str("2026-04-25T20:00:00+08:00", FIXED_NOW).unwrap();
+        assert_eq!(cutoff_z - cutoff_plus8, 8 * 3600);
+    }
+
+    #[test]
+    fn test_parse_since_rejects_garbage() {
+        assert!(parse_since_str("not-a-duration", FIXED_NOW).is_err());
+        assert!(parse_since_str("xyz", FIXED_NOW).is_err());
+        assert!(parse_since_str("", FIXED_NOW).is_err());
+    }
+
+    #[test]
+    fn test_try_parse_duration_secs() {
+        assert_eq!(try_parse_duration_secs("10m"), Some(600));
+        assert_eq!(try_parse_duration_secs("1h"), Some(3600));
+        assert_eq!(try_parse_duration_secs("1d"), Some(86400));
+        assert_eq!(try_parse_duration_secs("30s"), Some(30));
+        assert_eq!(try_parse_duration_secs("2026-04-25T20:00:00Z"), None);
+        assert_eq!(try_parse_duration_secs("not-a-duration"), None);
+        assert_eq!(try_parse_duration_secs(""), None);
+    }
 }

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -351,6 +351,10 @@ fn test_audit_novelty_lists_decisions() {
         ("novelty-01", NoveltyAction::Drop),
         ("novelty-00", NoveltyAction::Insert),
     ];
+    // Capture base time once so that each record's created_at is distinct
+    // (avoids a second-boundary race where two loop iterations call
+    // now_unix_secs() in the same second and produce identical timestamps).
+    let base_ts = now_unix_secs();
     for (index, (drawer_id, action)) in decisions.iter().enumerate() {
         insert_drawer(
             &env.db_path,
@@ -367,7 +371,7 @@ fn test_audit_novelty_lists_decisions() {
             &env.db_path,
             drawer_id,
             *action,
-            now_unix_secs() - 60 + (decisions.len() - index) as i64,
+            base_ts - 60 + (decisions.len() - index) as i64,
         );
     }
 
@@ -1165,4 +1169,144 @@ fn test_audit_filters_by_project_when_isolation_strict() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("audit-proj-a"), "{stdout}");
     assert!(!stdout.contains("audit-proj-b"), "{stdout}");
+}
+
+/// Insert a drawer whose `added_at` is `offset_secs` seconds before now.
+fn insert_drawer_at_offset(db_path: &std::path::Path, id: &str, offset_secs: u64) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .as_secs();
+    let ts = now.saturating_sub(offset_secs);
+    insert_drawer(
+        db_path,
+        &drawer_seed(
+            id,
+            format!("recent drawer {id}"),
+            "test-wing",
+            None,
+            ts.to_string(),
+            1,
+        ),
+    );
+}
+
+#[test]
+fn test_tail_since_10m_returns_recent_drawer() {
+    let env = DashboardEnv::new();
+    // drawer added 30 seconds ago — within the 10-minute window
+    insert_drawer_at_offset(&env.db_path, "recent-drawer", 30);
+    // old drawer outside the window (25 hours ago)
+    insert_drawer_at_offset(&env.db_path, "old-drawer", 25 * 3600);
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail", "--since", "10m"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("recent-drawer"),
+        "10m window should include recent drawer\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("old-drawer"),
+        "10m window should exclude old drawer\n{stdout}"
+    );
+}
+
+#[test]
+fn test_tail_since_1h_returns_recent_drawer() {
+    let env = DashboardEnv::new();
+    // drawer added 5 minutes ago — within the 1-hour window
+    insert_drawer_at_offset(&env.db_path, "five-min-drawer", 300);
+    // old drawer outside the window (2 hours ago)
+    insert_drawer_at_offset(&env.db_path, "two-hour-drawer", 2 * 3600);
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail", "--since", "1h"]);
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("five-min-drawer"),
+        "1h window should include 5-min-old drawer\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("two-hour-drawer"),
+        "1h window should exclude 2-hour-old drawer\n{stdout}"
+    );
+}
+
+#[test]
+fn test_tail_and_timeline_share_parser() {
+    let env = DashboardEnv::new();
+    // drawer added 30 seconds ago
+    insert_drawer_at_offset(&env.db_path, "shared-parser-drawer", 30);
+    // old drawer (2 hours ago, outside 1h window)
+    insert_drawer_at_offset(&env.db_path, "shared-parser-old", 2 * 3600);
+
+    let tail_out = run_mempal(&env.home, env.cwd(), &["tail", "--since", "1h"]);
+    let timeline_out = run_mempal(&env.home, env.cwd(), &["timeline", "--since", "1h"]);
+    assert!(tail_out.status.success(), "tail failed");
+    assert!(timeline_out.status.success(), "timeline failed");
+
+    let tail_stdout = String::from_utf8_lossy(&tail_out.stdout);
+    let timeline_stdout = String::from_utf8_lossy(&timeline_out.stdout);
+
+    // Both commands must include the recent drawer
+    assert!(
+        tail_stdout.contains("shared-parser-drawer"),
+        "tail --since 1h should include recent drawer\n{tail_stdout}"
+    );
+    assert!(
+        timeline_stdout.contains("shared-parser-drawer"),
+        "timeline --since 1h should include recent drawer\n{timeline_stdout}"
+    );
+    // Both commands must exclude the old drawer
+    assert!(
+        !tail_stdout.contains("shared-parser-old"),
+        "tail --since 1h should exclude old drawer\n{tail_stdout}"
+    );
+    assert!(
+        !timeline_stdout.contains("shared-parser-old"),
+        "timeline --since 1h should exclude old drawer\n{timeline_stdout}"
+    );
+}
+
+#[test]
+fn test_tail_since_iso_8601_accepted() {
+    let env = DashboardEnv::new();
+    // Use an ISO timestamp 1 hour in the past — anything newer should appear
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs();
+    insert_drawer_at_offset(&env.db_path, "iso-recent", 30);
+    insert_drawer_at_offset(&env.db_path, "iso-old", 2 * 3600);
+
+    // Build an ISO timestamp for 1h ago
+    let cutoff_secs = now - 3600;
+    let cutoff_ts = mempal::cowork::peek::format_rfc3339(
+        UNIX_EPOCH + std::time::Duration::from_secs(cutoff_secs),
+    );
+
+    let output = run_mempal(&env.home, env.cwd(), &["tail", "--since", &cutoff_ts]);
+    assert!(
+        output.status.success(),
+        "ISO timestamp should be accepted; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("iso-recent"),
+        "ISO cutoff should include recent drawer\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("iso-old"),
+        "ISO cutoff should exclude old drawer\n{stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

- Extend the `--since` parser to accept **ISO 8601 / RFC 3339** absolute timestamps (`2026-04-25T20:00:00Z`, `2026-04-25T20:00:00+08:00`) in addition to the existing duration-suffix format (`10s`, `15m`, `2h`, `3d`).
- All three `--since`-bearing subcommands (`tail`, `timeline`, `audit`, `gating stats`) share the **same** `parse_since_str` function — no duplication.
- Updated `--help` text for every `--since` flag to list both accepted forms.
- Fixed a pre-existing second-boundary race in `test_audit_novelty_lists_decisions` that caused non-deterministic sort order.

## Root cause

`parse_duration_spec` only handled `Ns/Nm/Nh/Nd` suffixes. ISO timestamps fell through to an error path (`invalid duration: ...`). The new `parse_since_str(raw, now)` function tries duration first, then delegates to the existing `parse_rfc3339` from `cowork::peek`.

## Tests added

**Unit** (`observability::tests`): `test_parse_since_10_minutes`, `test_parse_since_1_hour`, `test_parse_since_1_day`, `test_parse_since_seconds_suffix`, `test_parse_since_iso_8601_z`, `test_parse_since_iso_8601_offset`, `test_parse_since_rejects_garbage`, `test_try_parse_duration_secs`.

**Integration** (`tests/cli_dashboard.rs`): `test_tail_since_10m_returns_recent_drawer`, `test_tail_since_1h_returns_recent_drawer`, `test_tail_and_timeline_share_parser`, `test_tail_since_iso_8601_accepted`.

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo test` — all tests pass
- [x] `mempal tail --since 10m` returns drawers added in the last 10 minutes
- [x] `mempal tail --since 1h` returns drawers added in the last hour
- [x] `mempal tail --since 2026-04-25T20:00:00Z` accepted without error
- [x] `mempal tail --since garbage` exits with clear error message

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)