### PR TITLE
feat(cli): mempal ingest --json outputs created drawer_ids (#95)

### DIFF
--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -40,12 +40,13 @@ fn mempal_home_from_db(db: &Database) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IngestStats {
     pub files: usize,
     pub chunks: usize,
     pub skipped: usize,
     pub dropped_by_gate: usize,
+    pub drawer_ids: Vec<String>,
     /// Time waited acquiring the per-source ingest lock (P9-B). `None`
     /// when the lock was bypassed (e.g. dry-run) or when no wait was
     /// needed and the path took the fast exit before lock acquisition.
@@ -377,6 +378,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                 drawer_id: drawer.id.clone(),
                 source,
             })?;
+        stats.drawer_ids.push(drawer_id);
         stats.chunks += 1;
     }
 
@@ -443,6 +445,7 @@ pub async fn ingest_dir_with_options<E: Embedder + ?Sized>(
                 stats.chunks += file_stats.chunks;
                 stats.skipped += file_stats.skipped;
                 stats.dropped_by_gate += file_stats.dropped_by_gate;
+                stats.drawer_ids.extend(file_stats.drawer_ids);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use mempal::ingest::{IngestOptions, IngestStats, ingest_dir_with_options};
 use mempal::mcp::MempalMcpServer;
 use mempal::observability;
 use mempal::search::search;
+use serde::Serialize;
 
 mod longmemeval;
 #[path = "cli/prime.rs"]
@@ -65,6 +66,7 @@ struct IngestCommandOptions<'a> {
     project: Option<&'a str>,
     no_gate: bool,
     dry_run: bool,
+    json: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -92,6 +94,8 @@ enum Commands {
         no_gate: bool,
         #[arg(long)]
         dry_run: bool,
+        #[arg(long)]
+        json: bool,
     },
     Search {
         query: String,
@@ -504,6 +508,7 @@ fn run() -> Result<()> {
             project,
             no_gate,
             dry_run,
+            json,
         } => block_on_result(ingest_command(
             &db,
             config.as_ref(),
@@ -514,6 +519,7 @@ fn run() -> Result<()> {
                 project: project.as_deref(),
                 no_gate,
                 dry_run,
+                json,
             },
         )),
         Commands::Search {
@@ -891,9 +897,26 @@ async fn ingest_command(
         options.wing,
         options.format.as_deref(),
         options.dry_run,
-        stats,
+        &stats,
     )
     .context("failed to append ingest audit log")?;
+
+    if options.json {
+        let output = IngestJsonOutput {
+            dry_run: options.dry_run,
+            files: stats.files,
+            chunks: stats.chunks,
+            skipped: stats.skipped,
+            dropped_by_gate: stats.dropped_by_gate,
+            drawer_ids: &stats.drawer_ids,
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&output)
+                .context("failed to serialize ingest JSON output")?
+        );
+        return Ok(());
+    }
 
     println!(
         "dry_run={} files={} chunks={} skipped={} dropped_by_gate={}",
@@ -901,6 +924,16 @@ async fn ingest_command(
     );
 
     Ok(())
+}
+
+#[derive(Serialize)]
+struct IngestJsonOutput<'a> {
+    dry_run: bool,
+    files: usize,
+    chunks: usize,
+    skipped: usize,
+    dropped_by_gate: usize,
+    drawer_ids: &'a [String],
 }
 
 #[derive(Default)]
@@ -930,7 +963,7 @@ fn append_ingest_audit_log(
     wing: &str,
     format: Option<&str>,
     dry_run: bool,
-    stats: IngestStats,
+    stats: &IngestStats,
 ) -> Result<()> {
     let audit_path = db
         .path()

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -1,10 +1,14 @@
 //! Integration tests for issue #82: friendly error messages when `mempal ingest`
 //! receives a file path or a nonexistent path instead of a directory.
 
+mod common;
+
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
 
+use common::harness::start as start_embed_mock;
+use serde_json::Value;
 use tempfile::TempDir;
 
 fn mempal_bin() -> String {
@@ -33,6 +37,39 @@ fn run_ingest_dry(home: &Path, target: &str, wing: &str) -> Output {
         .env("HOME", home)
         .output()
         .expect("run mempal ingest --dry-run")
+}
+
+fn run_ingest_json(home: &Path, target: &str, wing: &str) -> Output {
+    Command::new(mempal_bin())
+        .args(["ingest", target, "--wing", wing, "--no-gate", "--json"])
+        .env("HOME", home)
+        .output()
+        .expect("run mempal ingest --json")
+}
+
+fn write_embed_config(home: &Path, base_url: &str) {
+    let db_path = home.join(".mempal").join("palace.db");
+    let config = format!(
+        r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+base_url = "{}"
+api_model = "test-embed"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+"#,
+        db_path.display(),
+        base_url,
+        base_url
+    );
+    fs::write(home.join(".mempal").join("config.toml"), config).expect("write config");
 }
 
 #[test]
@@ -93,5 +130,36 @@ fn test_ingest_dir_unchanged_behavior() {
     assert!(
         stdout.contains("files="),
         "output must contain file stats, got: {stdout}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_json_outputs_created_drawer_ids() {
+    let tmp = setup_home();
+    let source_dir = tmp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(source_dir.join("note.md"), "# Note\njson drawer id content").expect("write file");
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config(tmp.path(), &format!("http://{addr}/v1"));
+
+    let output = run_ingest_json(tmp.path(), source_dir.to_str().expect("source dir"), "test");
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "ingest --json must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse ingest JSON stdout");
+    assert_eq!(json["dry_run"], false);
+    assert_eq!(json["files"], 1);
+    let chunks = json["chunks"].as_u64().expect("chunks number");
+    let drawer_ids = json["drawer_ids"].as_array().expect("drawer_ids array");
+    assert!(!drawer_ids.is_empty(), "drawer_ids must be non-empty");
+    assert_eq!(drawer_ids.len() as u64, chunks);
+    assert!(
+        drawer_ids.iter().all(|value| value.as_str().is_some()),
+        "drawer_ids must contain strings"
     );
 }

--- a/tests/ingest_lock.rs
+++ b/tests/ingest_lock.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use mempal::core::db::Database;
 use mempal::embed::{Embedder, Result as EmbedResult};
-use mempal::ingest::{IngestOptions, ingest_file_with_options};
+use mempal::ingest::{IngestOptions, ingest_dir_with_options, ingest_file_with_options};
 use tempfile::TempDir;
 
 /// Stub embedder: returns a fixed vector regardless of input. 3 dims so
@@ -148,6 +148,65 @@ fn test_concurrent_ingest_same_source_single_drawer() {
     assert_eq!(
         waited, 1,
         "expected exactly one waiter; a={stats_a:?} b={stats_b:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_ingest_dir_stats_include_created_drawer_ids() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("init db");
+    let source_dir = tmp.path().join("source");
+    std::fs::create_dir_all(&source_dir).expect("create source dir");
+    write_file(&source_dir, "alpha.md", "alpha drawer id fixture");
+    write_file(&source_dir, "beta.md", "beta drawer id fixture");
+
+    let stats = ingest_dir_with_options(
+        &db,
+        &StubEmbedder,
+        &source_dir,
+        "test",
+        IngestOptions::default(),
+    )
+    .await
+    .expect("ingest dir");
+
+    assert_eq!(stats.files, 2);
+    assert!(!stats.drawer_ids.is_empty(), "drawer_ids must be reported");
+    assert_eq!(
+        stats.drawer_ids.len(),
+        stats.chunks,
+        "each inserted chunk must report one drawer_id"
+    );
+}
+
+#[tokio::test]
+async fn test_dry_run_ingest_stats_do_not_include_drawer_ids() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("init db");
+    let source_dir = tmp.path().join("source");
+    std::fs::create_dir_all(&source_dir).expect("create source dir");
+    write_file(&source_dir, "alpha.md", "dry run drawer id fixture");
+
+    let stats = ingest_dir_with_options(
+        &db,
+        &StubEmbedder,
+        &source_dir,
+        "test",
+        IngestOptions {
+            dry_run: true,
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("dry-run ingest dir");
+
+    assert_eq!(stats.files, 1);
+    assert_eq!(stats.chunks, 1);
+    assert!(
+        stats.drawer_ids.is_empty(),
+        "dry-run should not report drawer_ids"
     );
 }
 


### PR DESCRIPTION
## Summary
- Add `--json` flag to `mempal ingest` CLI that outputs structured JSON including all created `drawer_ids`
- Add `drawer_ids: Vec<String>` to `IngestStats` (removes `Copy` derive, keeps `Clone`)
- Collect drawer IDs during ingest pipeline (`ingest_single_source` + `ingest_dir_with_options`)
- Default text output unchanged when `--json` is not passed

## Test plan
- [x] `test_ingest_dir_stats_include_created_drawer_ids` — library-level: drawer_ids populated after real ingest
- [x] `test_dry_run_ingest_stats_do_not_include_drawer_ids` — dry-run returns empty drawer_ids
- [x] `test_ingest_json_outputs_created_drawer_ids` — CLI integration: `--json` produces valid JSON with correct drawer_ids array
- [x] `cargo test` full suite passes (158+ tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)