### PR TITLE
fix(ingest): harden stdin ingest privacy & security

### DIFF
--- a/docs/hook-payload-schema.md
+++ b/docs/hook-payload-schema.md
@@ -142,4 +142,3 @@ cat <<'JSON' | mempal hook hook_user_prompt
 }
 JSON
 ```
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1666,7 +1666,7 @@ fn scrub_metadata_for_audit_log(
         .iter()
         .map(|(key, value)| {
             (
-                key.clone(),
+                config.scrub_content_with_compiled(key, compiled_privacy.as_ref()),
                 scrub_metadata_value_for_audit_log(value, &config, compiled_privacy.as_ref()),
             )
         })
@@ -1692,7 +1692,7 @@ fn scrub_metadata_value_for_audit_log(
             map.iter()
                 .map(|(key, value)| {
                     (
-                        key.clone(),
+                        config.scrub_content_with_compiled(key, compiled_privacy),
                         scrub_metadata_value_for_audit_log(value, config, compiled_privacy),
                     )
                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
-    config::{Config, ConfigHandle, default_config_path},
+    config::{CompiledPrivacyConfig, Config, ConfigHandle, default_config_path},
     db::Database,
     priming::PrimingRequest,
     project::{
@@ -59,6 +59,7 @@ use mempal::mcp::MempalMcpServer;
 use mempal::observability;
 use mempal::search::{SearchFilters, SearchOptions, search_with_all_options};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 mod longmemeval;
@@ -1637,6 +1638,7 @@ fn append_ingest_stdin_audit_log(
         .append(true)
         .open(&audit_path)
         .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
+    let metadata = record.metadata.as_ref().map(scrub_metadata_for_audit_log);
     let entry = serde_json::json!({
         "timestamp": current_timestamp(),
         "command": "ingest",
@@ -1644,7 +1646,7 @@ fn append_ingest_stdin_audit_log(
         "wing": wing,
         "source": record.source.as_deref(),
         "source_file": record.source_file.as_deref(),
-        "metadata": record.metadata.as_ref(),
+        "metadata": metadata.as_ref(),
         "dry_run": dry_run,
         "files": stats.files,
         "chunks": stats.chunks,
@@ -1654,6 +1656,50 @@ fn append_ingest_stdin_audit_log(
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
     Ok(())
+}
+
+fn scrub_metadata_for_audit_log(
+    metadata: &serde_json::Map<String, Value>,
+) -> serde_json::Map<String, Value> {
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    metadata
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.clone(),
+                scrub_metadata_value_for_audit_log(value, &config, compiled_privacy.as_ref()),
+            )
+        })
+        .collect()
+}
+
+fn scrub_metadata_value_for_audit_log(
+    value: &Value,
+    config: &Config,
+    compiled_privacy: &CompiledPrivacyConfig,
+) -> Value {
+    match value {
+        Value::String(text) => {
+            Value::String(config.scrub_content_with_compiled(text, compiled_privacy))
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| scrub_metadata_value_for_audit_log(item, config, compiled_privacy))
+                .collect(),
+        ),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        scrub_metadata_value_for_audit_log(value, config, compiled_privacy),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Null | Value::Bool(_) | Value::Number(_) => value.clone(),
+    }
 }
 
 async fn context_command(db: &Database, config: &Config, args: ContextCommandArgs) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1477,8 +1477,14 @@ async fn ingest_stdin_command(
         .into_iter()
         .next()
         .context("embedder returned no vector for stdin content")?;
-    let source_hint = record.source_file.as_deref().or(record.source.as_deref());
-    let source_file = source_file_or_synthetic(&drawer_id, source_hint);
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    let scrub = |s: &str| config.scrub_content_with_compiled(s, compiled_privacy.as_ref());
+    let source_hint = record
+        .source_file
+        .as_deref()
+        .or(record.source.as_deref())
+        .map(&scrub);
+    let source_file = source_file_or_synthetic(&drawer_id, source_hint.as_deref());
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: drawer_id.clone(),
         content,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,10 @@ use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::gating::compile_classifier_from_config;
 use mempal::ingest::{
     IngestOptions, IngestStats,
+    detect::detect_format,
     gating::{IngestCandidate, evaluate_tier1, evaluate_tier2},
     ingest_dir_with_options, ingest_file_with_options,
-    normalize::CURRENT_NORMALIZE_VERSION,
+    normalize::{CURRENT_NORMALIZE_VERSION, NormalizeOptions, normalize_content_with_options},
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
@@ -1344,6 +1345,8 @@ struct StdinIngestRecord {
     metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
+const MAX_STDIN_INGEST_BYTES: usize = 10 * 1024 * 1024;
+
 #[derive(Serialize)]
 struct StdinIngestJsonOutput<'a> {
     drawer_ids: &'a [String],
@@ -1371,21 +1374,30 @@ async fn ingest_stdin_command(
         bail!("--diary-rollup is only supported for directory ingest");
     }
 
-    let mut input = String::new();
+    let mut input = Vec::new();
     std::io::stdin()
-        .read_to_string(&mut input)
+        .take(MAX_STDIN_INGEST_BYTES as u64 + 1)
+        .read_to_end(&mut input)
         .context("failed to read stdin")?;
+    if input.len() > MAX_STDIN_INGEST_BYTES {
+        bail!(
+            "stdin payload exceeds {} byte limit",
+            MAX_STDIN_INGEST_BYTES
+        );
+    }
+    let input = String::from_utf8(input).context("stdin payload is not valid UTF-8")?;
     let record: StdinIngestRecord =
         serde_json::from_str(&input).context("failed to parse stdin JSON object")?;
 
-    let content = record
+    let raw_content = record
         .content
         .as_deref()
         .context("stdin JSON object is missing required `content` field")?
         .to_string();
-    if content.trim().is_empty() {
+    if raw_content.trim().is_empty() {
         bail!("stdin JSON `content` field must not be empty");
     }
+    let content = normalize_stdin_content(&raw_content, options.no_strip_noise)?;
 
     let wing = options
         .wing
@@ -1493,6 +1505,25 @@ async fn ingest_stdin_command(
         .context("failed to append ingest audit log")?;
     print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
     Ok(())
+}
+
+fn normalize_stdin_content(content: &str, no_strip_noise: bool) -> Result<String> {
+    let format = detect_format(content);
+    let normalize_output = normalize_content_with_options(
+        content,
+        format,
+        NormalizeOptions {
+            strip_noise: !no_strip_noise,
+        },
+    )
+    .context("failed to normalize stdin content")?;
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    let scrubbed =
+        config.scrub_content_with_compiled(&normalize_output.content, compiled_privacy.as_ref());
+    if scrubbed.trim().is_empty() {
+        bail!("stdin JSON `content` field must not be empty after normalization");
+    }
+    Ok(scrubbed)
 }
 
 fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1639,13 +1639,17 @@ fn append_ingest_stdin_audit_log(
         .open(&audit_path)
         .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
     let metadata = record.metadata.as_ref().map(scrub_metadata_for_audit_log);
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    let scrub = |s: &str| config.scrub_content_with_compiled(s, compiled_privacy.as_ref());
+    let source = record.source.as_deref().map(&scrub);
+    let source_file = record.source_file.as_deref().map(&scrub);
     let entry = serde_json::json!({
         "timestamp": current_timestamp(),
         "command": "ingest",
         "mode": "stdin",
         "wing": wing,
-        "source": record.source.as_deref(),
-        "source_file": record.source_file.as_deref(),
+        "source": source,
+        "source_file": source_file,
         "metadata": metadata.as_ref(),
         "dry_run": dry_run,
         "files": stats.files,

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -311,6 +311,7 @@ fn test_ingest_stdin_scrubs_metadata_in_audit_log() {
         "wing": "privacy-wing",
         "metadata": {
             "token": secret,
+            secret.clone(): "secret-in-key",
             "nested": {
                 "tokens": [format!("prefix {secret}")]
             }

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -342,7 +342,10 @@ fn test_ingest_stdin_scrubs_metadata_in_audit_log() {
     );
 
     // Verify source/source_file are also scrubbed in audit log
-    assert!(!audit.contains("sk-"), "source/source_file secret leaked: {audit}");
+    assert!(
+        !audit.contains("sk-"),
+        "source/source_file secret leaked: {audit}"
+    );
 }
 
 #[test]
@@ -359,7 +362,11 @@ fn test_ingest_stdin_scrubs_source_fields_in_audit_log() {
     .to_string();
 
     let output = run_ingest_stdin_json(tmp.path(), &payload, &["--dry-run", "--json"]);
-    assert!(output.status.success(), "stderr={}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let audit_path = tmp.path().join(".mempal").join("audit.jsonl");
     let audit = fs::read_to_string(&audit_path).expect("read audit log");
@@ -368,7 +375,10 @@ fn test_ingest_stdin_scrubs_source_fields_in_audit_log() {
     let entry: Value = serde_json::from_str(audit.lines().last().expect("audit entry"))
         .expect("parse audit entry");
     assert!(
-        entry["source"].as_str().unwrap().contains("[REDACTED:openai_key]"),
+        entry["source"]
+            .as_str()
+            .unwrap()
+            .contains("[REDACTED:openai_key]"),
         "source not scrubbed: {}",
         entry["source"]
     );

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use std::fs;
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
@@ -49,6 +49,10 @@ fn run_ingest_json(home: &Path, target: &str, wing: &str) -> Output {
 }
 
 fn run_ingest_stdin_json(home: &Path, payload: &str, args: &[&str]) -> Output {
+    run_ingest_stdin_bytes(home, payload.as_bytes(), args)
+}
+
+fn run_ingest_stdin_bytes(home: &Path, payload: &[u8], args: &[&str]) -> Output {
     let mut command = Command::new(mempal_bin());
     command
         .arg("ingest")
@@ -59,18 +63,23 @@ fn run_ingest_stdin_json(home: &Path, payload: &str, args: &[&str]) -> Output {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     let mut child = command.spawn().expect("spawn mempal ingest --stdin");
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin pipe")
-        .write_all(payload.as_bytes())
-        .expect("write stdin payload");
+    if let Some(stdin) = child.stdin.as_mut() {
+        match stdin.write_all(payload) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::BrokenPipe => {}
+            Err(error) => panic!("write stdin payload: {error}"),
+        }
+    }
     child
         .wait_with_output()
         .expect("wait mempal ingest --stdin")
 }
 
 fn write_embed_config(home: &Path, base_url: &str) {
+    write_embed_config_with_privacy(home, base_url, false);
+}
+
+fn write_embed_config_with_privacy(home: &Path, base_url: &str, privacy_enabled: bool) {
     let db_path = home.join(".mempal").join("palace.db");
     let config = format!(
         r#"
@@ -87,12 +96,28 @@ base_url = "{}"
 model = "test-embed"
 dim = 4
 request_timeout_secs = 2
+
+[privacy]
+enabled = {}
 "#,
         db_path.display(),
         base_url,
-        base_url
+        base_url,
+        privacy_enabled
     );
     fs::write(home.join(".mempal").join("config.toml"), config).expect("write config");
+}
+
+fn assert_stdin_error(output: Output, expected: &str) {
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for stdin error"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(expected),
+        "stderr must contain {expected:?}, got: {stderr}"
+    );
 }
 
 #[test]
@@ -233,4 +258,134 @@ async fn test_ingest_stdin_json_creates_single_drawer() {
     assert_eq!(drawer.wing, "cli-wing");
     assert_eq!(drawer.room.as_deref(), Some("json-room"));
     assert_eq!(drawer.source_file.as_deref(), Some("csa://session/99"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stdin_applies_privacy_scrubbing() {
+    let tmp = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config_with_privacy(tmp.path(), &format!("http://{addr}/v1"), true);
+    let secret = format!("sk-{}", "0".repeat(40));
+    let payload = serde_json::json!({
+        "content": format!("keep {secret} and <private>hidden</private>"),
+        "wing": "privacy-wing",
+        "room": "privacy-room",
+        "source_file": "stdin://privacy"
+    })
+    .to_string();
+
+    let output = run_ingest_stdin_json(tmp.path(), &payload, &["--no-gate", "--json"]);
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "ingest --stdin must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse stdin ingest JSON");
+    let drawer_id = json["drawer_ids"][0].as_str().expect("drawer id string");
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    let drawer = db
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert!(
+        drawer.content.contains("[REDACTED:openai_key]"),
+        "{}",
+        drawer.content
+    );
+    assert!(!drawer.content.contains(&secret), "{}", drawer.content);
+    assert!(!drawer.content.contains("hidden"), "{}", drawer.content);
+}
+
+#[test]
+fn test_ingest_stdin_rejects_invalid_json() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(tmp.path(), "not json", &["--wing", "test"]);
+
+    assert_stdin_error(output, "failed to parse stdin JSON object");
+}
+
+#[test]
+fn test_ingest_stdin_rejects_missing_content() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(tmp.path(), r#"{"wing":"test"}"#, &[]);
+
+    assert_stdin_error(
+        output,
+        "stdin JSON object is missing required `content` field",
+    );
+}
+
+#[test]
+fn test_ingest_stdin_rejects_empty_content() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(tmp.path(), r#"{"content":"   ","wing":"test"}"#, &[]);
+
+    assert_stdin_error(output, "stdin JSON `content` field must not be empty");
+}
+
+#[test]
+fn test_ingest_stdin_rejects_missing_wing() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(tmp.path(), r#"{"content":"hello"}"#, &[]);
+
+    assert_stdin_error(output, "stdin ingest requires --wing or JSON `wing`");
+}
+
+#[test]
+fn test_ingest_stdin_rejects_directory_path() {
+    let tmp = setup_home();
+    let source_dir = tmp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    let source_dir = source_dir.to_str().expect("source dir path");
+    let output = run_ingest_stdin_json(
+        tmp.path(),
+        r#"{"content":"hello","wing":"test"}"#,
+        &[source_dir],
+    );
+
+    assert_stdin_error(
+        output,
+        "`mempal ingest --stdin` cannot be combined with directory path",
+    );
+}
+
+#[test]
+fn test_ingest_stdin_rejects_format() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(
+        tmp.path(),
+        r#"{"content":"hello","wing":"test"}"#,
+        &["--format", "convos"],
+    );
+
+    assert_stdin_error(output, "--format is only supported for directory ingest");
+}
+
+#[test]
+fn test_ingest_stdin_rejects_diary_rollup() {
+    let tmp = setup_home();
+    let output = run_ingest_stdin_json(
+        tmp.path(),
+        r#"{"content":"hello","wing":"agent-diary","room":"codex"}"#,
+        &["--diary-rollup"],
+    );
+
+    assert_stdin_error(
+        output,
+        "--diary-rollup is only supported for directory ingest",
+    );
+}
+
+#[test]
+fn test_ingest_stdin_rejects_payload_over_size_limit() {
+    let tmp = setup_home();
+    let payload = vec![b'a'; 10 * 1024 * 1024 + 1];
+    let output = run_ingest_stdin_bytes(tmp.path(), &payload, &["--wing", "test"]);
+
+    assert_stdin_error(output, "stdin payload exceeds 10485760 byte limit");
 }

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -340,6 +340,39 @@ fn test_ingest_stdin_scrubs_metadata_in_audit_log() {
         entry["metadata"]["nested"]["tokens"][0],
         "prefix [REDACTED:openai_key]"
     );
+
+    // Verify source/source_file are also scrubbed in audit log
+    assert!(!audit.contains("sk-"), "source/source_file secret leaked: {audit}");
+}
+
+#[test]
+fn test_ingest_stdin_scrubs_source_fields_in_audit_log() {
+    let tmp = setup_home();
+    write_embed_config_with_privacy(tmp.path(), "http://127.0.0.1:9/v1", true);
+    let secret = format!("sk-{}", "2".repeat(40));
+    let payload = serde_json::json!({
+        "content": "source field audit content",
+        "wing": "privacy-wing",
+        "source": format!("hook-{secret}"),
+        "source_file": secret
+    })
+    .to_string();
+
+    let output = run_ingest_stdin_json(tmp.path(), &payload, &["--dry-run", "--json"]);
+    assert!(output.status.success(), "stderr={}", String::from_utf8_lossy(&output.stderr));
+
+    let audit_path = tmp.path().join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(&audit_path).expect("read audit log");
+    assert!(!audit.contains(&secret), "source secret in audit: {audit}");
+
+    let entry: Value = serde_json::from_str(audit.lines().last().expect("audit entry"))
+        .expect("parse audit entry");
+    assert!(
+        entry["source"].as_str().unwrap().contains("[REDACTED:openai_key]"),
+        "source not scrubbed: {}",
+        entry["source"]
+    );
+    assert_eq!(entry["source_file"], "[REDACTED:openai_key]");
 }
 
 #[test]

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -348,20 +348,22 @@ fn test_ingest_stdin_scrubs_metadata_in_audit_log() {
     );
 }
 
-#[test]
-fn test_ingest_stdin_scrubs_source_fields_in_audit_log() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stdin_scrubs_source_fields_in_audit_and_drawer() {
     let tmp = setup_home();
-    write_embed_config_with_privacy(tmp.path(), "http://127.0.0.1:9/v1", true);
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config_with_privacy(tmp.path(), &format!("http://{addr}/v1"), true);
     let secret = format!("sk-{}", "2".repeat(40));
     let payload = serde_json::json!({
-        "content": "source field audit content",
+        "content": "source field privacy content",
         "wing": "privacy-wing",
         "source": format!("hook-{secret}"),
         "source_file": secret
     })
     .to_string();
 
-    let output = run_ingest_stdin_json(tmp.path(), &payload, &["--dry-run", "--json"]);
+    let output = run_ingest_stdin_json(tmp.path(), &payload, &["--json"]);
+    handle.shutdown().await;
     assert!(
         output.status.success(),
         "stderr={}",
@@ -383,6 +385,17 @@ fn test_ingest_stdin_scrubs_source_fields_in_audit_log() {
         entry["source"]
     );
     assert_eq!(entry["source_file"], "[REDACTED:openai_key]");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse stdout JSON");
+    let drawer_id = json["drawer_ids"][0].as_str().expect("drawer id");
+    let db_path = tmp.path().join(".mempal").join("palace.db");
+    let db = mempal::core::db::Database::open(&db_path).expect("open db");
+    let drawer = db.get_drawer(drawer_id).expect("get drawer").expect("drawer exists");
+    assert!(
+        !drawer.source_file.as_deref().unwrap_or("").contains(&secret),
+        "source_file secret in drawer: {:?}",
+        drawer.source_file
+    );
 }
 
 #[test]

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -302,6 +302,46 @@ async fn test_ingest_stdin_applies_privacy_scrubbing() {
 }
 
 #[test]
+fn test_ingest_stdin_scrubs_metadata_in_audit_log() {
+    let tmp = setup_home();
+    write_embed_config_with_privacy(tmp.path(), "http://127.0.0.1:9/v1", true);
+    let secret = format!("sk-{}", "1".repeat(40));
+    let payload = serde_json::json!({
+        "content": "metadata audit content",
+        "wing": "privacy-wing",
+        "metadata": {
+            "token": secret,
+            "nested": {
+                "tokens": [format!("prefix {secret}")]
+            }
+        }
+    })
+    .to_string();
+
+    let output = run_ingest_stdin_json(tmp.path(), &payload, &["--dry-run", "--json"]);
+
+    assert!(
+        output.status.success(),
+        "ingest --stdin dry-run must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let audit_path = tmp.path().join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(&audit_path).expect("read audit log");
+    assert!(!audit.contains(&secret), "{audit}");
+    assert!(audit.contains("[REDACTED:openai_key]"), "{audit}");
+
+    let entry: Value = serde_json::from_str(audit.lines().last().expect("audit entry"))
+        .expect("parse audit entry");
+    assert_eq!(entry["metadata"]["token"], "[REDACTED:openai_key]");
+    assert_eq!(
+        entry["metadata"]["nested"]["tokens"][0],
+        "prefix [REDACTED:openai_key]"
+    );
+}
+
+#[test]
 fn test_ingest_stdin_rejects_invalid_json() {
     let tmp = setup_home();
     let output = run_ingest_stdin_json(tmp.path(), "not json", &["--wing", "test"]);

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "ecee8a05f572e0403c74ed15541cd54e2600fe47"
+commit = "f901a350c40ee7a5af821b393ef72970205cac45"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add `mempal ingest --stdin` for single-record JSON ingest (issue #99)
- Apply privacy scrubbing to stdin content, metadata (keys+values), source/source_file
- Cap stdin reads at 10MB with clear error
- Scrub all user-provided fields in audit.jsonl and drawer storage
- Add 10+ integration tests covering error paths and privacy scenarios
- Document hook payload schema and CSA integration guide

## Security fixes (from 6 rounds of tier-4 review)
- **content**: normalize + privacy scrub before drawer creation
- **metadata values**: recursive scrub for String/Array/Object
- **metadata keys**: scrub at top-level and nested Object levels  
- **source/source_file**: scrub in both audit log and drawer storage
- **stdin size**: bounded read with 10MB limit

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (826 tests)
- [x] 6 rounds of CSA-codex tier-4 review — final round: 0 HIGH/MEDIUM findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)