### PR TITLE
fix(hooks): checkpoint-countdown TTY guard blocks in Claude Code subprocess

### DIFF
--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -9,7 +9,7 @@
 # Guards:
 #   - Sub-agents (CLAUDE_CODE_ENTRY_POINT=task) skip
 #   - CSA sessions (CSA_SESSION_ID set) skip
-#   - Non-interactive (stdin not TTY) skip
+#   - Non-interactive (no TERM, no CLAUDE_CODE_SESSION_ID) skip
 #   - Dedup via flag file prevents stacked countdowns
 set -euo pipefail
 
@@ -23,8 +23,10 @@ if [ -n "${CSA_SESSION_ID:-}" ]; then
     exit 0
 fi
 
-# Guard: non-interactive sessions (piped stdin)
-if [ ! -t 0 ] 2>/dev/null; then
+# Guard: non-interactive sessions (headless CI, cron, pipe)
+# NOTE: Cannot use `[ -t 0 ]` — Claude Code hooks always run as subprocesses
+# without a TTY. Use TERM/CLAUDE_CODE_SESSION_ID as proxy instead.
+if [ -z "${TERM:-}" ] && [ -z "${CLAUDE_CODE_SESSION_ID:-}" ]; then
     exit 0
 fi
 
@@ -82,7 +84,7 @@ before KV cache expires (1h TTL), run this background countdown:
 \`\`\`bash
 export MEMPAL_CHECKPOINT_LOCKFILE=$LOCKFILE_SHELL
 export MEMPAL_CHECKPOINT_PROJECT=$PROJECT_NAME_SHELL
-bash -lc 'trap '\''rmdir "$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; mempal checkpoint save --project "$MEMPAL_CHECKPOINT_PROJECT" --content "Session checkpoint auto-saved. Summarize current work state here."'
+bash -lc 'trap '\''rmdir "\$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; mempal checkpoint save --project "\$MEMPAL_CHECKPOINT_PROJECT" --content "Session checkpoint auto-saved. Summarize current work state here."'
 \`\`\`
 
 Run the countdown command with run_in_background: true. When the notification fires

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "5faf2918b4635a34e7b30bffaf07f931773bebc9"
+commit = "0c20b01df8045ac5849cb3fc4c4317af77c56e98"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "0c20b01df8045ac5849cb3fc4c4317af77c56e98"
+commit = "038641c2ee3de95a6a52febd01797963ed70756f"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Root cause: `[ ! -t 0 ]` TTY check always fails in Claude Code hook subprocesses (stdin is never a TTY) — checkpoint hook silently exited on every invocation since PR #107
- Fix: replace with `TERM`/`CLAUDE_CODE_SESSION_ID` env var proxy detection
- Also fix: unescaped heredoc variables that would trigger `set -u` abort

## Verification
- Hook now correctly outputs checkpoint prompt in Claude Code environment
- Lockfile dedup works (second invocation produces no output)
- All 400+ Rust tests pass (shell-only change, no code impact)
- Variable expansion in generated command verified empirically: inner `bash -lc` correctly expands `$MEMPAL_CHECKPOINT_LOCKFILE` and `$MEMPAL_CHECKPOINT_PROJECT`

## Test plan
- [x] `just fmt && just clippy` — pass
- [x] `cargo test --all` — 400+ tests pass
- [x] Manual: run hook with TERM set → prompt emitted
- [x] Manual: run hook twice → dedup blocks second
- [x] Manual: execute generated command → variables expand, checkpoint saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)