### PR TITLE
feat: mempal rollback --since for time-based undo (#94)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -11,7 +11,9 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, OpenFlags, OptionalExtension, params, params_from_iter};
+use rusqlite::{
+    Connection, OpenFlags, OptionalExtension, params, params_from_iter, types::Value as SqlValue,
+};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -1039,6 +1041,50 @@ impl Database {
         Ok(affected > 0)
     }
 
+    pub fn soft_delete_drawers_since(
+        &self,
+        since: &str,
+        wing: Option<&str>,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<Vec<String>, DbError> {
+        let mut sql = String::from(
+            "UPDATE drawers SET deleted_at = ?1 \
+             WHERE added_at > ?2 AND deleted_at IS NULL",
+        );
+        let mut values = vec![
+            SqlValue::Text(super::utils::current_timestamp()),
+            SqlValue::Text(since.to_string()),
+        ];
+        append_drawers_since_filters(&mut sql, &mut values, wing, room, project_id);
+        sql.push_str(" RETURNING id");
+
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement
+            .query_map(params_from_iter(values), |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn count_drawers_since(
+        &self,
+        since: &str,
+        wing: Option<&str>,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<i64, DbError> {
+        let mut sql = String::from(
+            "SELECT COUNT(*) FROM drawers \
+             WHERE added_at > ?1 AND deleted_at IS NULL",
+        );
+        let mut values = vec![SqlValue::Text(since.to_string())];
+        append_drawers_since_filters(&mut sql, &mut values, wing, room, project_id);
+
+        Ok(self
+            .conn
+            .query_row(&sql, params_from_iter(values), |row| row.get(0))?)
+    }
+
     pub fn purge_deleted(&self, before: Option<&str>) -> Result<u64, DbError> {
         // First collect IDs to purge, then delete from both tables
         let ids: Vec<String> = if let Some(before) = before {
@@ -1697,6 +1743,21 @@ fn read_user_version(conn: &Connection) -> Result<u32, DbError> {
 fn set_user_version(conn: &Connection, version: u32) -> Result<(), DbError> {
     conn.execute_batch(&format!("PRAGMA user_version = {version};"))?;
     Ok(())
+}
+
+fn append_drawers_since_filters(
+    sql: &mut String,
+    values: &mut Vec<SqlValue>,
+    wing: Option<&str>,
+    room: Option<&str>,
+    project_id: Option<&str>,
+) {
+    for (column, value) in [("wing", wing), ("room", room), ("project_id", project_id)] {
+        if let Some(value) = value {
+            values.push(SqlValue::Text(value.to_string()));
+            sql.push_str(&format!(" AND {column} = ?{}", values.len()));
+        }
+    }
 }
 
 const V2_MIGRATION_SQL: &str = r#"

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -70,6 +70,13 @@ pub fn iso_timestamp() -> String {
     format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs))
 }
 
+/// Validate an RFC 3339 timestamp and normalize it to UTC seconds precision.
+pub fn normalize_rfc3339_timestamp(value: &str) -> Option<String> {
+    let secs = parse_rfc3339(value)?;
+    let secs = u64::try_from(secs).ok()?;
+    Some(format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs)))
+}
+
 /// Attempt to normalise a stored `added_at` value to RFC 3339 UTC.
 ///
 /// Returns:
@@ -216,5 +223,14 @@ mod tests {
         assert_eq!(normalize_added_at("not-a-date"), None);
         assert_eq!(normalize_added_at(""), None);
         assert_eq!(normalize_added_at("   "), None);
+    }
+
+    #[test]
+    fn test_normalize_rfc3339_timestamp_converts_offset_to_utc_z() {
+        assert_eq!(
+            normalize_rfc3339_timestamp("2026-04-25T20:00:00+08:00"),
+            Some("2026-04-25T12:00:00Z".to_string())
+        );
+        assert_eq!(normalize_rfc3339_timestamp("not-a-date"), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,10 @@ use mempal::core::{
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     reindex::ReindexProgressStore,
     types::TaxonomyEntry,
-    utils::{build_triple_id, current_timestamp, normalize_added_at as normalize_added_at_value},
+    utils::{
+        build_triple_id, current_timestamp, normalize_added_at as normalize_added_at_value,
+        normalize_rfc3339_timestamp,
+    },
 };
 use mempal::embed::build_backend_from_name;
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
@@ -67,6 +70,23 @@ struct IngestCommandOptions<'a> {
     no_gate: bool,
     dry_run: bool,
     json: bool,
+}
+
+struct RollbackCommandOptions<'a> {
+    since: &'a str,
+    wing: Option<&'a str>,
+    room: Option<&'a str>,
+    project: Option<&'a str>,
+    dry_run: bool,
+    json: bool,
+}
+
+#[derive(Serialize)]
+struct RollbackOutput {
+    since: String,
+    deleted_count: usize,
+    drawer_ids: Vec<String>,
+    dry_run: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -136,6 +156,20 @@ enum Commands {
     },
     Delete {
         drawer_id: String,
+    },
+    Rollback {
+        #[arg(long)]
+        since: String,
+        #[arg(long)]
+        wing: Option<String>,
+        #[arg(long)]
+        room: Option<String>,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        dry_run: bool,
+        #[arg(long)]
+        json: bool,
     },
     Purge {
         /// Only purge drawers soft-deleted before this ISO timestamp
@@ -547,6 +581,25 @@ fn run() -> Result<()> {
         )),
         Commands::Project { command } => project_command(&db, command),
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
+        Commands::Rollback {
+            since,
+            wing,
+            room,
+            project,
+            dry_run,
+            json,
+        } => rollback_command(
+            &db,
+            config.as_ref(),
+            RollbackCommandOptions {
+                since: &since,
+                wing: wing.as_deref(),
+                room: room.as_deref(),
+                project: project.as_deref(),
+                dry_run,
+                json,
+            },
+        ),
         Commands::Purge { before } => purge_command(&db, before.as_deref()),
         Commands::WakeUp { format } => wake_up_command(&db, format),
         Commands::Prime(_) => unreachable!(),
@@ -1425,6 +1478,62 @@ fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
             bail!("drawer not found: {drawer_id}");
         }
     }
+    Ok(())
+}
+
+fn rollback_command(
+    db: &Database,
+    config: &Config,
+    options: RollbackCommandOptions<'_>,
+) -> Result<()> {
+    let since = normalize_rfc3339_timestamp(options.since)
+        .with_context(|| format!("invalid --since ISO 8601 timestamp: {}", options.since))?;
+    let current_dir = env::current_dir().ok();
+    let project_id = resolve_project_id(options.project, config, current_dir.as_deref())
+        .context("failed to resolve rollback project id")?;
+
+    let output = if options.dry_run {
+        let count = db
+            .count_drawers_since(&since, options.wing, options.room, project_id.as_deref())
+            .context("failed to count rollback drawers")?;
+        RollbackOutput {
+            since,
+            deleted_count: count.max(0) as usize,
+            drawer_ids: Vec::new(),
+            dry_run: true,
+        }
+    } else {
+        let drawer_ids = db
+            .soft_delete_drawers_since(&since, options.wing, options.room, project_id.as_deref())
+            .context("failed to rollback drawers")?;
+        RollbackOutput {
+            since,
+            deleted_count: drawer_ids.len(),
+            drawer_ids,
+            dry_run: false,
+        }
+    };
+
+    if options.json {
+        println!(
+            "{}",
+            serde_json::to_string(&output).context("failed to serialize rollback output")?
+        );
+    } else if output.dry_run {
+        println!(
+            "would delete {} drawers since {}",
+            output.deleted_count, output.since
+        );
+    } else {
+        println!(
+            "deleted {} drawers since {}",
+            output.deleted_count, output.since
+        );
+        for drawer_id in &output.drawer_ids {
+            println!("  {drawer_id}");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,6 +8,6 @@ pub use server::MempalMcpServer;
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
-    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse, SearchRequest,
-    SearchResponse, StatusResponse,
+    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    RollbackRequest, RollbackResponse, SearchRequest, SearchResponse, StatusResponse,
 };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,7 +8,10 @@ use crate::core::{
     db::Database,
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
     types::{Drawer, SourceType, Triple},
-    utils::{build_triple_id, current_timestamp, iso_timestamp, source_file_or_synthetic},
+    utils::{
+        build_triple_id, current_timestamp, iso_timestamp, normalize_rfc3339_timestamp,
+        source_file_or_synthetic,
+    },
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
 use crate::embed::{EmbedderFactory, global_embed_status};
@@ -33,9 +36,9 @@ use super::tools::{
     IngestResponse, KgRequest, KgResponse, KgStatsDto, MAX_READ_DRAWERS_MAX_COUNT,
     MAX_READ_DRAWERS_REQUEST_IDS, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
     QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
-    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, StatusResponse,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TripleDto, TunnelDto,
-    TunnelsResponse,
+    RollbackRequest, RollbackResponse, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse,
+    SearchResultDto, StatusResponse, SystemWarning, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TripleDto, TunnelDto, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -1058,6 +1061,62 @@ impl MempalMcpServer {
             drawer_id: request.drawer_id,
             deleted,
             message,
+            system_warnings: current_system_warnings(),
+        }))
+    }
+
+    #[tool(
+        name = "mempal_rollback",
+        description = "Roll back (soft-delete) all drawers created after a given timestamp. Scope can be narrowed by wing/room/project. Use dry_run=true to preview without mutating."
+    )]
+    pub async fn mempal_rollback(
+        &self,
+        Parameters(request): Parameters<RollbackRequest>,
+    ) -> std::result::Result<Json<RollbackResponse>, ErrorData> {
+        let since = normalize_rfc3339_timestamp(&request.since).ok_or_else(|| {
+            ErrorData::invalid_params(
+                format!(
+                    "invalid since timestamp; expected RFC3339: {}",
+                    request.since
+                ),
+                None,
+            )
+        })?;
+        let project_id = match request.project_id.as_deref() {
+            Some(project_id) => Some(validate_project_id(project_id).map_err(|error| {
+                ErrorData::invalid_params(format!("invalid project scope: {error}"), None)
+            })?),
+            None => None,
+        };
+        let db = self.open_db()?;
+        let dry_run = request.dry_run.unwrap_or(false);
+        let (deleted_count, drawer_ids) = if dry_run {
+            let count = db
+                .count_drawers_since(
+                    &since,
+                    request.wing.as_deref(),
+                    request.room.as_deref(),
+                    project_id.as_deref(),
+                )
+                .map_err(db_error)?;
+            (count.max(0) as usize, Vec::new())
+        } else {
+            let drawer_ids = db
+                .soft_delete_drawers_since(
+                    &since,
+                    request.wing.as_deref(),
+                    request.room.as_deref(),
+                    project_id.as_deref(),
+                )
+                .map_err(db_error)?;
+            (drawer_ids.len(), drawer_ids)
+        };
+
+        Ok(Json(RollbackResponse {
+            since,
+            deleted_count,
+            drawer_ids,
+            dry_run,
             system_warnings: current_system_warnings(),
         }))
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -191,6 +191,25 @@ pub struct DeleteResponse {
     pub system_warnings: Vec<SystemWarning>,
 }
 
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct RollbackRequest {
+    pub since: String,
+    pub wing: Option<String>,
+    pub room: Option<String>,
+    pub project_id: Option<String>,
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RollbackResponse {
+    pub since: String,
+    pub deleted_count: usize,
+    pub drawer_ids: Vec<String>,
+    pub dry_run: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct IngestResponse {
     /// ID of the first (or only) drawer created. For backward compatibility,

--- a/tests/rollback.rs
+++ b/tests/rollback.rs
@@ -1,0 +1,234 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use mempal::core::db::Database;
+use mempal::core::types::{Drawer, SourceType};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    db_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let mempal_home = home.join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open database");
+        fs::write(
+            mempal_home.join("config.toml"),
+            format!(
+                r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+"#,
+                db_path.display()
+            ),
+        )
+        .expect("write config");
+        Self {
+            _tmp: tmp,
+            home,
+            db_path,
+        }
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open database")
+    }
+}
+
+fn insert_drawer(
+    db: &Database,
+    id: &str,
+    added_at: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+) {
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: id.to_string(),
+            content: format!("content for {id}"),
+            wing: wing.to_string(),
+            room: room.map(str::to_string),
+            source_file: Some(format!("{id}.md")),
+            source_type: SourceType::Manual,
+            added_at: added_at.to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+        },
+        project_id,
+    )
+    .expect("insert drawer");
+}
+
+fn is_deleted(db: &Database, id: &str) -> bool {
+    db.conn()
+        .query_row(
+            "SELECT deleted_at IS NOT NULL FROM drawers WHERE id = ?1",
+            [id],
+            |row| row.get::<_, bool>(0),
+        )
+        .expect("read deleted_at")
+}
+
+fn deleted_ids(mut ids: Vec<String>) -> Vec<String> {
+    ids.sort();
+    ids
+}
+
+#[test]
+fn test_rollback_deletes_only_after_since() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(&db, "before", "2026-01-01T00:00:00Z", "default", None, None);
+    insert_drawer(&db, "middle", "2026-02-01T00:00:00Z", "default", None, None);
+    insert_drawer(&db, "after", "2026-03-01T00:00:00Z", "default", None, None);
+
+    let ids = db
+        .soft_delete_drawers_since("2026-02-01T00:00:00Z", None, None, None)
+        .expect("rollback");
+
+    assert_eq!(deleted_ids(ids), vec!["after"]);
+    assert!(!is_deleted(&db, "before"));
+    assert!(!is_deleted(&db, "middle"));
+    assert!(is_deleted(&db, "after"));
+}
+
+#[test]
+fn test_rollback_wing_filter() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "target",
+        "2026-03-01T00:00:00Z",
+        "target-wing",
+        None,
+        None,
+    );
+    insert_drawer(
+        &db,
+        "other",
+        "2026-03-01T00:00:00Z",
+        "other-wing",
+        None,
+        None,
+    );
+
+    let ids = db
+        .soft_delete_drawers_since("2026-02-01T00:00:00Z", Some("target-wing"), None, None)
+        .expect("rollback");
+
+    assert_eq!(deleted_ids(ids), vec!["target"]);
+    assert!(is_deleted(&db, "target"));
+    assert!(!is_deleted(&db, "other"));
+}
+
+#[test]
+fn test_rollback_dry_run_no_mutation() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(&db, "before", "2026-01-01T00:00:00Z", "default", None, None);
+    insert_drawer(&db, "after", "2026-03-01T00:00:00Z", "default", None, None);
+
+    let count = db
+        .count_drawers_since("2026-02-01T00:00:00Z", None, None, None)
+        .expect("count rollback");
+
+    assert_eq!(count, 1);
+    assert!(!is_deleted(&db, "before"));
+    assert!(!is_deleted(&db, "after"));
+}
+
+#[test]
+fn test_rollback_already_deleted_not_re_deleted() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "already",
+        "2026-03-01T00:00:00Z",
+        "default",
+        None,
+        None,
+    );
+    assert!(db.soft_delete_drawer("already").expect("soft delete"));
+
+    let ids = db
+        .soft_delete_drawers_since("2026-02-01T00:00:00Z", None, None, None)
+        .expect("rollback");
+
+    assert!(ids.is_empty());
+    assert!(is_deleted(&db, "already"));
+}
+
+#[test]
+fn test_rollback_empty_result() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(&db, "old", "2026-03-01T00:00:00Z", "default", None, None);
+
+    let ids = db
+        .soft_delete_drawers_since("2027-01-01T00:00:00Z", None, None, None)
+        .expect("rollback");
+
+    assert!(ids.is_empty());
+    assert!(!is_deleted(&db, "old"));
+}
+
+#[test]
+fn test_rollback_cli_dry_run_no_mutation() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "old",
+        "2026-01-01T00:00:00Z",
+        "default",
+        None,
+        Some("home"),
+    );
+    insert_drawer(
+        &db,
+        "new",
+        "2026-03-01T00:00:00Z",
+        "default",
+        None,
+        Some("home"),
+    );
+
+    let output = Command::new(mempal_bin())
+        .env("HOME", &env.home)
+        .env_remove("MEMPAL_PROJECT_ID")
+        .current_dir(&env.home)
+        .args(["rollback", "--since", "2026-02-01T00:00:00Z", "--dry-run"])
+        .output()
+        .expect("run rollback dry-run");
+
+    assert!(
+        output.status.success(),
+        "rollback dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("would delete 1 drawers since 2026-02-01T00:00:00Z"),
+        "unexpected stdout: {stdout}"
+    );
+    let db = env.db();
+    assert!(!is_deleted(&db, "old"));
+    assert!(!is_deleted(&db, "new"));
+}


### PR DESCRIPTION
## Summary
- Add `mempal rollback --since <ISO8601>` CLI command to batch soft-delete drawers created after a timestamp
- Add `mempal_rollback` MCP tool with dry_run support for AI agent integrations
- Scope filters: `--wing`, `--room`, `--project` narrow the rollback; `--dry-run` previews without mutation; `--json` for structured output

## Changes
- `src/core/db.rs`: `soft_delete_drawers_since()` and `count_drawers_since()` with dynamic SQL filters
- `src/core/utils.rs`: `normalize_rfc3339_timestamp()` for timezone offset → UTC normalization
- `src/main.rs`: `Rollback` CLI subcommand with `--since/--wing/--room/--project/--dry-run/--json`
- `src/mcp/tools.rs`: `RollbackRequest`/`RollbackResponse` types
- `src/mcp/server.rs`: `mempal_rollback` tool handler
- `tests/rollback.rs`: 6 tests covering since cutoff, wing filter, dry-run, already-deleted, empty result, CLI dry-run

## Test plan
- [x] `cargo test --test rollback` — 6/6 pass
- [x] `cargo test` — full suite passes (exit 0)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)