### PR TITLE
spec(fork-ext): add P13-P15 specs for MemOS-inspired improvements

### DIFF
--- a/specs/fork-ext/p13-importance-decay.spec.md
+++ b/specs/fork-ext/p13-importance-decay.spec.md
@@ -1,0 +1,204 @@
+spec: task
+name: "P13: Importance decay & retrieval-driven value backpropagation"
+tags: [feature, importance, decay, ranking, schema]
+estimate: 1.5d
+---
+
+## Intent
+
+mempal 的 `importance` 是 ingest 时写死的 1-5 静态标量——经过验证有用的 drawer 和事后证明误导性的 drawer 重要度相同，没有从任务结果向记忆质量反馈的回路。
+
+**核心设计**：模仿 MemOS V7 "Reflect2Evolve" 的价值回传思想，但**完全 LLM-free**——纯 SQLite 算术实现 heuristic 衰减：
+1. **时间衰减**：`effective_importance = base_importance × decay(days_since_last_hit)` — 长时间未命中的记忆自然下沉
+2. **检索提升**：drawer 出现在搜索结果中且 agent 随后在同一 session 写入新内容 → 正向信号（"这条记忆是有用上下文"），轻微提升 effective_importance
+3. **陈旧惩罚**：关联 KG triple 被 invalidate 的 drawer 按系数扣分
+4. **存储**：新列 `last_accessed_at`、`access_count`、`effective_importance`；后者在访问时异步重算写回（查询路径不同步阻塞）
+
+**动机**：issue #115；MemOS V7 reward backpropagation 概念验证。p5-wake-up-importance 提供基础 importance 字段，本 spec 在其之上增加动态层。
+
+## Decisions
+
+- fork-ext `fork_ext_version` `5 → 6` migration：
+  - `drawers` 表加三列（`ALTER TABLE ADD COLUMN`，regular table 支持）：
+    - `last_accessed_at INTEGER` — unix epoch ms，NULL 表示从未命中
+    - `access_count INTEGER NOT NULL DEFAULT 0`
+    - `effective_importance REAL NOT NULL DEFAULT 0.0`
+  - 存量 drawer migration 时 `effective_importance = CAST(importance AS REAL)`（与原始重要度一致）
+  - `CREATE INDEX idx_drawers_eff_importance ON drawers(effective_importance DESC)`
+
+- **衰减公式**（参数均可热重载）：
+  ```
+  let days = (now_ms - last_accessed_at) / 86_400_000.0   // NULL → use ingest age
+  let decay = (1.0 - decay_rate * (1.0 + days).ln()).max(floor)
+  effective_importance = base_importance as f64 * decay + min(access_boost, boost_cap)
+  ```
+  `[importance]` config 子段（default 值）：
+  - `decay_rate: f64 = 0.05`
+  - `floor: f64 = 0.1`（防止有用 drawer 被完全压制）
+  - `boost_per_access: f64 = 0.15`（每次 session ingest boost）
+  - `boost_cap: f64 = 2.0`（防止无限膨胀）
+  - `stale_penalty: f64 = 0.5`（KG invalidated 乘数）
+
+- **命中信号**：`mempal_search` 返回结果时，对每个命中的 drawer 异步执行：
+  ```sql
+  UPDATE drawers SET
+    last_accessed_at = :now_ms,
+    access_count = access_count + 1
+  WHERE id = :id
+  ```
+  此写操作在 tokio task 中批量 commit，不阻塞 search 响应路径
+
+- **Session ingest boost**：MCP server 维护 per-session 命中 drawer id 集合（内存，不持久化）；同一 session 调用 `mempal_ingest` 时对命中集合内的 drawer 触发 `effective_importance` 提升并清空集合
+  - 结构：`MempalMcpContext` 加 `session_hit_drawers: HashSet<DrawerId>`
+  - boost 触发条件：集合非空 AND `mempal_ingest` 在同 session 内被调用
+
+- **陈旧惩罚**：`mempal_fact_check` 发现 `StaleFact` 时，对关联 drawer 执行 `effective_importance *= stale_penalty`（同步，低频）
+
+- **搜索排序**：RRF 融合产生候选集后，以 `effective_importance` 做**后处理二次排序**（不改 RRF 权重公式）
+
+- **Config 热重载**：`decay_rate`、`floor`、`boost_per_access`、`boost_cap`、`stale_penalty` 全部属于 hot-reload 白名单
+
+- **CLI 命令**：
+  - `mempal audit --stale [--threshold 0.5]` — 列出 `effective_importance < threshold` 的 drawer，展示 id / wing / room / effective_importance / access_count / last_accessed_at
+  - `mempal recompute-importance` — 全库批量重算 `effective_importance`（用于参数调整后校正）
+
+- `mempal_search` 结果 DTO 新增 `effective_importance: f64` 字段（只读，让 agent 可观察衰减状态）
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/db/schema.rs` — fork_ext_version 5 → 6 migration
+- `crates/mempal-core/src/config.rs` — 新增 `[importance]` config 子段 `ImportanceConfig`
+- `crates/mempal-core/src/decay.rs` — 新建：衰减/提升算法（纯函数，便于单元测试）
+- `crates/mempal-core/src/lib.rs` — `pub mod decay`
+- `crates/mempal-search/src/hybrid.rs` — 后处理二次排序，异步 access update 分发
+- `crates/mempal-mcp/src/server.rs` — `session_hit_drawers` 维护
+- `crates/mempal-mcp/src/tools.rs` — search DTO 新增 `effective_importance`，ingest 触发 boost
+- `crates/mempal-cli/src/audit.rs` — 新建：`mempal audit --stale` 实现
+- `crates/mempal-cli/src/main.rs` — `audit` 子命令注册，`recompute-importance` 子命令
+- `tests/importance_decay.rs` — 新建集成测试
+
+### Forbidden
+- 不要在 search 关键路径（返回响应之前）同步 `UPDATE drawers`（影响 p99 latency）
+- 不要修改 RRF 权重公式（只改后处理排序步骤）
+- 不要把 `effective_importance` 写入 AAAK signal 字段（内部排序信号，非对外内容信号）
+- 不要允许 `mempal_ingest` 调用方显式设置 `effective_importance`（由系统计算）
+- 不要对异步 access update 使用 `BEGIN IMMEDIATE`（高并发 search 时会产生锁竞争；WAL + deferred transaction）
+- 不要自动删除低 effective_importance 的 drawer（`audit --stale` 仅展示，决策权在用户）
+
+## Out of Scope
+
+- LLM 评估记忆质量（违反 LLM-free 硬约束）
+- 显式任务 episode 打分协议（需 agent-side 扩展，留未来）
+- `effective_importance` 参与 FTS5 内部 BM25 分数（FTS5 分数轴独立，不支持自定义权重注入）
+- Web UI 可视化（违反 CLI-first 约束）
+
+## Completion Criteria
+
+Scenario: fork-ext migration 5 → 6 添加重要度相关列
+  Test:
+    Filter: test_fork_ext_migration_v5_to_v6_adds_importance_columns
+    Level: integration
+    Targets: crates/mempal-core/src/db/schema.rs
+  Given palace.db `fork_ext_version == "5"`
+  When 启动 mempal
+  Then `fork_ext_version == "6"`
+  And `drawers` 表含 `last_accessed_at`、`access_count`、`effective_importance` 三列
+  And 存量 drawer `effective_importance == CAST(importance AS REAL)`，`access_count == 0`，`last_accessed_at IS NULL`
+  And 存在索引 `idx_drawers_eff_importance`
+
+Scenario: 长时间未访问的 drawer effective_importance 低于原始 importance
+  Test:
+    Filter: test_decay_reduces_importance_over_time
+    Level: unit
+    Targets: crates/mempal-core/src/decay.rs
+  Given `base_importance = 3.0`, `decay_rate = 0.05`, `floor = 0.1`, `days_since_last_hit = 30.0`, `access_boost = 0.0`
+  When 调 `compute_effective_importance(...)`
+  Then 返回值 < 3.0
+  And 返回值 >= 0.1（floor 生效，不归零）
+
+Scenario: floor 确保 effective_importance 不低于下限
+  Test:
+    Filter: test_decay_floor_prevents_zero
+    Level: unit
+    Targets: crates/mempal-core/src/decay.rs
+  Given `base_importance = 1.0`, `floor = 0.1`, `days_since_last_hit = 10000.0`（极端天数）
+  When 调 `compute_effective_importance(...)`
+  Then 返回值 == 0.1
+
+Scenario: 累计访问提升 effective_importance
+  Test:
+    Filter: test_access_boost_increases_effective_importance
+    Level: unit
+    Targets: crates/mempal-core/src/decay.rs
+  Given `base_importance = 2.0`, `days = 0.0`, `access_boost = 0.3`（2 次 session boost）
+  When 调 `compute_effective_importance(...)`
+  Then 返回值 > 2.0
+
+Scenario: access boost 不超过 boost_cap
+  Test:
+    Filter: test_access_boost_capped_at_max
+    Level: unit
+    Targets: crates/mempal-core/src/decay.rs
+  Given `boost_per_access = 0.15`, `boost_cap = 2.0`，累计 `access_boost = 3.0`（超过 cap）
+  When 调 `compute_effective_importance(base=3.0, days=0.0, access_boost=3.0, config)`
+  Then 返回值 == 3.0 + 2.0（boost 被 cap 在 2.0）
+
+Scenario: search 命中后异步更新 access 字段
+  Test:
+    Filter: test_search_hit_updates_access_fields_async
+    Level: integration
+    Targets: crates/mempal-search/src/hybrid.rs
+  Given palace.db 含 1 条 drawer，`access_count = 0`，`last_accessed_at IS NULL`
+  When `mempal_search` 返回结果中含该 drawer，等待异步 write flush
+  Then 该 drawer `access_count == 1`
+  And `last_accessed_at IS NOT NULL`
+
+Scenario: session 内 ingest 触发命中 drawer 的 boost
+  Test:
+    Filter: test_session_ingest_boosts_hit_drawers
+    Level: integration
+    Targets: crates/mempal-mcp/src/server.rs, crates/mempal-mcp/src/tools.rs
+  Given MCP session 内 `mempal_search` 返回结果含 drawer-A，记录到 session_hit_drawers
+  When 同 session 内调用 `mempal_ingest` 写入新内容
+  Then drawer-A 的 `effective_importance` 增加了 `boost_per_access`
+  And session_hit_drawers 清空
+
+Scenario: KG triple 被 invalidate 后 effective_importance 下降
+  Test:
+    Filter: test_stale_kg_triple_penalizes_importance
+    Level: integration
+    Targets: crates/mempal-core/src/decay.rs（stale 惩罚调用路径）
+  Given drawer-A `effective_importance = 3.0`，关联 KG triple 状态 = invalidated
+  When 执行 `mempal_fact_check`（触发 StaleFact 检测）
+  Then drawer-A `effective_importance == 1.5`（3.0 × 0.5 stale_penalty）
+
+Scenario: mempal audit --stale 列出低 effective_importance 的 drawer
+  Test:
+    Filter: test_audit_stale_surfaces_decayed_drawers
+    Level: integration
+    Targets: crates/mempal-cli/src/audit.rs
+  Given drawer-A `effective_importance = 0.4`，drawer-B `effective_importance = 3.0`
+  When 执行 `mempal audit --stale --threshold 0.5`
+  Then stdout 含 drawer-A 的 id 和 `effective_importance`
+  And stdout 不含 drawer-B
+
+Scenario: mempal_search 结果 DTO 含 effective_importance 字段
+  Test:
+    Filter: test_search_result_dto_includes_effective_importance
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given palace.db 含有若干 drawer（fork_ext_version >= 6）
+  When 调用 `mempal_search({query: "foo"})`
+  Then 每条结果 JSON 含 `"effective_importance": <number>` 字段
+
+Scenario: config hot-reload 改变 decay_rate 立即生效
+  Test:
+    Filter: test_importance_config_hot_reload_decay_rate
+    Level: integration
+    Targets: crates/mempal-core/src/config.rs, crates/mempal-core/src/decay.rs
+  Given daemon 运行中，`decay_rate = 0.05`
+  When 修改 config 文件将 `decay_rate` 改为 `0.0`（零衰减）
+  And config hot-reload 触发
+  Then 下一次 `compute_effective_importance` 使用新 `decay_rate = 0.0`（decay 项为零）
+  And 无需重启 daemon

--- a/specs/fork-ext/p13-importance-decay.spec.md
+++ b/specs/fork-ext/p13-importance-decay.spec.md
@@ -48,7 +48,7 @@ mempal 的 `importance` 是 ingest 时写死的 1-5 静态标量——经过验�
     access_count = access_count + 1,
     effective_importance = (
       CAST(importance AS REAL)
-      * MAX(EXP(-:decay_rate * (:now_ms - COALESCE(last_accessed_at, added_at)) / 86400000.0), :floor)
+      * MIN(1.0, MAX(EXP(-:decay_rate * MAX(0, :now_ms - COALESCE(last_accessed_at, added_at)) / 86400000.0), :floor))
       + MIN(accumulated_boost, :boost_cap)
     )
   WHERE id = :id
@@ -58,7 +58,7 @@ mempal 的 `importance` 是 ingest 时写死的 1-5 静态标量——经过验�
 - **Session ingest boost**：MCP server 维护 per-session 命中 drawer id 集合（内存，不持久化）；同一 session 调用 `mempal_ingest` 时对命中集合内的 drawer 在单条 SQL UPDATE 内原子增加 `accumulated_boost` 并重算 `effective_importance`，然后清空集合
   - 结构：`MempalMcpContext` 加 `session_hit_drawers: HashSet<DrawerId>`
   - boost 触发条件：集合非空 AND `mempal_ingest` 在同 session 内被调用
-  - **boost 必须原子写入**：`accumulated_boost = accumulated_boost + :boost_per_access` 与 `effective_importance` 重算在同一 SQL UPDATE 语句内执行
+  - **boost 必须原子写入**：`accumulated_boost = accumulated_boost + :boost_per_access` 与 `effective_importance` 重算在同一 SQL UPDATE 语句内执行；注意 SQLite SET 子句使用 pre-update 值，因此 `effective_importance` 公式中必须显式使用 `(accumulated_boost + :boost_per_access)` 而非依赖同语句中已更新的 `accumulated_boost`
 
 - **陈旧惩罚**：`mempal_fact_check` 发现 `StaleFact` 时，对关联 drawer 执行 `effective_importance *= stale_penalty`（同步，低频）
 

--- a/specs/fork-ext/p13-importance-decay.spec.md
+++ b/specs/fork-ext/p13-importance-decay.spec.md
@@ -19,38 +19,46 @@ mempal 的 `importance` 是 ingest 时写死的 1-5 静态标量——经过验�
 ## Decisions
 
 - fork-ext `fork_ext_version` `5 → 6` migration：
-  - `drawers` 表加三列（`ALTER TABLE ADD COLUMN`，regular table 支持）：
-    - `last_accessed_at INTEGER` — unix epoch ms，NULL 表示从未命中
+  - `drawers` 表加四列（`ALTER TABLE ADD COLUMN`，regular table 支持）：
+    - `last_accessed_at INTEGER` — unix epoch ms，NULL 表示从未命中；**NULL → 使用 `added_at`（drawer 创建时间戳）作为 fallback**
     - `access_count INTEGER NOT NULL DEFAULT 0`
+    - `accumulated_boost REAL DEFAULT 0.0` — 累计 session ingest boost，持久化存储
     - `effective_importance REAL NOT NULL DEFAULT 0.0`
   - 存量 drawer migration 时 `effective_importance = CAST(importance AS REAL)`（与原始重要度一致）
   - `CREATE INDEX idx_drawers_eff_importance ON drawers(effective_importance DESC)`
 
 - **衰减公式**（参数均可热重载）：
   ```
