### PR TITLE
feat(fork-ext): implement p15-skill-crystallization (closes #119)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,7 @@ use crate::core::{
     db::Database,
     db::DbError,
     patterns::PatternSummary,
+    skills::SkillForContext,
     types::{
         AnchorKind, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, RouteDecision,
         SearchResult, TriggerHints,
@@ -69,6 +70,9 @@ pub struct TieredAssembly {
     pub t2_items: Vec<TieredItem>,
     pub t3_items: Vec<TieredItem>,
     pub budget_used: BudgetUsed,
+    /// Active skills injected at the head of T1 (P15).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_skills: Vec<SkillForContext>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -92,6 +96,9 @@ pub struct ContextPack {
     /// Active repair warnings injected at T1 priority (P14 decision-repair).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repair_warnings: Vec<crate::repair::RepairWarning>,
+    /// Active skills injected at T1 head priority (P15 skill crystallization).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_skills: Vec<SkillForContext>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -277,11 +284,19 @@ fn assemble_tiered(
     // Build legacy sections for backward compat.
     let sections = build_tiered_sections(db, &t1_items, &t2_results, &t3_all, &request)?;
 
+    let active_skills = load_active_skills(
+        db,
+        project_id,
+        query_vector,
+        &crate::core::config::ConfigHandle::current().skills,
+    );
+
     let tiered = TieredAssembly {
         t1_items,
         t2_items: t2_results,
         t3_items: t3_all,
         budget_used,
+        active_skills: active_skills.clone(),
     };
 
     let anchors = context_anchors(&request)?;
@@ -303,6 +318,7 @@ fn assemble_tiered(
         recurring_themes,
         tiered: Some(tiered),
         repair_warnings,
+        active_skills,
     })
 }
 
@@ -570,6 +586,12 @@ fn assemble_flat(
 
     let recurring_themes = load_recurring_themes(db, request.project_id.as_deref());
     let repair_warnings = load_repair_warnings(db, request.project_id.as_deref());
+    let active_skills = load_active_skills(
+        db,
+        request.project_id.as_deref(),
+        query_vector,
+        &crate::core::config::ConfigHandle::current().skills,
+    );
 
     Ok(ContextPack {
         query: request.query,
@@ -586,7 +608,31 @@ fn assemble_flat(
         recurring_themes,
         tiered: None,
         repair_warnings,
+        active_skills,
     })
+}
+
+fn load_active_skills(
+    db: &Database,
+    project_id: Option<&str>,
+    query_vector: &[f32],
+    skills_cfg: &crate::core::config::SkillsConfig,
+) -> Vec<SkillForContext> {
+    if !crate::core::skills::skills_table_exists(db.conn()) {
+        return vec![];
+    }
+    match crate::core::skills::load_active_skills_for_context(
+        db.conn(),
+        project_id,
+        query_vector,
+        skills_cfg.skill_surfacing_threshold as f32,
+    ) {
+        Ok(skills) => skills,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to load active skills for context");
+            vec![]
+        }
+    }
 }
 
 fn load_repair_warnings(

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -60,6 +60,10 @@ const DEFAULT_CONTEXT_T1_RECENCY_LAMBDA: f64 = 0.01;
 const DEFAULT_REPAIR_WINDOW_DAYS: u64 = 7;
 const DEFAULT_REPAIR_MIN_FAILURES: usize = 3;
 const DEFAULT_REPAIR_ALERT_THRESHOLD: usize = 3;
+const DEFAULT_SKILLS_ACTIVE_THRESHOLD: i64 = 3;
+const DEFAULT_SKILLS_RETIRE_THRESHOLD: i64 = 3;
+const DEFAULT_SKILLS_MIN_SESSIONS: usize = 5;
+const DEFAULT_SKILLS_SURFACING_THRESHOLD: f64 = 0.70;
 static DEFAULT_SENSITIVE_SCRUBBER: OnceLock<Option<CompiledPrivacyConfig>> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -84,6 +88,7 @@ pub struct Config {
     pub patterns: PatternsConfig,
     pub context: ContextConfig,
     pub repair: RepairConfig,
+    pub skills: SkillsConfig,
 }
 
 impl Default for Config {
@@ -106,6 +111,7 @@ impl Default for Config {
             patterns: PatternsConfig::default(),
             context: ContextConfig::default(),
             repair: RepairConfig::default(),
+            skills: SkillsConfig::default(),
         }
     }
 }
@@ -1262,6 +1268,33 @@ impl Default for RepairConfig {
             window_days: DEFAULT_REPAIR_WINDOW_DAYS,
             min_failures: DEFAULT_REPAIR_MIN_FAILURES,
             alert_threshold: DEFAULT_REPAIR_ALERT_THRESHOLD,
+        }
+    }
+}
+
+/// Configuration for skill crystallization (P15).
+/// All fields are hot-reload whitelisted.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct SkillsConfig {
+    /// Minimum adopt signals needed to promote from probationary → active.
+    pub active_threshold: i64,
+    /// Minimum reject signals (with zero adoptions) to auto-retire a probationary skill.
+    pub retire_threshold: i64,
+    /// Minimum pattern session_count required to promote a pattern to a skill.
+    pub skill_min_sessions: usize,
+    /// Cosine similarity threshold between query vector and pattern signature for
+    /// surfacing matching active skills in T1 context.
+    pub skill_surfacing_threshold: f64,
+}
+
+impl Default for SkillsConfig {
+    fn default() -> Self {
+        Self {
+            active_threshold: DEFAULT_SKILLS_ACTIVE_THRESHOLD,
+            retire_threshold: DEFAULT_SKILLS_RETIRE_THRESHOLD,
+            skill_min_sessions: DEFAULT_SKILLS_MIN_SESSIONS,
+            skill_surfacing_threshold: DEFAULT_SKILLS_SURFACING_THRESHOLD,
         }
     }
 }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -2,8 +2,9 @@
 // harness-point: PR0 — re-export MigrationHook trait + hooked migration runner for tests
 pub use db_fork_ext::{
     CURRENT_FORK_EXT_VERSION, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
-    FORK_EXT_V3_SCHEMA_SQL, MigrationHook, apply_fork_ext_migrations, apply_fork_ext_migrations_to,
-    apply_fork_ext_migrations_with_hook, read_fork_ext_version, set_fork_ext_version,
+    FORK_EXT_V3_SCHEMA_SQL, FORK_EXT_V13_SCHEMA_SQL, MigrationHook, apply_fork_ext_migrations,
+    apply_fork_ext_migrations_to, apply_fork_ext_migrations_with_hook, read_fork_ext_version,
+    set_fork_ext_version,
 };
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,25 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 12;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 13;
+
+pub const FORK_EXT_V13_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS skills (
+    skill_id             TEXT PRIMARY KEY,
+    name                 TEXT NOT NULL,
+    trigger_description  TEXT NOT NULL,
+    pattern_id           TEXT NOT NULL,
+    exemplar_ids         TEXT NOT NULL,
+    adoption_count       INTEGER NOT NULL DEFAULT 0,
+    rejection_count      INTEGER NOT NULL DEFAULT 0,
+    status               TEXT NOT NULL DEFAULT 'probationary',
+    promoted_at          INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL,
+    project_id           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status);
+CREATE INDEX IF NOT EXISTS idx_skills_pattern ON skills(pattern_id);
+"#;
 
 pub const FORK_EXT_V12_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS failure_events (
@@ -261,6 +279,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 12,
             up: apply_v12,
         },
+        Migration {
+            version: 13,
+            up: apply_v13,
+        },
     ]
 }
 
