### PR TITLE
fix(llm): handle Qwen3 thinking mode and broaden verdict update scope

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -409,15 +409,14 @@ impl Database {
         verdict: &str,
         score: Option<f64>,
     ) -> Result<(), DbError> {
-        // Update the existing llm_pending row written during ingest (identified by drawer_id +
-        // llm_pending label). The row already has a valid explain_json; we only patch the two
-        // LLM-specific columns. Using an UPDATE avoids fighting the NOT NULL constraint on
-        // explain_json that a fresh INSERT would trigger.
+        // Patch the LLM verdict columns on the existing gating_audit row for this drawer.
+        // The row may carry label='llm_pending' (MCP path) or the original Tier 2 label
+        // (daemon path), so we match only on drawer_id.
         self.conn.execute(
             r#"
             UPDATE gating_audit
             SET llm_verdict = ?1, llm_score = ?2
-            WHERE drawer_id = ?3 AND label = 'llm_pending'
+            WHERE drawer_id = ?3
             "#,
             params![verdict, score, drawer_id],
         )?;

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -173,6 +173,9 @@ impl LlmClient {
                 messages: &request.messages,
                 temperature: request.temperature,
                 max_tokens: request.max_tokens,
+                chat_template_kwargs: Some(ChatTemplateKwargs {
+                    enable_thinking: false,
+                }),
             })
             .send()
             .await
@@ -196,7 +199,7 @@ impl LlmClient {
             .json::<OpenAiChatResponse>()
             .await
             .map_err(map_decode_error)?;
-        let content = response
+        let message = response
             .choices
             .into_iter()
             .next()
@@ -205,8 +208,8 @@ impl LlmClient {
                     "chat completion response did not include any choices".to_string(),
                 )
             })?
-            .message
-            .content;
+            .message;
+        let content = message.content.or(message.reasoning).unwrap_or_default();
 
         Ok(LlmResponse {
             content,
@@ -295,6 +298,13 @@ struct OpenAiChatRequest<'a> {
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chat_template_kwargs: Option<ChatTemplateKwargs>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ChatTemplateKwargs {
+    enable_thinking: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -311,5 +321,8 @@ struct OpenAiChoice {
 
 #[derive(Debug, Deserialize)]
 struct OpenAiMessage {
-    content: String,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    reasoning: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Fix LLM gating judge failure with Qwen3-35B-A3B thinking mode: `content: null` broke serde decode → infinite retry loop
- Send `chat_template_kwargs.enable_thinking: false` for structured gating output
- Make `OpenAiMessage.content` nullable with `reasoning` fallback for defense in depth
- Remove `label = 'llm_pending'` filter from `upsert_llm_verdict` so daemon-path audits also receive LLM verdicts

## Test plan
- [x] End-to-end verified: important decision scored 0.90 (kept), git-status noise scored 0.20 (soft-deleted via LLM reject)
- [x] Daemon logs show `LLM task completed in 5347ms` (was infinite retry before)
- [x] `gating_audit` table correctly populated with `llm_verdict` and `llm_score` columns
- [x] 955 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)