-  let days = (now_ms - last_accessed_at) / 86_400_000.0   // NULL → use ingest age
-  let decay = (1.0 - decay_rate * (1.0 + days).ln()).max(floor)
-  effective_importance = base_importance as f64 * decay + min(access_boost, boost_cap)
+  let days = (now_ms - last_accessed_at.unwrap_or(added_at)) / 86_400_000.0
+  //         NULL fallback: use added_at (drawer creation timestamp)
+  let decay = (-decay_rate * days).exp().max(floor)
+  effective_importance = base_importance as f64 * decay + accumulated_boost.min(boost_cap)
   ```
   `[importance]` config 子段（default 值）：
-  - `decay_rate: f64 = 0.05`
+  - `decay_rate: f64 = 0.01`（半衰期约 69 天；旧对数衰减 0.05 约需 60 年减半）
   - `floor: f64 = 0.1`（防止有用 drawer 被完全压制）
   - `boost_per_access: f64 = 0.15`（每次 session ingest boost）
   - `boost_cap: f64 = 2.0`（防止无限膨胀）
   - `stale_penalty: f64 = 0.5`（KG invalidated 乘数）
 
-- **命中信号**：`mempal_search` 返回结果时，对每个命中的 drawer 异步执行：
+- **命中信号**：`mempal_search` 返回结果时，对每个命中的 drawer 异步执行单条 SQL UPDATE（**禁止先 SELECT 再 UPDATE 的 read-modify-write，整个计算和写回必须在一条 SQL UPDATE 语句内完成**）：
   ```sql
   UPDATE drawers SET
     last_accessed_at = :now_ms,
-    access_count = access_count + 1
+    access_count = access_count + 1,
+    effective_importance = (
+      CAST(importance AS REAL)
+      * MAX(EXP(-:decay_rate * (:now_ms - COALESCE(last_accessed_at, added_at)) / 86400000.0), :floor)
+      + MIN(accumulated_boost, :boost_cap)
+    )
   WHERE id = :id
   ```
   此写操作在 tokio task 中批量 commit，不阻塞 search 响应路径
 
-- **Session ingest boost**：MCP server 维护 per-session 命中 drawer id 集合（内存，不持久化）；同一 session 调用 `mempal_ingest` 时对命中集合内的 drawer 触发 `effective_importance` 提升并清空集合
+- **Session ingest boost**：MCP server 维护 per-session 命中 drawer id 集合（内存，不持久化）；同一 session 调用 `mempal_ingest` 时对命中集合内的 drawer 在单条 SQL UPDATE 内原子增加 `accumulated_boost` 并重算 `effective_importance`，然后清空集合
   - 结构：`MempalMcpContext` 加 `session_hit_drawers: HashSet<DrawerId>`
   - boost 触发条件：集合非空 AND `mempal_ingest` 在同 session 内被调用
+  - **boost 必须原子写入**：`accumulated_boost = accumulated_boost + :boost_per_access` 与 `effective_importance` 重算在同一 SQL UPDATE 语句内执行
 
 - **陈旧惩罚**：`mempal_fact_check` 发现 `StaleFact` 时，对关联 drawer 执行 `effective_importance *= stale_penalty`（同步，低频）
 

--- a/specs/fork-ext/p13-pattern-induction.spec.md
+++ b/specs/fork-ext/p13-pattern-induction.spec.md
@@ -23,16 +23,20 @@ mempal 的语义去重（p5-semantic-dedup）在新内容与已有 drawer 相似
   - 新建 `patterns` 表：
     ```sql
     CREATE TABLE IF NOT EXISTS patterns (
-        pattern_id    TEXT PRIMARY KEY,     -- UUID v4
-        signature     BLOB NOT NULL,        -- centroid embedding (same dim as drawer_vectors)
-        exemplar_ids  TEXT NOT NULL,        -- JSON array of drawer_id strings
-        session_ids   TEXT NOT NULL,        -- JSON array of session_id strings (dedup)
-        session_count INTEGER NOT NULL DEFAULT 0,
-        topic_tags    TEXT,                 -- JSON array of top-N keywords (overlap heuristic)
-        status        TEXT NOT NULL DEFAULT 'candidate', -- candidate | active | retired
-        first_seen_at INTEGER NOT NULL,     -- unix epoch ms
-        updated_at    INTEGER NOT NULL,
-        project_id    TEXT                  -- optional, links to p10-project-vector-isolation
+        pattern_id     TEXT PRIMARY KEY,     -- UUID v4
+        signature      BLOB NOT NULL,        -- centroid embedding (same dim as drawer_vectors)
+        exemplar_ids   TEXT NOT NULL,        -- JSON array of drawer_id strings
+        exemplar_count INTEGER NOT NULL DEFAULT 0, -- used as divisor in incremental centroid mean
+        session_ids    TEXT NOT NULL,        -- JSON array of session_id strings (dedup)
+        session_count  INTEGER NOT NULL DEFAULT 0,
+        topic_tags     TEXT,                 -- JSON array of top-N keywords (overlap heuristic)
+        model_id       TEXT,                 -- embedder model that produced signature; patterns with
+                                             -- mismatched model_id are excluded from matching until
+                                             -- re-computed via `mempal reindex`
+        status         TEXT NOT NULL DEFAULT 'candidate', -- candidate | active | retired
+        first_seen_at  INTEGER NOT NULL,     -- unix epoch ms
+        updated_at     INTEGER NOT NULL,
+        project_id     TEXT                  -- optional, links to p10-project-vector-isolation
     );
     CREATE INDEX IF NOT EXISTS idx_patterns_status ON patterns(status);
     CREATE INDEX IF NOT EXISTS idx_patterns_project ON patterns(project_id);
@@ -42,14 +46,15 @@ mempal 的语义去重（p5-semantic-dedup）在新内容与已有 drawer 相似
   - 去重警告触发（cosine ≥ `similarity_threshold`）时，额外检查命中的已有 drawer 的 `session_id`
   - 如果已有 drawer 集中，来自 ≥ `min_sessions` 个**不同** session 的相似 drawer 数量 ≥ `min_exemplars`，则满足 pattern candidate 条件
   - 创建 pattern：
-    - `signature` = exemplar embeddings 的向量质心（逐元素算术均值）
+    - `signature` = exemplar embeddings 的向量质心（逐元素算术均值，`exemplar_count` 初始化为 exemplar 数量）
+    - `model_id` = 当前 embedder 的 model identifier（`OpenAiCompatibleEmbedder` 的 model 字段或 `model2vec` 常量）；**model_id 不匹配当前 embedder 的 pattern 在搜索时跳过，直到 `mempal reindex` 重计算质心**
     - `topic_tags` = exemplar drawers 中 TF-IDF top-5 词（基于 FTS5 已有词频，不新增依赖）
     - `exemplar_ids` = 满足条件的 drawer id 列表
     - `session_ids` = 对应 session id 去重列表
 
 - **Pattern 生命周期**：
   - `candidate`（初始）→ `active`（当 `session_count >= promote_threshold`，默认 5）→ `retired`（手动或 `session_count` 无新增超过 `retire_after_days`）