@@ -355,6 +377,10 @@ fn apply_v11(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v12(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V12_SCHEMA_SQL)
+}
+
+fn apply_v13(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V13_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod project;
 pub mod protocol;
 pub mod queue;
 pub mod reindex;
+pub mod skills;
 pub mod timeline;
 pub mod types;
 pub mod utils;

--- a/src/core/skills.rs
+++ b/src/core/skills.rs
@@ -1,0 +1,553 @@
+//! Skill crystallization (P15): promote validated patterns into callable skills.
+
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+
+pub const SKILLS_SCHEMA_MIN_FORK_EXT_VERSION: u32 = 13;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillStatus {
+    Probationary,
+    Active,
+    Retired,
+}
+
+impl SkillStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Probationary => "probationary",
+            Self::Active => "active",
+            Self::Retired => "retired",
+        }
+    }
+}
+
+impl std::str::FromStr for SkillStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "probationary" => Ok(Self::Probationary),
+            "active" => Ok(Self::Active),
+            "retired" => Ok(Self::Retired),
+            other => Err(format!("unknown skill status: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Skill {
+    pub skill_id: String,
+    pub name: String,
+    pub trigger_description: String,
+    pub pattern_id: String,
+    pub exemplar_ids: Vec<String>,
+    pub adoption_count: i64,
+    pub rejection_count: i64,
+    pub status: SkillStatus,
+    pub promoted_at: i64,
+    pub updated_at: i64,
+    pub project_id: Option<String>,
+}
+
+impl Skill {
+    /// Laplace-smoothed adoption rate. Computed at query time, not stored.
+    pub fn eta(&self) -> f64 {
+        compute_eta(self.adoption_count, self.rejection_count)
+    }
+}
+
+/// Lightweight skill summary for context injection into T1.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillForContext {
+    pub skill_id: String,
+    pub name: String,
+    pub trigger_description: String,
+    pub eta: f64,
+    pub exemplar_count: usize,
+}
+
+/// Compute Laplace-smoothed adoption rate.
+/// Formula: adoption / (adoption + rejection + 1.0)
+pub fn compute_eta(adoption: i64, rejection: i64) -> f64 {
+    adoption as f64 / (adoption as f64 + rejection as f64 + 1.0)
+}
+
+#[derive(Debug, Error)]
+pub enum PromotionError {
+    #[error("pattern not found: {0}")]
+    PatternNotFound(String),
+    #[error("pattern is not active (current status: {0})")]
+    PatternNotActive(String),
+    #[error("pattern has insufficient session count ({0} < {1})")]
+    InsufficientSessions(usize, usize),
+    #[error("a probationary or active skill already exists for this pattern")]
+    SkillAlreadyExists,
+    #[error("database error: {0}")]
+    Db(#[from] rusqlite::Error),
+}
+
+pub struct PromoteArgs<'a> {
+    pub pattern_id: &'a str,
+    pub name: &'a str,
+    pub trigger_description: &'a str,
+    pub skill_min_sessions: usize,
+    pub project_id: Option<&'a str>,
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn new_skill_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!(
+        "{:08x}-{:04x}-4{:03x}-{:04x}-{:012x}",
+        (ts >> 96) as u32,
+        (ts >> 80) as u16,
+        (ts >> 68) as u16 & 0x0fff,
+        ((ts >> 52) as u16 & 0x3fff) | 0x8000,
+        ts as u64 & 0xffffffffffff,
+    )
+}
+
+/// Returns true if the `skills` table exists (fork_ext_version >= 13).
+pub fn skills_table_exists(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='skills'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+        > 0
+}
+
+/// Promote an active pattern to a probationary skill.
+pub fn promote_pattern_to_skill(
+    conn: &Connection,
+    args: &PromoteArgs<'_>,
+) -> Result<Skill, PromotionError> {
+    // Fetch pattern, check status and session_count.
+    let row = conn
+        .query_row(
+            "SELECT status, session_count, exemplar_ids FROM patterns WHERE pattern_id = ?1",
+            [args.pattern_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(PromotionError::Db)?;
+
+    let (status_str, session_count, exemplar_json) =
+        row.ok_or_else(|| PromotionError::PatternNotFound(args.pattern_id.to_string()))?;
+
+    if status_str != "active" {
+        return Err(PromotionError::PatternNotActive(status_str));
+    }
+    if (session_count as usize) < args.skill_min_sessions {
+        return Err(PromotionError::InsufficientSessions(
+            session_count as usize,
+            args.skill_min_sessions,
+        ));
+    }
+
+    // Check for existing probationary/active skill on this pattern.
+    let existing = conn
+        .query_row(
+            "SELECT COUNT(*) FROM skills WHERE pattern_id = ?1 AND status IN ('probationary', 'active')",
+            [args.pattern_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(PromotionError::Db)?;
+    if existing > 0 {
+        return Err(PromotionError::SkillAlreadyExists);
+    }
+
+    let exemplar_ids: Vec<String> = serde_json::from_str(&exemplar_json).unwrap_or_default();
+    let exemplar_ids_json =
+        serde_json::to_string(&exemplar_ids).unwrap_or_else(|_| "[]".to_string());
+
+    let skill_id = new_skill_id();
+    let now = now_ms();
+
+    conn.execute(
+        r#"
+        INSERT INTO skills (
+            skill_id, name, trigger_description, pattern_id, exemplar_ids,
+            adoption_count, rejection_count, status, promoted_at, updated_at, project_id
+        ) VALUES (?1, ?2, ?3, ?4, ?5, 0, 0, 'probationary', ?6, ?6, ?7)
+        "#,
+        params![
+            skill_id,
+            args.name,
+            args.trigger_description,
+            args.pattern_id,
+            exemplar_ids_json,
+            now,
+            args.project_id,
+        ],
+    )
+    .map_err(PromotionError::Db)?;
+
+    Ok(Skill {
+        skill_id,
+        name: args.name.to_string(),
+        trigger_description: args.trigger_description.to_string(),
+        pattern_id: args.pattern_id.to_string(),
+        exemplar_ids,
+        adoption_count: 0,
+        rejection_count: 0,
+        status: SkillStatus::Probationary,
+        promoted_at: now,
+        updated_at: now,
+        project_id: args.project_id.map(str::to_string),
+    })
+}
+
+/// Record an adoption signal. Returns new status after the signal.
+/// If adoption_count reaches active_threshold, skill transitions to active.
+pub fn adopt_skill(
+    conn: &Connection,
+    skill_id: &str,
+    active_threshold: i64,
+) -> rusqlite::Result<Option<SkillStatus>> {
+    let now = now_ms();
+    // Fetch current state.
+    let row = conn
+        .query_row(
+            "SELECT adoption_count, status FROM skills WHERE skill_id = ?1",
+            [skill_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    let Some((adoption_count, status_str)) = row else {
+        return Ok(None);
+    };
+
+    // Don't record on retired skills (spec allows free signalling, but retired is final).
+    if status_str == "retired" {
+        return Ok(Some(SkillStatus::Retired));
+    }
+
+    let new_adoption = adoption_count + 1;
+    let new_status = if new_adoption >= active_threshold && status_str == "probationary" {
+        "active"
+    } else {
+        &status_str
+    };
+
+    conn.execute(
+        "UPDATE skills SET adoption_count = ?2, status = ?3, updated_at = ?4 WHERE skill_id = ?1",
+        params![skill_id, new_adoption, new_status, now],
+    )?;
+
+    Ok(Some(
+        new_status
+            .parse()
+            .map_err(|_| rusqlite::Error::InvalidQuery)?,
+    ))
+}
+
+/// Record a rejection signal. Returns new status after the signal.
+/// If rejection_count >= retire_threshold AND adoption_count == 0, auto-retires.
+pub fn reject_skill(
+    conn: &Connection,
+    skill_id: &str,
+    retire_threshold: i64,
+) -> rusqlite::Result<Option<SkillStatus>> {
+    let now = now_ms();
+    let row = conn
+        .query_row(
+            "SELECT adoption_count, rejection_count, status FROM skills WHERE skill_id = ?1",
+            [skill_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((adoption_count, rejection_count, status_str)) = row else {
+        return Ok(None);
+    };
+
+    if status_str == "retired" {
+        return Ok(Some(SkillStatus::Retired));
+    }
+
+    let new_rejection = rejection_count + 1;
+    let new_status = if new_rejection >= retire_threshold && adoption_count == 0 {
+        "retired"
+    } else {
+        &status_str
+    };
+
+    conn.execute(
+        "UPDATE skills SET rejection_count = ?2, status = ?3, updated_at = ?4 WHERE skill_id = ?1",
+        params![skill_id, new_rejection, new_status, now],
+    )?;
+
+    Ok(Some(
+        new_status
+            .parse()
+            .map_err(|_| rusqlite::Error::InvalidQuery)?,
+    ))
+}
+
+/// Manually retire a skill. Returns true if found and updated.
+pub fn retire_skill(conn: &Connection, skill_id: &str) -> rusqlite::Result<bool> {
+    let now = now_ms();
+    let count = conn.execute(
+        "UPDATE skills SET status = 'retired', updated_at = ?2 WHERE skill_id = ?1 AND status != 'retired'",
+        params![skill_id, now],
+    )?;
+    Ok(count > 0)
+}
+
+/// Fetch all skills matching optional status and project_id filters.
+pub fn list_skills(
+    conn: &Connection,
+    status: Option<&str>,
+    project_id: Option<&str>,
+) -> rusqlite::Result<Vec<Skill>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT skill_id, name, trigger_description, pattern_id, exemplar_ids,
+               adoption_count, rejection_count, status, promoted_at, updated_at, project_id
+        FROM skills
+        WHERE (?1 IS NULL OR status = ?1)
+          AND (?2 IS NULL OR project_id = ?2 OR project_id IS NULL)
+        ORDER BY updated_at DESC
+        "#,
+    )?;
+    let rows = stmt
+        .query_map(params![status, project_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, i64>(8)?,
+                row.get::<_, i64>(9)?,
+                row.get::<_, Option<String>>(10)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    rows.into_iter()
+        .map(
+            |(
+                skill_id,
+                name,
+                trigger_description,
+                pattern_id,
+                exemplar_json,
+                adoption_count,
+                rejection_count,
+                status_str,
+                promoted_at,
+                updated_at,
+                project_id,
+            )| {
+                let status = status_str
+                    .parse::<SkillStatus>()
+                    .map_err(|_| rusqlite::Error::InvalidQuery)?;
+                Ok(Skill {
+                    skill_id,
+                    name,
+                    trigger_description,
+                    pattern_id,
+                    exemplar_ids: serde_json::from_str(&exemplar_json).unwrap_or_default(),
+                    adoption_count,
+                    rejection_count,
+                    status,
+                    promoted_at,
+                    updated_at,
+                    project_id,
+                })
+            },
+        )
+        .collect()
+}
+
+/// Fetch a single skill by ID.
+pub fn get_skill(conn: &Connection, skill_id: &str) -> rusqlite::Result<Option<Skill>> {
+    let result = conn
+        .query_row(
+            r#"
+            SELECT skill_id, name, trigger_description, pattern_id, exemplar_ids,
+                   adoption_count, rejection_count, status, promoted_at, updated_at, project_id
+            FROM skills WHERE skill_id = ?1
+            "#,
+            [skill_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, i64>(5)?,
+                    row.get::<_, i64>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, i64>(9)?,
+                    row.get::<_, Option<String>>(10)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    let Some((
+        skill_id,
+        name,
+        trigger_description,
+        pattern_id,
+        exemplar_json,
+        adoption_count,
+        rejection_count,
+        status_str,
+        promoted_at,
+        updated_at,
+        project_id,
+    )) = result
+    else {
+        return Ok(None);
+    };
+
+    let status = status_str
+        .parse::<SkillStatus>()
+        .map_err(|_| rusqlite::Error::InvalidQuery)?;
+
+    Ok(Some(Skill {
+        skill_id,
+        name,
+        trigger_description,
+        pattern_id,
+        exemplar_ids: serde_json::from_str(&exemplar_json).unwrap_or_default(),
+        adoption_count,
+        rejection_count,
+        status,
+        promoted_at,
+        updated_at,
+        project_id,
+    }))
+}
+
+/// Load active skills for context injection into T1.
+/// Filters by cosine similarity between query_vector and the pattern signature.
+/// Returns skills ordered by eta DESC.
+pub fn load_active_skills_for_context(
+    conn: &Connection,
+    project_id: Option<&str>,
+    query_vector: &[f32],
+    similarity_threshold: f32,
+) -> rusqlite::Result<Vec<SkillForContext>> {
+    // Fetch all active skills (with pattern signatures).
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT s.skill_id, s.name, s.trigger_description, s.exemplar_ids,
+               s.adoption_count, s.rejection_count, p.signature
+        FROM skills s
+        JOIN patterns p ON p.pattern_id = s.pattern_id
+        WHERE s.status = 'active'
+          AND (?1 IS NULL OR s.project_id = ?1 OR s.project_id IS NULL)
+        "#,
+    )?;
+
+    let rows = stmt
+        .query_map([project_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, Vec<u8>>(6)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let mut skills: Vec<SkillForContext> = rows
+        .into_iter()
+        .filter_map(
+            |(
+                skill_id,
+                name,
+                trigger_description,
+                exemplar_json,
+                adoption,
+                rejection,
+                sig_blob,
+            )| {
+                let sig = blob_to_vec(&sig_blob);
+                let sim = if query_vector.is_empty() || sig.is_empty() {
+                    0.0f32
+                } else {
+                    cosine_similarity(query_vector, &sig)
+                };
+                if sim < similarity_threshold {
+                    return None;
+                }
+                let exemplar_ids: Vec<String> =
+                    serde_json::from_str(&exemplar_json).unwrap_or_default();
+                Some(SkillForContext {
+                    skill_id,
+                    name,
+                    trigger_description,
+                    eta: compute_eta(adoption, rejection),
+                    exemplar_count: exemplar_ids.len(),
+                })
+            },
+        )
+        .collect();
+
+    // Sort by eta descending (higher adoption rate first).
+    skills.sort_by(|a, b| {
+        b.eta
+            .partial_cmp(&a.eta)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    Ok(skills)
+}
+
+fn blob_to_vec(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect()
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
+}

--- a/src/core/skills.rs
+++ b/src/core/skills.rs
@@ -535,7 +535,8 @@ pub fn load_active_skills_for_context(
 fn blob_to_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
         .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .filter_map(|chunk| chunk.try_into().ok())
+        .map(f32::from_le_bytes)
         .collect()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ mod patterns;
 #[path = "cli/prime.rs"]
 mod prime_cli;
 mod repair_cli;
+mod skills;
 
 use crate::longmemeval::{BenchMode, LongMemEvalArgs, LongMemEvalGranularity, default_top_k};
 use crate::prime_cli::{PrimeArgs, PrimeFormat};
@@ -444,6 +445,11 @@ enum Commands {
     Patterns {
         #[command(subcommand)]
         command: patterns::PatternsCommands,
+    },
+    /// Skill management (list, show, promote, adopt, reject, retire).
+    Skills {
+        #[command(subcommand)]
+        command: skills::SkillsCommands,
     },
     /// Anti-pattern detection and repair (list, show).
     Repair {
@@ -1136,6 +1142,7 @@ fn run() -> Result<()> {
             block_on_result(checkpoint_command(&db, config.as_ref(), command))
         }
         Commands::Patterns { command } => patterns::run_command(config.as_ref(), command),
+        Commands::Skills { command } => skills::run_command(config.as_ref(), command),
         Commands::Repair { command } => repair_cli::run_command(config.as_ref(), command),
         Commands::CoworkDrain { .. }
         | Commands::CoworkStatus { .. }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -62,9 +62,10 @@ use super::tools::{
     LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, PeekMessageDto,
     PeekPartnerRequest, PeekPartnerResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse,
     ReadDrawersRequest, ReadDrawersResponse, RollbackRequest, RollbackResponse, ScopeCount,
-    ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, SystemWarning,
-    TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto,
-    TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest,
+    SkillResponse, SkillSummaryDto, StatusResponse, SystemWarning, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -2494,6 +2495,235 @@ impl MempalMcpServer {
             repair_packages: report.repair_packages,
             system_warnings: current_system_warnings(),
         }))
+    }
+
+    #[tool(
+        name = "mempal_skill",
+        description = "Skill crystallization (P15): manage skills promoted from validated recurring patterns. Actions: list (list skills, optional status/project_id filter), show (full detail for one skill), promote (promote an active pattern to a probationary skill — you MUST provide name and trigger_description; mempal does NOT generate these), adopt (signal the skill was useful — adoption_count += 1, may promote to active), reject (signal the skill was not useful — rejection_count += 1, may auto-retire), retire (manually retire a skill). Only active skills are injected into context. Probationary skills need adopt signals to graduate. eta = adoption / (adoption + rejection + 1.0), computed at query time."
+    )]
+    pub async fn mempal_skill(
+        &self,
+        Parameters(request): Parameters<SkillRequest>,
+    ) -> std::result::Result<Json<SkillResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let config = ConfigHandle::current();
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), &config)
+            .await?;
+
+        if !crate::core::skills::skills_table_exists(db.conn()) {
+            return Err(ErrorData::internal_error(
+                "skills table not yet created — run `mempal init` to apply migrations",
+                None,
+            ));
+        }
+
+        match request.action.as_str() {
+            "list" => {
+                let skills = tokio::task::block_in_place(|| {
+                    crate::core::skills::list_skills(
+                        db.conn(),
+                        request.status.as_deref(),
+                        project_id.as_deref(),
+                    )
+                })
+                .map_err(|e| ErrorData::internal_error(format!("list_skills failed: {e}"), None))?;
+
+                let dtos: Vec<SkillSummaryDto> = skills
+                    .iter()
+                    .map(|s| SkillSummaryDto {
+                        skill_id: s.skill_id.clone(),
+                        name: s.name.clone(),
+                        trigger_description: s.trigger_description.clone(),
+                        eta: s.eta(),
+                        status: s.status.as_str().to_string(),
+                        adoption_count: s.adoption_count,
+                        rejection_count: s.rejection_count,
+                    })
+                    .collect();
+
+                Ok(Json(SkillResponse {
+                    action: "list".to_string(),
+                    status: None,
+                    skill: None,
+                    skills: dtos,
+                    message: None,
+                }))
+            }
+
+            "show" => {
+                let skill_id = request.skill_id.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params("skill_id is required for show", None)
+                })?;
+                let skill = tokio::task::block_in_place(|| {
+                    crate::core::skills::get_skill(db.conn(), skill_id)
+                })
+                .map_err(|e| ErrorData::internal_error(format!("get_skill failed: {e}"), None))?
+                .ok_or_else(|| {
+                    ErrorData::invalid_params(format!("skill not found: {skill_id}"), None)
+                })?;
+
+                Ok(Json(SkillResponse {
+                    action: "show".to_string(),
+                    status: Some(skill.status.as_str().to_string()),
+                    skill: Some(skill_to_dto(&skill)),
+                    skills: vec![],
+                    message: None,
+                }))
+            }
+
+            "promote" => {
+                let pattern_id = request.pattern_id.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params("pattern_id is required for promote", None)
+                })?;
+                let name = request.name.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params(
+                        "name is required for promote (agent must provide, mempal does not generate)",
+                        None,
+                    )
+                })?;
+                let trigger_description = request.trigger_description.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params(
+                        "trigger_description is required for promote (agent must provide, mempal does not generate)",
+                        None,
+                    )
+                })?;
+
+                let skill_min_sessions = config.skills.skill_min_sessions;
+                let skill = tokio::task::block_in_place(|| {
+                    crate::core::skills::promote_pattern_to_skill(
+                        db.conn(),
+                        &crate::core::skills::PromoteArgs {
+                            pattern_id,
+                            name,
+                            trigger_description,
+                            skill_min_sessions,
+                            project_id: project_id.as_deref(),
+                        },
+                    )
+                })
+                .map_err(|e| match e {
+                    crate::core::skills::PromotionError::PatternNotFound(_)
+                    | crate::core::skills::PromotionError::PatternNotActive(_)
+                    | crate::core::skills::PromotionError::InsufficientSessions(_, _)
+                    | crate::core::skills::PromotionError::SkillAlreadyExists => {
+                        ErrorData::invalid_params(e.to_string(), None)
+                    }
+                    crate::core::skills::PromotionError::Db(db_err) => {
+                        ErrorData::internal_error(format!("promote_skill db error: {db_err}"), None)
+                    }
+                })?;
+
+                Ok(Json(SkillResponse {
+                    action: "promote".to_string(),
+                    status: Some(skill.status.as_str().to_string()),
+                    skill: Some(skill_to_dto(&skill)),
+                    skills: vec![],
+                    message: Some(format!("skill '{}' created as probationary", skill.name)),
+                }))
+            }
+
+            "adopt" => {
+                let skill_id = request.skill_id.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params("skill_id is required for adopt", None)
+                })?;
+                let active_threshold = config.skills.active_threshold;
+                let new_status = tokio::task::block_in_place(|| {
+                    crate::core::skills::adopt_skill(db.conn(), skill_id, active_threshold)
+                })
+                .map_err(|e| ErrorData::internal_error(format!("adopt_skill failed: {e}"), None))?
+                .ok_or_else(|| {
+                    ErrorData::invalid_params(format!("skill not found: {skill_id}"), None)
+                })?;
+
+                Ok(Json(SkillResponse {
+                    action: "adopt".to_string(),
+                    status: Some(new_status.as_str().to_string()),
+                    skill: None,
+                    skills: vec![],
+                    message: Some(format!(
+                        "adoption recorded; skill status: {}",
+                        new_status.as_str()
+                    )),
+                }))
+            }
+
+            "reject" => {
+                let skill_id = request.skill_id.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params("skill_id is required for reject", None)
+                })?;
+                let retire_threshold = config.skills.retire_threshold;
+                let new_status = tokio::task::block_in_place(|| {
+                    crate::core::skills::reject_skill(db.conn(), skill_id, retire_threshold)
+                })
+                .map_err(|e| ErrorData::internal_error(format!("reject_skill failed: {e}"), None))?
+                .ok_or_else(|| {
+                    ErrorData::invalid_params(format!("skill not found: {skill_id}"), None)
+                })?;
+
+                Ok(Json(SkillResponse {
+                    action: "reject".to_string(),
+                    status: Some(new_status.as_str().to_string()),
+                    skill: None,
+                    skills: vec![],
+                    message: Some(format!(
+                        "rejection recorded; skill status: {}",
+                        new_status.as_str()
+                    )),
+                }))
+            }
+
+            "retire" => {
+                let skill_id = request.skill_id.as_deref().ok_or_else(|| {
+                    ErrorData::invalid_params("skill_id is required for retire", None)
+                })?;
+                let found = tokio::task::block_in_place(|| {
+                    crate::core::skills::retire_skill(db.conn(), skill_id)
+                })
+                .map_err(|e| {
+                    ErrorData::internal_error(format!("retire_skill failed: {e}"), None)
+                })?;
+
+                if !found {
+                    return Err(ErrorData::invalid_params(
+                        format!("skill not found or already retired: {skill_id}"),
+                        None,
+                    ));
+                }
+
+                Ok(Json(SkillResponse {
+                    action: "retire".to_string(),
+                    status: Some("retired".to_string()),
+                    skill: None,
+                    skills: vec![],
+                    message: Some(format!("skill {skill_id} retired")),
+                }))
+            }
+
+            unknown => Err(ErrorData::invalid_params(
+                format!(
+                    "unknown action '{unknown}'; valid: list, show, promote, adopt, reject, retire"
+                ),
+                None,
+            )),
+        }
+    }
+}
+
+fn skill_to_dto(skill: &crate::core::skills::Skill) -> SkillDto {
+    SkillDto {
+        skill_id: skill.skill_id.clone(),
+        name: skill.name.clone(),
+        trigger_description: skill.trigger_description.clone(),
+        pattern_id: skill.pattern_id.clone(),
+        exemplar_ids: skill.exemplar_ids.clone(),
+        adoption_count: skill.adoption_count,
+        rejection_count: skill.rejection_count,
+        eta: skill.eta(),
+        status: skill.status.as_str().to_string(),
+        promoted_at_unix_ms: skill.promoted_at,
+        updated_at_unix_ms: skill.updated_at,
+        project_id: skill.project_id.clone(),
     }
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -160,6 +160,84 @@ pub struct ContextResponse {
     /// Active repair warnings (P14 decision-repair). Non-empty when anti-patterns detected.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repair_warnings: Vec<crate::repair::RepairWarning>,
+    /// Active skills injected at T1 head priority (P15). Agent should consult these
+    /// trigger_descriptions before deciding which skills to invoke.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub active_skills: Vec<SkillSummaryDto>,
+}
+
+/// Lightweight skill summary for context responses and list actions (P15).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SkillSummaryDto {
+    pub skill_id: String,
+    pub name: String,
+    pub trigger_description: String,
+    /// Laplace-smoothed adoption rate (computed at query time).
+    pub eta: f64,
+    pub status: String,
+    pub adoption_count: i64,
+    pub rejection_count: i64,
+}
+
+/// Full skill detail for the `show` action.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SkillDto {
+    pub skill_id: String,
+    pub name: String,
+    pub trigger_description: String,
+    pub pattern_id: String,
+    pub exemplar_ids: Vec<String>,
+    pub adoption_count: i64,
+    pub rejection_count: i64,
+    /// Laplace-smoothed adoption rate (computed at query time).
+    pub eta: f64,
+    pub status: String,
+    pub promoted_at_unix_ms: i64,
+    pub updated_at_unix_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}
+
+/// Request for the `mempal_skill` MCP tool (P15).
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct SkillRequest {
+    /// Action to perform: list | show | promote | adopt | reject | retire
+    pub action: String,
+    /// Skill ID (required for show, adopt, reject, retire).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_id: Option<String>,
+    /// Pattern ID (required for promote).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern_id: Option<String>,
+    /// Human-readable name for the skill (required for promote).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// When to invoke this skill — provided by agent, NOT generated (required for promote).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_description: Option<String>,
+    /// Filter by status for list: probationary | active | retired. Omit for all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Optional project scope.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+}
+
+/// Response from the `mempal_skill` MCP tool.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SkillResponse {
+    pub action: String,
+    /// New or updated status after the action (adopt/reject/retire).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Full skill detail (show action or promote).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill: Option<SkillDto>,
+    /// List of skills (list action).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub skills: Vec<SkillSummaryDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
 }
 
 /// Lightweight pattern summary for context responses.
