### PR TITLE
fix(cli): wake-up --format uses clap value_enum (#79)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,12 @@ struct IngestCommandOptions<'a> {
     dry_run: bool,
 }
 
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum WakeUpFormat {
+    Aaak,
+    Protocol,
+}
+
 #[derive(Subcommand)]
 enum Commands {
     Init {
@@ -113,8 +119,8 @@ enum Commands {
         command: GatingCommands,
     },
     WakeUp {
-        #[arg(long)]
-        format: Option<String>,
+        #[arg(long, value_enum)]
+        format: Option<WakeUpFormat>,
     },
     Prime(PrimeArgs),
     Compress {
@@ -531,7 +537,7 @@ fn run() -> Result<()> {
         Commands::Project { command } => project_command(&db, command),
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
-        Commands::WakeUp { format } => wake_up_command(&db, format.as_deref()),
+        Commands::WakeUp { format } => wake_up_command(&db, format),
         Commands::Prime(_) => unreachable!(),
         Commands::Compress { text } => compress_command(&text),
         Commands::Bench { command } => block_on_result(bench_command(config.as_ref(), command)),
@@ -1018,16 +1024,14 @@ fn project_command(db: &Database, command: ProjectCommands) -> Result<()> {
     }
 }
 
-fn wake_up_command(db: &Database, format: Option<&str>) -> Result<()> {
-    if let Some("aaak") = format {
-        return wake_up_aaak_command(db);
-    }
-    if let Some("protocol") = format {
-        println!("{MEMORY_PROTOCOL}");
-        return Ok(());
-    }
-    if let Some(format) = format {
-        bail!("unsupported wake-up format: {format}");
+fn wake_up_command(db: &Database, format: Option<WakeUpFormat>) -> Result<()> {
+    match format {
+        Some(WakeUpFormat::Aaak) => return wake_up_aaak_command(db),
+        Some(WakeUpFormat::Protocol) => {
+            println!("{MEMORY_PROTOCOL}");
+            return Ok(());
+        }
+        None => {}
     }
 
     let drawer_count = db.drawer_count().context("failed to count drawers")?;

--- a/tests/wake_up_format.rs
+++ b/tests/wake_up_format.rs
@@ -1,0 +1,125 @@
+//! Integration tests for issue #79: `mempal wake-up --format` clap value_enum.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+    mempal::core::db::Database::open(&mempal_home.join("palace.db")).expect("open db");
+    tmp
+}
+
+fn run_wake_up(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .arg("wake-up")
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal wake-up")
+}
+
+#[test]
+fn test_wake_up_format_help_lists_possible_values() {
+    let output = Command::new(mempal_bin())
+        .args(["wake-up", "--help"])
+        .output()
+        .expect("run mempal wake-up --help");
+
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        help.contains("aaak"),
+        "help should mention 'aaak', got: {help}"
+    );
+    assert!(
+        help.contains("protocol"),
+        "help should mention 'protocol', got: {help}"
+    );
+    assert!(
+        help.contains("possible values") || help.contains("aaak") && help.contains("protocol"),
+        "help should list possible values, got: {help}"
+    );
+}
+
+#[test]
+fn test_wake_up_format_rejects_text_at_parse_time() {
+    let tmp = setup();
+    let output = run_wake_up(tmp.path(), &["--format", "text"]);
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for invalid format 'text'"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("text") || stderr.contains("invalid"),
+        "expected parse error mentioning 'text', got: {stderr}"
+    );
+    // Must NOT be a runtime bail — clap must reject it before any DB access
+    // (no "unsupported wake-up format" runtime message)
+    assert!(
+        !stderr.contains("unsupported wake-up format"),
+        "should be clap parse error, not runtime bail: {stderr}"
+    );
+}
+
+#[test]
+fn test_wake_up_format_aaak_unchanged_behavior() {
+    let tmp = setup();
+    let output = run_wake_up(tmp.path(), &["--format", "aaak"]);
+
+    assert!(
+        output.status.success(),
+        "expected success for --format aaak, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // AAAK output contains the AAAK codec header or "no recent drawers" message
+    assert!(
+        !stdout.is_empty(),
+        "expected non-empty output for --format aaak"
+    );
+}
+
+#[test]
+fn test_wake_up_format_protocol_unchanged_behavior() {
+    let tmp = setup();
+    let output = run_wake_up(tmp.path(), &["--format", "protocol"]);
+
+    assert!(
+        output.status.success(),
+        "expected success for --format protocol, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // MEMORY_PROTOCOL begins with "MEMPAL MEMORY PROTOCOL"
+    assert!(
+        stdout.contains("MEMPAL MEMORY PROTOCOL"),
+        "expected protocol content in output, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_wake_up_no_format_unchanged_behavior() {
+    let tmp = setup();
+    let output = run_wake_up(tmp.path(), &[]);
+
+    assert!(
+        output.status.success(),
+        "expected success when --format omitted, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Default output includes "L0" section header
+    assert!(
+        stdout.contains("L0") || stdout.contains("drawer_count"),
+        "expected default wake-up output, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Convert `--format` in `mempal wake-up` from `Option<String>` to `Option<WakeUpFormat>` clap value enum
- Clap now rejects invalid values at parse time with a helpful error listing possible values
- Removes runtime `bail!` and string-matching in favor of a clean enum match

## Changes

- `src/main.rs`: Add `WakeUpFormat` enum (deriving `clap::ValueEnum`), update `WakeUp` command variant and `wake_up_command` signature
- `tests/wake_up_format.rs`: 5 new integration tests covering help output, parse-time rejection, and behavioral regressions

## Test plan

- [x] `test_wake_up_format_help_lists_possible_values` — `--help` shows `aaak` and `protocol`
- [x] `test_wake_up_format_rejects_text_at_parse_time` — `--format text` fails at parse time (not runtime bail)
- [x] `test_wake_up_format_aaak_unchanged_behavior` — `--format aaak` still works
- [x] `test_wake_up_format_protocol_unchanged_behavior` — `--format protocol` still works
- [x] `test_wake_up_no_format_unchanged_behavior` — omitting `--format` still works
- [x] `cargo clippy` clean
- [x] `just test` passes (all suites)

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)