-  - 每次新的相似 ingest 命中已有 pattern 时：更新 `session_ids`（追加，去重）、更新质心（滑动平均）、检查升级条件
+  - 每次新的相似 ingest 命中已有 pattern 时：更新 `session_ids`（追加，去重）、更新质心（**增量均值**：`new_centroid = (old_centroid * (exemplar_count - 1) + new_embedding) / exemplar_count`，`exemplar_count` 列作为除数，禁用简单 `(old+new)/2` 均值）、检查升级条件
 
 - **Config** `[patterns]` 子段（可热重载）：
   - `enabled: bool = true`

--- a/specs/fork-ext/p13-pattern-induction.spec.md
+++ b/specs/fork-ext/p13-pattern-induction.spec.md
@@ -1,0 +1,222 @@
+spec: task
+name: "P13: Cross-session pattern induction from recurring semantic similarity"
+tags: [feature, patterns, dedup, knowledge, schema, mcp]
+estimate: 2d
+---
+
+## Intent
+
+mempal 的语义去重（p5-semantic-dedup）在新内容与已有 drawer 相似时只发出警告。重复出现在多个 session 中的模式被当作噪声处理——但反复出现本身就是信号：**多个 session 独立地产生了相似记忆，说明这是一个值得关注的固定模式**。
+
+**核心设计**：模仿 MemOS V7 "L2 Policy induction"，但**完全 LLM-free**——以向量质心 + 关键词重叠作为"归纳"机制，agent 自己完成从 exemplar 到规则的认知工作：
+1. **Pattern detection**：扩展语义去重；当跨 N ≥ 3 个不同 session 的 drawer 余弦相似度 ≥ threshold，将其标记为"pattern candidate"
+2. **Pattern storage**：新 `patterns` 表，记录 `signature`（topic/tag 向量质心）、exemplar 列表、session 计数、生命周期状态
+3. **Pattern surfacing**：`mempal_search` 对命中 active pattern 的 exemplar 集群给予 score boost；`mempal_context` 包含 "recurring themes" 段
+4. **CLI**：`mempal patterns list/show/retire` 手动管理生命周期
+5. **MCP**：patterns 注入 `mempal_context` 的 T1/dao_tian 层（按 p14-tiered-retrieval 的分层设计）
+
+**动机**：issue #116；MemOS V7 L2 policy induction。p5-semantic-dedup 是直接前驱（复用相似度计算路径）。
+
+## Decisions
+
+- fork-ext `fork_ext_version` `6 → 7` migration：
+  - 新建 `patterns` 表：
+    ```sql
+    CREATE TABLE IF NOT EXISTS patterns (
+        pattern_id    TEXT PRIMARY KEY,     -- UUID v4
+        signature     BLOB NOT NULL,        -- centroid embedding (same dim as drawer_vectors)
+        exemplar_ids  TEXT NOT NULL,        -- JSON array of drawer_id strings
+        session_ids   TEXT NOT NULL,        -- JSON array of session_id strings (dedup)
+        session_count INTEGER NOT NULL DEFAULT 0,
+        topic_tags    TEXT,                 -- JSON array of top-N keywords (overlap heuristic)
+        status        TEXT NOT NULL DEFAULT 'candidate', -- candidate | active | retired
+        first_seen_at INTEGER NOT NULL,     -- unix epoch ms
+        updated_at    INTEGER NOT NULL,
+        project_id    TEXT                  -- optional, links to p10-project-vector-isolation
+    );
+    CREATE INDEX IF NOT EXISTS idx_patterns_status ON patterns(status);
+    CREATE INDEX IF NOT EXISTS idx_patterns_project ON patterns(project_id);
+    ```
+
+- **Pattern detection** — 扩展现有 dedup 路径（`mempal-ingest` 中的语义去重检查）：
+  - 去重警告触发（cosine ≥ `similarity_threshold`）时，额外检查命中的已有 drawer 的 `session_id`
+  - 如果已有 drawer 集中，来自 ≥ `min_sessions` 个**不同** session 的相似 drawer 数量 ≥ `min_exemplars`，则满足 pattern candidate 条件
+  - 创建 pattern：
+    - `signature` = exemplar embeddings 的向量质心（逐元素算术均值）
+    - `topic_tags` = exemplar drawers 中 TF-IDF top-5 词（基于 FTS5 已有词频，不新增依赖）
+    - `exemplar_ids` = 满足条件的 drawer id 列表
+    - `session_ids` = 对应 session id 去重列表
+
+- **Pattern 生命周期**：
+  - `candidate`（初始）→ `active`（当 `session_count >= promote_threshold`，默认 5）→ `retired`（手动或 `session_count` 无新增超过 `retire_after_days`）
+  - 每次新的相似 ingest 命中已有 pattern 时：更新 `session_ids`（追加，去重）、更新质心（滑动平均）、检查升级条件
+
+- **Config** `[patterns]` 子段（可热重载）：
+  - `enabled: bool = true`
+  - `similarity_threshold: f64 = 0.82`（与 p5-semantic-dedup 的阈值分开，允许独立调参）
+  - `min_sessions: usize = 3`（触发 candidate 所需不同 session 数）
+  - `min_exemplars: usize = 3`
+  - `promote_threshold: usize = 5`（升为 active 所需 session_count）
+  - `retire_after_days: u64 = 90`（无新增超过此天数自动 retire）
+
+- **Pattern surfacing in `mempal_search`**：
+  - 为每个 active pattern，计算 query embedding 与 `signature`（质心）的余弦相似度
+  - 若相似度 ≥ `surfacing_threshold`（默认 0.75），pattern 匹配的 exemplar drawers 在 RRF 后处理阶段获得 `pattern_boost`（默认 +0.2，叠加在 effective_importance 上）
+  - 搜索结果 DTO 新增可选字段 `matched_pattern_id: Option<String>`
+
+- **`mempal_context` 集成**：
+  - 响应新增 `recurring_themes: Vec<PatternSummary>` 段
+  - `PatternSummary` = `{ pattern_id, topic_tags, session_count, exemplar_preview }`（截取第一条 exemplar 的 preview）
+  - 只包含 `status = active` 且 `project_id` 匹配当前请求的 pattern（或 NULL）
+
+- **Session ID 来源**：
+  - 从 drawer 的 `source_file` 中提取（按现有 session_id 字段）
+  - 若 drawer 无 session_id，用 `ingest_batch_id`（一次 ingest CLI 调用的 UUID）作为代理 session_id
+
+- **CLI 命令**：
+  - `mempal patterns list [--status candidate|active|retired] [--project <id>]` — 表格输出 pattern_id / topic_tags / session_count / status
+  - `mempal patterns show <pattern_id>` — 详情：exemplar drawer 摘要列表 + signature 维度
+  - `mempal patterns retire <pattern_id>` — 手动 retire
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/db/schema.rs` — fork_ext_version 6 → 7，创建 `patterns` 表
+- `crates/mempal-core/src/config.rs` — 新增 `[patterns]` config 子段 `PatternsConfig`
+- `crates/mempal-core/src/patterns.rs` — 新建：pattern CRUD、质心计算、lifecycle 逻辑
+- `crates/mempal-core/src/lib.rs` — `pub mod patterns`
+- `crates/mempal-ingest/src/dedup.rs` (或等价) — 扩展 dedup 检查，触发 pattern candidate 创建
+- `crates/mempal-search/src/hybrid.rs` — active pattern 匹配 + exemplar boost
+- `crates/mempal-mcp/src/tools.rs` — `mempal_context` 新增 `recurring_themes`；`mempal_search` DTO 新增 `matched_pattern_id`
+- `crates/mempal-cli/src/patterns.rs` — 新建：`mempal patterns` 子命令实现
+- `crates/mempal-cli/src/main.rs` — `patterns` 子命令注册
+- `tests/pattern_induction.rs` — 新建集成测试
+
+### Forbidden
+- 不要用 LLM 生成 pattern 描述或 topic_tags（违反 LLM-free 约束；topic_tags 来自 FTS5 词频）
+- 不要在 ingest 关键路径上同步计算质心（embedding 维度可能达 4096d，批量算术需异步）
+- 不要把 `patterns` 表的 `signature` 列声明为 `vec0` virtual table（质心是元数据，不做 ANN 检索）
+- 不要自动生成"规则文本"或"policy 语句"（agent 负责认知工作；mempal 只存 exemplars + tags）
+- 不要让 pattern 检测阻塞 ingest 返回（失败时仅 warn，不 fail ingest）
+- 不要在 `patterns` 表中存储 embedding 维度以外的 BLOB（`topic_tags` 用 JSON TEXT，不用 BLOB）
+
+## Out of Scope
+
+- 自动文本生成 policy/rule（需要 LLM）
+- Pattern 的自动 skill 提升（见 p15-skill-crystallization）
+- Pattern 跨 project 合并（不同 project 的 pattern 相互独立）
+- Pattern 版本化历史（lifecycle 状态变更不记录 changelog）
+- Web UI（违反 CLI-first 约束）
+
+## Completion Criteria
+
+Scenario: fork-ext migration 6 → 7 创建 patterns 表
+  Test:
+    Filter: test_fork_ext_migration_v6_to_v7_creates_patterns_table
+    Level: integration
+    Targets: crates/mempal-core/src/db/schema.rs
+  Given palace.db `fork_ext_version == "6"`
+  When 启动 mempal
+  Then `fork_ext_version == "7"`
+  And sqlite_master 中存在 table `patterns`，含 `pattern_id`, `signature`, `exemplar_ids`, `session_ids`, `session_count`, `status` 列
+  And 存在索引 `idx_patterns_status`
+
+Scenario: 来自 3 个不同 session 的相似 drawer 触发 pattern candidate 创建
+  Test:
+    Filter: test_pattern_candidate_created_from_three_sessions
+    Level: integration
+    Targets: crates/mempal-ingest/src/dedup.rs, crates/mempal-core/src/patterns.rs
+  Given 3 条已有 drawer，来自 3 个不同 session_id，两两余弦相似度 >= 0.82
+  When ingest 第 4 条与上述 3 条相似的 drawer（第 4 个不同 session）
+  Then `patterns` 表新增 1 条 `status = "candidate"` 的记录
+  And `session_count >= 3`
+  And `exemplar_ids` JSON 数组长度 >= 3
+  And `signature` blob 非空（质心已计算）
+
+Scenario: 来自同一 session 的多条相似 drawer 不触发 pattern
+  Test:
+    Filter: test_same_session_drawers_dont_create_pattern
+    Level: integration
+    Targets: crates/mempal-ingest/src/dedup.rs
+  Given 3 条相似 drawer，全部来自同一 session_id
+  When ingest 第 4 条（同 session）
+  Then `patterns` 表**不**新增记录（需要跨 session，非同 session 重复）
+
+Scenario: session_count 达到 promote_threshold 后 pattern 升为 active
+  Test:
+    Filter: test_pattern_promotes_to_active_at_threshold
+    Level: integration
+    Targets: crates/mempal-core/src/patterns.rs
+  Given `promote_threshold = 5`，已有 candidate pattern，session_count = 4
+  When ingest 1 条新 session 的相似 drawer（session_count → 5）
+  Then 该 pattern `status == "active"`
+
+Scenario: active pattern 的 exemplar 在搜索中获得 boost
+  Test:
+    Filter: test_active_pattern_boosts_exemplar_results
+    Level: integration
+    Targets: crates/mempal-search/src/hybrid.rs
+  Given 1 个 `status = "active"` pattern，query embedding 与其 signature 余弦相似度 >= 0.75
+  When 调用 `mempal_search({query: "..."})`
+  Then pattern 关联的 exemplar drawer 在结果中 `matched_pattern_id` 字段非 NULL
+  And 该 drawer 排名高于相同 base effective_importance 但无 pattern 匹配的 drawer
+
+Scenario: mempal_context 包含 active patterns 的 recurring_themes
+  Test:
+    Filter: test_context_includes_recurring_themes
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given 2 个 `status = "active"` pattern（含当前 project_id 或 NULL）
+  When 调用 `mempal_context`
+  Then 响应含 `recurring_themes` 数组，长度 == 2
+  And 每条含 `pattern_id`、`topic_tags`、`session_count`
+
+Scenario: candidate pattern 不出现在 mempal_context
+  Test:
+    Filter: test_context_excludes_candidate_patterns
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given 仅有 `status = "candidate"` pattern
+  When 调用 `mempal_context`
+  Then 响应 `recurring_themes` 为空数组
+
+Scenario: mempal patterns list 输出 active 状态的 pattern
+  Test:
+    Filter: test_patterns_list_cli_shows_active
+    Level: integration
+    Targets: crates/mempal-cli/src/patterns.rs
+  Given 1 个 active pattern，1 个 candidate pattern
+  When 执行 `mempal patterns list --status active`
+  Then stdout 含 active pattern 的 pattern_id 和 topic_tags
+  And 不含 candidate pattern
+
+Scenario: mempal patterns retire 手动 retire pattern
+  Test:
+    Filter: test_patterns_retire_cli
+    Level: integration
+    Targets: crates/mempal-cli/src/patterns.rs
+  Given 1 个 `status = "active"` pattern
+  When 执行 `mempal patterns retire <pattern_id>`
+  Then 该 pattern `status == "retired"`
+  And 后续 `mempal_search` 不再对其 exemplar 施加 boost
+
+Scenario: patterns disabled 时 ingest 不进行 pattern 检查
+  Test:
+    Filter: test_patterns_disabled_skips_detection
+    Level: integration
+    Targets: crates/mempal-ingest/src/dedup.rs
+  Given config `[patterns] enabled = false`
+  When ingest 若干高相似 drawer
+  Then `patterns` 表始终为空
+  And ingest 正常完成（无 error）
+
+Scenario: pattern 检测失败不阻塞 ingest
+  Test:
+    Filter: test_pattern_detection_failure_does_not_fail_ingest
+    Level: integration
+    Targets: crates/mempal-ingest/src/dedup.rs
+  Given 模拟 pattern 质心计算 panic（如 embedding 维度为 0）
+  When ingest 触发 pattern detection 路径
+  Then ingest 成功返回（drawer 被写入）
+  And 日志含 warn 级别的 pattern detection 错误
+  And `patterns` 表无新增记录

--- a/specs/fork-ext/p14-decision-repair.spec.md
+++ b/specs/fork-ext/p14-decision-repair.spec.md
@@ -1,0 +1,235 @@
+spec: task
+name: "P14: Decision repair via anti-pattern detection"
+tags: [feature, repair, anti-patterns, fact-check, schema, mcp]
+estimate: 2d
+---
+
+## Intent
+
+mempal 的 `mempal_fact_check` 检测存储知识中的矛盾（SimilarNameConflict / RelationContradiction / StaleFact），但不检测**行为反模式**——agent 反复犯同一错误的情况。每次失败都被当作独立事件入库，失败集群对未来 session 没有预警作用。
+
+**核心设计**：模仿 MemOS V7 "Decision Repair" 的"不阻塞当前步骤、修复下一步"哲学，扩展 `mempal_fact_check` 引入新检测类型 `RepeatedFailurePattern`：
+1. **检测**：ingest 时检查内容中的 failure 关键词；在同 wing/room 集群内，若同一 topic 下 ≥ 3 次失败事件出现在 `window_days` 内，标记为 anti-pattern candidate
+2. **证据装配**：收集该 topic 下的失败 drawer + 成功 drawer，产出结构化的 "do/avoid" 对比（不使用 LLM 生成描述——agent 收到证据，自行归纳）
+3. **预警注入**：`mempal_context` 响应新增 `repair_warnings` 段，在 T1 层最高优先级注入，确保 agent 在 session 开始时就看到
+4. **存储**：新 `failure_events` 表记录失败事件，`anti_patterns` 标签打在相关 drawer 上
+
+**动机**：issue #118；MemOS V7 Decision Repair 机制。`p9-fact-checker` 是扩展基础（复用其检测触发逻辑）；`p14-tiered-retrieval` 的 repair trigger 是主要消费场景。
+
+## Decisions
+
+- fork-ext `fork_ext_version` `7 → 8` migration：
+  - 新建 `failure_events` 表：
+    ```sql
+    CREATE TABLE IF NOT EXISTS failure_events (
+        event_id      TEXT PRIMARY KEY,       -- UUID v4
+        drawer_id     TEXT NOT NULL,          -- 关联失败 drawer
+        wing          TEXT NOT NULL,
+        room          TEXT,
+        topic_sig     TEXT NOT NULL,          -- 归一化 topic 签名（FTS5 top keywords hash）
+        failure_type  TEXT NOT NULL,          -- error | reverted | rolled_back | failed | custom
+        detected_at   INTEGER NOT NULL,       -- unix epoch ms
+        project_id    TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_failure_events_topic ON failure_events(topic_sig, detected_at);
+    CREATE INDEX IF NOT EXISTS idx_failure_events_wing  ON failure_events(wing, room, detected_at);
+    ```
+  - `drawers` 表新增可选 tag `anti_pattern=true` 通过现有 metadata / flags 机制标记（不加新列）
+
+- **Failure 关键词检测**（ingest pipeline 新增步骤，在 dedup 之后）：
+  - 内置关键词列表（可在 config 扩展）：`["error", "failed", "failure", "reverted", "rolled back", "exception", "panic", "aborted", "wrong", "mistake", "incorrect"]`
+  - 检测策略：case-insensitive 全词匹配（`\bword\b` 正则），命中任意关键词即视为 failure 事件
+  - 写入 `failure_events` 表（异步，不阻塞 ingest 关键路径）
+
+- **Topic 签名**（`topic_sig`）：
+  - 取 drawer content 经 FTS5 已有词频计算的 top-5 TF-IDF 词（与 p13-pattern-induction 的 `topic_tags` 同一机制，可共用实现）
+  - `topic_sig = sha256(sorted_top5_words)[:16]`（固定长度字符串，便于精确匹配）
+
+- **RepeatedFailurePattern 检测** — 触发时机：
+  1. 每次 `mempal_ingest` 写入 failure 事件后
+  2. 每次 `mempal_fact_check` 调用时（全量扫描）
+  - 检测逻辑：
+    ```sql
+    SELECT topic_sig, COUNT(*) as cnt, MIN(detected_at) as first, MAX(detected_at) as last
+    FROM failure_events
+    WHERE detected_at >= :window_start  -- now - window_days * 86400000
+      AND (project_id = :project_id OR project_id IS NULL)
+    GROUP BY topic_sig
+    HAVING cnt >= :min_failures          -- 默认 3
+    ```
+  - 命中的 `topic_sig` 组成 anti-pattern 候选集
+
+- **证据装配**（`RepairPackage`）：
+  - 失败方：`WHERE drawer_id IN (SELECT drawer_id FROM failure_events WHERE topic_sig = :sig AND detected_at >= :window_start) LIMIT 5`
+  - 成功方：语义相近（vector cosine >= 0.75）但**不含 failure 关键词**的 drawer，同 wing/room，`LIMIT 5`
+  - `RepairPackage` 结构：
+    ```json
+    {
+      "topic_sig": "...",
+      "failure_count": 4,
+      "window_days": 7,
+      "failure_drawers": [ { "drawer_id": "...", "preview": "..." } ],
+      "success_drawers": [ { "drawer_id": "...", "preview": "..." } ]
+    }
+    ```
+
+- **`mempal_fact_check` 扩展**：
+  - 新增 `check_type: "RepeatedFailurePattern"` 的检测结果
+  - 结果格式：`{ check_type: "RepeatedFailurePattern", repair_packages: [RepairPackage], confidence: "heuristic" }`
+  - 现有三种 check type 不受影响（SimilarNameConflict / RelationContradiction / StaleFact）
+
+- **`mempal_context` `repair_warnings` 注入**：
+  - 若存在未解决的 anti-pattern（最近 `window_days` 内 failure_count >= `alert_threshold`），在 `mempal_context` 响应中注入：
+    ```json
+    "repair_warnings": [
+      {
+        "severity": "warn",
+        "message": "Repeated failure pattern detected in wing={W} room={R}: {topic_preview}",
+        "repair_package_id": "..."
+      }
+    ]
+    ```
+  - `repair trigger` 时（p14-tiered-retrieval）repair_warnings 也注入 T1 层顶部
+
+- **Config** `[repair]` 子段（可热重载）：
+  - `enabled: bool = true`
+  - `failure_keywords: Vec<String> = [...]`（追加扩展，不覆盖内置）
+  - `window_days: u64 = 7`
+  - `min_failures: usize = 3`（触发 RepeatedFailurePattern 的最小次数）
+  - `alert_threshold: usize = 3`（注入 repair_warnings 的阈值，默认等于 min_failures）
+
+- **CLI 命令**：
+  - `mempal repair list [--wing <W>] [--since <days>]` — 列出检测到的反模式，输出 topic_sig / failure_count / wing / preview
+  - `mempal repair show <topic_sig>` — 详情：失败 drawer 列表 + 成功对比 drawer
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/db/schema.rs` — fork_ext_version 7 → 8，创建 `failure_events` 表
+- `crates/mempal-core/src/config.rs` — 新增 `[repair]` config 子段 `RepairConfig`
+- `crates/mempal-core/src/repair.rs` — 新建：failure keyword 检测、topic_sig 计算、RepairPackage 装配
+- `crates/mempal-core/src/lib.rs` — `pub mod repair`
+- `crates/mempal-ingest/src/pipeline.rs` — ingest 后 failure 事件异步写入
+- `crates/mempal-search/src/lib.rs`（或等价）— success drawer 语义检索（复用现有 vector search）
+- `crates/mempal-mcp/src/tools.rs` — `mempal_fact_check` 新增 RepeatedFailurePattern；`mempal_context` 新增 repair_warnings
+- `crates/mempal-cli/src/repair.rs` — 新建：`mempal repair` 子命令实现
+- `crates/mempal-cli/src/main.rs` — `repair` 子命令注册
+- `tests/decision_repair.rs` — 新建集成测试
+
+### Forbidden
+- 不要用 LLM 生成 repair 建议文本（违反 LLM-free 约束；agent 基于 RepairPackage 中的 exemplar drawers 自行归纳）
+- 不要在 ingest 关键路径上同步检测（failure event 写入 + anti-pattern 扫描必须异步）
+- 不要在 `failure_events` 表中存储 drawer 全文内容（只存 drawer_id 引用，内容从 `drawers` 表查）
+- 不要让 failure keyword 匹配大小写敏感（必须 case-insensitive）
+- 不要让 `mempal_fact_check` 在 `[repair] enabled = false` 时运行 RepeatedFailurePattern 检测
+- 不要删改 `mempal_fact_check` 现有三种 check type（向下兼容）
+
+## Out of Scope
+
+- LLM 驱动的根因分析（无 LLM 依赖）
+- 自动 apply repair（repair_warnings 是建议，agent 自主决策；mempal 不自动修改任何 drawer）
+- Failure event 的细粒度 severity 分级（目前只有 binary：failure / success）
+- Anti-pattern 跨 wing 聚合（每个 topic_sig 在 wing 内独立检测）
+- Web UI（违反 CLI-first 约束）
+
+## Completion Criteria
+
+Scenario: fork-ext migration 7 → 8 创建 failure_events 表
+  Test:
+    Filter: test_fork_ext_migration_v7_to_v8_creates_failure_events
+    Level: integration
+    Targets: crates/mempal-core/src/db/schema.rs
+  Given palace.db `fork_ext_version == "7"`
+  When 启动 mempal
+  Then `fork_ext_version == "8"`
+  And sqlite_master 中存在 table `failure_events`，含 `event_id`、`drawer_id`、`topic_sig`、`failure_type`、`detected_at` 列
+  And 存在索引 `idx_failure_events_topic`
+
+Scenario: ingest 含 failure 关键词的 drawer 触发 failure_events 写入
+  Test:
+    Filter: test_ingest_failure_keyword_creates_event
+    Level: integration
+    Targets: crates/mempal-ingest/src/pipeline.rs, crates/mempal-core/src/repair.rs
+  Given palace.db 空
+  When ingest 内容含 "the migration failed with SQLITE_ERROR" 的 drawer（wing=code-memory）
+  And 等待异步 failure event 写入
+  Then `failure_events` 表含 1 条记录，`failure_type = "failed"`，`wing = "code-memory"`
+  And `topic_sig` 非空
+
+Scenario: ingest 不含 failure 关键词的 drawer 不写入 failure_events
+  Test:
+    Filter: test_ingest_no_failure_keyword_skips_event
+    Level: integration
+    Targets: crates/mempal-ingest/src/pipeline.rs
+  Given palace.db 空
+  When ingest 普通内容 drawer（无 failure 关键词）
+  Then `failure_events` 表为空
+
+Scenario: 同 topic_sig 3 次失败后 fact_check 检测到 RepeatedFailurePattern
+  Test:
+    Filter: test_fact_check_detects_repeated_failure_pattern
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs, crates/mempal-core/src/repair.rs
+  Given `min_failures = 3`，`window_days = 7`
+  And failure_events 表含同 `topic_sig` 的 3 条记录，均在 7 天内
+  When 调用 `mempal_fact_check`
+  Then 响应含 `check_type = "RepeatedFailurePattern"` 的检测结果
+  And `repair_packages[0].failure_count == 3`
+  And `repair_packages[0].failure_drawers` 数组长度 == 3
+
+Scenario: RepairPackage 包含失败和成功 drawer 的对比证据
+  Test:
+    Filter: test_repair_package_assembles_evidence
+    Level: integration
+    Targets: crates/mempal-core/src/repair.rs
+  Given 失败 drawer 3 条（同 topic_sig），同 wing 还有 2 条相似但无 failure 关键词的成功 drawer
+  When 装配 RepairPackage
+  Then `failure_drawers` 列表长度 == 3
+  And `success_drawers` 列表长度 >= 1（至少找到 1 条成功对比 drawer）
+
+Scenario: repair_warnings 注入 mempal_context
+  Test:
+    Filter: test_repair_warnings_injected_in_context
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given 存在触发 RepeatedFailurePattern 的 failure_events（>=3 次同 topic）
+  When 调用 `mempal_context`
+  Then 响应含 `repair_warnings` 数组，至少 1 条含 `severity = "warn"`
+  And 警告 message 提及检测到的 wing
+
+Scenario: window_days 外的 failure_events 不触发检测
+  Test:
+    Filter: test_repair_window_excludes_old_events
+    Level: integration
+    Targets: crates/mempal-core/src/repair.rs
+  Given `window_days = 7`，failure_events 表含同 topic_sig 的 3 条记录，均在 10 天前
+  When 调用 `mempal_fact_check`
+  Then 响应**不含** `RepeatedFailurePattern` 检测结果（时间窗外）
+
+Scenario: repair disabled 时 fact_check 不运行 RepeatedFailurePattern
+  Test:
+    Filter: test_repair_disabled_skips_detection
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given config `[repair] enabled = false`
+  When 调用 `mempal_fact_check`
+  Then 响应不含 `RepeatedFailurePattern` 类型（其他 check type 正常运行）
+
+Scenario: mempal repair list 列出反模式
+  Test:
+    Filter: test_repair_list_cli_shows_patterns
+    Level: integration
+    Targets: crates/mempal-cli/src/repair.rs
+  Given 1 个 RepeatedFailurePattern（wing=code-memory，4 次失败）
+  When 执行 `mempal repair list --wing code-memory`
+  Then stdout 含该 topic_sig、`failure_count = 4`、wing 信息
+
+Scenario: ingest 失败检测不阻塞 ingest 成功响应
+  Test:
+    Filter: test_ingest_failure_detection_is_nonblocking
+    Level: integration
+    Targets: crates/mempal-ingest/src/pipeline.rs
+  Given failure event 写入路径模拟慢速（delay 200ms）
+  When ingest 含 failure 关键词的 drawer
+  Then ingest 响应在 200ms 内返回（不等待 failure_events 写入完成）
+  And failure_events 最终写入成功（eventual consistency）

--- a/specs/fork-ext/p14-decision-repair.spec.md
+++ b/specs/fork-ext/p14-decision-repair.spec.md
@@ -43,7 +43,7 @@ mempal 的 `mempal_fact_check` 检测存储知识中的矛盾（SimilarNameConfl
 
 - **Topic 签名**（`topic_sig`）：
   - 取 drawer content 经 FTS5 已有词频计算的 top-5 TF-IDF 词（与 p13-pattern-induction 的 `topic_tags` 同一机制，可共用实现）
-  - `topic_sig = sha256(sorted_top5_words)[:16]`（固定长度字符串，便于精确匹配）
+  - `topic_sig = sha256(sorted_top5_words)[:32]`（固定长度字符串，便于精确匹配；32 字符提供足够的碰撞抵抗性，16 字符在大规模 failure 事件集中碰撞概率不可接受）
 
 - **RepeatedFailurePattern 检测** — 触发时机：
   1. 每次 `mempal_ingest` 写入 failure 事件后

--- a/specs/fork-ext/p14-decision-repair.spec.md
+++ b/specs/fork-ext/p14-decision-repair.spec.md
@@ -43,7 +43,7 @@ mempal 的 `mempal_fact_check` 检测存储知识中的矛盾（SimilarNameConfl
 
 - **Topic 签名**（`topic_sig`）：
   - 取 drawer content 经 FTS5 已有词频计算的 top-5 TF-IDF 词（与 p13-pattern-induction 的 `topic_tags` 同一机制，可共用实现）
-  - `topic_sig = sha256(sorted_top5_words)[:32]`（固定长度字符串，便于精确匹配；32 字符提供足够的碰撞抵抗性，16 字符在大规模 failure 事件集中碰撞概率不可接受）
+  - `topic_sig = sha256(sorted_top5_words.join("|"))[:32]`（使用 `|` 分隔符防止拼接碰撞如 `["a","bc"]` vs `["ab","c"]`；32 hex 字符 = 128-bit 碰撞抵抗，16 字符在大规模 failure 事件集中碰撞概率不可接受）
 
 - **RepeatedFailurePattern 检测** — 触发时机：
   1. 每次 `mempal_ingest` 写入 failure 事件后

--- a/specs/fork-ext/p14-tiered-retrieval.spec.md
+++ b/specs/fork-ext/p14-tiered-retrieval.spec.md
@@ -1,0 +1,222 @@
+spec: task
+name: "P14: Tiered retrieval for mempal_context (T1/T2/T3 assembly with budget allocation)"
+tags: [feature, context, retrieval, mcp, ranking]
+estimate: 1.5d
+---
+
+## Intent
+
+mempal 目前只有一个检索入口 `mempal_search`，所有 drawer 均以同一策略（BM25 + vector + RRF）召回。`mempal_context` 虽已按 dao/shu/qi 分层组装知识，但底层检索依然扁平——dao_tian（决策/规则）和 shu（证据）使用相同的相关度评分，没有反映二者不同的使用场景。
+
+**核心设计**：模仿 MemOS V7 三层检索策略，为 `mempal_context` 引入**分层装配**：
+
+| Tier | mempal 映射 | 内容特征 | 评分策略 |
+|------|------------|---------|---------|
+| T1 | dao_tian（决策/规则/feedback） | 高 importance + type=decision/feedback | importance（或 effective_importance）× recency |
+| T2 | shu（evidence） | query 相关的原始 drawer | hybrid search（BM25 + vector + RRF） |
+| T3 | qi（operational） | 最近 session 上下文、active tunnels、KG 邻居 | pure recency + graph proximity |
+
+三层之间有**可配 token budget 分配**，并支持 `trigger` 参数（session_start / on_demand / repair）在不同使用场景下动态调整各层权重。
+
+**动机**：issue #117；MemOS V7 three-tier retrieval。本 spec 为**纯逻辑增强**，无 schema 迁移；受益于 p13-importance-decay 的 `effective_importance` 字段（若已实现则 T1 使用 effective_importance，否则 fallback 到 importance）。
+
+## Decisions
+
+### 三层评分策略
+
+**T1 — dao_tian 层**：
+- 候选来源：`WHERE drawer.type IN ('decision', 'feedback', 'rule')` 且 `importance >= min_t1_importance`（默认 3）
+- 排序：`score = (effective_importance OR CAST(importance AS REAL)) × recency_weight`
+  - `recency_weight = exp(-λ × days_since_ingest)`，默认 `λ = 0.01`（缓慢衰减，决策记忆保持长期相关）
+- Budget：按 token 估算（字符数 / 4），取前 K 条直到 T1 budget 耗尽
+- Active patterns（p13-pattern-induction 已实现时）也在 T1 中注入 `recurring_themes`
+
+**T2 — shu 层**：
+- 候选来源：现有 `mempal_search` 混合检索（BM25 + vector + RRF）
+- 排序：原 RRF 分数（不改）；若 p13-importance-decay 已实现，以 `effective_importance` 做后处理二次排序
+- Budget：token budget 中最大的一层（默认 50%）
+
+**T3 — qi 层**：
+- 候选来源：
+  1. `WHERE drawer.created_at >= now - recency_window_days`（默认 3 天内）
+  2. KG 邻居：query drawer 的一度 KG triples 对端 entity 关联的 drawer
+  3. Active tunnels：`mempal_tunnels` 中指向当前 wing 的 tunnel target
+- 排序：`created_at DESC`（纯时间序）
+
+### Budget 分配
+
+```toml
+[context.budget]
+total_chars = 8000           # 总 token 预算（字符估算）
+t1_ratio = 0.30              # T1 分配 30%
+t2_ratio = 0.50              # T2 分配 50%
+t3_ratio = 0.20              # T3 分配 20%
+overflow_to_t2 = true        # T1/T3 未用完的预算转入 T2
+```
+
+各层独立截断：先按 ratio 分配 chars，各层取前 K 条不超过分配量；`overflow_to_t2 = true` 时将剩余 budget 追加给 T2。
+
+### Trigger 参数
+
+`mempal_context` 新增可选 `trigger` 字段：
+
+| Trigger | T1 weight | T2 weight | T3 weight | 说明 |
+|---------|-----------|-----------|-----------|------|
+| `session_start`（默认）| 1.0 | 0.8 | 1.2 | 重视近期上下文和决策规则 |
+| `on_demand` | 0.7 | 1.3 | 0.5 | 重视 query 相关性（深度任务中） |
+| `repair` | 1.5 | 0.8 | 0.5 | 重视决策记忆（出错修复场景）|
+
+Tier budget 按 weight 比例动态调整（权重归一化后再乘以 total_chars × tier_ratio）。
+
+### 输出结构变化
+
+`mempal_context` 响应（JSON）结构增加分层标记：
+
+```json
+{
+  "t1_dao_tian": [ { "drawer_id": "...", "content": "...", "type": "decision", ... } ],
+  "t2_shu": [ { "drawer_id": "...", "content": "...", "matched_pattern_id": null, ... } ],
+  "t3_qi": [ { "drawer_id": "...", "content": "...", "source": "recency|kg|tunnel", ... } ],
+  "recurring_themes": [...],   // from p13-pattern-induction if available
+  "system_warnings": [...],
+  "budget_used": { "t1_chars": 2100, "t2_chars": 3800, "t3_chars": 1200, "total": 7100 }
+}
+```
+
+现有消费方兼容：原有 `dao_tian`/`shu`/`qi` 字段**保留**（与 t1/t2/t3 别名共存），避免破坏现有 agent 的 context 解析。
+
+### Config
+
+`[context]` 子段，全部属于热重载白名单：
+- `tiered_retrieval_enabled: bool = true`（false 时退化为现有平铺行为，向下兼容）
+- budget 子段（见上）
+- `min_t1_importance: u8 = 3`
+- `t3_recency_window_days: u64 = 3`
+- `t1_recency_lambda: f64 = 0.01`
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/config.rs` — 新增 `[context]` 子段 `ContextConfig`（含 budget、trigger 权重）
+- `crates/mempal-mcp/src/tools/context.rs`（或等价）— 三层装配逻辑、trigger 参数处理、budget 分配
+- `crates/mempal-search/src/tiered.rs` — 新建：T1/T2/T3 各层检索策略实现
+- `crates/mempal-search/src/hybrid.rs` — T2 调用路径复用现有混合检索
+- `crates/mempal-mcp/src/tools.rs` — `mempal_context` input schema 新增 `trigger` 字段，output schema 新增 t1/t2/t3/budget_used
+- `crates/mempal-cli/src/context.rs`（或等价）— CLI `mempal context` 子命令支持 `--trigger` 参数（若 CLI context 已存在）
+- `tests/tiered_retrieval.rs` — 新建集成测试
+
+### Forbidden
+- 不要改 `mempal_search` 工具的签名（tiered retrieval 仅影响 `mempal_context`；`mempal_search` 保持独立）
+- 不要引入 schema migration（本 spec 为纯逻辑增强，无新表/新列）
+- 不要删除现有 `dao_tian`/`shu`/`qi` 字段（新的 `t1`/`t2`/`t3` 别名并存，避免 breaking change）
+- 不要在 T3 中执行向量 ANN 搜索（T3 是 recency + graph，不是 embedding 相关性）
+- 不要让 trigger 参数影响 T2 的 RRF 融合权重（trigger 只影响 budget 分配比例，不改 RRF）
+- 不要在 `tiered_retrieval_enabled = false` 路径引入新行为（fallback 必须与现有 `mempal_context` 行为完全一致）
+
+## Out of Scope
+
+- 跨 MCP 工具的检索策略统一（`mempal_search` 与 `mempal_context` 各自独立，不合并入口）
+- T1 type 字段自动分类（drawer type 仍由 ingest 时 agent 显式提供，不做自动推断）
+- 自适应 budget 学习（根据历史 session 动态调 ratio；留未来）
+- Web UI（违反 CLI-first 约束）
+- schema 迁移（本 spec 不涉及）
+
+## Completion Criteria
+
+Scenario: session_start trigger 按默认权重分层装配 context
+  Test:
+    Filter: test_tiered_context_session_start_default_weights
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given palace.db 含若干 decision/feedback type drawer（importance >= 3）、普通 drawer、近 3 天 drawer
+  When 调用 `mempal_context({trigger: "session_start"})`
+  Then 响应含 `t1_dao_tian`、`t2_shu`、`t3_qi` 三个非空数组（数据充足时）
+  And `t1_dao_tian` 中每条 drawer 的 `type` 为 `"decision"` 或 `"feedback"` 或 `"rule"`
+  And `budget_used.total_chars` <= `total_chars` 配置值
+
+Scenario: repair trigger 提升 T1 权重，T1 获得更多 budget
+  Test:
+    Filter: test_tiered_context_repair_trigger_boosts_t1
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given 相同 palace.db
+  When 分别调用 `mempal_context({trigger: "session_start"})` 和 `mempal_context({trigger: "repair"})`
+  Then repair 响应的 `budget_used.t1_chars` 大于 session_start 响应的 `budget_used.t1_chars`
+  And repair 响应的 `t1_dao_tian` 数组长度 >= session_start 响应的同数组长度（相同数据集下）
+
+Scenario: on_demand trigger 向 T2 倾斜 budget
+  Test:
+    Filter: test_tiered_context_on_demand_boosts_t2
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given 相同 palace.db
+  When 分别调用 `mempal_context({trigger: "on_demand"})` 和 `mempal_context({trigger: "session_start"})`
+  Then on_demand 响应的 `budget_used.t2_chars` 大于 session_start 响应的 `budget_used.t2_chars`
+
+Scenario: budget 分配不超过 total_chars 上限
+  Test:
+    Filter: test_tiered_context_budget_does_not_exceed_total
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given palace.db 含大量 drawer（各层足以超出 budget）
+  When 调用 `mempal_context({trigger: "session_start"})`
+  Then `budget_used.total_chars <= total_chars`（不溢出）
+  And `budget_used.t1_chars + budget_used.t2_chars + budget_used.t3_chars == budget_used.total_chars`
+
+Scenario: overflow_to_t2=true 时 T1 未用完的 budget 转给 T2
+  Test:
+    Filter: test_tiered_context_overflow_budget_to_t2
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given `overflow_to_t2 = true`，T1 只有 1 条 drawer（远小于 t1 分配 budget）
+  When 调用 `mempal_context`，T2 数据充足
+  Then `budget_used.t2_chars` 超过 `total_chars * t2_ratio`（接收了 T1 溢出）
+
+Scenario: T3 只包含 recency_window_days 内的 drawer
+  Test:
+    Filter: test_tiered_t3_respects_recency_window
+    Level: integration
+    Targets: crates/mempal-search/src/tiered.rs
+  Given drawer-old 在 10 天前创建，drawer-new 在今天创建，均含 query 词
+  When 调用 `mempal_context`（`t3_recency_window_days = 3`）
+  Then `t3_qi` 含 drawer-new
+  And `t3_qi` 不含 drawer-old
+
+Scenario: tiered_retrieval_enabled=false 时退化为现有行为
+  Test:
+    Filter: test_tiered_context_disabled_falls_back
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given config `tiered_retrieval_enabled = false`
+  When 调用 `mempal_context`
+  Then 响应结构与旧有 `mempal_context` 兼容（含 `dao_tian`、`shu`、`qi` 字段）
+  And 响应**不含** `budget_used` 字段
+
+Scenario: 现有 dao_tian/shu/qi 字段在 tiered_retrieval 启用时仍保留
+  Test:
+    Filter: test_tiered_context_preserves_legacy_fields
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools/context.rs
+  Given `tiered_retrieval_enabled = true`
+  When 调用 `mempal_context`
+  Then 响应同时含 `dao_tian`（等于 `t1_dao_tian` 别名）、`shu`（等于 `t2_shu` 别名）、`qi`（等于 `t3_qi` 别名）
+  And 别名数组内容与对应 tier 数组相同
+
+Scenario: mempal_search 不受 tiered_retrieval 影响
+  Test:
+    Filter: test_search_unaffected_by_tiered_context_config
+    Level: integration
+    Targets: crates/mempal-search/src/hybrid.rs
+  Given `tiered_retrieval_enabled = false` 或 `true`
+  When 调用 `mempal_search({query: "foo"})`
+  Then 返回结果格式与 tiered_retrieval 配置无关（search 工具独立）
+
+Scenario: T1 recency_lambda 影响 decision drawer 排序
+  Test:
+    Filter: test_t1_recency_lambda_affects_ordering
+    Level: unit
+    Targets: crates/mempal-search/src/tiered.rs
+  Given 2 条 decision drawer：drawer-old（30 天前 ingest，importance=5）和 drawer-new（今天 ingest，importance=3）
+  And `t1_recency_lambda = 0.1`（相对大，近期偏好明显）
+  When 计算 T1 scores
+  Then drawer-new 的 score > drawer-old 的 score（recency 压过 importance 差距）

--- a/specs/fork-ext/p14-tiered-retrieval.spec.md
+++ b/specs/fork-ext/p14-tiered-retrieval.spec.md
@@ -28,7 +28,7 @@ mempal 目前只有一个检索入口 `mempal_search`，所有 drawer 均以同�
 - 候选来源：`WHERE drawer.type IN ('decision', 'feedback', 'rule')` 且 `importance >= min_t1_importance`（默认 3）
 - 排序：`score = (effective_importance OR CAST(importance AS REAL)) × recency_weight`
   - `recency_weight = exp(-λ × days_since_ingest)`，默认 `λ = 0.01`（缓慢衰减，决策记忆保持长期相关）
-- Budget：按 token 估算（字符数 / 4），取前 K 条直到 T1 budget 耗尽
+- Budget：按 token 估算，取前 K 条直到 T1 budget 耗尽；**Token 估算 MUST 使用 `crates/mempal-ingest` 中共享的 `estimate_tokens()` 函数（已处理 CJK 多字节字符），禁止使用 `chars / 4` 原始启发式**
 - Active patterns（p13-pattern-induction 已实现时）也在 T1 中注入 `recurring_themes`
 
 **T2 — shu 层**：
@@ -47,14 +47,14 @@ mempal 目前只有一个检索入口 `mempal_search`，所有 drawer 均以同�
 
 ```toml
 [context.budget]
-total_chars = 8000           # 总 token 预算（字符估算）
+total_tokens = 8000          # 总 token 预算（通过 estimate_tokens() 估算，非 chars/4）
 t1_ratio = 0.30              # T1 分配 30%
 t2_ratio = 0.50              # T2 分配 50%
 t3_ratio = 0.20              # T3 分配 20%
 overflow_to_t2 = true        # T1/T3 未用完的预算转入 T2
 ```
 
-各层独立截断：先按 ratio 分配 chars，各层取前 K 条不超过分配量；`overflow_to_t2 = true` 时将剩余 budget 追加给 T2。
+各层独立截断：先按 ratio 分配 token budget（使用 `estimate_tokens()` 计算，**禁止 `chars / 4`**），各层取前 K 条不超过分配量；`overflow_to_t2 = true` 时将剩余 budget 追加给 T2。
 
 ### Trigger 参数
 
@@ -66,7 +66,7 @@ overflow_to_t2 = true        # T1/T3 未用完的预算转入 T2
 | `on_demand` | 0.7 | 1.3 | 0.5 | 重视 query 相关性（深度任务中） |
 | `repair` | 1.5 | 0.8 | 0.5 | 重视决策记忆（出错修复场景）|
 
-Tier budget 按 weight 比例动态调整（权重归一化后再乘以 total_chars × tier_ratio）。
+Tier budget 按 weight 比例动态调整（权重归一化后再乘以 total_tokens × tier_ratio）。
 
 ### 输出结构变化
 
@@ -79,7 +79,7 @@ Tier budget 按 weight 比例动态调整（权重归一化后再乘以 total_ch
   "t3_qi": [ { "drawer_id": "...", "content": "...", "source": "recency|kg|tunnel", ... } ],
   "recurring_themes": [...],   // from p13-pattern-induction if available
   "system_warnings": [...],
-  "budget_used": { "t1_chars": 2100, "t2_chars": 3800, "t3_chars": 1200, "total": 7100 }
+  "budget_used": { "t1_tokens": 2100, "t2_tokens": 3800, "t3_tokens": 1200, "total_tokens": 7100 }
 }
 ```
 
@@ -132,7 +132,7 @@ Scenario: session_start trigger 按默认权重分层装配 context
   When 调用 `mempal_context({trigger: "session_start"})`
   Then 响应含 `t1_dao_tian`、`t2_shu`、`t3_qi` 三个非空数组（数据充足时）
   And `t1_dao_tian` 中每条 drawer 的 `type` 为 `"decision"` 或 `"feedback"` 或 `"rule"`
-  And `budget_used.total_chars` <= `total_chars` 配置值
+  And `budget_used.total_tokens` <= `total_tokens` 配置值
 
 Scenario: repair trigger 提升 T1 权重，T1 获得更多 budget
   Test:
@@ -141,7 +141,7 @@ Scenario: repair trigger 提升 T1 权重，T1 获得更多 budget
     Targets: crates/mempal-mcp/src/tools/context.rs
   Given 相同 palace.db
   When 分别调用 `mempal_context({trigger: "session_start"})` 和 `mempal_context({trigger: "repair"})`
-  Then repair 响应的 `budget_used.t1_chars` 大于 session_start 响应的 `budget_used.t1_chars`
+  Then repair 响应的 `budget_used.t1_tokens` 大于 session_start 响应的 `budget_used.t1_tokens`
   And repair 响应的 `t1_dao_tian` 数组长度 >= session_start 响应的同数组长度（相同数据集下）
 
 Scenario: on_demand trigger 向 T2 倾斜 budget
@@ -151,17 +151,17 @@ Scenario: on_demand trigger 向 T2 倾斜 budget
     Targets: crates/mempal-mcp/src/tools/context.rs
   Given 相同 palace.db
   When 分别调用 `mempal_context({trigger: "on_demand"})` 和 `mempal_context({trigger: "session_start"})`
-  Then on_demand 响应的 `budget_used.t2_chars` 大于 session_start 响应的 `budget_used.t2_chars`
+  Then on_demand 响应的 `budget_used.t2_tokens` 大于 session_start 响应的 `budget_used.t2_tokens`
 
-Scenario: budget 分配不超过 total_chars 上限
+Scenario: budget 分配不超过 total_tokens 上限
   Test:
     Filter: test_tiered_context_budget_does_not_exceed_total
     Level: integration
     Targets: crates/mempal-mcp/src/tools/context.rs
   Given palace.db 含大量 drawer（各层足以超出 budget）
   When 调用 `mempal_context({trigger: "session_start"})`
-  Then `budget_used.total_chars <= total_chars`（不溢出）
-  And `budget_used.t1_chars + budget_used.t2_chars + budget_used.t3_chars == budget_used.total_chars`
+  Then `budget_used.total_tokens <= total_tokens`（不溢出）
+  And `budget_used.t1_tokens + budget_used.t2_tokens + budget_used.t3_tokens == budget_used.total_tokens`
 
 Scenario: overflow_to_t2=true 时 T1 未用完的 budget 转给 T2
   Test:
@@ -170,7 +170,7 @@ Scenario: overflow_to_t2=true 时 T1 未用完的 budget 转给 T2
     Targets: crates/mempal-mcp/src/tools/context.rs
   Given `overflow_to_t2 = true`，T1 只有 1 条 drawer（远小于 t1 分配 budget）
   When 调用 `mempal_context`，T2 数据充足
-  Then `budget_used.t2_chars` 超过 `total_chars * t2_ratio`（接收了 T1 溢出）
+  Then `budget_used.t2_tokens` 超过 `total_tokens * t2_ratio`（接收了 T1 溢出）
 
 Scenario: T3 只包含 recency_window_days 内的 drawer
   Test:

--- a/specs/fork-ext/p15-skill-crystallization.spec.md
+++ b/specs/fork-ext/p15-skill-crystallization.spec.md
@@ -54,7 +54,7 @@ mempal 存储原始记忆并让 agent 检索，但没有将频繁验证的知识
 - **Feedback 信号** — agent 显式调用：
   - `mempal_skill adopt <skill_id>` / CLI `mempal skills adopt <skill_id>`：`adoption_count += 1`，检查是否升为 active
   - `mempal_skill reject <skill_id>` / CLI `mempal skills reject <skill_id>`：`rejection_count += 1`；若 `rejection_count >= retire_threshold`（默认 3）且 `adoption_count == 0`，自动 retire
-  - **Eta 计算**（展示用）：`eta = adoption_count / (adoption_count + rejection_count + 1.0)`（Laplace smoothed，不影响状态机）
+  - **Eta 计算**（展示用，**查询时动态计算，不存储**）：`eta = adoption_count / (adoption_count + rejection_count + 1.0)`（Laplace smoothed，不影响状态机）；eta **不在 `skills` 表中存储**，由 SELECT 查询的 application layer 实时计算后附加到响应 DTO
 
 - **`mempal_context` T1 集成**：
   - Active skills 注入 T1 层（p14-tiered-retrieval），优先级高于普通 decision drawer
@@ -119,7 +119,8 @@ Scenario: fork-ext migration 8 → 9 创建 skills 表
   Given palace.db `fork_ext_version == "8"`
   When 启动 mempal
   Then `fork_ext_version == "9"`
-  And sqlite_master 中存在 table `skills`，含 `skill_id`、`name`、`trigger_description`、`pattern_id`、`adoption_count`、`rejection_count`、`status`、`eta` 相关列
+  And sqlite_master 中存在 table `skills`，含 `skill_id`、`name`、`trigger_description`、`pattern_id`、`adoption_count`、`rejection_count`、`status` 相关列
+  And `skills` 表**不含** `eta` 列（eta 为查询时动态计算，不存储）
   And 存在索引 `idx_skills_status`
 
 Scenario: active pattern 满足条件时可被提升为 probationary skill

--- a/specs/fork-ext/p15-skill-crystallization.spec.md
+++ b/specs/fork-ext/p15-skill-crystallization.spec.md
@@ -1,0 +1,229 @@
+spec: task
+name: "P15: Skill crystallization from validated recurring patterns"
+tags: [feature, skills, patterns, knowledge, schema, mcp]
+estimate: 2d
+---
+
+## Intent
+
+mempal 存储原始记忆并让 agent 检索，但没有将频繁验证的知识**结晶**为更高层次、可直接行动的格式的机制。Agent 每个 session 都需从原始 drawer 重新推导同样的经验，造成认知重复劳动。
+
+**核心设计**：模仿 MemOS V7 "Skill Crystallization"，将 active pattern 提升为结构化可调用单元——`Skill`。关键设计选择：
+- **LLM-free**：`trigger_description`（何时使用）和 skill 结构体由 **agent 在提升时提供**，mempal 只存储和检索；mempal 不生成文本
+- **依赖 p13-pattern-induction**：pattern 基础设施是前驱；技能从 active pattern 提升，不从裸 drawer 直接提升
+- **显式生命周期**：probationary → active → retired，需人工或 agent 显式触发，不自动提升
+- **反馈回路**：agent 通过 `mempal_skill adopt/reject` 信号更新 `eta`（采用率），驱动生命周期决策
+
+**动机**：issue #119；MemOS V7 skill crystallization。`p13-pattern-induction` 是硬依赖（需 patterns 表和 active pattern 基础设施）。
+
+## Decisions
+
+- fork-ext `fork_ext_version` `8 → 9` migration：
+  - 新建 `skills` 表：
+    ```sql
+    CREATE TABLE IF NOT EXISTS skills (
+        skill_id             TEXT PRIMARY KEY,   -- UUID v4
+        name                 TEXT NOT NULL,       -- human-readable name (provided by agent at promote)
+        trigger_description  TEXT NOT NULL,       -- when to invoke (provided by agent, NOT generated)
+        pattern_id           TEXT NOT NULL,       -- FK to patterns.pattern_id
+        exemplar_ids         TEXT NOT NULL,       -- JSON array (inherited from pattern at promote time)
+        adoption_count       INTEGER NOT NULL DEFAULT 0,
+        rejection_count      INTEGER NOT NULL DEFAULT 0,
+        status               TEXT NOT NULL DEFAULT 'probationary', -- probationary | active | retired
+        promoted_at          INTEGER NOT NULL,    -- unix epoch ms
+        updated_at           INTEGER NOT NULL,
+        project_id           TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status);
+    CREATE INDEX IF NOT EXISTS idx_skills_pattern ON skills(pattern_id);
+    ```
+
+- **Promotion gate** — 满足所有条件时 pattern 才可被提升为 skill：
+  1. `patterns.status == "active"`
+  2. `patterns.session_count >= min_supporting_sessions`（默认 5，与 patterns promote_threshold 一致）
+  3. `patterns.session_count >= skill_min_sessions`（config，默认 5，可独立于 pattern threshold 调参）
+  4. 不存在已有 `status IN ('probationary', 'active')` 的 skill 关联同一 `pattern_id`（防止重复提升）
+
+- **Promote 操作**（仅通过显式调用触发，不自动）：
+  - MCP 工具 `mempal_skill promote` — 需提供 `pattern_id`、`name`、`trigger_description`（agent 必须提供描述，mempal 不生成）
+  - CLI `mempal skills promote <pattern_id> --name "..." --trigger "..."`
+  - 提升时：创建 `skills` 行，`status = "probationary"`
+
+- **Probationary → Active** 升级条件：`adoption_count >= active_threshold`（默认 3）
+
+- **Feedback 信号** — agent 显式调用：
+  - `mempal_skill adopt <skill_id>` / CLI `mempal skills adopt <skill_id>`：`adoption_count += 1`，检查是否升为 active
+  - `mempal_skill reject <skill_id>` / CLI `mempal skills reject <skill_id>`：`rejection_count += 1`；若 `rejection_count >= retire_threshold`（默认 3）且 `adoption_count == 0`，自动 retire
+  - **Eta 计算**（展示用）：`eta = adoption_count / (adoption_count + rejection_count + 1.0)`（Laplace smoothed，不影响状态机）
+
+- **`mempal_context` T1 集成**：
+  - Active skills 注入 T1 层（p14-tiered-retrieval），优先级高于普通 decision drawer
+  - 每条 skill 在 T1 中以简洁格式展示：`{ skill_id, name, trigger_description, eta, exemplar_count }`
+  - 匹配当前 query 向量（query embedding 与 pattern signature 余弦相似度 >= `skill_surfacing_threshold`，默认 0.70）的 skill 优先注入
+
+- **MCP 工具 `mempal_skill`**（新建，独立工具）：
+  - `list` — 列出 skill（可按 status / project_id 过滤），返回 `[{skill_id, name, trigger_description, eta, status, adoption_count, rejection_count}]`
+  - `show <skill_id>` — 完整详情 + exemplar drawer previews
+  - `promote` — 从 pattern 提升（见 Promote 操作）
+  - `adopt <skill_id>` — 正向反馈
+  - `reject <skill_id>` — 负向反馈
+  - `retire <skill_id>` — 手动 retire
+
+- **CLI 命令**：`mempal skills list/show/promote/adopt/reject/retire`（镜像 MCP 工具）
+
+- **Skill 与 pattern 的关系**：
+  - pattern retire 不自动 retire 关联 skill（skill 独立生命周期）
+  - skill 被 retire 后，pattern 可再次被提升为新 skill（允许 reset cycle）
+  - skill 的 `exemplar_ids` 在 promote 时快照（不随 pattern 后续更新变化）
+
+## Boundaries
+
+### Allowed
+- `crates/mempal-core/src/db/schema.rs` — fork_ext_version 8 → 9，创建 `skills` 表
+- `crates/mempal-core/src/config.rs` — 新增 `[skills]` config 子段 `SkillsConfig`
+- `crates/mempal-core/src/skills.rs` — 新建：skill CRUD、promotion gate、feedback、eta 计算
+- `crates/mempal-core/src/lib.rs` — `pub mod skills`
+- `crates/mempal-mcp/src/tools.rs` — 新建 `mempal_skill` MCP 工具（6 actions）；`mempal_context` T1 集成
+- `crates/mempal-mcp/src/server.rs` — 注册 `mempal_skill` 工具
+- `crates/mempal-search/src/tiered.rs` — T1 中 skill query-matching 逻辑（复用 pattern.signature 相似度）
+- `crates/mempal-cli/src/skills.rs` — 新建：`mempal skills` 子命令实现
+- `crates/mempal-cli/src/main.rs` — `skills` 子命令注册
+- `tests/skill_crystallization.rs` — 新建集成测试
+
+### Forbidden
+- 不要让 mempal 自动生成 `name` 或 `trigger_description`（必须由 agent 在 promote 时提供；违反 LLM-free 约束）
+- 不要自动触发 pattern → skill 提升（必须显式调用 promote；防止未审查的 skill 污染 T1）
+- 不要让 pattern retire 连带 retire skill（skill 生命周期独立）
+- 不要把 skill 内容写入 `drawers` 表（skill 存在 `skills` 表，不是普通记忆）
+- 不要在 `mempal_context` 注入 probationary skill（只有 `status = "active"` 的 skill 进入 T1 注入）
+- 不要对 adoption/rejection signal 添加速率限制（agent 应可自由发信号，限制留未来）
+- 不要让 skill 的 exemplar_ids 随 pattern 后续更新而变化（promote 时快照，之后独立）
+
+## Out of Scope
+
+- 自动文本生成 `trigger_description`（需要 LLM）
+- Skill 版本化（每次 promote 创建新 skill，旧的 retire；不维护 revision history）
+- Skill 组合（multi-skill 工作流编排，留未来）
+- Skill 跨项目共享（skills 与 project_id 绑定，不跨 project 传播）
+- Skill 导入/导出（留未来）
+- Web UI（违反 CLI-first 约束）
+- 自动 skill 重新提升（pattern 可再次 promote 为新 skill，但需显式操作）
+
+## Completion Criteria
+
+Scenario: fork-ext migration 8 → 9 创建 skills 表
+  Test:
+    Filter: test_fork_ext_migration_v8_to_v9_creates_skills_table
+    Level: integration
+    Targets: crates/mempal-core/src/db/schema.rs
+  Given palace.db `fork_ext_version == "8"`
+  When 启动 mempal
+  Then `fork_ext_version == "9"`
+  And sqlite_master 中存在 table `skills`，含 `skill_id`、`name`、`trigger_description`、`pattern_id`、`adoption_count`、`rejection_count`、`status`、`eta` 相关列
+  And 存在索引 `idx_skills_status`
+
+Scenario: active pattern 满足条件时可被提升为 probationary skill
+  Test:
+    Filter: test_pattern_promote_creates_probationary_skill
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs, crates/mempal-mcp/src/tools.rs
+  Given 1 个 `status = "active"` pattern，`session_count = 6`（>= skill_min_sessions=5）
+  When 调用 `mempal_skill promote({ pattern_id: "...", name: "Deploy guard", trigger_description: "When about to deploy, verify tests pass first" })`
+  Then `skills` 表新增 1 条 `status = "probationary"` 记录
+  And `name = "Deploy guard"`，`trigger_description` 按原文存储（不被修改）
+  And `adoption_count == 0`，`rejection_count == 0`
+
+Scenario: candidate pattern 不可被提升为 skill
+  Test:
+    Filter: test_candidate_pattern_cannot_be_promoted
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs
+  Given `status = "candidate"` pattern
+  When 调用 `mempal_skill promote({ pattern_id: "...", name: "...", trigger_description: "..." })`
+  Then 返回错误（`PromotionError::PatternNotActive`）
+  And `skills` 表无新记录
+
+Scenario: 同一 pattern 不可重复提升（已有 active/probationary skill）
+  Test:
+    Filter: test_duplicate_promotion_rejected
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs
+  Given 已有 `status = "probationary"` skill 关联 pattern-A
+  When 再次对 pattern-A 调用 promote
+  Then 返回错误（`PromotionError::SkillAlreadyExists`）
+  And 不创建第二条 skill 记录
+
+Scenario: adopt 信号累计到 active_threshold 后 skill 升为 active
+  Test:
+    Filter: test_skill_adopts_to_active_at_threshold
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs
+  Given `active_threshold = 3`，probationary skill，`adoption_count = 2`
+  When 调用 `mempal_skill adopt <skill_id>`（第 3 次）
+  Then skill `status == "active"`，`adoption_count == 3`
+
+Scenario: 足量 reject 信号且无 adoption 触发自动 retire
+  Test:
+    Filter: test_skill_auto_retires_on_rejection
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs
+  Given `retire_threshold = 3`，probationary skill，`adoption_count = 0`，`rejection_count = 2`
+  When 调用 `mempal_skill reject <skill_id>`（第 3 次）
+  Then skill `status == "retired"`
+
+Scenario: eta 反映 adoption/rejection 比例
+  Test:
+    Filter: test_skill_eta_calculation
+    Level: unit
+    Targets: crates/mempal-core/src/skills.rs
+  Given `adoption_count = 3`，`rejection_count = 1`
+  When 调用 `compute_eta(adoption=3, rejection=1)`
+  Then 返回值 == 3.0 / (3 + 1 + 1.0) = 0.6（Laplace smoothed）
+
+Scenario: active skill 注入 mempal_context T1 层
+  Test:
+    Filter: test_active_skill_injected_in_t1
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs, crates/mempal-search/src/tiered.rs
+  Given 1 个 `status = "active"` skill，其关联 pattern signature 与 query embedding 余弦相似度 >= 0.70
+  When 调用 `mempal_context({trigger: "session_start"})`
+  Then `t1_dao_tian` 数组首部含该 skill 的 `{ skill_id, name, trigger_description, eta }`
+  And skill 条目的 rank 高于普通 decision drawer（skill 优先级更高）
+
+Scenario: probationary skill 不注入 mempal_context
+  Test:
+    Filter: test_probationary_skill_excluded_from_context
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given 1 个 `status = "probationary"` skill
+  When 调用 `mempal_context`
+  Then `t1_dao_tian` 不含该 skill 的 skill_id
+
+Scenario: pattern retire 不连带 retire 关联 skill
+  Test:
+    Filter: test_pattern_retire_does_not_cascade_to_skill
+    Level: integration
+    Targets: crates/mempal-core/src/skills.rs, crates/mempal-core/src/patterns.rs
+  Given active pattern-A 关联 active skill-B
+  When 执行 `mempal patterns retire pattern-A`
+  Then pattern-A `status == "retired"`
+  And skill-B `status` **仍为** `"active"`（不受影响）
+
+Scenario: mempal_skill list 仅显示当前 project 的 skill
+  Test:
+    Filter: test_skill_list_filters_by_project
+    Level: integration
+    Targets: crates/mempal-mcp/src/tools.rs
+  Given skill-A.project_id = "proj-X"，skill-B.project_id = "proj-Y"
+  When 调用 `mempal_skill list({project_id: "proj-X"})`
+  Then 结果含 skill-A，不含 skill-B
+
+Scenario: mempal skills promote CLI 提升 pattern 为 skill
+  Test:
+    Filter: test_skills_promote_cli
+    Level: integration
+    Targets: crates/mempal-cli/src/skills.rs
+  Given 1 个 active pattern（session_count >= 5）
+  When 执行 `mempal skills promote <pattern_id> --name "Test guard" --trigger "Run tests before deploy"`
+  Then stdout 含成功提示和新 skill_id
+  And `skills` 表含对应记录，`name = "Test guard"`，`trigger_description = "Run tests before deploy"`


### PR DESCRIPTION
## Summary

Adds 5 new fork-ext spec files for mempal improvements inspired by MemOS V7 analysis (issues #115–#119).

## Specs added

| File | Issue | Description |
|------|-------|-------------|
| `specs/fork-ext/p13-importance-decay.spec.md` | #115 | LLM-free importance decay + retrieval-driven value backpropagation. New columns `last_accessed_at`, `access_count`, `effective_importance` on `drawers`; fork_ext_version 5→6 |
| `specs/fork-ext/p13-pattern-induction.spec.md` | #116 | Cross-session pattern detection from recurring semantic similarity. New `patterns` table; fork_ext_version 6→7 |
| `specs/fork-ext/p14-tiered-retrieval.spec.md` | #117 | T1/T2/T3 tiered assembly for `mempal_context` with configurable budget allocation and `trigger` parameter. No schema migration. |
| `specs/fork-ext/p14-decision-repair.spec.md` | #118 | Anti-pattern detection via failure keyword clustering. New `failure_events` table; fork_ext_version 7→8. Extends `mempal_fact_check` with `RepeatedFailurePattern` check type. |
| `specs/fork-ext/p15-skill-crystallization.spec.md` | #119 | Skill crystallization from validated patterns. New `skills` table + `mempal_skill` MCP tool; fork_ext_version 8→9. **Depends on p13-pattern-induction.** |

## Dependency chain

```
p13-importance-decay (ext_v5→v6)
  └→ p14-tiered-retrieval (uses effective_importance for T1 sorting)

p13-pattern-induction (ext_v6→v7)
  └→ p14-tiered-retrieval (recurring_themes in T1)
  └→ p15-skill-crystallization (ext_v8→v9) [hard dependency]

p14-decision-repair (ext_v7→v8)
  └→ p14-tiered-retrieval (repair_warnings in repair trigger)

Implementation order: p13-importance-decay → p13-pattern-induction → p14-decision-repair → p15-skill-crystallization
p14-tiered-retrieval: implement after p13-importance-decay
```

## Hard constraints respected

- Zero external LLM API dependency — vector cosine, FTS5 keywords, arithmetic decay, regex only
- CLI-only visualization — audit/patterns/repair/skills subcommands; no Web UI
- Raw verbatim storage — no LLM rewriting; agents supply skill descriptions at promote time
- fork_ext_version axis independent of upstream PRAGMA user_version

🤖 Generated with [Claude Code](https://claude.com/claude-code)