@@ -1250,6 +1328,19 @@ impl From<ContextPack> for ContextResponse {
             t3_qi,
             budget_used,
             repair_warnings: value.repair_warnings,
+            active_skills: value
+                .active_skills
+                .into_iter()
+                .map(|s| SkillSummaryDto {
+                    skill_id: s.skill_id,
+                    name: s.name,
+                    trigger_description: s.trigger_description,
+                    eta: s.eta,
+                    status: "active".to_string(),
+                    adoption_count: 0,
+                    rejection_count: 0,
+                })
+                .collect(),
         }
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,302 @@
+#![warn(clippy::all)]
+
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+
+use mempal::core::{
+    config::Config,
+    db::Database,
+    skills::{
+        PromoteArgs, PromotionError, adopt_skill, get_skill, list_skills, promote_pattern_to_skill,
+        reject_skill, retire_skill, skills_table_exists,
+    },
+};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum SkillsCommands {
+    /// List skills (all or filtered by status).
+    List {
+        /// Filter by status: probationary, active, retired. Omit for all.
+        #[arg(long)]
+        status: Option<String>,
+        /// Filter by project ID.
+        #[arg(long)]
+        project: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show details for a single skill.
+    Show {
+        /// Skill ID.
+        skill_id: String,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Promote an active pattern to a probationary skill.
+    Promote {
+        /// Pattern ID to promote.
+        pattern_id: String,
+        /// Human-readable name for the skill.
+        #[arg(long)]
+        name: String,
+        /// Trigger description used to decide when to apply the skill.
+        #[arg(long)]
+        trigger: String,
+        /// Optional project scope.
+        #[arg(long)]
+        project: Option<String>,
+    },
+    /// Record adoption of a skill (positive signal).
+    Adopt {
+        /// Skill ID.
+        skill_id: String,
+    },
+    /// Record rejection of a skill (negative signal).
+    Reject {
+        /// Skill ID.
+        skill_id: String,
+    },
+    /// Manually retire a skill.
+    Retire {
+        /// Skill ID.
+        skill_id: String,
+    },
+}
+
+pub fn run_command(config: &Config, command: SkillsCommands) -> Result<()> {
+    let db_path = mempal::core::utils::expand_home(&config.db_path);
+    let db = Database::open(std::path::Path::new(&db_path))
+        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
+
+    if !skills_table_exists(db.conn()) {
+        bail!("skills table not yet created — run `mempal init` to apply migrations");
+    }
+
+    match command {
+        SkillsCommands::List {
+            status,
+            project,
+            json,
+        } => cmd_list(&db, status.as_deref(), project.as_deref(), json),
+        SkillsCommands::Show { skill_id, json } => cmd_show(&db, &skill_id, json),
+        SkillsCommands::Promote {
+            pattern_id,
+            name,
+            trigger,
+            project,
+        } => cmd_promote(
+            &db,
+            config,
+            &pattern_id,
+            &name,
+            &trigger,
+            project.as_deref(),
+        ),
+        SkillsCommands::Adopt { skill_id } => cmd_adopt(&db, config, &skill_id),
+        SkillsCommands::Reject { skill_id } => cmd_reject(&db, config, &skill_id),
+        SkillsCommands::Retire { skill_id } => cmd_retire(&db, &skill_id),
+    }
+}
+
+fn cmd_list(db: &Database, status: Option<&str>, project: Option<&str>, json: bool) -> Result<()> {
+    let skills = list_skills(db.conn(), status, project).context("failed to list skills")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&skills).context("failed to serialize skills")?
+        );
+        return Ok(());
+    }
+
+    if skills.is_empty() {
+        println!("no skills found");
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<14} {:>6} {:>7}  {:>6}  NAME",
+        "SKILL_ID", "STATUS", "ADOPT", "REJECT", "ETA"
+    );
+    println!("{}", "-".repeat(100));
+    for s in &skills {
+        println!(
+            "{:<38} {:<14} {:>6} {:>7}  {:>5.2}  {}",
+            s.skill_id,
+            s.status.as_str(),
+            s.adoption_count,
+            s.rejection_count,
+            s.eta(),
+            s.name,
+        );
+    }
+    Ok(())
+}
+
+fn cmd_show(db: &Database, skill_id: &str, json: bool) -> Result<()> {
+    let skill = get_skill(db.conn(), skill_id)
+        .context("failed to fetch skill")?
+        .with_context(|| format!("skill not found: {skill_id}"))?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&skill).context("failed to serialize skill")?
+        );
+        return Ok(());
+    }
+
+    println!("Skill ID:         {}", skill.skill_id);
+    println!("Name:             {}", skill.name);
+    println!("Status:           {}", skill.status.as_str());
+    println!("Pattern ID:       {}", skill.pattern_id);
+    println!("Adoption count:   {}", skill.adoption_count);
+    println!("Rejection count:  {}", skill.rejection_count);
+    println!("ETA:              {:.4}", skill.eta());
+    println!(
+        "Project ID:       {}",
+        skill.project_id.as_deref().unwrap_or("(all)")
+    );
+    println!("Promoted at:      {}", format_epoch_ms(skill.promoted_at));
+    println!("Updated at:       {}", format_epoch_ms(skill.updated_at));
+    println!("Trigger:          {}", skill.trigger_description);
+    println!("\nExemplar drawer IDs:");
+    for id in &skill.exemplar_ids {
+        println!("  {}", id);
+    }
+    Ok(())
+}
+
+fn cmd_promote(
+    db: &Database,
+    config: &Config,
+    pattern_id: &str,
+    name: &str,
+    trigger: &str,
+    project: Option<&str>,
+) -> Result<()> {
+    let args = PromoteArgs {
+        pattern_id,
+        name,
+        trigger_description: trigger,
+        project_id: project,
+        skill_min_sessions: config.skills.skill_min_sessions,
+    };
+    match promote_pattern_to_skill(db.conn(), &args) {
+        Ok(skill) => {
+            println!(
+                "skill {} created (probationary) — adopt {} more time(s) to activate",
+                skill.skill_id,
+                config.skills.active_threshold - skill.adoption_count
+            );
+        }
+        Err(PromotionError::PatternNotFound(_)) => {
+            bail!("pattern not found: {pattern_id}");
+        }
+        Err(PromotionError::PatternNotActive(_)) => {
+            bail!("pattern {pattern_id} is not active — only active patterns can be promoted");
+        }
+        Err(PromotionError::InsufficientSessions(have, need)) => {
+            bail!("pattern {pattern_id} has only {have} sessions; need at least {need} to promote");
+        }
+        Err(PromotionError::SkillAlreadyExists) => {
+            bail!("a probationary or active skill already exists for this pattern");
+        }
+        Err(PromotionError::Db(e)) => {
+            bail!("database error during promotion: {e}");
+        }
+    }
+    Ok(())
+}
+
+fn cmd_adopt(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
+    let new_status = adopt_skill(db.conn(), skill_id, config.skills.active_threshold)
+        .with_context(|| format!("failed to adopt skill {skill_id}"))?;
+    match new_status {
+        None => bail!("skill not found: {skill_id}"),
+        Some(s) => println!(
+            "skill {skill_id} adoption recorded — status: {}",
+            s.as_str()
+        ),
+    }
+    Ok(())
+}
+
+fn cmd_reject(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
+    let new_status = reject_skill(db.conn(), skill_id, config.skills.retire_threshold)
+        .with_context(|| format!("failed to reject skill {skill_id}"))?;
+    match new_status {
+        None => bail!("skill not found: {skill_id}"),
+        Some(s) => println!(
+            "skill {skill_id} rejection recorded — status: {}",
+            s.as_str()
+        ),
+    }
+    Ok(())
+}
+
+fn cmd_retire(db: &Database, skill_id: &str) -> Result<()> {
+    let found = retire_skill(db.conn(), skill_id)
+        .with_context(|| format!("failed to retire skill {skill_id}"))?;
+    if found {
+        println!("skill {skill_id} retired");
+    } else {
+        println!("skill {skill_id} not found");
+    }
+    Ok(())
+}
+
+fn format_epoch_ms(ms: i64) -> String {
+    use std::time::{Duration, UNIX_EPOCH};
+    UNIX_EPOCH
+        .checked_add(Duration::from_millis(ms as u64))
+        .map(|t| {
+            let secs = t
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let (y, mo, d, h, min, s) = epoch_to_ymd_hms(secs);
+            format!("{y:04}-{mo:02}-{d:02}T{h:02}:{min:02}:{s:02}Z")
+        })
+        .unwrap_or_else(|| ms.to_string())
+}
+
+fn epoch_to_ymd_hms(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    let y400 = days / 146097;
+    let d1 = days % 146097;
+    let y100 = d1 / 36524;
+    let d2 = d1 % 36524;
+    let y4 = d2 / 1461;
+    let d3 = d2 % 1461;
+    let y1 = d3 / 365;
+    let yd = d3 % 365;
+    let year = y400 * 400 + y100 * 100 + y4 * 4 + y1 + 1970;
+    let (mo, d) = doy_to_md(yd + 1, is_leap(year));
+    (year, mo as u64, d as u64, h, m, s)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn doy_to_md(doy: u64, leap: bool) -> (u32, u32) {
+    let months = if leap {
+        [31u32, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut rem = doy as u32;
+    for (i, &days) in months.iter().enumerate() {
+        if rem <= days {
+            return (i as u32 + 1, rem);
+        }
+        rem -= days;
+    }
+    (12, 31)
+}

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -535,7 +535,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 12"),
+            .any(|line| line.trim() == "fork_ext_version: 13"),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/skill_crystallization.rs
+++ b/tests/skill_crystallization.rs
@@ -1,0 +1,662 @@
+#![warn(clippy::all)]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use mempal::context::{ContextRequest, assemble_context};
+use mempal::core::db::{
+    Database, apply_fork_ext_migrations_to, read_fork_ext_version, set_fork_ext_version,
+};
+use mempal::core::patterns::{NewPattern, insert_pattern, promote_pattern, retire_pattern};
+use mempal::core::skills::{
+    PromoteArgs, PromotionError, SkillStatus, adopt_skill, compute_eta, get_skill, list_skills,
+    promote_pattern_to_skill, reject_skill,
+};
+use mempal::core::types::MemoryDomain;
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn new_db() -> (TempDir, PathBuf, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db_path, db)
+}
+
+/// Returns column names for a table via PRAGMA table_info.
+fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table_info");
+    stmt.query_map([], |row| row.get::<_, String>(1))
+        .expect("query table_info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect column names")
+}
+
+/// Build a unit vector of given dimension (all values set to `val`).
+fn unit_vec(dim: usize, val: f32) -> Vec<f32> {
+    let norm = (dim as f32 * val * val).sqrt();
+    if norm == 0.0 {
+        return vec![0.0; dim];
+    }
+    vec![val / norm; dim]
+}
+
+/// Insert a pattern and promote it to active status.
+fn insert_active_pattern(
+    conn: &Connection,
+    pattern_id: &str,
+    session_count: usize,
+    signature: Vec<f32>,
+    project_id: Option<&str>,
+) {
+    let session_ids: Vec<String> = (0..session_count)
+        .map(|i| format!("sess-{pattern_id}-{i}"))
+        .collect();
+    let exemplar_ids: Vec<String> = (0..session_count.min(3))
+        .map(|i| format!("ex-{pattern_id}-{i}"))
+        .collect();
+    insert_pattern(
+        conn,
+        &NewPattern {
+            pattern_id: pattern_id.to_string(),
+            signature,
+            exemplar_ids,
+            session_ids,
+            topic_tags: vec!["test".to_string()],
+            model_id: Some("test-model".to_string()),
+            project_id: project_id.map(str::to_string),
+        },
+    )
+    .expect("insert pattern");
+    promote_pattern(conn, pattern_id).expect("promote pattern to active");
+}
+
+struct StubEmbedder {
+    vector: Vec<f32>,
+}
+
+#[async_trait::async_trait]
+impl mempal::embed::Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: fork-ext migration 12 → 13 creates skills table
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_fork_ext_migration_v8_to_v9_creates_skills_table() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+
+    // Roll back to version 12 (pre-skills).
+    set_fork_ext_version(conn, 12).expect("set version 12");
+    assert_eq!(read_fork_ext_version(conn).unwrap(), 12);
+
+    // Apply up to version 13.
+    apply_fork_ext_migrations_to(conn, 13).expect("apply v13 migration");
+
+    assert_eq!(read_fork_ext_version(conn).unwrap(), 13);
+
+    // Skills table must exist.
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='skills'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("check skills table");
+    assert_eq!(count, 1, "skills table should exist");
+
+    let cols = column_names(conn, "skills");
+    for expected in &[
+        "skill_id",
+        "name",
+        "trigger_description",
+        "pattern_id",
+        "adoption_count",
+        "rejection_count",
+        "status",
+    ] {
+        assert!(
+            cols.iter().any(|c| c == expected),
+            "missing column: {expected}"
+        );
+    }
+    // eta must NOT be a stored column.
+    assert!(
+        !cols.iter().any(|c| c == "eta"),
+        "eta must not be a stored column"
+    );
+
+    // idx_skills_status index must exist.
+    let idx_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_skills_status'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("check idx_skills_status");
+    assert_eq!(idx_count, 1, "idx_skills_status index should exist");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: active pattern with sufficient sessions → probationary skill
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pattern_promote_creates_probationary_skill() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-alpha", 6, sig, None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-alpha",
+        name: "Deploy guard",
+        trigger_description: "When about to deploy, verify tests pass first",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+
+    assert_eq!(skill.status, SkillStatus::Probationary);
+    assert_eq!(skill.name, "Deploy guard");
+    assert_eq!(
+        skill.trigger_description,
+        "When about to deploy, verify tests pass first"
+    );
+    assert_eq!(skill.adoption_count, 0);
+    assert_eq!(skill.rejection_count, 0);
+    assert_eq!(skill.pattern_id, "pat-alpha");
+
+    // Verify persistence.
+    let fetched = get_skill(conn, &skill.skill_id)
+        .expect("get skill ok")
+        .expect("skill should exist");
+    assert_eq!(fetched.status, SkillStatus::Probationary);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: candidate pattern cannot be promoted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_candidate_pattern_cannot_be_promoted() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    // Insert pattern but do NOT promote it — stays candidate.
+    insert_pattern(
+        conn,
+        &NewPattern {
+            pattern_id: "pat-candidate".to_string(),
+            signature: sig,
+            exemplar_ids: vec![
+                "e1".to_string(),
+                "e2".to_string(),
+                "e3".to_string(),
+                "e4".to_string(),
+                "e5".to_string(),
+                "e6".to_string(),
+            ],
+            session_ids: (0..6).map(|i| format!("s{i}")).collect(),
+            topic_tags: vec![],
+            model_id: None,
+            project_id: None,
+        },
+    )
+    .expect("insert pattern");
+
+    let args = PromoteArgs {
+        pattern_id: "pat-candidate",
+        name: "some skill",
+        trigger_description: "some trigger",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let result = promote_pattern_to_skill(conn, &args);
+    assert!(
+        matches!(result, Err(PromotionError::PatternNotActive(_))),
+        "expected PatternNotActive, got {result:?}"
+    );
+
+    // No skill row should have been created.
+    let skills = list_skills(conn, None, None).expect("list skills");
+    assert!(skills.is_empty(), "no skills should exist");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: duplicate promotion rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_duplicate_promotion_rejected() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-dup", 6, sig, None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-dup",
+        name: "First skill",
+        trigger_description: "trigger one",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    promote_pattern_to_skill(conn, &args).expect("first promotion ok");
+
+    // Second promotion must fail.
+    let args2 = PromoteArgs {
+        pattern_id: "pat-dup",
+        name: "Second skill",
+        trigger_description: "trigger two",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let result = promote_pattern_to_skill(conn, &args2);
+    assert!(
+        matches!(result, Err(PromotionError::SkillAlreadyExists)),
+        "expected SkillAlreadyExists, got {result:?}"
+    );
+
+    // Still only one skill.
+    let skills = list_skills(conn, None, None).expect("list skills");
+    assert_eq!(skills.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: adoption reaches active_threshold → skill promoted to active
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skill_adopts_to_active_at_threshold() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-adopt", 6, sig, None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-adopt",
+        name: "Adopt guard",
+        trigger_description: "trigger",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+
+    let active_threshold = 3_i64;
+
+    // First two adoptions — still probationary.
+    for _ in 0..2 {
+        let status = adopt_skill(conn, &skill.skill_id, active_threshold)
+            .expect("adopt ok")
+            .expect("skill exists");
+        assert_eq!(status, SkillStatus::Probationary);
+    }
+
+    // Third adoption — must flip to active.
+    let status = adopt_skill(conn, &skill.skill_id, active_threshold)
+        .expect("adopt ok")
+        .expect("skill exists");
+    assert_eq!(
+        status,
+        SkillStatus::Active,
+        "should be active after 3 adoptions"
+    );
+
+    let fetched = get_skill(conn, &skill.skill_id)
+        .expect("get ok")
+        .expect("exists");
+    assert_eq!(fetched.adoption_count, 3);
+    assert_eq!(fetched.status, SkillStatus::Active);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: sufficient rejections with no adoptions → auto-retire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skill_auto_retires_on_rejection() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-reject", 6, sig, None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-reject",
+        name: "Reject guard",
+        trigger_description: "trigger",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+
+    let retire_threshold = 3_i64;
+
+    // First two rejections — still probationary.
+    for _ in 0..2 {
+        let status = reject_skill(conn, &skill.skill_id, retire_threshold)
+            .expect("reject ok")
+            .expect("skill exists");
+        assert_eq!(status, SkillStatus::Probationary);
+    }
+
+    // Third rejection — no adoptions → auto-retire.
+    let status = reject_skill(conn, &skill.skill_id, retire_threshold)
+        .expect("reject ok")
+        .expect("skill exists");
+    assert_eq!(
+        status,
+        SkillStatus::Retired,
+        "should auto-retire after 3 rejections with 0 adoptions"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: eta calculation (unit test)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skill_eta_calculation() {
+    // 3 adoptions, 1 rejection → 3.0 / (3 + 1 + 1.0) = 0.6
+    let eta = compute_eta(3, 1);
+    let expected = 3.0_f64 / 5.0_f64;
+    assert!(
+        (eta - expected).abs() < 1e-9,
+        "eta expected {expected}, got {eta}"
+    );
+
+    // 0 adoptions, 0 rejections → 0.0 / 1.0 = 0.0
+    let eta_zero = compute_eta(0, 0);
+    assert!((eta_zero - 0.0).abs() < 1e-9, "zero eta expected");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: active skill injected in T1
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_active_skill_injected_in_t1() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+
+    // Create an active pattern + active skill.
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-t1", 6, sig.clone(), None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-t1",
+        name: "T1 skill",
+        trigger_description: "Apply at session start",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+
+    // Manually activate the skill.
+    conn.execute(
+        "UPDATE skills SET status = 'active', adoption_count = 3 WHERE skill_id = ?1",
+        rusqlite::params![skill.skill_id],
+    )
+    .expect("activate skill");
+
+    // Use a stub embedder that returns the same vector as the pattern signature
+    // so cosine similarity = 1.0 (above 0.70 threshold).
+    let embedder = StubEmbedder { vector: sig };
+
+    let request = ContextRequest {
+        query: "session start".to_string(),
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        cwd: _db_path.parent().unwrap().to_path_buf(),
+        include_evidence: false,
+        max_items: 12,
+        dao_tian_limit: 1,
+        project_id: None,
+        trigger: None,
+        context_cfg_override: None,
+    };
+
+    let pack = assemble_context(&db, &embedder, request)
+        .await
+        .expect("assemble context ok");
+
+    // Active skills should be injected at T1.
+    assert!(
+        !pack.active_skills.is_empty(),
+        "active_skills should be non-empty"
+    );
+    let found = pack
+        .active_skills
+        .iter()
+        .any(|s| s.skill_id == skill.skill_id);
+    assert!(
+        found,
+        "skill {} should appear in active_skills",
+        skill.skill_id
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: probationary skill NOT injected in T1
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_probationary_skill_excluded_from_context() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-prob", 6, sig.clone(), None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-prob",
+        name: "Prob skill",
+        trigger_description: "not active yet",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+    // Skill remains probationary.
+    assert_eq!(skill.status, SkillStatus::Probationary);
+
+    let embedder = StubEmbedder { vector: sig };
+    let request = ContextRequest {
+        query: "session start".to_string(),
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        cwd: _db_path.parent().unwrap().to_path_buf(),
+        include_evidence: false,
+        max_items: 12,
+        dao_tian_limit: 1,
+        project_id: None,
+        trigger: None,
+        context_cfg_override: None,
+    };
+
+    let pack = assemble_context(&db, &embedder, request)
+        .await
+        .expect("assemble context ok");
+
+    let found = pack
+        .active_skills
+        .iter()
+        .any(|s| s.skill_id == skill.skill_id);
+    assert!(
+        !found,
+        "probationary skill should not appear in active_skills"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: retiring pattern does NOT cascade retire to skill
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pattern_retire_does_not_cascade_to_skill() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-cascade", 6, sig, None);
+
+    let args = PromoteArgs {
+        pattern_id: "pat-cascade",
+        name: "Cascade skill",
+        trigger_description: "trigger",
+        skill_min_sessions: 5,
+        project_id: None,
+    };
+    let skill = promote_pattern_to_skill(conn, &args).expect("promote ok");
+
+    // Activate skill manually.
+    conn.execute(
+        "UPDATE skills SET status = 'active' WHERE skill_id = ?1",
+        rusqlite::params![skill.skill_id],
+    )
+    .expect("activate skill");
+
+    // Retire the pattern.
+    let retired = retire_pattern(conn, "pat-cascade").expect("retire pattern ok");
+    assert!(retired, "pattern should have been found and retired");
+
+    // Verify skill is still active.
+    let fetched = get_skill(conn, &skill.skill_id)
+        .expect("get skill ok")
+        .expect("skill exists");
+    assert_eq!(
+        fetched.status,
+        SkillStatus::Active,
+        "skill must remain active after pattern retirement"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: list_skills filters by project_id
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skill_list_filters_by_project() {
+    let (_tmp, _db_path, db) = new_db();
+    let conn = db.conn();
+
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-px", 6, sig.clone(), Some("proj-X"));
+    insert_active_pattern(conn, "pat-py", 6, sig, Some("proj-Y"));
+
+    let args_x = PromoteArgs {
+        pattern_id: "pat-px",
+        name: "Skill X",
+        trigger_description: "trigger",
+        skill_min_sessions: 5,
+        project_id: Some("proj-X"),
+    };
+    let args_y = PromoteArgs {
+        pattern_id: "pat-py",
+        name: "Skill Y",
+        trigger_description: "trigger",
+        skill_min_sessions: 5,
+        project_id: Some("proj-Y"),
+    };
+    let skill_x = promote_pattern_to_skill(conn, &args_x).expect("promote x ok");
+    promote_pattern_to_skill(conn, &args_y).expect("promote y ok");
+
+    let result = list_skills(conn, None, Some("proj-X")).expect("list ok");
+    assert_eq!(result.len(), 1, "only proj-X skill should appear");
+    assert_eq!(result[0].skill_id, skill_x.skill_id);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario: skills promote CLI command works end-to-end
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_skills_promote_cli() {
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join("home");
+    let mempal_home = home.join(".mempal");
+    std::fs::create_dir_all(&mempal_home).expect("create .mempal dir");
+    let db_path = mempal_home.join("palace.db");
+    let config_path = mempal_home.join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+
+[config_hot_reload]
+enabled = false
+
+[ingest_gating]
+enabled = false
+
+[patterns]
+enabled = true
+
+[skills]
+skill_min_sessions = 5
+active_threshold = 3
+retire_threshold = 3
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+
+    let db = Database::open(&db_path).expect("open db");
+    let conn = db.conn();
+    let sig = unit_vec(8, 1.0);
+    insert_active_pattern(conn, "pat-cli", 6, sig, None);
+    drop(db);
+
+    let bin = env!("CARGO_BIN_EXE_mempal");
+    let output = Command::new(bin)
+        .env("HOME", &home)
+        .args([
+            "skills",
+            "promote",
+            "pat-cli",
+            "--name",
+            "Test guard",
+            "--trigger",
+            "Run tests before deploy",
+        ])
+        .output()
+        .expect("run mempal skills promote");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "mempal skills promote failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("probationary") || stdout.contains("skill"),
+        "expected success message, got: {stdout}"
+    );
+
+    // Verify skill was created in DB.
+    let db2 = Database::open(&db_path).expect("open db after promote");
+    let skills = list_skills(db2.conn(), None, None).expect("list skills");
+    assert_eq!(skills.len(), 1, "one skill should exist");
+    assert_eq!(skills[0].name, "Test guard");
+    assert_eq!(skills[0].trigger_description, "Run tests before deploy");
+}


### PR DESCRIPTION
## Summary

Implements skill crystallization — the capstone of the MemOS-inspired improvement chain. Promotes validated patterns into structured, callable skills with adoption feedback.

- **Schema**: fork_ext_version v13 — new `skills` table
- **Promotion**: active patterns with sufficient sessions/exemplars can be promoted to probationary skills
- **Lifecycle**: probationary → active (eta > threshold) → retired (eta drops or manual)
- **Adoption feedback**: `adopt/reject` signals update eta = adoption / (adoption + rejection + 1.0), computed at query time (not stored)
- **MCP**: `mempal_skill` tool with list/show/promote/adopt/reject/retire actions
- **Context T1**: active skills injected at highest priority in tiered retrieval
- **CLI**: `mempal skills list/show/promote/retire`
- **Config**: skill thresholds in hot-reload whitelist

## Dependency chain complete

```
p13-importance-decay (#115, PR #121) ✅
p13-pattern-induction (#116, PR #122) ✅
  └→ p15-skill-crystallization (#119, this PR)
p14-tiered-retrieval (#117, PR #123) ✅
p14-decision-repair (#118, PR #124) ✅
```

## Test plan

- [x] 12 new integration tests covering schema, promotion, lifecycle, feedback, CLI
- [x] All pre-existing tests pass
- [x] `just pre-commit` green
- [x] Local `csa review` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)