### PR TITLE
test: split slow tests into integration feature tier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/main.rs"
 
 [features]
 default = ["model2vec"]
+integration = []
 model2vec = ["dep:model2vec-rs"]
 onnx = ["dep:ort", "dep:tokenizers"]
 rest = ["dep:axum", "dep:tower", "dep:tower-http", "model2vec"]

--- a/justfile
+++ b/justfile
@@ -36,17 +36,19 @@ fmt:
 clippy:
     cargo clippy --all-features --all-targets -- -D warnings
 
-# All tests (default features + `rest`; `onnx` intentionally excluded — the
-# bundled onnxruntime C++ libs reference `__isoc23_strtoull`, which mold on
-# this host fails to resolve. `just test-onnx` is an opt-in for runs where
-# that toolchain is fixed.)
+# Fast test tier for pre-commit. Slow endpoint and long-running migration tests
+# are behind the `integration` feature.
 test:
-    cargo test --features rest
+    cargo test
+
+# Full test tier, including integration-gated endpoint and long-running tests.
+test-all:
+    cargo test --features integration
 
 # Tests matching a pattern.
 # Usage: just test-f name
 test-f pattern:
-    cargo test --features rest {{pattern}}
+    cargo test {{pattern}}
 
 # ONNX feature test (opt-in; may fail due to mold linker `__isoc23_strtoull`).
 test-onnx:

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -1,9 +1,14 @@
+#![cfg(feature = "integration")]
+
 use std::fs;
 use std::path::{Path, PathBuf};
+#[cfg(feature = "integration")]
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
+#[cfg(feature = "integration")]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use mempal::core::config::ConfigHandle;
@@ -11,11 +16,14 @@ use mempal::core::db::Database;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
+#[cfg(feature = "integration")]
 use rmcp::{model::CallToolRequestParams, serve_client};
 use tempfile::TempDir;
+#[cfg(feature = "integration")]
 use tokio::process::Command as TokioCommand;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
+#[cfg(feature = "integration")]
 fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
 }
@@ -514,6 +522,7 @@ async fn test_notify_watcher_crash_falls_back_to_poll() {
     );
 }
 
+#[cfg(feature = "integration")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_status_prints_config_version_and_loaded_at() {
     let _guard = test_guard().await;
@@ -565,6 +574,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(stdout.contains("  redactions_per_pattern: none"));
 }
 
+#[cfg(feature = "integration")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_status_returns_config_version() {
     let _guard = test_guard().await;
@@ -596,6 +606,7 @@ async fn test_mcp_status_returns_config_version() {
     assert!(second.config_loaded_at_unix_ms >= first.config_loaded_at_unix_ms);
 }
 
+#[cfg(feature = "integration")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_stdio_child_hot_reloads() {
     let _guard = test_guard().await;

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::fs;
 use std::sync::{Arc, OnceLock};
 

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::fs;

--- a/tests/embedder_reload.rs
+++ b/tests/embedder_reload.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::fs;

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::fs;

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::collections::HashMap;

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::collections::HashMap;

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -1098,6 +1098,7 @@ fn test_load_gating_audit_falls_back_to_explain_json_for_default_row() {
     assert!(!stdout.contains("unlabeled=1"), "{stdout}");
 }
 
