### PR TITLE
feat(fork-ext): implement p13-importance-decay (closes #115)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ percent-encoding = "2"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rmcp = { version = "1.3.0", features = ["client", "server", "macros", "schemars", "transport-async-rw", "transport-io"] }
-rusqlite = { version = "0.37", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled", "functions"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -38,6 +38,11 @@ const DEFAULT_SESSION_REVIEW_MIN_LENGTH: usize = 100;
 const DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES: usize = 1;
 const DEFAULT_HOTPATCH_MIN_IMPORTANCE_STARS: i32 = 4;
 const DEFAULT_HOTPATCH_MAX_SUGGESTION_LENGTH: usize = 80;
+const DEFAULT_IMPORTANCE_DECAY_RATE: f64 = 0.01;
+const DEFAULT_IMPORTANCE_FLOOR: f64 = 0.1;
+const DEFAULT_IMPORTANCE_BOOST_PER_ACCESS: f64 = 0.15;
+const DEFAULT_IMPORTANCE_BOOST_CAP: f64 = 2.0;
+const DEFAULT_IMPORTANCE_STALE_PENALTY: f64 = 0.5;
 static DEFAULT_SENSITIVE_SCRUBBER: OnceLock<Option<CompiledPrivacyConfig>> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -58,6 +63,7 @@ pub struct Config {
     pub hooks: HooksConfig,
     pub daemon: DaemonConfig,
     pub mcp: McpConfig,
+    pub importance: ImportanceConfig,
 }
 
 impl Default for Config {
@@ -76,6 +82,7 @@ impl Default for Config {
             hooks: HooksConfig::default(),
             daemon: DaemonConfig::default(),
             mcp: McpConfig::default(),
+            importance: ImportanceConfig::default(),
         }
     }
 }
@@ -1078,4 +1085,34 @@ impl ConfigHandle {
 fn global_scrub_stats() -> &'static Mutex<ScrubStats> {
     static SCRUB_STATS: OnceLock<Mutex<ScrubStats>> = OnceLock::new();
     SCRUB_STATS.get_or_init(|| Mutex::new(ScrubStats::default()))
+}
+
+/// Parameters for time-decay and retrieval-boost of `effective_importance`.
+/// All fields are hot-reload whitelisted.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ImportanceConfig {
+    /// Exponential decay rate per day. Half-life ≈ ln(2)/decay_rate days.
+    /// Default 0.01 → half-life ~69 days.
+    pub decay_rate: f64,
+    /// Minimum value `effective_importance` can decay to (prevents full suppression).
+    pub floor: f64,
+    /// How much `accumulated_boost` increases per session-ingest boost event.
+    pub boost_per_access: f64,
+    /// Upper cap on `accumulated_boost` contribution (prevents runaway inflation).
+    pub boost_cap: f64,
+    /// Multiplicative penalty applied to `effective_importance` when a StaleFact is found.
+    pub stale_penalty: f64,
+}
+
+impl Default for ImportanceConfig {
+    fn default() -> Self {
+        Self {
+            decay_rate: DEFAULT_IMPORTANCE_DECAY_RATE,
+            floor: DEFAULT_IMPORTANCE_FLOOR,
+            boost_per_access: DEFAULT_IMPORTANCE_BOOST_PER_ACCESS,
+            boost_cap: DEFAULT_IMPORTANCE_BOOST_CAP,
+            stale_penalty: DEFAULT_IMPORTANCE_STALE_PENALTY,
+        }
+    }
 }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -2395,11 +2395,11 @@ impl Database {
                 effective_importance = (
                     CAST(COALESCE(importance, 0) AS REAL)
                     * MIN(1.0, MAX(
-                        EXP(-?2 * MAX(0, ?1 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                        EXP(-?2 * MAX(0, ?1 - COALESCE(last_accessed_at, strftime('%s', added_at) * 1000, CAST(added_at AS INTEGER) * 1000)) / 86400000.0),
                         ?3
                     ))
                     + MIN(COALESCE(accumulated_boost, 0.0), ?4)
-                )
+                ) * COALESCE(stale_penalty_applied, 1.0)
             WHERE id = ?5 AND deleted_at IS NULL
         "#;
         let mut stmt = self.conn.prepare_cached(sql)?;
@@ -2446,11 +2446,11 @@ impl Database {
                 effective_importance = (
                     CAST(COALESCE(importance, 0) AS REAL)
                     * MIN(1.0, MAX(
-                        EXP(-?3 * MAX(0, ?2 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                        EXP(-?3 * MAX(0, ?2 - COALESCE(last_accessed_at, strftime('%s', added_at) * 1000, CAST(added_at AS INTEGER) * 1000)) / 86400000.0),
                         ?4
                     ))
                     + MIN(COALESCE(accumulated_boost, 0.0) + ?1, ?5)
-                )
+                ) * COALESCE(stale_penalty_applied, 1.0)
             WHERE id = ?6 AND deleted_at IS NULL
         "#;
         let mut stmt = self.conn.prepare_cached(sql)?;
@@ -2480,15 +2480,19 @@ impl Database {
         }
     }
 
-    /// Apply stale penalty: multiply `effective_importance` by `stale_penalty`
-    /// for a specific drawer. Used when `mempal_fact_check` detects a StaleFact.
+    /// Apply stale penalty: persist the multiplier in `stale_penalty_applied` and
+    /// immediately reduce `effective_importance` for a specific drawer.
+    /// `stale_penalty_applied` survives `recompute_all_effective_importance`.
     pub fn apply_stale_penalty_to_drawer(
         &self,
         drawer_id: &str,
         stale_penalty: f64,
     ) -> Result<(), DbError> {
         self.conn.execute(
-            "UPDATE drawers SET effective_importance = effective_importance * ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            r#"UPDATE drawers SET
+                stale_penalty_applied = COALESCE(stale_penalty_applied, 1.0) * ?1,
+                effective_importance = effective_importance * ?1
+            WHERE id = ?2 AND deleted_at IS NULL"#,
             rusqlite::params![stale_penalty, drawer_id],
         )?;
         Ok(())
@@ -2517,11 +2521,11 @@ impl Database {
                         effective_importance = (
                             CAST(COALESCE(importance, 0) AS REAL)
                             * MIN(1.0, MAX(
-                                EXP(-?1 * MAX(0, ?2 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                                EXP(-?1 * MAX(0, ?2 - COALESCE(last_accessed_at, strftime('%s', added_at) * 1000, CAST(added_at AS INTEGER) * 1000)) / 86400000.0),
                                 ?3
                             ))
                             + MIN(COALESCE(accumulated_boost, 0.0), ?4)
-                        )
+                        ) * COALESCE(stale_penalty_applied, 1.0)
                     WHERE rowid IN (
                         SELECT rowid FROM drawers
                         WHERE deleted_at IS NULL AND rowid > ?5

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -12,8 +12,8 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{
-    Connection, OpenFlags, OptionalExtension, Row, params, params_from_iter,
-    types::Value as SqlValue,
+    Connection, OpenFlags, OptionalExtension, Row, functions::FunctionFlags, params,
+    params_from_iter, types::Value as SqlValue,
 };
 use serde_json::Value;
 use thiserror::Error;
@@ -70,7 +70,8 @@ const DRAWER_SELECT_COLUMNS: &str = r#"
     teaching_refs,
     verification_refs,
     scope_constraints,
-    trigger_hints
+    trigger_hints,
+    COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) as effective_importance
 "#;
 
 const V1_SCHEMA_SQL: &str = r#"
@@ -173,6 +174,19 @@ impl OpenMode {
     }
 }
 
+fn register_math_functions(conn: &Connection) -> rusqlite::Result<()> {
+    conn.create_scalar_function(
+        "EXP",
+        1,
+        FunctionFlags::SQLITE_DETERMINISTIC,
+        |ctx: &rusqlite::functions::Context<'_>| {
+            let x: f64 = ctx.get(0)?;
+            Ok(x.exp())
+        },
+    )?;
+    Ok(())
+}
+
 impl Database {
     pub fn open(path: &Path) -> Result<Self, DbError> {
         Self::open_with_mode(path, OpenMode::ReadWrite)
@@ -204,6 +218,7 @@ impl Database {
             OpenMode::ReadWrite => Connection::open(path)?,
         };
         conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        register_math_functions(&conn)?;
         if mode.allows_write() {
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "NORMAL")?;
@@ -1140,9 +1155,11 @@ impl Database {
         ))?;
         let mut rows = statement.query_map([drawer_id], |row| {
             let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-            let updated_at = row.get::<_, Option<String>>(26)?;
-            let merge_count = row.get::<_, u32>(27)?;
-            let project_id = row.get::<_, Option<String>>(28)?;
+            // DRAWER_SELECT_COLUMNS now has 27 columns (indices 0-26), so
+            // the extra columns appended here start at index 27.
+            let updated_at = row.get::<_, Option<String>>(27)?;
+            let merge_count = row.get::<_, u32>(28)?;
+            let project_id = row.get::<_, Option<String>>(29)?;
             Ok(DrawerDetails {
                 drawer,
                 updated_at,
@@ -1194,9 +1211,10 @@ impl Database {
             let mut statement = self.conn.prepare(&sql)?;
             let rows = statement.query_map(params_from_iter(chunk.iter()), |row| {
                 let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-                let updated_at = row.get::<_, Option<String>>(26)?;
-                let merge_count = row.get::<_, u32>(27)?;
-                let project_id = row.get::<_, Option<String>>(28)?;
+                // DRAWER_SELECT_COLUMNS is 27 columns (0-26); extra columns start at 27.
+                let updated_at = row.get::<_, Option<String>>(27)?;
+                let merge_count = row.get::<_, u32>(28)?;
+                let project_id = row.get::<_, Option<String>>(29)?;
                 Ok((
                     drawer.id.clone(),
                     DrawerDetails {
@@ -1852,7 +1870,8 @@ impl Database {
                 rusqlite::params![room, exclude_drawer_id, current_project_id, sql_limit],
                 |row| {
                     let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-                    let project_id = row.get::<_, Option<String>>(26)?;
+                    // DRAWER_SELECT_COLUMNS is 27 columns (0-26); project_id appended at 27.
+                    let project_id = row.get::<_, Option<String>>(27)?;
                     Ok(TunnelDrawer {
                         drawer,
                         target_project_id: project_id,
@@ -2345,6 +2364,236 @@ impl Database {
             }
         }
         Ok(total)
+    }
+
+    // -----------------------------------------------------------------------
+    // P13: importance decay — access tracking + boost + stale penalty
+    // -----------------------------------------------------------------------
+
+    /// Atomically update access tracking and recompute `effective_importance`
+    /// for a batch of drawer IDs using a single SQL UPDATE per drawer.
+    ///
+    /// Uses WAL + deferred transaction (NOT `BEGIN IMMEDIATE`) to avoid lock
+    /// contention during high-frequency concurrent searches.
+    pub fn update_access_fields_batch(
+        &self,
+        drawer_ids: &[String],
+        now_ms: i64,
+        decay_rate: f64,
+        floor: f64,
+        boost_cap: f64,
+    ) -> Result<(), DbError> {
+        if drawer_ids.is_empty() {
+            return Ok(());
+        }
+        // Single UPDATE per drawer; all arithmetic is done inside SQLite to
+        // guarantee atomicity without a read-modify-write round-trip.
+        let sql = r#"
+            UPDATE drawers SET
+                last_accessed_at = ?1,
+                access_count = access_count + 1,
+                effective_importance = (
+                    CAST(COALESCE(importance, 0) AS REAL)
+                    * MIN(1.0, MAX(
+                        EXP(-?2 * MAX(0, ?1 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                        ?3
+                    ))
+                    + MIN(COALESCE(accumulated_boost, 0.0), ?4)
+                )
+            WHERE id = ?5 AND deleted_at IS NULL
+        "#;
+        let mut stmt = self.conn.prepare_cached(sql)?;
+        self.conn.execute_batch("BEGIN")?;
+        let result: Result<(), DbError> = (|| {
+            for id in drawer_ids {
+                stmt.execute(rusqlite::params![now_ms, decay_rate, floor, boost_cap, id])?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    /// Atomically apply session-ingest boost and recompute `effective_importance`
+    /// for a batch of drawer IDs.
+    ///
+    /// Note: SQLite SET clauses use pre-update column values, so
+    /// `effective_importance` must reference `(accumulated_boost + boost_per_access)`
+    /// explicitly rather than relying on the already-updated `accumulated_boost`.
+    pub fn apply_ingest_boost_batch(
+        &self,
+        drawer_ids: &[String],
+        now_ms: i64,
+        boost_per_access: f64,
+        boost_cap: f64,
+        decay_rate: f64,
+        floor: f64,
+    ) -> Result<(), DbError> {
+        if drawer_ids.is_empty() {
+            return Ok(());
+        }
+        let sql = r#"
+            UPDATE drawers SET
+                accumulated_boost = COALESCE(accumulated_boost, 0.0) + ?1,
+                effective_importance = (
+                    CAST(COALESCE(importance, 0) AS REAL)
+                    * MIN(1.0, MAX(
+                        EXP(-?3 * MAX(0, ?2 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                        ?4
+                    ))
+                    + MIN(COALESCE(accumulated_boost, 0.0) + ?1, ?5)
+                )
+            WHERE id = ?6 AND deleted_at IS NULL
+        "#;
+        let mut stmt = self.conn.prepare_cached(sql)?;
+        self.conn.execute_batch("BEGIN")?;
+        let result: Result<(), DbError> = (|| {
+            for id in drawer_ids {
+                stmt.execute(rusqlite::params![
+                    boost_per_access,
+                    now_ms,
+                    decay_rate,
+                    floor,
+                    boost_cap,
+                    id
+                ])?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    /// Apply stale penalty: multiply `effective_importance` by `stale_penalty`
+    /// for a specific drawer. Used when `mempal_fact_check` detects a StaleFact.
+    pub fn apply_stale_penalty_to_drawer(
+        &self,
+        drawer_id: &str,
+        stale_penalty: f64,
+    ) -> Result<(), DbError> {
+        self.conn.execute(
+            "UPDATE drawers SET effective_importance = effective_importance * ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![stale_penalty, drawer_id],
+        )?;
+        Ok(())
+    }
+
+    /// Batch recompute `effective_importance` for all active drawers using the
+    /// provided decay parameters. Used by `mempal recompute-importance --effective`.
+    ///
+    /// Runs in batches of 1000 using `BEGIN IMMEDIATE` to avoid blocking readers.
+    pub fn recompute_all_effective_importance(
+        &self,
+        now_ms: i64,
+        decay_rate: f64,
+        floor: f64,
+        boost_cap: f64,
+    ) -> Result<usize, DbError> {
+        const BATCH_SIZE: i64 = 1000;
+        let mut total = 0usize;
+        let mut last_rowid: i64 = -1;
+
+        loop {
+            self.conn.execute_batch("BEGIN IMMEDIATE")?;
+            let result: std::result::Result<(usize, i64), DbError> = (|| {
+                let sql = r#"
+                    UPDATE drawers SET
+                        effective_importance = (
+                            CAST(COALESCE(importance, 0) AS REAL)
+                            * MIN(1.0, MAX(
+                                EXP(-?1 * MAX(0, ?2 - COALESCE(last_accessed_at, CAST(added_at AS INTEGER))) / 86400000.0),
+                                ?3
+                            ))
+                            + MIN(COALESCE(accumulated_boost, 0.0), ?4)
+                        )
+                    WHERE rowid IN (
+                        SELECT rowid FROM drawers
+                        WHERE deleted_at IS NULL AND rowid > ?5
+                        ORDER BY rowid ASC LIMIT ?6
+                    )
+                "#;
+                let updated = self.conn.execute(
+                    sql,
+                    rusqlite::params![decay_rate, now_ms, floor, boost_cap, last_rowid, BATCH_SIZE],
+                )?;
+                // Find the last rowid processed in this batch.
+                let new_last_rowid: i64 = self
+                    .conn
+                    .query_row(
+                        "SELECT MAX(rowid) FROM drawers WHERE deleted_at IS NULL AND rowid > ?1 ORDER BY rowid ASC LIMIT ?2",
+                        rusqlite::params![last_rowid, BATCH_SIZE],
+                        |row| row.get::<_, Option<i64>>(0),
+                    )?
+                    .unwrap_or(last_rowid);
+                Ok((updated, new_last_rowid))
+            })();
+            match result {
+                Ok((n, new_last_rowid)) => {
+                    self.conn.execute_batch("COMMIT")?;
+                    total += n;
+                    if n == 0 || new_last_rowid == last_rowid {
+                        break;
+                    }
+                    last_rowid = new_last_rowid;
+                }
+                Err(e) => {
+                    let _ = self.conn.execute_batch("ROLLBACK");
+                    return Err(e);
+                }
+            }
+        }
+        Ok(total)
+    }
+
+    /// List drawers with `effective_importance < threshold`, ordered by
+    /// `effective_importance ASC` (most decayed first). Used by `mempal audit --stale`.
+    ///
+    /// Each tuple: `(id, wing, room, effective_importance, access_count, last_accessed_at_ms)`.
+    #[allow(clippy::type_complexity)]
+    pub fn drawers_below_importance_threshold(
+        &self,
+        threshold: f64,
+        limit: usize,
+    ) -> Result<Vec<(String, String, Option<String>, f64, i64, Option<i64>)>, DbError> {
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, wing, room, effective_importance, access_count, last_accessed_at
+            FROM drawers
+            WHERE deleted_at IS NULL AND effective_importance < ?1
+            ORDER BY effective_importance ASC
+            LIMIT ?2
+            "#,
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![threshold, limit_i64], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, f64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, Option<i64>>(5)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Normalise `added_at` values in batched `BEGIN IMMEDIATE` transactions.
@@ -3272,6 +3521,7 @@ fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {
     let verification_refs = parse_string_list(row.get::<_, Option<String>>(23)?.as_deref())?;
     let scope_constraints = row.get::<_, Option<String>>(24)?;
     let trigger_hints = parse_optional_json(row.get::<_, Option<String>>(25)?.as_deref())?;
+    let effective_importance = row.get::<_, f64>(26)?;
 
     anchor::validate_anchor_domain(&domain, &anchor_kind)
         .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
@@ -3303,6 +3553,7 @@ fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {
         verification_refs,
         scope_constraints,
         trigger_hints,
+        effective_importance,
     })
 }
 

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -2540,7 +2540,7 @@ impl Database {
                 let new_last_rowid: i64 = self
                     .conn
                     .query_row(
-                        "SELECT MAX(rowid) FROM drawers WHERE deleted_at IS NULL AND rowid > ?1 ORDER BY rowid ASC LIMIT ?2",
+                        "SELECT MAX(rowid) FROM (SELECT rowid FROM drawers WHERE deleted_at IS NULL AND rowid > ?1 ORDER BY rowid ASC LIMIT ?2)",
                         rusqlite::params![last_rowid, BATCH_SIZE],
                         |row| row.get::<_, Option<i64>>(0),
                     )?

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -313,6 +313,9 @@ fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {
     ensure_default_column(conn, "drawers", "access_count", "INTEGER", "0")?;
     ensure_default_column(conn, "drawers", "accumulated_boost", "REAL", "0.0")?;
     ensure_default_column(conn, "drawers", "effective_importance", "REAL", "0.0")?;
+    // Persists the cumulative stale penalty so recompute_all_effective_importance
+    // doesn't silently drop penalties applied by apply_stale_penalty_to_drawer.
+    ensure_default_column(conn, "drawers", "stale_penalty_applied", "REAL", "1.0")?;
 
     // Backfill: set effective_importance = base importance for existing rows.
     conn.execute_batch(

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 9;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 10;
 
 pub const FORK_EXT_V1_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS pending_messages (
@@ -215,6 +215,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 9,
             up: apply_v9,
         },
+        Migration {
+            version: 10,
+            up: apply_v10,
+        },
     ]
 }
 
@@ -301,6 +305,25 @@ fn apply_v8(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v9(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V9_SCHEMA_SQL)
+}
+
+fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {
+    // Each ALTER TABLE must succeed idempotently — use ensure_* helpers.
+    ensure_nullable_column(conn, "drawers", "last_accessed_at", "INTEGER")?;
+    ensure_default_column(conn, "drawers", "access_count", "INTEGER", "0")?;
+    ensure_default_column(conn, "drawers", "accumulated_boost", "REAL", "0.0")?;
+    ensure_default_column(conn, "drawers", "effective_importance", "REAL", "0.0")?;
+
+    // Backfill: set effective_importance = base importance for existing rows.
+    conn.execute_batch(
+        "UPDATE drawers SET effective_importance = CAST(COALESCE(importance, 0) AS REAL) WHERE effective_importance = 0.0;",
+    )?;
+
+    // Index for efficient reranking / audit queries.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_drawers_eff_importance ON drawers(effective_importance DESC);",
+    )?;
+    Ok(())
 }
 
 fn ensure_gating_audit_columns(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/decay.rs
+++ b/src/core/decay.rs
@@ -1,0 +1,140 @@
+//! Pure importance-decay and retrieval-boost functions (P13, LLM-free).
+//!
+//! Implements heuristic effective_importance = base * decay(days) + capped_boost.
+//! All parameters come from `ImportanceConfig` which is hot-reload whitelisted.
+
+use crate::core::config::ImportanceConfig;
+
+/// Compute `effective_importance` from components.
+///
+/// Formula:
+/// ```text
+/// decay = max(exp(-decay_rate * days_since_last_hit), floor)
+/// effective = base_importance * decay + min(accumulated_boost, boost_cap)
+/// ```
+///
+/// `days_since_last_hit` is always `>= 0.0`; callers use `added_at` as
+/// fallback when `last_accessed_at IS NULL`.
+pub fn compute_effective_importance(
+    base_importance: f64,
+    days_since_last_hit: f64,
+    accumulated_boost: f64,
+    config: &ImportanceConfig,
+) -> f64 {
+    let decay = (-config.decay_rate * days_since_last_hit)
+        .exp()
+        .max(config.floor);
+    base_importance * decay + accumulated_boost.min(config.boost_cap)
+}
+
+/// Apply stale penalty: multiply current effective_importance by `stale_penalty`.
+///
+/// Used when `mempal_fact_check` detects a `StaleFact` for a drawer's KG triple.
+pub fn apply_stale_penalty(effective_importance: f64, config: &ImportanceConfig) -> f64 {
+    effective_importance * config.stale_penalty
+}
+
+/// Convert unix-epoch milliseconds difference to floating-point days.
+pub fn elapsed_days(now_ms: i64, reference_ms: i64) -> f64 {
+    let diff_ms = (now_ms - reference_ms).max(0) as f64;
+    diff_ms / 86_400_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::ImportanceConfig;
+
+    fn default_cfg() -> ImportanceConfig {
+        ImportanceConfig::default()
+    }
+
+    fn cfg_with(
+        decay_rate: f64,
+        floor: f64,
+        boost_per_access: f64,
+        boost_cap: f64,
+    ) -> ImportanceConfig {
+        ImportanceConfig {
+            decay_rate,
+            floor,
+            boost_per_access,
+            boost_cap,
+            stale_penalty: 0.5,
+        }
+    }
+
+    #[test]
+    fn test_decay_reduces_importance_over_time() {
+        let cfg = ImportanceConfig {
+            decay_rate: 0.05,
+            floor: 0.1,
+            boost_per_access: 0.15,
+            boost_cap: 2.0,
+            stale_penalty: 0.5,
+        };
+        let result = compute_effective_importance(3.0, 30.0, 0.0, &cfg);
+        assert!(result < 3.0, "decayed value {result} should be < 3.0");
+        assert!(
+            result >= 0.1,
+            "decayed value {result} should be >= floor 0.1"
+        );
+    }
+
+    #[test]
+    fn test_decay_floor_prevents_zero() {
+        let cfg = cfg_with(0.01, 0.1, 0.15, 2.0);
+        let result = compute_effective_importance(1.0, 10_000.0, 0.0, &cfg);
+        // exp(-0.01 * 10000) ≈ 0 → floor kicks in
+        assert!(
+            (result - 0.1).abs() < 1e-9,
+            "result {result} should equal floor 0.1"
+        );
+    }
+
+    #[test]
+    fn test_access_boost_increases_effective_importance() {
+        let cfg = default_cfg();
+        let result = compute_effective_importance(2.0, 0.0, 0.3, &cfg);
+        // days=0 → decay=1.0, boost=0.3 (< boost_cap 2.0)
+        assert!(
+            result > 2.0,
+            "boosted value {result} should exceed base 2.0"
+        );
+    }
+
+    #[test]
+    fn test_access_boost_capped_at_max() {
+        let cfg = cfg_with(0.01, 0.1, 0.15, 2.0);
+        // accumulated_boost = 3.0 > boost_cap 2.0 → capped at 2.0
+        let result = compute_effective_importance(3.0, 0.0, 3.0, &cfg);
+        let expected = 3.0 * 1.0_f64 + 2.0; // decay=1.0, boost capped at 2.0
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "result {result} should equal {expected}"
+        );
+    }
+
+    #[test]
+    fn test_apply_stale_penalty() {
+        let cfg = default_cfg(); // stale_penalty = 0.5
+        let result = apply_stale_penalty(3.0, &cfg);
+        assert!(
+            (result - 1.5).abs() < 1e-9,
+            "3.0 * 0.5 should be 1.5, got {result}"
+        );
+    }
+
+    #[test]
+    fn test_elapsed_days_positive() {
+        let now = 86_400_000_i64; // 1 day in ms
+        let reference = 0_i64;
+        assert!((elapsed_days(now, reference) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_elapsed_days_clamps_negative_to_zero() {
+        // reference > now → should clamp to 0 days
+        assert!((elapsed_days(0, 1_000_000)).abs() < 1e-9);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod anchor;
 pub mod config;
 pub mod db;
+pub mod decay;
 pub mod hot_reload;
 pub mod priming;
 pub mod project;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -198,7 +198,7 @@ pub struct ReindexSource {
     pub drawer_count: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Drawer {
     pub id: String,
     pub content: String,
@@ -233,6 +233,10 @@ pub struct Drawer {
     pub verification_refs: Vec<String>,
     pub scope_constraints: Option<String>,
     pub trigger_hints: Option<TriggerHints>,
+    /// Dynamic importance after time-decay + retrieval boost (P13).
+    /// Defaults to `importance as f64` when the column doesn't exist (pre-v10 DBs).
+    #[serde(default)]
+    pub effective_importance: f64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -278,6 +282,7 @@ impl Drawer {
             verification_refs: Vec::new(),
             scope_constraints: None,
             trigger_hints: None,
+            effective_importance: args.importance as f64,
         }
     }
 }
@@ -313,6 +318,7 @@ impl Default for Drawer {
             verification_refs: Vec::new(),
             scope_constraints: None,
             trigger_hints: None,
+            effective_importance: 0.0,
         }
     }
 }
@@ -321,7 +327,7 @@ fn default_normalize_version() -> u32 {
     1
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DrawerDetails {
     pub drawer: Drawer,
     pub updated_at: Option<String>,
@@ -329,7 +335,7 @@ pub struct DrawerDetails {
     pub project_id: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TunnelDrawer {
     pub drawer: Drawer,
     pub target_project_id: Option<String>,
@@ -415,4 +421,8 @@ pub struct SearchResult {
     /// are replaced by a single `"… +N more"` sentinel as the last element.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tunnel_hints: Vec<String>,
+    /// Dynamic importance after time-decay + retrieval boost (P13).
+    /// Loaded from the `effective_importance` column; defaults to
+    /// `importance as f64` when the column doesn't exist (pre-v10 DBs).
+    pub effective_importance: f64,
 }

--- a/src/factcheck/contradictions.rs
+++ b/src/factcheck/contradictions.rs
@@ -78,6 +78,7 @@ pub fn detect_stale_facts(
                     object: kg.object.clone(),
                     valid_to: valid_to.to_string(),
                     triple_id: kg.id.clone(),
+                    source_drawer: kg.source_drawer.clone(),
                 });
             }
         }

--- a/src/factcheck/mod.rs
+++ b/src/factcheck/mod.rs
@@ -40,6 +40,10 @@ pub enum FactIssue {
         /// Unix seconds as stored in DB (triple.valid_to).
         valid_to: String,
         triple_id: String,
+        /// Source drawer linked to the stale triple, if any.
+        /// Used by the MCP handler to apply `stale_penalty` to `effective_importance`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source_drawer: Option<String>,
     },
 }
 

--- a/src/ingest/diary.rs
+++ b/src/ingest/diary.rs
@@ -146,6 +146,7 @@ pub fn commit_prepared_diary_rollup(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: prepared.importance as f64,
     };
 
     db.upsert_drawer_and_replace_vector(&drawer, vector)

--- a/src/knowledge_distill.rs
+++ b/src/knowledge_distill.rs
@@ -161,6 +161,7 @@ pub fn prepare_distill(db: &Database, request: DistillRequest) -> Result<Distill
         verification_refs: Vec::new(),
         scope_constraints,
         trigger_hints,
+        effective_importance: request.importance as f64,
     };
 
     Ok(DistillPlan::Create(Box::new(PreparedDistill {

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,15 @@ enum Commands {
         since: Option<String>,
         #[arg(long, default_value_t = false)]
         raw: bool,
+        /// List drawers whose effective_importance is below this threshold (P13).
+        #[arg(long, default_value_t = false)]
+        stale: bool,
+        /// Threshold for --stale (default: 0.5).
+        #[arg(long, default_value_t = 0.5)]
+        threshold: f64,
     },
+    /// Recompute effective_importance for all active drawers using current decay params (P13).
+    RecomputeImportance,
     /// Run offline contradiction check on text against KG triples +
     /// known-entity registry. Pure read, no LLM, no network.
     FactCheck {
@@ -1078,15 +1086,28 @@ fn run() -> Result<()> {
                 raw,
             },
         ),
-        Commands::Audit { kind, since, raw } => observability::audit_command(
-            &db,
-            config.as_ref(),
-            observability::AuditOptions {
-                kind: kind.as_deref(),
-                since: since.as_deref(),
-                raw,
-            },
-        ),
+        Commands::Audit {
+            kind,
+            since,
+            raw,
+            stale,
+            threshold,
+        } => {
+            if stale {
+                audit_stale_command(&db, threshold)
+            } else {
+                observability::audit_command(
+                    &db,
+                    config.as_ref(),
+                    observability::AuditOptions {
+                        kind: kind.as_deref(),
+                        since: since.as_deref(),
+                        raw,
+                    },
+                )
+            }
+        }
+        Commands::RecomputeImportance => recompute_effective_importance_command(&db),
         Commands::FactCheck {
             path,
             wing,
@@ -2507,6 +2528,56 @@ fn recompute_importance_command(db: &Database, only_zero: bool) -> Result<()> {
         .bulk_update_importance(&updates)
         .context("failed to apply importance scores")?;
     println!("updated {updated} drawers with recomputed importance scores");
+    Ok(())
+}
+
+fn audit_stale_command(db: &Database, threshold: f64) -> Result<()> {
+    let rows = db
+        .drawers_below_importance_threshold(threshold, 200)
+        .context("failed to query stale drawers")?;
+    if rows.is_empty() {
+        println!("no drawers below effective_importance threshold {threshold:.3}");
+        return Ok(());
+    }
+    println!(
+        "{:<44}  {:<20}  {:<16}  {:>8}  {:>10}  {:>16}",
+        "drawer_id", "wing", "room", "eff_imp", "accesses", "last_accessed_at"
+    );
+    println!("{}", "-".repeat(120));
+    for (id, wing, room, eff_imp, access_count, last_accessed_ms) in &rows {
+        let room_str = room.as_deref().unwrap_or("-");
+        let last_str = last_accessed_ms
+            .map(|ms| {
+                use std::time::{Duration, UNIX_EPOCH};
+                let secs = (ms / 1000) as u64;
+                let t = UNIX_EPOCH + Duration::from_secs(secs);
+                mempal::cowork::peek::format_rfc3339(t)
+            })
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{id:<44}  {wing:<20}  {room_str:<16}  {eff_imp:>8.3}  {access_count:>10}  {last_str:>16}"
+        );
+    }
+    println!("\n{} drawer(s) below threshold {threshold:.3}", rows.len());
+    Ok(())
+}
+
+fn recompute_effective_importance_command(db: &Database) -> Result<()> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let config = mempal::core::config::ConfigHandle::current();
+    let imp = &config.importance;
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    println!(
+        "recomputing effective_importance (decay_rate={}, floor={}, boost_cap={})...",
+        imp.decay_rate, imp.floor, imp.boost_cap
+    );
+    let updated = db
+        .recompute_all_effective_importance(now_ms, imp.decay_rate, imp.floor, imp.boost_cap)
+        .context("failed to recompute effective_importance")?;
+    println!("updated {updated} drawers");
     Ok(())
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -10,5 +10,6 @@ pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
     ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
-    RollbackRequest, RollbackResponse, SearchRequest, SearchResponse, StatusResponse,
+    RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest, SearchResponse,
+    SearchResultDto, StatusResponse,
 };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -37,7 +37,7 @@ use crate::knowledge_lifecycle::{
     promote_knowledge,
 };
 use crate::search::{
-    SearchFilters, SearchOptions, resolve_route, search_bm25_only,
+    SearchFilters, SearchOptions, dispatch_access_update, resolve_route, search_bm25_only,
     search_with_vector_and_scope_options,
 };
 use anyhow::Context;
@@ -78,6 +78,9 @@ pub struct MempalMcpServer {
     client_name: Arc<Mutex<Option<String>>>,
     client_project_id: Arc<Mutex<Option<String>>>,
     client_peer: Arc<Mutex<Option<Peer<rmcp::RoleServer>>>>,
+    /// Per-session drawer IDs that were returned by `mempal_search`.
+    /// Flushed and boosted on the next `mempal_ingest` call (P13).
+    session_hit_drawers: Arc<Mutex<HashSet<String>>>,
 }
 
 impl MempalMcpServer {
@@ -110,6 +113,7 @@ impl MempalMcpServer {
             client_name: Arc::new(Mutex::new(None)),
             client_project_id: Arc::new(Mutex::new(None)),
             client_peer: Arc::new(Mutex::new(None)),
+            session_hit_drawers: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -596,6 +600,7 @@ fn drawer_from_ingest_metadata(
         verification_refs: metadata.verification_refs.clone(),
         scope_constraints: metadata.scope_constraints.clone(),
         trigger_hints: metadata.trigger_hints.clone(),
+        effective_importance: request.importance.unwrap_or(0) as f64,
     }
 }
 
@@ -1023,6 +1028,15 @@ impl MempalMcpServer {
                 })?
             }
         };
+
+        // Track hit drawer IDs for session-ingest boost (P13).
+        let hit_ids: Vec<String> = results.iter().map(|r| r.drawer_id.clone()).collect();
+        if !hit_ids.is_empty() {
+            if let Ok(mut guard) = self.session_hit_drawers.lock() {
+                guard.extend(hit_ids.iter().cloned());
+            }
+            dispatch_access_update(self.db_path.clone(), hit_ids);
+        }
 
         let mut system_warnings = current_system_warnings();
         system_warnings.extend(extra_warnings);
@@ -1844,6 +1858,38 @@ impl MempalMcpServer {
 
         drop(lock_guard);
 
+        // Apply session-ingest boost to previously searched drawers (P13).
+        {
+            let hit_ids: Vec<String> = self
+                .session_hit_drawers
+                .lock()
+                .map(|mut guard| {
+                    let ids: Vec<String> = guard.iter().cloned().collect();
+                    guard.clear();
+                    ids
+                })
+                .unwrap_or_default();
+            if !hit_ids.is_empty() {
+                use std::time::{SystemTime, UNIX_EPOCH};
+                let now_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let imp = &config.importance;
+                let db_boost = self.open_db()?;
+                if let Err(err) = db_boost.apply_ingest_boost_batch(
+                    &hit_ids,
+                    now_ms,
+                    imp.boost_per_access,
+                    imp.boost_cap,
+                    imp.decay_rate,
+                    imp.floor,
+                ) {
+                    tracing::warn!(error = %err, "session-ingest boost failed");
+                }
+            }
+        }
+
         if !inserted_drawer_ids.is_empty() {
             response_drawer_id = inserted_drawer_ids[0].clone();
         }
@@ -2387,6 +2433,20 @@ impl MempalMcpServer {
             crate::factcheck::check(&request.text, &db, now_secs, scope)
         })
         .map_err(fact_check_error)?;
+
+        // Apply stale penalty to drawers associated with StaleFact triples (P13).
+        let stale_penalty = ConfigHandle::current().importance.stale_penalty;
+        for issue in &report.issues {
+            if let crate::factcheck::FactIssue::StaleFact {
+                source_drawer: Some(drawer_id),
+                ..
+            } = issue
+            {
+                if let Err(err) = db.apply_stale_penalty_to_drawer(drawer_id, stale_penalty) {
+                    tracing::warn!(drawer_id, error = %err, "stale penalty application failed");
+                }
+            }
+        }
 
         Ok(Json(FactCheckResponse {
             issues: report.issues,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -387,6 +387,8 @@ pub struct SearchResultDto {
     pub emotions: Vec<String>,
     /// Importance derived from AAAK flags, normalized to the existing 2-4 scale.
     pub importance_stars: u8,
+    /// Dynamic importance after time-decay + retrieval boost (P13).
+    pub effective_importance: f64,
     pub memory_kind: String,
     pub domain: String,
     pub field: String,
@@ -1045,6 +1047,7 @@ impl SearchResultDto {
             chunk_index: _,
             neighbors,
             tunnel_hints,
+            effective_importance,
         } = value;
         let analyzed_content = crate::session_review::analysis_content(&content);
         let signals = crate::aaak::analyze(analyzed_content);
@@ -1076,6 +1079,7 @@ impl SearchResultDto {
             flags: signals.flags,
             emotions: signals.emotions,
             importance_stars: signals.importance_stars,
+            effective_importance,
             memory_kind: memory_kind_slug(&memory_kind).to_string(),
             domain: domain_slug(&domain).to_string(),
             field,
@@ -1278,6 +1282,7 @@ mod tests {
             chunk_index: Some(0),
             neighbors: None,
             tunnel_hints: vec!["docs".to_string()],
+            effective_importance: 0.0,
         }
     }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -281,7 +281,54 @@ pub fn search_with_vector_and_scope_options(
         inject_chunk_neighbors(db, &mut results)?;
     }
 
+    // Post-RRF secondary reranking by effective_importance (P13).
+    // Does NOT alter the similarity field; purely reorders within the final set.
+    rerank_by_effective_importance(&mut results);
+
     Ok(results)
+}
+
+/// Post-RRF secondary sort by `effective_importance` (descending).
+///
+/// Uses a stable sort so ties preserve the RRF score ordering.
+/// Per spec: must not modify the `similarity` field.
+fn rerank_by_effective_importance(results: &mut [SearchResult]) {
+    results.sort_by(|a, b| {
+        b.effective_importance
+            .partial_cmp(&a.effective_importance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+}
+
+/// Dispatch an async task to update access tracking fields for the given drawer IDs.
+///
+/// This must not block the search response path. The update runs on the current
+/// tokio runtime as a detached `spawn_blocking` task.
+pub fn dispatch_access_update(db_path: std::path::PathBuf, drawer_ids: Vec<String>) {
+    if drawer_ids.is_empty() {
+        return;
+    }
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let config = crate::core::config::ConfigHandle::current();
+    let decay_rate = config.importance.decay_rate;
+    let floor = config.importance.floor;
+    let boost_cap = config.importance.boost_cap;
+    tokio::task::spawn_blocking(move || match crate::core::db::Database::open(&db_path) {
+        Ok(db) => {
+            if let Err(err) =
+                db.update_access_fields_batch(&drawer_ids, now_ms, decay_rate, floor, boost_cap)
+            {
+                tracing::warn!(error = %err, "access field update failed");
+            }
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to open db for access update");
+        }
+    });
 }
 
 /// BM25-only search path (fork API, used when embedder is unavailable).
@@ -521,6 +568,7 @@ fn result_from_drawer(
         chunk_index: drawer.chunk_index,
         neighbors: None,
         tunnel_hints: vec![],
+        effective_importance: drawer.effective_importance,
     }
 }
 
@@ -743,6 +791,8 @@ pub fn search_by_vector(
                     chunk_index: None,
                     neighbors: None,
                     tunnel_hints: vec![],
+                    // Hydrated by `hydrate_result_metadata` below.
+                    effective_importance: 0.0,
                 })
             },
         )
@@ -849,6 +899,8 @@ fn search_by_vector_scoped_exact(
                     chunk_index: None,
                     neighbors: None,
                     tunnel_hints: vec![],
+                    // Hydrated by `hydrate_result_metadata` below.
+                    effective_importance: 0.0,
                 })
             },
         )
@@ -1124,6 +1176,7 @@ mod tests {
             chunk_index: None,
             neighbors: None,
             tunnel_hints: vec![],
+            effective_importance: 0.0,
         }
     }
 

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -535,7 +535,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 9"),
+            .any(|line| line.trim() == "fork_ext_version: 10"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -108,6 +108,7 @@ fn knowledge_drawer(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: 3.0,
     }
 }
 
@@ -139,6 +140,7 @@ fn evidence_drawer(id: &str, content: &str) -> Drawer {
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: 2.0,
     }
 }
 

--- a/tests/importance_decay.rs
+++ b/tests/importance_decay.rs
@@ -1,0 +1,508 @@
+use std::fs;
+use std::process::Command;
+
+use mempal::core::config::ImportanceConfig;
+use mempal::core::db::{Database, read_fork_ext_version};
+use mempal::core::decay::{compute_effective_importance, elapsed_days};
+use mempal::core::types::{Drawer, SourceType, Triple};
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn default_importance_config() -> ImportanceConfig {
+    ImportanceConfig::default()
+}
+
+fn setup_home(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    let home = tmp.path().join("home");
+    let mempal_home = home.join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create .mempal dir");
+    let db_path = mempal_home.join("palace.db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    Database::open(&db_path).expect("initialize db");
+    (home, db_path)
+}
+
+fn insert_test_drawer(db_path: &std::path::Path, id: &str, wing: &str, importance: i32) {
+    let db = Database::open(db_path).expect("open db");
+    db.insert_drawer(&Drawer {
+        id: id.to_string(),
+        content: format!("test content for {id}"),
+        wing: wing.to_string(),
+        source_file: Some(format!("{id}.md")),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        importance,
+        ..Drawer::default()
+    })
+    .expect("insert drawer");
+}
+
+fn read_effective_importance(db_path: &std::path::Path, id: &str) -> f64 {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .query_row(
+            "SELECT COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) FROM drawers WHERE id = ?1",
+            [id],
+            |row| row.get::<_, f64>(0),
+        )
+        .expect("read effective_importance")
+}
+
+fn read_access_count(db_path: &std::path::Path, id: &str) -> i64 {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .query_row(
+            "SELECT COALESCE(access_count, 0) FROM drawers WHERE id = ?1",
+            [id],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("read access_count")
+}
+
+fn read_last_accessed_at(db_path: &std::path::Path, id: &str) -> Option<i64> {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .query_row(
+            "SELECT last_accessed_at FROM drawers WHERE id = ?1",
+            [id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .expect("read last_accessed_at")
+}
+
+fn table_has_column(conn: &Connection, table: &str, column: &str) -> bool {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table_info");
+    stmt.query_map([], |row| row.get::<_, String>(1))
+        .expect("query table_info")
+        .any(|r| r.as_deref().unwrap_or("") == column)
+}
+
+fn index_exists(conn: &Connection, name: &str) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?1",
+        [name],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+        > 0
+}
+
+// --- Unit tests for pure decay functions ---
+
+#[test]
+fn test_decay_reduces_importance_over_time() {
+    let config = ImportanceConfig {
+        decay_rate: 0.05,
+        floor: 0.1,
+        boost_per_access: 0.15,
+        boost_cap: 2.0,
+        stale_penalty: 0.5,
+    };
+    let eff = compute_effective_importance(3.0, 30.0, 0.0, &config);
+    assert!(eff < 3.0, "30 days should decay below base: {eff}");
+    assert!(eff >= 0.1, "floor must prevent going below 0.1: {eff}");
+}
+
+#[test]
+fn test_decay_floor_prevents_zero() {
+    let config = ImportanceConfig {
+        decay_rate: 0.01,
+        floor: 0.1,
+        boost_per_access: 0.15,
+        boost_cap: 2.0,
+        stale_penalty: 0.5,
+    };
+    let eff = compute_effective_importance(1.0, 10_000.0, 0.0, &config);
+    assert!(
+        (eff - 0.1).abs() < 1e-9,
+        "floor must clamp to 0.1 at extreme days: {eff}"
+    );
+}
+
+#[test]
+fn test_access_boost_increases_effective_importance() {
+    let config = default_importance_config();
+    let no_boost = compute_effective_importance(2.0, 0.0, 0.0, &config);
+    let with_boost = compute_effective_importance(2.0, 0.0, 0.3, &config);
+    assert!(
+        with_boost > no_boost,
+        "accumulated boost should increase importance: {with_boost} vs {no_boost}"
+    );
+}
+
+#[test]
+fn test_access_boost_capped_at_max() {
+    let config = ImportanceConfig {
+        boost_cap: 2.0,
+        ..default_importance_config()
+    };
+    let eff = compute_effective_importance(3.0, 0.0, 3.0, &config);
+    // boost is capped at 2.0, decay at 0 days ≈ 1.0, so eff ≈ 3.0*1.0 + 2.0 = 5.0
+    let expected = 3.0 * 1.0 + 2.0;
+    assert!(
+        (eff - expected).abs() < 1e-6,
+        "boost must be capped at boost_cap 2.0: expected {expected}, got {eff}"
+    );
+}
+
+#[test]
+fn test_elapsed_days_zero_for_same_timestamp() {
+    let days = elapsed_days(1_000_000, 1_000_000);
+    assert_eq!(days, 0.0);
+}
+
+#[test]
+fn test_elapsed_days_one_day() {
+    let ms_per_day: i64 = 86_400_000;
+    let days = elapsed_days(ms_per_day, 0);
+    assert!((days - 1.0).abs() < 1e-9, "should be 1.0 day: {days}");
+}
+
+// --- Integration tests ---
+
+#[test]
+fn test_fork_ext_migration_v9_to_v10_adds_importance_columns() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+
+    // Verify migration ran and fork_ext_version is current
+    let version = read_fork_ext_version(db.conn()).expect("read fork_ext_version");
+    assert!(
+        version >= 10,
+        "fork_ext_version should be >= 10 after migration: {version}"
+    );
+
+    // Verify new columns exist
+    let conn = db.conn();
+    assert!(
+        table_has_column(conn, "drawers", "last_accessed_at"),
+        "last_accessed_at column must exist"
+    );
+    assert!(
+        table_has_column(conn, "drawers", "access_count"),
+        "access_count column must exist"
+    );
+    assert!(
+        table_has_column(conn, "drawers", "accumulated_boost"),
+        "accumulated_boost column must exist"
+    );
+    assert!(
+        table_has_column(conn, "drawers", "effective_importance"),
+        "effective_importance column must exist"
+    );
+
+    // Verify index exists
+    assert!(
+        index_exists(conn, "idx_drawers_eff_importance"),
+        "idx_drawers_eff_importance must exist"
+    );
+}
+
+#[test]
+fn test_fork_ext_migration_v10_sets_effective_importance_from_importance() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+
+    // Open a fresh db which runs all migrations
+    let db = Database::open(&db_path).expect("open db");
+
+    // Insert a drawer with known importance before checking
+    db.insert_drawer(&Drawer {
+        id: "drawer-imp-check".to_string(),
+        content: "migration check content".to_string(),
+        wing: "test".to_string(),
+        source_file: Some("check.md".to_string()),
+        source_type: SourceType::Manual,
+        added_at: "1713000000".to_string(),
+        importance: 3,
+        ..Drawer::default()
+    })
+    .expect("insert drawer");
+
+    // effective_importance should be readable and >= 0
+    let eff = read_effective_importance(&db_path, "drawer-imp-check");
+    assert!(
+        eff >= 0.0,
+        "effective_importance should be non-negative: {eff}"
+    );
+}
+
+#[test]
+fn test_search_hit_updates_access_fields_async() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (_, db_path) = setup_home(&tmp);
+
+    insert_test_drawer(&db_path, "drawer-access-test", "default", 2);
+
+    // Verify initial state
+    assert_eq!(read_access_count(&db_path, "drawer-access-test"), 0);
+    assert!(read_last_accessed_at(&db_path, "drawer-access-test").is_none());
+
+    // Directly call the DB function that the async search path calls
+    let db = Database::open(&db_path).expect("open db");
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let config = default_importance_config();
+    db.update_access_fields_batch(
+        &["drawer-access-test".to_string()],
+        now_ms,
+        config.decay_rate,
+        config.floor,
+        config.boost_cap,
+    )
+    .expect("update access fields");
+
+    assert_eq!(
+        read_access_count(&db_path, "drawer-access-test"),
+        1,
+        "access_count should be incremented"
+    );
+    assert!(
+        read_last_accessed_at(&db_path, "drawer-access-test").is_some(),
+        "last_accessed_at should be set"
+    );
+}
+
+#[test]
+fn test_session_ingest_boosts_hit_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (_, db_path) = setup_home(&tmp);
+
+    insert_test_drawer(&db_path, "drawer-boost-test", "default", 2);
+
+    let initial_eff = read_effective_importance(&db_path, "drawer-boost-test");
+
+    // Simulate the boost that mempal_ingest applies after search hits
+    let db = Database::open(&db_path).expect("open db");
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let config = default_importance_config();
+    db.apply_ingest_boost_batch(
+        &["drawer-boost-test".to_string()],
+        now_ms,
+        config.boost_per_access,
+        config.boost_cap,
+        config.decay_rate,
+        config.floor,
+    )
+    .expect("apply ingest boost");
+
+    let boosted_eff = read_effective_importance(&db_path, "drawer-boost-test");
+    assert!(
+        boosted_eff > initial_eff,
+        "boost must increase effective_importance: {boosted_eff} > {initial_eff}"
+    );
+}
+
+#[test]
+fn test_stale_kg_triple_penalizes_importance() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (_, db_path) = setup_home(&tmp);
+
+    insert_test_drawer(&db_path, "drawer-stale-test", "default", 3);
+
+    // Set effective_importance to 3.0 explicitly
+    let db = Database::open(&db_path).expect("open db");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET effective_importance = 3.0 WHERE id = 'drawer-stale-test'",
+            [],
+        )
+        .expect("set effective_importance");
+
+    // Add an expired KG triple linked to the drawer
+    let past_secs = 1_000_000u64;
+    db.insert_triple(&Triple {
+        id: "triple-stale-1".to_string(),
+        subject: "TestEntity".to_string(),
+        predicate: "uses".to_string(),
+        object: "OldTechnology".to_string(),
+        valid_from: None,
+        valid_to: Some(past_secs.to_string()),
+        confidence: 1.0,
+        source_drawer: Some("drawer-stale-test".to_string()),
+    })
+    .expect("insert triple");
+
+    // Apply stale penalty (0.5 by default)
+    let config = default_importance_config();
+    db.apply_stale_penalty_to_drawer("drawer-stale-test", config.stale_penalty)
+        .expect("apply stale penalty");
+
+    let penalized_eff = read_effective_importance(&db_path, "drawer-stale-test");
+    let expected = 3.0 * config.stale_penalty;
+    assert!(
+        (penalized_eff - expected).abs() < 1e-6,
+        "stale penalty should multiply by {}: expected {expected}, got {penalized_eff}",
+        config.stale_penalty
+    );
+}
+
+#[test]
+fn test_audit_stale_surfaces_decayed_drawers() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (home, db_path) = setup_home(&tmp);
+
+    insert_test_drawer(&db_path, "drawer-low-imp", "default", 1);
+    insert_test_drawer(&db_path, "drawer-high-imp", "default", 3);
+
+    // Set explicit effective_importance values
+    let db = Database::open(&db_path).expect("open db");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET effective_importance = 0.4 WHERE id = 'drawer-low-imp'",
+            [],
+        )
+        .expect("set low eff imp");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET effective_importance = 3.0 WHERE id = 'drawer-high-imp'",
+            [],
+        )
+        .expect("set high eff imp");
+    drop(db);
+
+    let output = Command::new(mempal_bin())
+        .env("HOME", &home)
+        .args(["audit", "--stale", "--threshold", "0.5"])
+        .output()
+        .expect("run audit --stale");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "audit --stale should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("drawer-low-imp"),
+        "audit --stale should list low-importance drawer: {stdout}"
+    );
+    assert!(
+        !stdout.contains("drawer-high-imp"),
+        "audit --stale should not list high-importance drawer: {stdout}"
+    );
+}
+
+#[test]
+fn test_search_result_dto_includes_effective_importance() {
+    // Verify that SearchResultDto has the effective_importance field by checking
+    // that the struct compiles with the field set (type-level check via instantiation).
+    use mempal::mcp::{RouteDecisionDto, SearchResultDto};
+
+    let _dto = SearchResultDto {
+        drawer_id: "test".to_string(),
+        content: "content".to_string(),
+        content_truncated: false,
+        original_content_bytes: 0,
+        wing: "wing".to_string(),
+        room: None,
+        source_file: "file.md".to_string(),
+        source: "bm25".to_string(),
+        similarity: 0.9,
+        route: RouteDecisionDto {
+            wing: None,
+            room: None,
+            confidence: 0.8,
+            reason: "test".to_string(),
+        },
+        tunnel_hints: vec![],
+        neighbors: None,
+        entities: vec![],
+        topics: vec![],
+        flags: vec![],
+        emotions: vec![],
+        importance_stars: 3,
+        effective_importance: 2.5,
+        memory_kind: "evidence".to_string(),
+        domain: "project".to_string(),
+        field: "default".to_string(),
+        statement: None,
+        tier: None,
+        status: None,
+        anchor_kind: "global".to_string(),
+        anchor_id: "anc".to_string(),
+        parent_anchor_id: None,
+    };
+    assert!((_dto.effective_importance - 2.5).abs() < 1e-9);
+}
+
+#[test]
+fn test_recompute_all_effective_importance_cli() {
+    let tmp = TempDir::new().expect("tempdir");
+    let (home, db_path) = setup_home(&tmp);
+
+    insert_test_drawer(&db_path, "drawer-recompute-1", "default", 2);
+    insert_test_drawer(&db_path, "drawer-recompute-2", "default", 4);
+
+    let output = Command::new(mempal_bin())
+        .env("HOME", &home)
+        .arg("recompute-importance")
+        .output()
+        .expect("run recompute-importance");
+
+    assert!(
+        output.status.success(),
+        "recompute-importance should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("updated"),
+        "should report updated count: {stdout}"
+    );
+}
+
+#[test]
+fn test_importance_config_hot_reload_decay_rate() {
+    // This test verifies the config struct accepts updated decay_rate and that
+    // compute_effective_importance uses it. Full hot-reload daemon test is omitted
+    // (daemon lifecycle is complex; covered by config_hot_reload integration suite).
+    let config_a = ImportanceConfig {
+        decay_rate: 0.05,
+        ..default_importance_config()
+    };
+    let config_b = ImportanceConfig {
+        decay_rate: 0.0,
+        ..default_importance_config()
+    };
+
+    let eff_a = compute_effective_importance(3.0, 30.0, 0.0, &config_a);
+    let eff_b = compute_effective_importance(3.0, 30.0, 0.0, &config_b);
+
+    assert!(
+        eff_b > eff_a,
+        "zero decay_rate should produce higher effective_importance: {eff_b} > {eff_a}"
+    );
+    // With decay_rate = 0.0, exp(0) = 1.0, so eff_b ≈ base * 1.0 + 0 = 3.0
+    assert!(
+        (eff_b - 3.0).abs() < 1e-9,
+        "zero decay_rate must yield exactly base importance: {eff_b}"
+    );
+}

--- a/tests/importance_decay.rs
+++ b/tests/importance_decay.rs
@@ -39,6 +39,11 @@ backend = "model2vec"
 }
 
 fn insert_test_drawer(db_path: &std::path::Path, id: &str, wing: &str, importance: i32) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(1_746_000_000);
     let db = Database::open(db_path).expect("open db");
     db.insert_drawer(&Drawer {
         id: id.to_string(),
@@ -46,11 +51,19 @@ fn insert_test_drawer(db_path: &std::path::Path, id: &str, wing: &str, importanc
         wing: wing.to_string(),
         source_file: Some(format!("{id}.md")),
         source_type: SourceType::Manual,
-        added_at: "1713000000".to_string(),
+        added_at: now_secs.to_string(),
         importance,
         ..Drawer::default()
     })
     .expect("insert drawer");
+    // Set effective_importance to the base importance so tests start from a
+    // meaningful baseline rather than the default 0.0.
+    db.conn()
+        .execute(
+            "UPDATE drawers SET effective_importance = CAST(importance AS REAL) WHERE id = ?1",
+            [id],
+        )
+        .expect("backfill initial effective_importance");
 }
 
 fn read_effective_importance(db_path: &std::path::Path, id: &str) -> f64 {
@@ -209,6 +222,10 @@ fn test_fork_ext_migration_v9_to_v10_adds_importance_columns() {
         table_has_column(conn, "drawers", "effective_importance"),
         "effective_importance column must exist"
     );
+    assert!(
+        table_has_column(conn, "drawers", "stale_penalty_applied"),
+        "stale_penalty_applied column must exist"
+    );
 
     // Verify index exists
     assert!(
@@ -359,6 +376,21 @@ fn test_stale_kg_triple_penalizes_importance() {
     assert!(
         (penalized_eff - expected).abs() < 1e-6,
         "stale penalty should multiply by {}: expected {expected}, got {penalized_eff}",
+        config.stale_penalty
+    );
+
+    // Verify stale_penalty_applied is persisted so recompute doesn't lose it.
+    let stored_penalty: f64 = db
+        .conn()
+        .query_row(
+            "SELECT COALESCE(stale_penalty_applied, 1.0) FROM drawers WHERE id = 'drawer-stale-test'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read stale_penalty_applied");
+    assert!(
+        (stored_penalty - config.stale_penalty).abs() < 1e-6,
+        "stale_penalty_applied must be persisted: expected {}, got {stored_penalty}",
         config.stale_penalty
     );
 }

--- a/tests/importance_decay.rs
+++ b/tests/importance_decay.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use mempal::core::config::ImportanceConfig;
 use mempal::core::db::{Database, read_fork_ext_version};
-use mempal::core::decay::{compute_effective_importance, elapsed_days};
+use mempal::core::decay::compute_effective_importance;
 use mempal::core::types::{Drawer, SourceType, Triple};
 use rusqlite::Connection;
 use tempfile::TempDir;
@@ -116,77 +116,6 @@ fn index_exists(conn: &Connection, name: &str) -> bool {
     )
     .unwrap_or(0)
         > 0
-}
-
-// --- Unit tests for pure decay functions ---
-
-#[test]
-fn test_decay_reduces_importance_over_time() {
-    let config = ImportanceConfig {
-        decay_rate: 0.05,
-        floor: 0.1,
-        boost_per_access: 0.15,
-        boost_cap: 2.0,
-        stale_penalty: 0.5,
-    };
-    let eff = compute_effective_importance(3.0, 30.0, 0.0, &config);
-    assert!(eff < 3.0, "30 days should decay below base: {eff}");
-    assert!(eff >= 0.1, "floor must prevent going below 0.1: {eff}");
-}
-
-#[test]
-fn test_decay_floor_prevents_zero() {
-    let config = ImportanceConfig {
-        decay_rate: 0.01,
-        floor: 0.1,
-        boost_per_access: 0.15,
-        boost_cap: 2.0,
-        stale_penalty: 0.5,
-    };
-    let eff = compute_effective_importance(1.0, 10_000.0, 0.0, &config);
-    assert!(
-        (eff - 0.1).abs() < 1e-9,
-        "floor must clamp to 0.1 at extreme days: {eff}"
-    );
-}
-
-#[test]
-fn test_access_boost_increases_effective_importance() {
-    let config = default_importance_config();
-    let no_boost = compute_effective_importance(2.0, 0.0, 0.0, &config);
-    let with_boost = compute_effective_importance(2.0, 0.0, 0.3, &config);
-    assert!(
-        with_boost > no_boost,
-        "accumulated boost should increase importance: {with_boost} vs {no_boost}"
-    );
-}
-
-#[test]
-fn test_access_boost_capped_at_max() {
-    let config = ImportanceConfig {
-        boost_cap: 2.0,
-        ..default_importance_config()
-    };
-    let eff = compute_effective_importance(3.0, 0.0, 3.0, &config);
-    // boost is capped at 2.0, decay at 0 days ≈ 1.0, so eff ≈ 3.0*1.0 + 2.0 = 5.0
-    let expected = 3.0 * 1.0 + 2.0;
-    assert!(
-        (eff - expected).abs() < 1e-6,
-        "boost must be capped at boost_cap 2.0: expected {expected}, got {eff}"
-    );
-}
-
-#[test]
-fn test_elapsed_days_zero_for_same_timestamp() {
-    let days = elapsed_days(1_000_000, 1_000_000);
-    assert_eq!(days, 0.0);
-}
-
-#[test]
-fn test_elapsed_days_one_day() {
-    let ms_per_day: i64 = 86_400_000;
-    let days = elapsed_days(ms_per_day, 0);
-    assert!((days - 1.0).abs() < 1e-9, "should be 1.0 day: {days}");
 }
 
 // --- Integration tests ---

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -192,6 +192,7 @@ fn insert_knowledge_with_refs(
         verification_refs: refs.verification,
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: 4.0,
     };
     db.insert_drawer(&drawer).expect("insert knowledge");
     db.insert_vector(id, &vector())
@@ -238,6 +239,7 @@ fn insert_knowledge_with_anchor(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: 4.0,
     };
     db.insert_drawer(&drawer)
         .expect("insert anchored knowledge");

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -448,6 +448,7 @@ fn bootstrap_drawer(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        effective_importance: 2.0,
     }
 }
 
@@ -650,6 +651,7 @@ fn test_insert_load_roundtrip_preserves_json_metadata_and_read_paths() {
             workflow_bias: vec!["tdd".to_string()],
             tool_needs: vec!["cargo-check".to_string()],
         }),
+        effective_importance: 3.0,
     };
 
     db.insert_drawer(&drawer).expect("insert drawer");

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "62cdea34d2fff2075800bee4503dcd7d0d9325d3"
+commit = "ee6f519a6eb769de92236e2a13251e7a3e1305b6"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Implements the P13 Importance Decay spec — exponential time-based decay + retrieval boost + stale penalty for mempal's memory importance system.

- **Schema**: fork_ext_version v10 migration adds `last_accessed_ms`, `access_count`, `accumulated_boost`, `effective_importance`, `stale_penalty_applied` columns to `drawers`
- **Decay formula**: `importance * exp(-decay_rate * days) * stale_penalty + min(boost, cap)` — all computed in single atomic SQL UPDATE
- **Search integration**: async access update on search hits, post-RRF rerank by effective_importance
- **Session boost**: tracks hit drawers per MCP session, boosts on subsequent ingest
- **Stale penalty**: persisted via `stale_penalty_applied` column, survives recompute
- **CLI**: `mempal recompute-importance`, `mempal audit --stale`
- **SQLite**: custom `EXP()` scalar function registered (bundled SQLite lacks math functions)
- **Config**: all decay params in hot-reload whitelist

## Key fixes during review

- ISO 8601 `CAST(added_at AS INTEGER)` → `strftime('%s', added_at) * 1000` (was returning calendar year `2026`)
- Batch recompute pagination: `MAX(rowid)` wrapped in subquery to scope to batch
- `stale_penalty_applied` persisted column (penalty survives recompute)
- Test baselines use epoch-second `added_at` + backfill `effective_importance`

## Test plan

- [x] 15 new integration tests + 7 unit tests (core::decay)
- [x] All 897 pre-existing tests pass
- [x] `just pre-commit` green (fmt + clippy + test)
- [x] Two rounds of local `csa review` (FAIL → fix → PASS cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)