### PR TITLE
fix(cli): default --cwd to current working directory for cowork-* (#83)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,8 +243,9 @@ enum Commands {
         #[arg(long)]
         target: String,
 
-        /// Project cwd. Exactly ONE of --cwd or --cwd-source must be set.
-        /// Use this for Claude Code hook (pass ${CLAUDE_PROJECT_CWD:-$PWD}).
+        /// Project cwd — defaults to current working directory when neither
+        /// --cwd nor --cwd-source is provided. Use this for Claude Code hook
+        /// (pass ${CLAUDE_PROJECT_CWD:-$PWD}).
         #[arg(long, conflicts_with = "cwd_source")]
         cwd: Option<PathBuf>,
 
@@ -263,8 +264,9 @@ enum Commands {
     /// Show current cowork inbox state for both targets at the given cwd
     /// (read-only — does NOT drain).
     CoworkStatus {
+        /// Project cwd — defaults to current working directory.
         #[arg(long)]
-        cwd: PathBuf,
+        cwd: Option<PathBuf>,
     },
     /// Install cowork hooks: Claude Code (project-level .claude/hooks)
     /// and optionally Codex (global ~/.codex/hooks.json merge).
@@ -405,7 +407,10 @@ fn run() -> Result<()> {
             );
         }
         Commands::CoworkStatus { cwd } => {
-            return cowork_status_command(cwd.clone());
+            let resolved = cwd
+                .clone()
+                .unwrap_or_else(|| std::env::current_dir().expect("current_dir failed"));
+            return cowork_status_command(resolved);
         }
         Commands::CoworkInstallHooks { global_codex } => {
             return cowork_install_hooks_command(*global_codex);
@@ -2140,7 +2145,7 @@ fn cowork_drain_command(
             (None, Some(other)) => {
                 return Err(format!("unsupported --cwd-source: {other}").into());
             }
-            (None, None) => return Err("must provide --cwd or --cwd-source".into()),
+            (None, None) => std::env::current_dir()?,
             (Some(_), Some(_)) => unreachable!("clap conflicts_with prevents this"),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,9 +407,11 @@ fn run() -> Result<()> {
             );
         }
         Commands::CoworkStatus { cwd } => {
-            let resolved = cwd
-                .clone()
-                .unwrap_or_else(|| std::env::current_dir().expect("current_dir failed"));
+            let resolved = match cwd {
+                Some(p) => p.clone(),
+                None => std::env::current_dir()
+                    .context("cowork-status: failed to determine current directory")?,
+            };
             return cowork_status_command(resolved);
         }
         Commands::CoworkInstallHooks { global_codex } => {

--- a/tests/cowork_inbox.rs
+++ b/tests/cowork_inbox.rs
@@ -922,3 +922,140 @@ fn cowork_install_hooks_heals_stale_codex_drain_entry() {
         "unrelated UserPromptSubmit hook must be preserved"
     );
 }
+
+// --- Issue #83: --cwd defaults to current working directory ---
+
+#[test]
+fn test_cowork_status_no_cwd_uses_pwd() {
+    let tmp = TempDir::new().unwrap();
+    let mempal_home = tmp.path().join(".mempal");
+    let repo = setup_repo(&tmp, "proj-status-pwd");
+
+    push(
+        &mempal_home,
+        Tool::Codex,
+        Tool::Claude,
+        &repo,
+        "hello from codex".into(),
+        "2026-04-25T00:00:00Z".into(),
+    )
+    .unwrap();
+
+    // Run cowork-status without --cwd, but with current_dir set to repo.
+    let output = Command::new(mempal_bin())
+        .args(["cowork-status"])
+        .current_dir(&repo)
+        .env("HOME", tmp.path())
+        .output()
+        .expect("spawn cowork-status without --cwd");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "exit code must be 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("claude inbox"),
+        "should list claude inbox, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 message"),
+        "should show 1 message for claude, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_cowork_status_explicit_cwd_overrides() {
+    let tmp = TempDir::new().unwrap();
+    let mempal_home = tmp.path().join(".mempal");
+    let repo_a = setup_repo(&tmp, "proj-a");
+    let repo_b = setup_repo(&tmp, "proj-b");
+
+    // Push a message to repo_a only.
+    push(
+        &mempal_home,
+        Tool::Codex,
+        Tool::Claude,
+        &repo_a,
+        "message for repo-a".into(),
+        "2026-04-25T00:00:00Z".into(),
+    )
+    .unwrap();
+
+    // Run cowork-status with --cwd pointing at repo_a, but current_dir = repo_b.
+    // The explicit --cwd must win: we should see messages from repo_a.
+    let output = Command::new(mempal_bin())
+        .args(["cowork-status", "--cwd", repo_a.to_str().unwrap()])
+        .current_dir(&repo_b)
+        .env("HOME", tmp.path())
+        .output()
+        .expect("spawn cowork-status with explicit --cwd");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("1 message"),
+        "explicit --cwd must point at repo_a which has 1 message, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(repo_a.to_str().unwrap()),
+        "Project line must show repo_a path, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_cowork_drain_no_cwd_uses_pwd() {
+    let tmp = TempDir::new().unwrap();
+    let mempal_home = tmp.path().join(".mempal");
+    let repo = setup_repo(&tmp, "proj-drain-pwd");
+
+    push(
+        &mempal_home,
+        Tool::Codex,
+        Tool::Claude,
+        &repo,
+        "drain me via pwd".into(),
+        "2026-04-25T00:00:00Z".into(),
+    )
+    .unwrap();
+
+    // Run cowork-drain --target claude without --cwd, current_dir = repo.
+    let output = Command::new(mempal_bin())
+        .args(["cowork-drain", "--target", "claude"])
+        .current_dir(&repo)
+        .env("HOME", tmp.path())
+        .output()
+        .expect("spawn cowork-drain without --cwd");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "exit code must be 0, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("drain me via pwd"),
+        "should have drained the message, stdout: {stdout}"
+    );
+
+    // Verify inbox is now empty (message was actually drained).
+    let remaining = drain(&mempal_home, Tool::Claude, &repo).unwrap();
+    assert!(remaining.is_empty(), "inbox should be empty after drain");
+}
+
+#[test]
+fn test_cowork_status_help_documents_default() {
+    let output = Command::new(mempal_bin())
+        .args(["cowork-status", "--help"])
+        .output()
+        .expect("spawn cowork-status --help");
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        help.contains("current") || help.contains("PWD") || help.contains("default"),
+        "help text should mention cwd defaults to current directory, got: {help}"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "a4843e51f8b7f74ac3b7acb079ca1ba3ea5fad4a"
+commit = "3769f6559c1436cc11128efeee304cee80b95229"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- `mempal cowork-status` and `mempal cowork-drain` no longer require `--cwd` — both default to `std::env::current_dir()` when omitted
- `CoworkStatus.cwd` changed from `PathBuf` (required) to `Option<PathBuf>` with descriptive help text
- `cowork_drain_command`: `(None, None)` branch now falls back to `current_dir()` instead of returning an error
- Updated `CoworkDrain` doc comment to remove the "must provide one" constraint

## Test plan

- [x] `test_cowork_status_no_cwd_uses_pwd` — runs without `--cwd`, verifies current_dir is used
- [x] `test_cowork_status_explicit_cwd_overrides` — explicit `--cwd` wins over current_dir
- [x] `test_cowork_drain_no_cwd_uses_pwd` — drain without `--cwd` uses current_dir
- [x] `test_cowork_status_help_documents_default` — `--help` mentions the default
- [x] Full `cowork_inbox` test suite: 22/22 pass
- [x] `cargo clippy` clean

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)