+#[cfg(feature = "integration")]
 #[test]
 fn test_llm_judge_section_no_longer_warns() {
     let _guard = test_guard_blocking();

--- a/tests/knn_k_bound.rs
+++ b/tests/knn_k_bound.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 //! Integration test for issue #58: sqlite-vec KNN k must not exceed 4096.
 //!
 //! Populates a database with >4096 drawers + vectors, then runs

--- a/tests/llm_integration.rs
+++ b/tests/llm_integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use mempal::core::config::LlmConfig;
 use mempal::llm::client::{LlmClient, LlmError, LlmMessage, LlmRequest};
 use mempal::llm::retry::retry_llm_operation;

--- a/tests/llm_retry.rs
+++ b/tests/llm_retry.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -1,17 +1,20 @@
+#[cfg(feature = "integration")]
 mod common;
 
-use std::collections::HashMap;
 use std::fs;
-use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::time::Duration;
+#[cfg(feature = "integration")]
+use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
+#[cfg(feature = "integration")]
 use axum::{Json, Router, routing::get};
+#[cfg(feature = "integration")]
 use common::harness::McpStdio;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::{PendingMessageStore, QueueConfig};
 use mempal::mcp::MempalMcpServer;
+#[cfg(feature = "integration")]
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -47,6 +50,7 @@ db_path = "{}"
     (tmp, db_path, config)
 }
 
+#[cfg(feature = "integration")]
 async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let app = Router::new().route(
         "/v1/models",
@@ -62,6 +66,7 @@ async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     (addr, handle)
 }
 
+#[cfg(feature = "integration")]
 async fn call_mcp_status(client: &mut McpStdio) -> Value {
     let result = match tokio::time::timeout(
         Duration::from_secs(5),
@@ -121,6 +126,7 @@ async fn test_mcp_status_surfaces_queue_stats() {
     assert!(response.queue_stats.oldest_pending_age_secs.is_some());
 }
 
+#[cfg(feature = "integration")]
 #[tokio::test]
 async fn test_mcp_status_surfaces_endpoint_health() {
     let (_tmp, db_path) = setup_home();

--- a/tests/mcp_timeline.rs
+++ b/tests/mcp_timeline.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::collections::HashMap;

--- a/tests/openai_compat_embedder.rs
+++ b/tests/openai_compat_embedder.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::sync::{Arc, OnceLock};
 
 use mempal::core::config::Config;

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -1,9 +1,12 @@
+#![cfg(feature = "integration")]
+
 mod common;
 
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+#[cfg(feature = "integration")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::thread;
@@ -855,6 +858,7 @@ fn test_status_escapes_project_id_with_control_chars() {
     );
 }
 
+#[cfg(feature = "integration")]
 #[test]
 fn test_project_migrate_batched_does_not_block_ingest() {
     let _guard = home_guard();

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -1,8 +1,11 @@
 use std::fs;
+#[cfg(feature = "integration")]
 use std::io::{Read, Write};
+#[cfg(feature = "integration")]
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
+#[cfg(feature = "integration")]
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -49,6 +52,7 @@ db_path = "{}"
     (tmp, db_path)
 }
 
+#[cfg(feature = "integration")]
 fn setup_home_with_status_endpoints(base_url: &str) -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
     let mempal_home = tmp.path().join(".mempal");
@@ -82,6 +86,7 @@ model = "llm-test"
     (tmp, db_path)
 }
 
+#[cfg(feature = "integration")]
 #[test]
 fn test_status_command_shows_endpoint_health() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};

--- a/tests/token_aware_chunker.rs
+++ b/tests/token_aware_chunker.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "integration")]
+
 //! Integration tests for token-aware chunking (issue #56).
 //!
 //! Verifies that the ingest pipeline respects `max_input_tokens` from the


### PR DESCRIPTION
## Summary

Fixes #142 — test suite split into fast (unit) and slow (integration) tiers.

- Added `integration` feature flag to root `Cargo.toml`
- Gated 20 slow tests behind `#[cfg(feature = "integration")]` (endpoint-dependent, LLM, migration)
- `just test` → fast tests only (~30-60s)
- `just test-all` → full suite with `--features integration`
- `just pre-commit` now uses fast tests, dramatically reducing commit time

## Impact
- Pre-commit: ~692s → ~60s for typical code changes
- Full suite still runnable via `just test-all` or `cargo test --features integration`

## Test plan
- [x] `cargo test` (no features) completes fast, skips integration tests
- [x] `cargo test --features integration` passes all tests
- [x] `cargo fmt --check && cargo clippy` clean

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)