### PR TITLE
feat: CSA integration - stdin ingest + hook docs + integration guide

### DIFF
--- a/assets/integrations/csa/README.md
+++ b/assets/integrations/csa/README.md
@@ -1,1 +1,176 @@
-CSA integration assets are reserved for a later spec phase.
+# CSA integration
+
+This integration lets CSA (cli-sub-agent) use mempal as its persistent memory
+backend instead of maintaining a separate JSONL plus Tantivy/BM25 memory store.
+CSA keeps producing session summaries, review findings, merge summaries, tags,
+and extracted facts; mempal stores those records as raw drawers and makes them
+available through the normal CLI and MCP search paths.
+
+The integration is intentionally additive. CSA writes a new source of drawers
+under project-specific wings and CSA-specific rooms, while existing Claude Code,
+Codex, Gemini, MCP, hook, and search consumers continue to use mempal unchanged.
+
+## Hook configuration templates
+
+CSA can call `mempal ingest --stdin --json` from `hooks.toml` lifecycle hooks.
+The stdin payload for mempal ingest must be a JSON object. If CSA renders the
+environment variables below as complete JSON strings, these minimal templates
+are sufficient:
+
+```toml
+[session_complete]
+command = "echo '${SESSION_SUMMARY}' | mempal ingest --stdin --wing ${PROJECT_NAME} --room csa-session --json"
+timeout_seconds = 30
+
+[post_review]
+command = "echo '${REVIEW_FINDINGS}' | mempal ingest --stdin --wing ${PROJECT_NAME} --room csa-review --json"
+timeout_seconds = 30
+
+[merge_completed]
+command = "echo '${MERGE_SUMMARY}' | mempal ingest --stdin --wing ${PROJECT_NAME} --room csa-merge --json"
+timeout_seconds = 30
+```
+
+For raw text environment variables, wrap them as JSON before invoking mempal.
+The `jq -Rs` form preserves newlines and quotes:
+
+```toml
+[session_complete]
+command = "printf '%s' \"${SESSION_SUMMARY}\" | jq -Rs --arg wing \"${PROJECT_NAME}\" --arg project \"${PROJECT_NAME}\" --arg source \"${CSA_SESSION_ID}\" '{content: ., wing: $wing, room: \"csa-session\", project: $project, source: $source}' | mempal ingest --stdin --json"
+timeout_seconds = 30
+
+[post_review]
+command = "printf '%s' \"${REVIEW_FINDINGS}\" | jq -Rs --arg wing \"${PROJECT_NAME}\" --arg project \"${PROJECT_NAME}\" --arg source \"${CSA_SESSION_ID}\" '{content: ., wing: $wing, room: \"csa-review\", project: $project, source: $source}' | mempal ingest --stdin --json"
+timeout_seconds = 30
+
+[merge_completed]
+command = "printf '%s' \"${MERGE_SUMMARY}\" | jq -Rs --arg wing \"${PROJECT_NAME}\" --arg project \"${PROJECT_NAME}\" --arg source \"${CSA_SESSION_ID}\" '{content: ., wing: $wing, room: \"csa-merge\", project: $project, source: $source}' | mempal ingest --stdin --json"
+timeout_seconds = 30
+```
+
+Recommended rooms:
+
+| CSA event | mempal wing | mempal room | Stored content |
+|---|---|---|---|
+| `session_complete` | `${PROJECT_NAME}` | `csa-session` | Session summary and decisions |
+| `post_review` | `${PROJECT_NAME}` | `csa-review` | Findings, severity, files, and resolution notes |
+| `merge_completed` | `${PROJECT_NAME}` | `csa-merge` | Merge summary, PR metadata, and follow-up context |
+
+## Field mapping
+
+| CSA MemoryEntry field | mempal drawer field | Notes |
+|---|---|---|
+| `content` | `content` | Verbatim |
+| `project` | `project` | Maps to mempal project filter |
+| `source` | `source_file` | CSA session ID or path |
+| `facts[]` | extracted into `content` | CSA fact extraction stored inline |
+| `created_at` | `added_at` | ISO-8601 |
+| `tags[]` | metadata in `content` | Stored in content body |
+
+CSA should place structured data that has no first-class mempal drawer field
+inside the content body. A compact Markdown or JSON block is fine, as long as the
+original wording remains available for citation.
+
+## Stdin ingest JSON format
+
+`mempal ingest --stdin --json` reads one JSON object from stdin. `content` is
+required. `wing` may be provided either in the JSON object or through
+`--wing`; `room`, `project`, `source`, and `source_file` are optional but useful
+for filtering and citations.
+
+```json
+{
+  "content": "Session summary: implemented auth middleware...",
+  "wing": "my-project",
+  "room": "csa-session",
+  "project": "my-project",
+  "source": "csa-session-01ABCDEF"
+}
+```
+
+Equivalent CLI invocation:
+
+```bash
+cat csa-session.json | mempal ingest --stdin --json
+```
+
+Expected JSON output contains the created drawer IDs and ingest counters:
+
+```json
+{
+  "drawer_ids": ["drawer_my_project_csa_session_..."],
+  "stats": {
+    "dry_run": false,
+    "files": 1,
+    "chunks": 1,
+    "skipped": 0,
+    "dropped_by_gate": 0
+  }
+}
+```
+
+## Migration guide: JSONL to mempal
+
+Existing CSA JSONL memories can be replayed into mempal without a schema
+migration. The example below maps each legacy record into one stdin ingest JSON
+object and stores it in a `csa-migrated` room.
+
+```bash
+# Export existing memories
+cat ~/.local/state/cli-sub-agent/memory/*.jsonl | \
+  jq -c '{content: .content, wing: .project, room: "csa-migrated", project: .project, source: "csa-legacy"}' | \
+  while IFS= read -r line; do
+    echo "$line" | mempal ingest --stdin --json
+  done
+```
+
+For large migrations, run a small batch first and verify search quality:
+
+```bash
+cat ~/.local/state/cli-sub-agent/memory/*.jsonl | \
+  head -n 20 | \
+  jq -c '{content: .content, wing: .project, room: "csa-migrated", project: .project, source: "csa-legacy"}' | \
+  while IFS= read -r line; do
+    echo "$line" | mempal ingest --stdin --dry-run --json
+  done
+```
+
+## Non-breaking constraints
+
+- mempal's existing MCP interface, hook system, and search remain unchanged.
+- CSA adds itself as a new source and wing alongside existing data.
+- No schema migrations are required.
+- Existing Claude Code, Codex, and Gemini consumers are unaffected.
+- CSA should not rewrite existing mempal drawers during migration; import legacy
+  records as new `csa-migrated` drawers.
+- CSA should keep facts and tags inline in `content` unless a future mempal
+  schema adds dedicated fields.
+
+## Retrieval
+
+CSA memories are normal mempal drawers, so retrieval uses the existing CLI and
+MCP interfaces.
+
+```bash
+# Search CSA memories
+mempal search "auth middleware decision" --wing my-project --room csa-session --top-k 5
+```
+
+Via MCP:
+
+```text
+mempal_search(query="auth middleware", wing="my-project", room="csa-session")
+```
+
+Useful retrieval patterns:
+
+```bash
+# Review findings for a project
+mempal search "missing tests" --wing my-project --room csa-review --top-k 10
+
+# Merge decisions and follow-ups
+mempal search "follow-up refactor" --wing my-project --room csa-merge --top-k 10
+
+# Legacy CSA memories after migration
+mempal search "queue retry policy" --wing my-project --room csa-migrated --top-k 10
+```

