### PR TITLE
fix(repair): wire P14 failure detection into CLI stdin ingest path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1601,6 +1601,22 @@ async fn ingest_stdin_command(
     db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
 
+    // Failure detection (P14) — synchronous, lightweight DB write.
+    {
+        let config_snap = ConfigHandle::current();
+        if config_snap.repair.enabled {
+            mempal::repair::try_record_failure(
+                db.path(),
+                &drawer_id,
+                &drawer.content,
+                wing,
+                room,
+                project_id.as_deref(),
+                &config_snap.repair,
+            );
+        }
+    }
+
     stats.chunks = 1;
     stats.drawer_ids.push(drawer_id);
     append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)


### PR DESCRIPTION
## Summary

- CLI `ingest --stdin` has its own implementation in `main.rs` that bypasses `ingest/mod.rs` entirely, so the P14 `try_record_failure` call from PR #127 was never reached
- Add `try_record_failure` call after drawer insert in `ingest_stdin_command`

Part of #126

## Test plan

- [x] Compilation passes (clippy clean)
- [x] All tests pass (pre-commit hooks)
- [ ] Manual: `echo '{"wing":"mempal","content":"ERROR: build failed"}' | mempal ingest --stdin` → verify `failure_events` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)