### PR TITLE
fix(db): set busy_timeout=5s for concurrent MCP safety

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -203,6 +203,7 @@ impl Database {
             }
             OpenMode::ReadWrite => Connection::open(path)?,
         };
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
         if mode.allows_write() {
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "NORMAL")?;


### PR DESCRIPTION
## Summary
- Set `busy_timeout=5s` on all SQLite connections (read and write)
- Prevents `SQLITE_BUSY` failures when 20+ concurrent MCP instances write to the same `palace.db`
- WAL mode already handles concurrent reads; this fixes the writer serialization gap

## Context
Without `busy_timeout`, the default is 0ms — concurrent writers get immediate `SQLITE_BUSY` errors instead of queuing. With many CC/Codex sessions each running mempal MCP, this causes silent ingest data loss.

Closes #111

## Test plan
- [x] `cargo test --test db_wal_mode --test db_content_hash_dedup --test fork_ext_schema_axis` — 17 pass
- [x] `cargo test --test queue_claim_confirm --test queue_heartbeat --test queue_stats --test ingest_lock` — 42 pass
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)