--- a/docs/hook-payload-schema.md
+++ b/docs/hook-payload-schema.md
@@ -1,0 +1,145 @@
+# Hook Payload Schema
+
+This document describes the stdin payload interface for `mempal hook`.
+It is intended for external integrators that want to emit Claude Code-style
+session events into mempal without linking to mempal internals.
+
+## Supported Events
+
+`mempal hook` accepts four event commands. Each command also has a stable
+snake-case alias used as the queue `kind`.
+
+| Event command | Alias / queue kind | When to emit |
+| --- | --- | --- |
+| `PostToolUse` | `hook_post_tool` | After each tool call completes. |
+| `UserPromptSubmit` | `hook_user_prompt` | When the user submits a prompt. |
+| `SessionStart` | `hook_session_start` | At the beginning of an agent session. |
+| `SessionEnd` | `hook_session_end` | At the end of an agent session. |
+
+Examples:
+
+```bash
+mempal hook PostToolUse
+mempal hook hook_post_tool
+```
+
+## Input Contract
+
+All hook events read raw bytes from stdin. The input does not need to match a
+fixed schema: JSON, plain text, and arbitrary metadata are all accepted. mempal
+stores the payload as-is inside a capture envelope, except that invalid UTF-8 is
+decoded lossily with the Unicode replacement character.
+
+Small payloads are stored inline in the queued envelope. Payloads larger than
+10 MiB are written to disk and represented by a path plus a preview.
+
+## Captured Envelope
+
+The hook command serializes the stdin payload into a `CapturedHookEnvelope` and
+enqueues that JSON string in `pending_messages.payload`.
+
+```json
+{
+  "event": "SessionEnd",
+  "kind": "hook_session_end",
+  "agent": "claude",
+  "captured_at": "2026-04-29T12:34:56Z",
+  "claude_cwd": "/path/to/working/directory",
+  "payload": "{\"session_id\":\"abc\",\"summary\":\"Fixed auth bug\"}",
+  "payload_path": null,
+  "payload_preview": null,
+  "original_size_bytes": 55,
+  "truncated": false
+}
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `event` | string | Canonical event name: `PostToolUse`, `UserPromptSubmit`, `SessionStart`, or `SessionEnd`. |
+| `kind` | string | Queue kind and command alias, such as `hook_session_end`. |
+| `agent` | string | Inferred agent name. Current recognized values are `claude`, `codex`, and `gemini`; consumers should treat the field as an open string. |
+| `captured_at` | string | Capture timestamp in ISO-8601 format. |
+| `claude_cwd` | string | `CLAUDE_PROJECT_CWD` when set; otherwise the hook process current directory; otherwise `"."`. |
+| `payload` | string or null | Inline stdin payload when `original_size_bytes <= 10 MiB`. |
+| `payload_path` | string or null | Absolute path to the oversize payload file when `original_size_bytes > 10 MiB`. |
+| `payload_preview` | string or null | First 4 KiB preview for oversize payloads, truncated at a valid UTF-8 boundary. |
+| `original_size_bytes` | number | Original stdin byte length before UTF-8 decoding or overflow handling. |
+| `truncated` | boolean | `true` when the payload was stored out-of-line because it exceeded 10 MiB. |
+
+Agent detection first checks JSON string fields named `agent`, `originator`,
+and `model`, then falls back to substring matching in the payload text. If no
+known agent name is found, the current implementation emits `claude`.
+
+## Size Limits and Overflow
+
+Inline payload limit: `10 * 1024 * 1024` bytes (`MAX_INLINE_PAYLOAD_BYTES`).
+
+Preview limit: `4 * 1024` bytes (`PREVIEW_MAX_BYTES`).
+
+When stdin exceeds the inline limit:
+
+1. mempal writes the original bytes to `~/.mempal/hook-oversize/<blake3-hash>.json`.
+2. `payload` is set to `null`.
+3. `payload_path` points to the oversize file.
+4. `payload_preview` contains the first 4 KiB of the payload.
+5. `truncated` is set to `true`.
+
+The oversize directory is derived from the configured database path. With the
+default database, this is `~/.mempal/hook-oversize/`.
+
+## Queueing and Processing
+
+The hook path is designed to be fast. It loads config, opens the SQLite-backed
+`PendingMessageStore`, performs one queue insert into `pending_messages`, and
+returns without doing ingest work. Typical hook enqueue latency should stay
+below 50 ms on a healthy local SQLite database.
+
+The daemon processes queued hook envelopes asynchronously:
+
+| Event | Default daemon target |
+| --- | --- |
+| `PostToolUse` | `wing=hooks-raw`, `room=<tool_name>` or `unknown-tool`. |
+| `UserPromptSubmit` | `wing=hooks-raw`, `room=user-prompt`. |
+| `SessionStart` | `wing=hooks-raw`, `room=session-lifecycle`. |
+| `SessionEnd` | `wing=hooks-raw`, `room=session-lifecycle`; may also trigger session self-review extraction when enabled. |
+
+`mempal hook` itself writes no stdout on success. For oversized payloads, it may
+write a short diagnostic to stderr indicating that the payload was envelope-wrapped.
+
+## Usage Examples
+
+Session end with JSON metadata:
+
+```bash
+echo '{"session_id":"abc","summary":"Fixed auth bug"}' | mempal hook SessionEnd
+```
+
+Session start with plain text:
+
+```bash
+echo "Starting session for project X" | mempal hook SessionStart
+```
+
+Post-tool event with tool details:
+
+```bash
+echo '{"tool_name":"Read","input":{"file_path":"/src/main.rs"},"exit_code":0}' \
+  | mempal hook PostToolUse
+```
+
+User prompt event with arbitrary integration metadata:
+
+```bash
+cat <<'JSON' | mempal hook hook_user_prompt
+{
+  "agent": "codex",
+  "session_id": "abc",
+  "prompt": "Continue the integration work",
+  "metadata": {
+    "source": "external-runner",
+    "cwd": "/repo"
+  }
+}
+JSON
+```
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::env;
 use std::fs::OpenOptions;
 use std::future::Future;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(feature = "rest")]
 use std::sync::Arc;
@@ -24,13 +24,15 @@ use mempal::core::{
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     reindex::ReindexProgressStore,
     types::{
-        AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
-        KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
-        MemoryKind, TaxonomyEntry, TriggerHints, TunnelEndpoint,
+        AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeCardEvent,
+        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, SourceType, TaxonomyEntry,
+        TriggerHints, TunnelEndpoint,
     },
     utils::{
-        build_triple_id, current_timestamp, format_tunnel_endpoint,
-        normalize_added_at as normalize_added_at_value, normalize_rfc3339_timestamp,
+        build_bootstrap_evidence_drawer_id, build_triple_id, current_timestamp,
+        format_tunnel_endpoint, iso_timestamp, normalize_added_at as normalize_added_at_value,
+        normalize_rfc3339_timestamp, source_file_or_synthetic,
     },
 };
 use mempal::embed::build_backend_from_name;
@@ -38,7 +40,10 @@ use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::gating::compile_classifier_from_config;
 use mempal::ingest::{
-    IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
+    IngestOptions, IngestStats,
+    gating::{IngestCandidate, evaluate_tier1, evaluate_tier2},
+    ingest_dir_with_options, ingest_file_with_options,
+    normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
@@ -52,7 +57,7 @@ use mempal::knowledge_lifecycle::{
 use mempal::mcp::MempalMcpServer;
 use mempal::observability;
 use mempal::search::{SearchFilters, SearchOptions, search_with_all_options};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 mod longmemeval;
@@ -83,8 +88,9 @@ struct SearchCommandOptions<'a> {
 }
 
 struct IngestCommandOptions<'a> {
-    dir: &'a Path,
-    wing: &'a str,
+    dir: Option<&'a Path>,
+    stdin: bool,
+    wing: Option<&'a str>,
     room: Option<&'a str>,
     format: Option<String>,
     project: Option<&'a str>,
@@ -137,9 +143,11 @@ enum Commands {
         dry_run: bool,
     },
     Ingest {
-        dir: PathBuf,
+        dir: Option<PathBuf>,
         #[arg(long)]
-        wing: String,
+        stdin: bool,
+        #[arg(long)]
+        wing: Option<String>,
         #[arg(long)]
         room: Option<String>,
         #[arg(long)]
@@ -807,6 +815,7 @@ fn run() -> Result<()> {
         Commands::Init { dir, dry_run } => init_command(&db, &dir, dry_run),
         Commands::Ingest {
             dir,
+            stdin,
             wing,
             room,
             format,
@@ -820,8 +829,9 @@ fn run() -> Result<()> {
             &db,
             config.as_ref(),
             IngestCommandOptions {
-                dir: &dir,
-                wing: &wing,
+                dir: dir.as_deref(),
+                stdin,
+                wing: wing.as_deref(),
                 room: room.as_deref(),
                 format,
                 project: project.as_deref(),
@@ -1192,7 +1202,28 @@ async fn ingest_command(
     config: &Config,
     options: IngestCommandOptions<'_>,
 ) -> Result<()> {
-    let path = options.dir;
+    match (options.stdin, options.dir) {
+        (true, Some(path)) => {
+            bail!(
+                "`mempal ingest --stdin` cannot be combined with directory path `{}`",
+                path.display()
+            );
+        }
+        (true, None) => {
+            return ingest_stdin_command(db, config, options).await;
+        }
+        (false, None) => {
+            bail!("`mempal ingest` requires a directory path unless --stdin is used");
+        }
+        (false, Some(_)) => {}
+    }
+
+    let path = options
+        .dir
+        .expect("validated that non-stdin ingest has a directory path");
+    let wing = options
+        .wing
+        .context("`mempal ingest` requires --wing for directory ingest")?;
     if !path.exists() {
         bail!("path `{}` does not exist", path.display());
     }
@@ -1201,7 +1232,7 @@ async fn ingest_command(
             "`mempal ingest` expects a DIRECTORY, got file `{}`. To ingest a single file, create a temporary directory first, e.g. `mkdir -p /path/to/dir && cp {} /path/to/dir/ && mempal ingest /path/to/dir --wing {}`",
             path.display(),
             path.display(),
-            options.wing
+            wing
         );
     }
     if let Some(format) = options.format.as_deref()
@@ -1210,7 +1241,7 @@ async fn ingest_command(
         bail!("unsupported --format value: {format}");
     }
 
-    let project_id = resolve_project_id(options.project, config, Some(options.dir))
+    let project_id = resolve_project_id(options.project, config, Some(path))
         .context("failed to resolve ingest project id")?;
     let base_options = IngestOptions {
         room: options.room,
@@ -1231,7 +1262,7 @@ async fn ingest_command(
     };
 
     let stats = if options.dry_run {
-        ingest_path_with_options(db, &NoopEmbedder, path, options.wing, base_options).await?
+        ingest_path_with_options(db, &NoopEmbedder, path, wing, base_options).await?
     } else {
         let prototype_classifier = if config.ingest_gating.enabled && !options.no_gate {
             compile_classifier_from_config(config)
@@ -1259,13 +1290,13 @@ async fn ingest_command(
             diary_rollup: options.diary_rollup,
             diary_rollup_day: None,
         };
-        ingest_path_with_options(db, &*embedder, path, options.wing, live_options).await?
+        ingest_path_with_options(db, &*embedder, path, wing, live_options).await?
     };
 
     append_ingest_audit_log(
         db,
-        options.dir,
-        options.wing,
+        path,
+        wing,
         options.format.as_deref(),
         options.dry_run,
         &stats,
@@ -1298,6 +1329,195 @@ async fn ingest_command(
         stats.dropped_by_gate,
         stats.noise_bytes_stripped.unwrap_or(0),
         stats.lock_wait_ms.unwrap_or(0)
+    );
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct StdinIngestRecord {
+    content: Option<String>,
+    wing: Option<String>,
+    room: Option<String>,
+    project: Option<String>,
+    source: Option<String>,
+    source_file: Option<String>,
+    metadata: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Serialize)]
+struct StdinIngestJsonOutput<'a> {
+    drawer_ids: &'a [String],
+    stats: StdinIngestStatsJson,
+}
+
+#[derive(Serialize)]
+struct StdinIngestStatsJson {
+    dry_run: bool,
+    files: usize,
+    chunks: usize,
+    skipped: usize,
+    dropped_by_gate: usize,
+}
+
+async fn ingest_stdin_command(
+    db: &Database,
+    config: &Config,
+    options: IngestCommandOptions<'_>,
+) -> Result<()> {
+    if options.format.is_some() {
+        bail!("--format is only supported for directory ingest");
+    }
+    if options.diary_rollup {
+        bail!("--diary-rollup is only supported for directory ingest");
+    }
+
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read stdin")?;
+    let record: StdinIngestRecord =
+        serde_json::from_str(&input).context("failed to parse stdin JSON object")?;
+
+    let content = record
+        .content
+        .as_deref()
+        .context("stdin JSON object is missing required `content` field")?
+        .to_string();
+    if content.trim().is_empty() {
+        bail!("stdin JSON `content` field must not be empty");
+    }
+
+    let wing = options
+        .wing
+        .or(record.wing.as_deref())
+        .context("stdin ingest requires --wing or JSON `wing`")?;
+    let room = options.room.or(record.room.as_deref());
+    let project = options.project.or(record.project.as_deref());
+    let cwd = env::current_dir().ok();
+    let project_id = resolve_project_id(project, config, cwd.as_deref())
+        .context("failed to resolve stdin ingest project id")?;
+
+    let source_type = SourceType::Manual;
+    let drawer_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+    let mut stats = IngestStats {
+        files: 1,
+        ..IngestStats::default()
+    };
+
+    if options.dry_run {
+        stats.chunks = 1;
+        stats.drawer_ids.push(drawer_id.clone());
+        append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+            .context("failed to append ingest audit log")?;
+        print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+        return Ok(());
+    }
+
+    let prototype_classifier = if config.ingest_gating.enabled && !options.no_gate {
+        compile_classifier_from_config(config)
+            .await
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .context("gating prototypes unavailable")?
+    } else {
+        None
+    };
+    let embedder = build_embedder(config).await?;
+
+    if !options.no_gate {
+        let candidate = IngestCandidate {
+            content: content.clone(),
+            tool_name: None,
+            exit_code: None,
+        };
+        let mut gating_decision = evaluate_tier1(&candidate, &config.ingest_gating);
+        if gating_decision.is_none()
+            && let Some(classifier) = prototype_classifier.as_ref()
+        {
+            let tier2 = evaluate_tier2(
+                &candidate,
+                classifier,
+                embedder.as_ref(),
+                config.ingest_gating.embedding_classifier.threshold,
+            )
+            .await;
+            gating_decision = Some(tier2.decision);
+        }
+        if let Some(decision) = gating_decision.as_ref() {
+            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
+                .with_context(|| format!("failed to record gating audit for {drawer_id}"))?;
+            if decision.is_rejected() {
+                stats.dropped_by_gate = 1;
+                append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+                    .context("failed to append ingest audit log")?;
+                print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+                return Ok(());
+            }
+        }
+    }
+
+    let texts = [content.as_str()];
+    let vectors = embedder
+        .embed(&texts)
+        .await
+        .context("failed to embed stdin content")?;
+    let vector = vectors
+        .into_iter()
+        .next()
+        .context("embedder returned no vector for stdin content")?;
+    let source_hint = record.source_file.as_deref().or(record.source.as_deref());
+    let source_file = source_file_or_synthetic(&drawer_id, source_hint);
+    let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: drawer_id.clone(),
+        content,
+        wing: wing.to_string(),
+        room: room.map(ToOwned::to_owned),
+        source_file: Some(source_file),
+        source_type,
+        added_at: iso_timestamp(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    let drawer = Drawer {
+        normalize_version: CURRENT_NORMALIZE_VERSION,
+        ..drawer
+    };
+
+    db.insert_drawer_with_project(&drawer, project_id.as_deref())
+        .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
+    db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+        .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
+
+    stats.chunks = 1;
+    stats.drawer_ids.push(drawer_id);
+    append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+        .context("failed to append ingest audit log")?;
+    print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+    Ok(())
+}
+
+fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> Result<()> {
+    if json {
+        let output = StdinIngestJsonOutput {
+            drawer_ids: &stats.drawer_ids,
+            stats: StdinIngestStatsJson {
+                dry_run,
+                files: stats.files,
+                chunks: stats.chunks,
+                skipped: stats.skipped,
+                dropped_by_gate: stats.dropped_by_gate,
+            },
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&output)
+                .context("failed to serialize stdin ingest JSON output")?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={}",
+        dry_run, stats.files, stats.chunks, stats.skipped, stats.dropped_by_gate
     );
     Ok(())
 }
@@ -1364,6 +1584,42 @@ fn append_ingest_audit_log(
         .open(&audit_path)
         .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
     let entry = serde_json::json!({ "timestamp": current_timestamp(), "command": "ingest", "wing": wing, "dir": dir.to_string_lossy(), "format": format, "dry_run": dry_run, "files": stats.files, "chunks": stats.chunks, "skipped": stats.skipped, "dropped_by_gate": stats.dropped_by_gate });
+    writeln!(file, "{entry}")
+        .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
+    Ok(())
+}
+
+fn append_ingest_stdin_audit_log(
+    db: &Database,
+    wing: &str,
+    dry_run: bool,
+    record: &StdinIngestRecord,
+    stats: &IngestStats,
+) -> Result<()> {
+    let audit_path = db
+        .path()
+        .parent()
+        .map(|p| p.join("audit.jsonl"))
+        .unwrap_or_else(|| PathBuf::from("audit.jsonl"));
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&audit_path)
+        .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
+    let entry = serde_json::json!({
+        "timestamp": current_timestamp(),
+        "command": "ingest",
+        "mode": "stdin",
+        "wing": wing,
+        "source": record.source.as_deref(),
+        "source_file": record.source_file.as_deref(),
+        "metadata": record.metadata.as_ref(),
+        "dry_run": dry_run,
+        "files": stats.files,
+        "chunks": stats.chunks,
+        "skipped": stats.skipped,
+        "dropped_by_gate": stats.dropped_by_gate,
+    });
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
     Ok(())

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -4,8 +4,9 @@
 mod common;
 
 use std::fs;
+use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 
 use common::harness::start as start_embed_mock;
 use serde_json::Value;
@@ -45,6 +46,28 @@ fn run_ingest_json(home: &Path, target: &str, wing: &str) -> Output {
         .env("HOME", home)
         .output()
         .expect("run mempal ingest --json")
+}
+
+fn run_ingest_stdin_json(home: &Path, payload: &str, args: &[&str]) -> Output {
+    let mut command = Command::new(mempal_bin());
+    command
+        .arg("ingest")
+        .arg("--stdin")
+        .args(args)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().expect("spawn mempal ingest --stdin");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin pipe")
+        .write_all(payload.as_bytes())
+        .expect("write stdin payload");
+    child
+        .wait_with_output()
+        .expect("wait mempal ingest --stdin")
 }
 
 fn write_embed_config(home: &Path, base_url: &str) {
@@ -162,4 +185,52 @@ async fn test_ingest_json_outputs_created_drawer_ids() {
         drawer_ids.iter().all(|value| value.as_str().is_some()),
         "drawer_ids must contain strings"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stdin_json_creates_single_drawer() {
+    let tmp = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config(tmp.path(), &format!("http://{addr}/v1"));
+
+    let payload = r#"{
+        "content": "stdin memory content from issue 99",
+        "wing": "json-wing",
+        "room": "json-room",
+        "project": "json-project",
+        "source": "csa-session",
+        "source_file": "csa://session/99",
+        "metadata": { "issue": 99 }
+    }"#;
+    let output = run_ingest_stdin_json(
+        tmp.path(),
+        payload,
+        &["--wing", "cli-wing", "--no-gate", "--json"],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "ingest --stdin --json must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse stdin ingest JSON");
+    let drawer_ids = json["drawer_ids"].as_array().expect("drawer_ids array");
+    assert_eq!(drawer_ids.len(), 1);
+    assert_eq!(json["stats"]["files"], 1);
+    assert_eq!(json["stats"]["chunks"], 1);
+    assert_eq!(json["stats"]["dropped_by_gate"], 0);
+
+    let drawer_id = drawer_ids[0].as_str().expect("drawer id string");
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    let drawer = db
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.wing, "cli-wing");
+    assert_eq!(drawer.room.as_deref(), Some("json-room"));
+    assert_eq!(drawer.source_file.as_deref(), Some("csa://session/99"));
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "62a2e66b66bb761c461650b87b01c557f4ff3651"
+commit = "ecee8a05f572e0403c74ed15541cd54e2600fe47"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Implements [#99](https://github.com/RyderFreeman4Logos/mempal/issues/99) — CSA integration support.

- **`mempal ingest --stdin`**: Single-record JSON ingest via stdin. Accepts `{"content": "...", "wing": "...", "room": "...", "project": "...", "source": "...", "metadata": {...}}`. CLI flags take precedence over JSON fields. Includes gating, dry-run, and JSON output.
- **Hook payload schema docs**: New `docs/hook-payload-schema.md` documenting all 4 hook events (PostToolUse, UserPromptSubmit, SessionStart, SessionEnd), envelope format, latency characteristics, and overflow handling.
- **CSA integration assets**: Replaced placeholder `assets/integrations/csa/README.md` with practical hook config templates, field mapping table, migration guide, and retrieval examples.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (164+ tests including new stdin ingest test)
- [x] Smoke test: stdin JSON ingest + directory ingest backward compat verified
- [x] Pre-commit hooks pass (fmt + clippy + test)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)