### PR TITLE
chore: add just install recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,6 +48,10 @@ test-onnx:
 build:
     cargo build --release --all-features
 
+# Install mempal binary to /usr/local/bin.
+install:
+    CARGO_HOME=/usr/local cargo install --path . --force
+
 # Bump patch version (requires cargo-edit).
 bump-patch:
     cargo set-version --bump patch


### PR DESCRIPTION
## Summary
- Add `just install` recipe that runs `CARGO_HOME=/usr/local cargo install --path . --force` for convenient local binary installation

## Test plan
- [x] `just install` installs mempal to `/usr/local/bin/mempal`
- [x] Pre-commit hooks pass (fmt, clippy, 185+ unit tests, 300+ integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)