### PR TITLE
feat(cli): auto session checkpoint on idle (KV cache aware)

### DIFF
--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -31,8 +31,8 @@ fi
 PROJECT_HASH=$(echo -n "$(pwd)" | sha256sum | cut -c1-12)
 LOCKFILE="/tmp/mempal-checkpoint-${PROJECT_HASH}.lock"
 
-# Dedup: if a countdown is already pending for this project workspace, skip
-if [ -f "$LOCKFILE" ]; then
+# Dedup: mkdir is atomic — if it succeeds, we hold the lock
+if ! mkdir "$LOCKFILE" 2>/dev/null; then
     exit 0
 fi
 
@@ -44,7 +44,7 @@ cat <<CHECKPOINT_PROMPT
 before KV cache expires (1h TTL), run this background countdown:
 
 \`\`\`bash
-touch $LOCKFILE && sleep 3000 && mempal checkpoint save --project "$PROJECT_NAME" --content "$(echo 'Session checkpoint auto-saved. Summarize current work state here.')" && rm -f $LOCKFILE
+sleep 3000 && mempal checkpoint save --project "$PROJECT_NAME" --content "Session checkpoint auto-saved. Summarize current work state here." && rmdir "$LOCKFILE"
 \`\`\`
 
 Run the sleep command with run_in_background: true. When the notification fires

--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Session checkpoint countdown hook (SessionStop trigger).
+#
+# Injected into the main Claude Code agent's prompt via session stop hook.
+# The agent reads this output, then runs a background sleep 3000 (50 min)
+# countdown. When it fires, the agent checks for user activity and writes
+# a checkpoint to mempal if idle — this also refreshes KV cache TTL.
+#
+# Guards:
+#   - Sub-agents (CLAUDE_CODE_ENTRY_POINT=task) skip
+#   - CSA sessions (CSA_SESSION_ID set) skip
+#   - Non-interactive (stdin not TTY) skip
+#   - Dedup via flag file prevents stacked countdowns
+set -euo pipefail
+
+# Guard: sub-agents should not trigger checkpoints
+if [ "${CLAUDE_CODE_ENTRY_POINT:-}" = "task" ]; then
+    exit 0
+fi
+
+# Guard: CSA sessions should not trigger checkpoints
+if [ -n "${CSA_SESSION_ID:-}" ]; then
+    exit 0
+fi
+
+# Guard: non-interactive sessions (piped stdin)
+if [ ! -t 0 ] 2>/dev/null; then
+    exit 0
+fi
+
+LOCKFILE="/tmp/mempal-checkpoint-pending-$$"
+
+# Dedup: if a countdown is already pending for this session, skip
+if ls /tmp/mempal-checkpoint-pending-* 1>/dev/null 2>&1; then
+    exit 0
+fi
+
+PROJECT_NAME="${MEMPAL_PROJECT:-$(basename "$(pwd)")}"
+
+cat <<CHECKPOINT_PROMPT
+
+[SESSION CHECKPOINT] A tool stop was detected. To preserve your session state
+before KV cache expires (1h TTL), run this background countdown:
+
+\`\`\`bash
+touch $LOCKFILE && sleep 3000 && mempal checkpoint save --project "$PROJECT_NAME" --content "$(echo 'Session checkpoint auto-saved. Summarize current work state here.')" && rm -f $LOCKFILE
+\`\`\`
+
+Run the sleep command with run_in_background: true. When the notification fires
+(~50 min), check if the user has been active. If no activity, write a checkpoint
+summarizing: (1) what you were working on, (2) key decisions made, (3) next steps.
+The write itself generates tokens that refresh the KV cache.
+
+CHECKPOINT_PROMPT

--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -28,10 +28,11 @@ if [ ! -t 0 ] 2>/dev/null; then
     exit 0
 fi
 
-LOCKFILE="/tmp/mempal-checkpoint-pending-$$"
+PROJECT_HASH=$(echo -n "$(pwd)" | sha256sum | cut -c1-12)
+LOCKFILE="/tmp/mempal-checkpoint-${PROJECT_HASH}.lock"
 
-# Dedup: if a countdown is already pending for this session, skip
-if ls /tmp/mempal-checkpoint-pending-* 1>/dev/null 2>&1; then
+# Dedup: if a countdown is already pending for this project workspace, skip
+if [ -f "$LOCKFILE" ]; then
     exit 0
 fi
 

--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -30,13 +30,49 @@ fi
 
 PROJECT_HASH=$(echo -n "$(pwd)" | sha256sum | cut -c1-12)
 LOCKFILE="/tmp/mempal-checkpoint-${PROJECT_HASH}.lock"
+LOCK_TTL_SECS=3600
+LOCK_HELD=0
+PROMPT_EMITTED=0
+
+cleanup_lock() {
+    if [ "$LOCK_HELD" -eq 1 ]; then
+        rmdir "$LOCKFILE" 2>/dev/null || true
+        LOCK_HELD=0
+    fi
+}
+
+lock_is_stale() {
+    local now mtime age
+    mtime=$(stat -c %Y "$LOCKFILE" 2>/dev/null) || return 1
+    now=$(date +%s)
+    age=$((now - mtime))
+    [ "$age" -ge "$LOCK_TTL_SECS" ]
+}
+
+on_exit() {
+    if [ "$PROMPT_EMITTED" -eq 0 ]; then
+        cleanup_lock
+    fi
+}
+
+trap on_exit EXIT INT TERM
 
 # Dedup: mkdir is atomic — if it succeeds, we hold the lock
 if ! mkdir "$LOCKFILE" 2>/dev/null; then
-    exit 0
+    if lock_is_stale; then
+        rmdir "$LOCKFILE" 2>/dev/null || true
+        if ! mkdir "$LOCKFILE" 2>/dev/null; then
+            exit 0
+        fi
+    else
+        exit 0
+    fi
 fi
+LOCK_HELD=1
 
 PROJECT_NAME="${MEMPAL_PROJECT:-$(basename "$(pwd)")}"
+LOCKFILE_SHELL=$(printf '%q' "$LOCKFILE")
+PROJECT_NAME_SHELL=$(printf '%q' "$PROJECT_NAME")
 
 cat <<CHECKPOINT_PROMPT
 
@@ -44,12 +80,15 @@ cat <<CHECKPOINT_PROMPT
 before KV cache expires (1h TTL), run this background countdown:
 
 \`\`\`bash
-sleep 3000 && mempal checkpoint save --project "$PROJECT_NAME" --content "Session checkpoint auto-saved. Summarize current work state here." && rmdir "$LOCKFILE"
+export MEMPAL_CHECKPOINT_LOCKFILE=$LOCKFILE_SHELL
+export MEMPAL_CHECKPOINT_PROJECT=$PROJECT_NAME_SHELL
+bash -lc 'trap '\''rmdir "$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; mempal checkpoint save --project "$MEMPAL_CHECKPOINT_PROJECT" --content "Session checkpoint auto-saved. Summarize current work state here."'
 \`\`\`
 
-Run the sleep command with run_in_background: true. When the notification fires
+Run the countdown command with run_in_background: true. When the notification fires
 (~50 min), check if the user has been active. If no activity, write a checkpoint
 summarizing: (1) what you were working on, (2) key decisions made, (3) next steps.
 The write itself generates tokens that refresh the KV cache.
 
 CHECKPOINT_PROMPT
+PROMPT_EMITTED=1

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,6 +421,50 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         foreground: bool,
     },
+    /// Session checkpoint management (save/restore/cleanup).
+    Checkpoint {
+        #[command(subcommand)]
+        command: CheckpointCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum CheckpointCommands {
+    /// Save a session checkpoint drawer.
+    Save {
+        /// Explicit content. Reads from stdin if omitted.
+        #[arg(long)]
+        content: Option<String>,
+        /// Project ID override.
+        #[arg(long)]
+        project: Option<String>,
+    },
+    /// Retrieve the latest checkpoint content.
+    Latest {
+        /// Project ID filter.
+        #[arg(long)]
+        project: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Soft-delete checkpoints older than a given age.
+    Cleanup {
+        /// Max age to keep (e.g. '24h', '7d'). Default: 24h.
+        #[arg(long, default_value = "24h")]
+        max_age: String,
+        /// Show what would be deleted without doing it.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Extract session context from a Claude Code session JSONL file.
+    Extract {
+        /// Path to the session JSONL file.
+        path: PathBuf,
+        /// Only show the last N assistant messages. Default: 1.
+        #[arg(long, default_value_t = 1)]
+        last: usize,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1049,6 +1093,9 @@ fn run() -> Result<()> {
             room,
             now,
         } => fact_check_command(&db, path.as_deref(), wing.as_deref(), room.as_deref(), now),
+        Commands::Checkpoint { command } => {
+            block_on_result(checkpoint_command(&db, config.as_ref(), command))
+        }
         Commands::CoworkDrain { .. }
         | Commands::CoworkStatus { .. }
         | Commands::CoworkInstallHooks { .. }
@@ -1558,6 +1605,219 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
         dry_run, stats.files, stats.chunks, stats.skipped, stats.dropped_by_gate
     );
     Ok(())
+}
+
+async fn checkpoint_command(
+    db: &Database,
+    config: &Config,
+    command: CheckpointCommands,
+) -> Result<()> {
+    use rusqlite::OptionalExtension;
+
+    match command {
+        CheckpointCommands::Save { content, project } => {
+            let raw_content = match content {
+                Some(c) => c,
+                None => {
+                    let mut input = String::new();
+                    std::io::stdin()
+                        .read_to_string(&mut input)
+                        .context("failed to read checkpoint content from stdin")?;
+                    input
+                }
+            };
+            if raw_content.trim().is_empty() {
+                bail!("checkpoint content must not be empty");
+            }
+            let content = normalize_stdin_content(&raw_content, false)?;
+
+            let wing = "session-checkpoint";
+            let room: Option<&str> = Some("claude");
+            let source_type = SourceType::Manual;
+            let drawer_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+
+            let cwd = env::current_dir().ok();
+            let project_id = resolve_project_id(project.as_deref(), config, cwd.as_deref())
+                .context("failed to resolve checkpoint project id")?;
+
+            let embedder = build_embedder(config).await?;
+            let vectors = embedder
+                .embed(&[content.as_str()])
+                .await
+                .context("failed to embed checkpoint content")?;
+            let vector = vectors
+                .into_iter()
+                .next()
+                .context("embedder returned no vector for checkpoint")?;
+
+            let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+                id: drawer_id.clone(),
+                content,
+                wing: wing.to_string(),
+                room: room.map(ToOwned::to_owned),
+                source_file: Some("session-checkpoint".to_string()),
+                source_type,
+                added_at: iso_timestamp(),
+                chunk_index: Some(0),
+                importance: 4,
+            });
+            let drawer = Drawer {
+                normalize_version: CURRENT_NORMALIZE_VERSION,
+                ..drawer
+            };
+
+            db.insert_drawer_with_project(&drawer, project_id.as_deref())
+                .with_context(|| format!("failed to insert checkpoint drawer {}", drawer.id))?;
+            db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+                .with_context(|| format!("failed to insert vector for checkpoint {drawer_id}"))?;
+
+            println!("checkpoint saved: {drawer_id}");
+        }
+        CheckpointCommands::Latest { project, json } => {
+            let cwd = env::current_dir().ok();
+            let project_id = resolve_project_id(project.as_deref(), config, cwd.as_deref())
+                .context("failed to resolve project id")?;
+
+            let row = db
+                .conn()
+                .query_row(
+                    "SELECT id, content, added_at FROM drawers \
+                     WHERE wing = 'session-checkpoint' AND deleted_at IS NULL \
+                     AND (?1 IS NULL OR project_id = ?1) \
+                     ORDER BY added_at DESC LIMIT 1",
+                    [&project_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                        ))
+                    },
+                )
+                .optional()?;
+
+            if let Some((id, content, added_at)) = row {
+                if json {
+                    let output = serde_json::json!({
+                        "id": id,
+                        "content": content,
+                        "added_at": added_at,
+                    });
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&output)
+                            .context("failed to serialize checkpoint JSON")?
+                    );
+                } else {
+                    println!("{content}");
+                }
+            } else if json {
+                println!("{{}}");
+            } else {
+                eprintln!("no checkpoints found");
+            }
+        }
+        CheckpointCommands::Cleanup { max_age, dry_run } => {
+            let duration_secs =
+                parse_checkpoint_duration(&max_age).context("invalid max-age duration")?;
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before epoch")
+                .as_secs() as i64;
+            let cutoff_secs = now_unix - duration_secs;
+            let cutoff_ts = mempal::cowork::peek::format_rfc3339(
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(cutoff_secs as u64),
+            );
+
+            if dry_run {
+                let count: i64 = db.conn().query_row(
+                    "SELECT COUNT(*) FROM drawers \
+                     WHERE wing = 'session-checkpoint' AND deleted_at IS NULL \
+                     AND added_at < ?1",
+                    [&cutoff_ts],
+                    |row| row.get(0),
+                )?;
+                println!("dry-run: would delete {count} checkpoints older than {cutoff_ts}");
+            } else {
+                let now_ts = iso_timestamp();
+                let affected = db.conn().execute(
+                    "UPDATE drawers SET deleted_at = ?1 \
+                     WHERE wing = 'session-checkpoint' AND deleted_at IS NULL \
+                     AND added_at < ?2",
+                    [&now_ts, &cutoff_ts],
+                )?;
+                println!("deleted {affected} checkpoints older than {cutoff_ts}");
+            }
+        }
+        CheckpointCommands::Extract { path, last } => {
+            let file = std::fs::File::open(&path)
+                .with_context(|| format!("failed to open {}", path.display()))?;
+            let reader = std::io::BufReader::new(file);
+            use std::io::BufRead;
+            let mut assistant_texts: Vec<String> = Vec::new();
+            for line in reader.lines() {
+                let line = line.context("failed to read JSONL line")?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let v: Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if v.get("type").and_then(Value::as_str) != Some("assistant") {
+                    continue;
+                }
+                let msg = v.get("message").unwrap_or(&v);
+                if let Some(content) = msg.get("content") {
+                    let text = extract_text_from_content(content);
+                    if !text.is_empty() {
+                        assistant_texts.push(text);
+                    }
+                }
+            }
+            let start = assistant_texts.len().saturating_sub(last);
+            for text in &assistant_texts[start..] {
+                println!("{text}");
+                println!("---");
+            }
+            if assistant_texts.is_empty() {
+                eprintln!("no assistant messages found in {}", path.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn extract_text_from_content(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => {
+            let mut parts = Vec::new();
+            for item in arr {
+                if item.get("type").and_then(Value::as_str) == Some("text") {
+                    if let Some(t) = item.get("text").and_then(Value::as_str) {
+                        parts.push(t.to_string());
+                    }
+                }
+            }
+            parts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+fn parse_checkpoint_duration(raw: &str) -> Result<i64> {
+    if raw.is_empty() {
+        bail!("empty duration");
+    }
+    let (digits, unit) = raw.split_at(raw.len() - 1);
+    let value = digits.parse::<i64>().context("invalid duration digits")?;
+    let multiplier = match unit {
+        "h" => 3600,
+        "d" => 86400,
+        _ => bail!("unsupported duration unit: {unit} (use 'h' or 'd')"),
+    };
+    Ok(value * multiplier)
 }
 
 async fn ingest_path_with_options<'a, E: Embedder + ?Sized>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1724,7 +1724,7 @@ async fn checkpoint_command(
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("system clock before epoch")
                 .as_secs() as i64;
-            let cutoff_secs = now_unix - duration_secs;
+            let cutoff_secs = (now_unix - duration_secs).max(0);
             let cutoff_ts = mempal::cowork::peek::format_rfc3339(
                 std::time::UNIX_EPOCH + std::time::Duration::from_secs(cutoff_secs as u64),
             );
@@ -1810,12 +1810,16 @@ fn parse_checkpoint_duration(raw: &str) -> Result<i64> {
     if raw.is_empty() {
         bail!("empty duration");
     }
-    let (digits, unit) = raw.split_at(raw.len() - 1);
+    let (idx, unit_char) = raw
+        .char_indices()
+        .last()
+        .context("empty duration after trim")?;
+    let digits = &raw[..idx];
     let value = digits.parse::<i64>().context("invalid duration digits")?;
-    let multiplier = match unit {
-        "h" => 3600,
-        "d" => 86400,
-        _ => bail!("unsupported duration unit: {unit} (use 'h' or 'd')"),
+    let multiplier = match unit_char {
+        'h' => 3600,
+        'd' => 86400,
+        _ => bail!("unsupported duration unit: {unit_char} (use 'h' or 'd')"),
     };
     Ok(value * multiplier)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1807,6 +1807,7 @@ fn extract_text_from_content(content: &Value) -> String {
 }
 
 fn parse_checkpoint_duration(raw: &str) -> Result<i64> {
+    let raw = raw.trim();
     if raw.is_empty() {
         bail!("empty duration");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1634,7 +1634,8 @@ async fn checkpoint_command(
             let wing = "session-checkpoint";
             let room: Option<&str> = Some("claude");
             let source_type = SourceType::Manual;
-            let drawer_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+            let drawer_id = build_checkpoint_drawer_id(wing, room, &content, &source_type)
+                .context("failed to build checkpoint drawer id")?;
 
             let cwd = env::current_dir().ok();
             let project_id = resolve_project_id(project.as_deref(), config, cwd.as_deref())
@@ -1806,6 +1807,20 @@ fn extract_text_from_content(content: &Value) -> String {
     }
 }
 
+fn build_checkpoint_drawer_id(
+    wing: &str,
+    room: Option<&str>,
+    content: &str,
+    source_type: &SourceType,
+) -> Result<String> {
+    let base_id = build_bootstrap_evidence_drawer_id(wing, room, content, source_type);
+    let timestamp_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system clock before epoch")?
+        .as_secs();
+    Ok(format!("{base_id}_{timestamp_secs:x}"))
+}
+
 fn parse_checkpoint_duration(raw: &str) -> Result<i64> {
     let raw = raw.trim();
     if raw.is_empty() {
@@ -1817,12 +1832,15 @@ fn parse_checkpoint_duration(raw: &str) -> Result<i64> {
         .context("empty duration after trim")?;
     let digits = &raw[..idx];
     let value = digits.parse::<i64>().context("invalid duration digits")?;
-    let multiplier = match unit_char {
+    if value <= 0 {
+        bail!("duration must be positive");
+    }
+    let multiplier: i64 = match unit_char {
         'h' => 3600,
         'd' => 86400,
         _ => bail!("unsupported duration unit: {unit_char} (use 'h' or 'd')"),
     };
-    Ok(value * multiplier)
+    value.checked_mul(multiplier).context("duration overflow")
 }
 
 async fn ingest_path_with_options<'a, E: Embedder + ?Sized>(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "459293ce7453d61bf544362ef6bf74c634a267c8"
+commit = "6cefa52b3956535178e384db7d5d88c54ca7ca71"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "6cefa52b3956535178e384db7d5d88c54ca7ca71"
+commit = "23e475cfcfe071ce875b042eef811c0636ed8b4c"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Adds `mempal checkpoint` subcommand group with `save`, `latest`, `cleanup`, and `extract` operations
- `save` creates a session checkpoint drawer (wing='session-checkpoint', importance=4) with full embedding
- `extract` reads assistant messages directly from Claude Code session JSONL as fallback
- Includes hook script (`scripts/hooks/checkpoint-countdown.sh`) that prompts agents to start a background 50-minute countdown when idle, auto-saving session state before KV cache expires (1h TTL for Opus 1M)
- Guards prevent sub-agents, CSA sessions, and non-interactive contexts from triggering checkpoints
- Project-scoped lockfile deduplication prevents stacked countdowns

Closes #105

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 866 tests pass, zero regressions
- [x] `mempal checkpoint --help` shows all 4 sub-commands
- [x] `mempal checkpoint extract` successfully parses real Claude Code session JSONL
- [x] Local CSA review (csa-gemini): 3 findings fixed (panic paths + lockfile collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)