### PR TITLE
fix(cli): friendly error when ingest receives file path instead of dir (#82)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -799,8 +799,8 @@ async fn ingest_command(
         bail!(
             "`mempal ingest` expects a DIRECTORY of source files, but `{path_str}` is a single file.\n\
              To ingest a single file, place it in a directory first:\n\n\
-             mkdir -p /tmp/mempal-batch && cp {path_str} /tmp/mempal-batch/ && \\\n\
-             mempal ingest --wing {wing} /tmp/mempal-batch/"
+             mkdir -p /tmp/mempal-batch && cp \"{path_str}\" /tmp/mempal-batch/ && \\\n\
+             mempal ingest --wing \"{wing}\" /tmp/mempal-batch/"
         );
     }
     if !path.is_dir() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,6 +789,24 @@ async fn ingest_command(
     config: &Config,
     options: IngestCommandOptions<'_>,
 ) -> Result<()> {
+    let path = options.dir;
+    if !path.exists() {
+        bail!("path `{}` does not exist", path.display());
+    }
+    if path.is_file() {
+        let path_str = path.display();
+        let wing = options.wing;
+        bail!(
+            "`mempal ingest` expects a DIRECTORY of source files, but `{path_str}` is a single file.\n\
+             To ingest a single file, place it in a directory first:\n\n\
+             mkdir -p /tmp/mempal-batch && cp {path_str} /tmp/mempal-batch/ && \\\n\
+             mempal ingest --wing {wing} /tmp/mempal-batch/"
+        );
+    }
+    if !path.is_dir() {
+        bail!("`{}` is not a directory", path.display());
+    }
+
     if let Some(format) = options.format.as_deref()
         && format != "convos"
     {

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -1,0 +1,97 @@
+//! Integration tests for issue #82: friendly error messages when `mempal ingest`
+//! receives a file path or a nonexistent path instead of a directory.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    mempal::core::db::Database::open(&mempal_home.join("palace.db")).expect("open db");
+    tmp
+}
+
+fn run_ingest(home: &Path, target: &str, wing: &str) -> Output {
+    Command::new(mempal_bin())
+        .args(["ingest", target, "--wing", wing])
+        .env("HOME", home)
+        .output()
+        .expect("run mempal ingest")
+}
+
+fn run_ingest_dry(home: &Path, target: &str, wing: &str) -> Output {
+    Command::new(mempal_bin())
+        .args(["ingest", target, "--wing", wing, "--dry-run"])
+        .env("HOME", home)
+        .output()
+        .expect("run mempal ingest --dry-run")
+}
+
+#[test]
+fn test_ingest_file_path_returns_friendly_error() {
+    let tmp = setup_home();
+    let file = tmp.path().join("single-doc.md");
+    fs::write(&file, "# Hello\nsome content").expect("write fixture");
+
+    let output = run_ingest(tmp.path(), file.to_str().unwrap(), "test");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when given a file path"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("expects a DIRECTORY"),
+        "error must mention 'expects a DIRECTORY', got: {stderr}"
+    );
+    assert!(
+        stderr.contains("mkdir") && stderr.contains("mempal ingest"),
+        "error must include mkdir+cp+ingest workaround suggestion, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_ingest_nonexistent_path_returns_friendly_error() {
+    let tmp = setup_home();
+    let output = run_ingest(tmp.path(), "/nonexistent/path/does-not-exist", "test");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for nonexistent path"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "error must mention 'does not exist', got: {stderr}"
+    );
+}
+
+#[test]
+fn test_ingest_dir_unchanged_behavior() {
+    let tmp = setup_home();
+    let source_dir = tmp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(source_dir.join("note.md"), "# Note\nsome content here").expect("write file");
+
+    // Use --dry-run to avoid needing a live embedder in CI.
+    let output = run_ingest_dry(tmp.path(), source_dir.to_str().unwrap(), "test");
+
+    assert!(
+        output.status.success(),
+        "ingest of a directory must still succeed, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("files="),
+        "output must contain file stats, got: {stdout}"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "cbba6d7d113c0ea5dc1e7377cd6b177bd78d1165"
+commit = "a4843e51f8b7f74ac3b7acb079ca1ba3ea5fad4a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Adds a pre-flight path check in `ingest_command` (before any embedder/DB work) that detects three bad-input cases:
  - **Nonexistent path** → clear "does not exist" message
  - **File instead of directory** → "expects a DIRECTORY" + actionable `mkdir + cp + mempal ingest` workaround
  - **Exists but not a directory** → generic "not a directory" fallback

## Test plan

- [x] `test_ingest_file_path_returns_friendly_error` — error contains "expects a DIRECTORY" and `mkdir`/`mempal ingest` recipe
- [x] `test_ingest_nonexistent_path_returns_friendly_error` — error contains "does not exist"
- [x] `test_ingest_dir_unchanged_behavior` — valid directory still succeeds (regression guard, `--dry-run`)
- [x] `cargo clippy` clean
- [x] `just test` full suite passes

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)