### PR TITLE
fix(repair): wire P14 failure detection into MCP ingest path

### DIFF
--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -473,18 +473,18 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                 source,
             })?;
 
-        // Failure detection (P14) — fire-and-forget, never blocks ingest.
+        // Failure detection (P14) — synchronous, lightweight DB write.
         {
             let config_snap = ConfigHandle::current();
             if config_snap.repair.enabled {
-                crate::repair::spawn_failure_detection(
-                    db.path().to_path_buf(),
-                    drawer_id.clone(),
-                    chunk.to_string(),
-                    wing.to_string(),
-                    Some(resolved_room.clone()),
-                    options.project_id.map(ToOwned::to_owned),
-                    config_snap.repair.clone(),
+                crate::repair::try_record_failure(
+                    db.path(),
+                    &drawer_id,
+                    chunk,
+                    wing,
+                    Some(resolved_room.as_str()),
+                    options.project_id,
+                    &config_snap.repair,
                 );
             }
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1902,6 +1902,21 @@ impl MempalMcpServer {
             response_drawer_id = inserted_drawer_ids[0].clone();
         }
 
+        // Failure detection (P14) — fire-and-forget for each inserted drawer.
+        if config.repair.enabled && !inserted_drawer_ids.is_empty() {
+            for (drawer_id_r, chunk_r) in inserted_drawer_ids.iter().zip(chunks.iter()) {
+                crate::repair::spawn_failure_detection(
+                    db.path().to_path_buf(),
+                    drawer_id_r.clone(),
+                    chunk_r.to_string(),
+                    request.wing.clone(),
+                    room.map(ToOwned::to_owned),
+                    project_id.clone(),
+                    config.repair.clone(),
+                );
+            }
+        }
+
         // Pattern detection (P13) — fire-and-forget for each inserted drawer.
         if config.patterns.enabled && !inserted_drawer_ids.is_empty() {
             let session_id = request

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -172,10 +172,43 @@ pub fn record_failure_event(
     Ok(())
 }
 
-/// Fire-and-forget async failure detection after an ingest.
-///
-/// Opens a fresh DB connection (required because `Connection` is !Send) and
-/// records the event if a failure keyword is found.
+/// Synchronous failure detection: check content for failure keywords, record
+/// event if found.  Opens a fresh DB connection so it can be called from any
+/// context (sync or async, any thread).
+pub fn try_record_failure(
+    db_path: &Path,
+    drawer_id: &str,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+    config: &RepairConfig,
+) {
+    if let Some(failure_type) = detect_failure_keyword(content, &config.failure_keywords) {
+        let topic_sig = compute_topic_sig(content);
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        let event_id = new_event_id();
+        let args = FailureEventArgs {
+            event_id: &event_id,
+            drawer_id,
+            wing,
+            room,
+            topic_sig: &topic_sig,
+            failure_type: &failure_type,
+            project_id,
+            detected_at_ms: now_ms,
+        };
+        if let Err(e) = write_failure_event_to_path(db_path, &args) {
+            tracing::warn!(error = %e, drawer_id, "failure event write failed");
+        }
+    }
+}
+
+/// Fire-and-forget async failure detection after an ingest (MCP / long-lived
+/// runtime).  Spawns a tokio task that calls [`try_record_failure`].
 pub fn spawn_failure_detection(
     db_path: PathBuf,
     drawer_id: String,
@@ -186,27 +219,15 @@ pub fn spawn_failure_detection(
     config: RepairConfig,
 ) {
     tokio::spawn(async move {
-        if let Some(failure_type) = detect_failure_keyword(&content, &config.failure_keywords) {
-            let topic_sig = compute_topic_sig(&content);
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as i64)
-                .unwrap_or(0);
-            let event_id = new_event_id();
-            let args = FailureEventArgs {
-                event_id: &event_id,
-                drawer_id: &drawer_id,
-                wing: &wing,
-                room: room.as_deref(),
-                topic_sig: &topic_sig,
-                failure_type: &failure_type,
-                project_id: project_id.as_deref(),
-                detected_at_ms: now_ms,
-            };
-            if let Err(e) = write_failure_event_to_path(&db_path, &args) {
-                tracing::warn!(error = %e, drawer_id, "failure event write failed");
-            }
-        }
+        try_record_failure(
+            &db_path,
+            &drawer_id,
+            &content,
+            &wing,
+            room.as_deref(),
+            project_id.as_deref(),
+            &config,
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- Wire `spawn_failure_detection` into MCP server ingest handler, matching existing P13 pattern detection integration
- Extract `try_record_failure` as synchronous core function; CLI ingest calls it directly to avoid `tokio::spawn` task cancellation when temporary runtime drops
- MCP path keeps `spawn_failure_detection` (long-lived runtime ensures spawned tasks complete)

Closes #126

## Test plan

- [x] All 185 unit tests pass
- [x] All 17 decision_repair integration tests pass
- [x] Pre-commit hooks (fmt + clippy + full test suite) pass
- [ ] Manual: reconnect MCP, ingest content with failure keyword, verify `failure_events` row created
- [ ] Manual: CLI ingest with failure keyword, verify `failure_events` row created

🤖 Generated with [Claude Code](https://claude.com/claude-code)