### PR TITLE
feat(llm): add direct api_key config field

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -342,6 +342,9 @@ impl Config {
         if self.llm.model != other.llm.model {
             fields.push("llm.model");
         }
+        if self.llm.api_key != other.llm.api_key {
+            fields.push("llm.api_key");
+        }
         if self.llm.api_key_env != other.llm.api_key_env {
             fields.push("llm.api_key_env");
         }
@@ -362,6 +365,7 @@ impl Config {
         effective.embed.openai_compat = self.embed.openai_compat.clone();
         effective.llm.base_url = self.llm.base_url.clone();
         effective.llm.model = self.llm.model.clone();
+        effective.llm.api_key = self.llm.api_key.clone();
         effective.llm.api_key_env = self.llm.api_key_env.clone();
         effective
     }
@@ -566,6 +570,7 @@ pub struct LlmConfig {
     pub backend: String,
     pub base_url: Option<String>,
     pub model: Option<String>,
+    pub api_key: Option<String>,
     pub api_key_env: Option<String>,
     pub request_timeout_secs: u64,
     pub retry_interval_secs: u64,
@@ -580,6 +585,7 @@ impl Default for LlmConfig {
             backend: DEFAULT_LLM_BACKEND.to_string(),
             base_url: None,
             model: None,
+            api_key: None,
             api_key_env: None,
             request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
             retry_interval_secs: DEFAULT_LLM_RETRY_INTERVAL_SECS,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1,9 +1,9 @@
 #[rustfmt::skip] #[path = "db_fork_ext.rs"] mod db_fork_ext;
 // harness-point: PR0 — re-export MigrationHook trait + hooked migration runner for tests
 pub use db_fork_ext::{
-    apply_fork_ext_migrations, apply_fork_ext_migrations_to, apply_fork_ext_migrations_with_hook,
-    read_fork_ext_version, set_fork_ext_version, MigrationHook, CURRENT_FORK_EXT_VERSION,
-    FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL, FORK_EXT_V3_SCHEMA_SQL,
+    CURRENT_FORK_EXT_VERSION, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
+    FORK_EXT_V3_SCHEMA_SQL, MigrationHook, apply_fork_ext_migrations, apply_fork_ext_migrations_to,
+    apply_fork_ext_migrations_with_hook, read_fork_ext_version, set_fork_ext_version,
 };
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
@@ -12,8 +12,8 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{
-    params, params_from_iter, types::Value as SqlValue, Connection, OpenFlags, OptionalExtension,
-    Row,
+    Connection, OpenFlags, OptionalExtension, Row, params, params_from_iter,
+    types::Value as SqlValue,
 };
 use serde_json::Value;
 use thiserror::Error;

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -105,11 +105,13 @@ impl LlmClient {
             .to_string();
 
         let mut headers = HeaderMap::new();
-        if let Some(api_key) = read_api_key(config.api_key_env.as_deref())? {
+        let resolved_key =
+            resolve_api_key(config.api_key.as_deref(), config.api_key_env.as_deref())?;
+        if let Some(api_key) = resolved_key {
             let header_value =
                 HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|error| {
                     LlmError::MissingConfiguration(format!(
-                        "llm.api_key_env produced an invalid Authorization header: {error}"
+                        "llm api_key produced an invalid Authorization header: {error}"
                     ))
                 })?;
             headers.insert(AUTHORIZATION, header_value);
@@ -212,6 +214,16 @@ impl LlmClient {
             model: response.model,
         })
     }
+}
+
+fn resolve_api_key(
+    direct: Option<&str>,
+    env_name: Option<&str>,
+) -> Result<Option<String>, LlmError> {
+    if let Some(key) = direct.filter(|k| !k.trim().is_empty()) {
+        return Ok(Some(key.to_string()));
+    }
+    read_api_key(env_name)
 }
 
 fn read_api_key(api_key_env: Option<&str>) -> Result<Option<String>, LlmError> {

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "23e475cfcfe071ce875b042eef811c0636ed8b4c"
+commit = "62cdea34d2fff2075800bee4503dcd7d0d9325d3"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add `api_key` field to `LlmConfig` for direct API key in config.toml
- Priority chain: `api_key` (direct value) > `api_key_env` (env var lookup) > no key
- Backward compatible: `api_key_env` still works as fallback

## Motivation
Sessions without `LOCAL_ROUTER_API_KEY` env var would silently send requests without Authorization header, causing 401 errors from the local LLM API.

## Test plan
- [x] `cargo test --test llm_client --test llm_config --test llm_integration --test llm_concurrency` — 26 tests pass
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)