### PR TITLE
feat(llm): enable thinking mode, concurrent workers, and queue isolation

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -124,6 +124,7 @@ impl PendingMessageStore {
                 SELECT id, kind, payload, retry_count, source_hash
                 FROM pending_messages
                 WHERE status = 'pending' AND next_attempt_at <= ?1
+                  AND kind != 'llm_task'
                 ORDER BY next_attempt_at ASC, created_at ASC, id ASC
                 LIMIT 1
                 "#,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -77,32 +77,40 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
 
-    let llm_worker_handle = if context.config.llm.enabled {
+    let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
         match crate::llm::LlmClient::from_config(&context.config.llm) {
             Ok(llm_client) => {
+                let num_workers = context.config.llm.max_concurrent.max(1);
                 let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
                 let llm_store = std::sync::Arc::new(context.store.clone());
                 let llm_client = std::sync::Arc::new(llm_client);
                 let db_path = context.db.path().to_path_buf();
-                tracing::info!("spawning LLM worker task");
-                Some(tokio::spawn(async move {
-                    if let Err(e) = crate::llm::worker::run_llm_worker(
-                        llm_store, llm_client, llm_status, db_path,
-                    )
-                    .await
-                    {
-                        tracing::error!("LLM worker fatal error: {e:#}");
-                    }
-                    Ok::<(), anyhow::Error>(())
-                }))
+                tracing::info!("spawning {num_workers} LLM worker tasks");
+                (0..num_workers)
+                    .map(|i| {
+                        let store = llm_store.clone();
+                        let client = llm_client.clone();
+                        let status = llm_status.clone();
+                        let path = db_path.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) =
+                                crate::llm::worker::run_llm_worker(store, client, status, path)
+                                    .await
+                            {
+                                tracing::error!("LLM worker {i} fatal error: {e:#}");
+                            }
+                            Ok::<(), anyhow::Error>(())
+                        })
+                    })
+                    .collect()
             }
             Err(error) => {
                 tracing::warn!("LLM client init failed, skipping LLM worker: {error}");
-                None
+                vec![]
             }
         }
     } else {
-        None
+        vec![]
     };
 
     loop {
@@ -155,11 +163,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         }
     }
 
-    if let Some(handle) = llm_worker_handle {
+    for handle in llm_worker_handles {
         handle.abort();
         let _ = handle.await;
-        tracing::info!("LLM worker stopped");
     }
+    tracing::info!("LLM workers stopped");
 
     Ok(())
 }

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -173,9 +173,7 @@ impl LlmClient {
                 messages: &request.messages,
                 temperature: request.temperature,
                 max_tokens: request.max_tokens,
-                chat_template_kwargs: Some(ChatTemplateKwargs {
-                    enable_thinking: false,
-                }),
+                chat_template_kwargs: None,
             })
             .send()
             .await

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -35,14 +35,19 @@ pub async fn run_llm_worker(
     status: Arc<LlmStatus>,
     db_path: std::path::PathBuf,
 ) -> Result<()> {
-    let worker_id = format!("llm-worker-{}", std::process::id());
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static WORKER_INDEX: AtomicUsize = AtomicUsize::new(0);
+    let idx = WORKER_INDEX.fetch_add(1, Ordering::SeqCst);
+    let worker_id = format!("llm-worker-{}-{idx}", std::process::id());
     tracing::info!("LLM worker started: {worker_id}");
 
-    let reclaimed = store
-        .reclaim_stale(LLM_CLAIM_TTL_SECS)
-        .context("LLM worker failed to reclaim stale claims")?;
-    if reclaimed > 0 {
-        tracing::info!("LLM worker reclaimed {reclaimed} stale tasks");
+    if idx == 0 {
+        let reclaimed = store
+            .reclaim_stale(LLM_CLAIM_TTL_SECS)
+            .context("LLM worker failed to reclaim stale claims")?;
+        if reclaimed > 0 {
+            tracing::info!("LLM worker reclaimed {reclaimed} stale tasks");
+        }
     }
 
     loop {
@@ -166,7 +171,7 @@ async fn process_gating_task(
         ],
         model: None,
         temperature: Some(0.0),
-        max_tokens: Some(256),
+        max_tokens: Some(1024),
     };
 
     let retry_interval = config.llm.retry_interval_secs;


### PR DESCRIPTION
## Summary
- Enable Qwen3 thinking mode for gating judge (better accuracy, ~30s vs ~5s latency — acceptable for async daemon)
- Increase `max_tokens` from 256 to 1024 for reasoning + JSON output
- Spawn N concurrent LLM workers (N = `max_concurrent`, default 16) instead of single serial worker
- Exclude `llm_task` from daemon main loop's `claim_next` to prevent hook-envelope decode errors
- Unique worker IDs per worker to avoid claim conflicts

## Test plan
- [x] Thinking mode verified: rate-limiting decision scored 0.85, completed in 33s
- [x] 16 workers confirmed running concurrently in daemon logs
- [x] Queue ETA dropped from ~11h (single worker) to ~1.5h (16 workers)
- [x] No hook-envelope decode errors after queue isolation fix
- [x] 955 tests pass (1 flaky timing test `test_retry_interval_hot_reload` — pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)