### PR TITLE
fix(hooks): auto-install mempal binary after merges

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,11 @@
 # Install: just install-hooks  (or: lefthook install)
 # Docs: https://github.com/evilmartians/lefthook
 
+post-merge:
+  commands:
+    auto-install:
+      run: scripts/hooks/post-merge.sh
+
 pre-commit:
   commands:
     branch-protection:

--- a/scripts/hooks/post-merge.sh
+++ b/scripts/hooks/post-merge.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Auto-install mempal after merges that change the binary source.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+if ! git rev-parse --verify ORIG_HEAD >/dev/null 2>&1; then
+  exit 0
+fi
+
+changed_files=$(git diff-tree -r --name-only ORIG_HEAD HEAD 2>/dev/null || true)
+if ! grep -Eq '^(src/|Cargo\.toml$|crates/)' <<<"$changed_files"; then
+  exit 0
+fi
+
+cargo_home=/usr/local
+install_bin_dir="${cargo_home}/bin"
+log_file=/tmp/mempal-post-merge-install.log
+
+if [ ! -w "$cargo_home" ] || { [ -d "$install_bin_dir" ] && [ ! -w "$install_bin_dir" ]; }; then
+  echo "[mempal] Binary update skipped: ${cargo_home} is not writable (requires sudo)" >&2
+  exit 0
+fi
+
+nohup bash -c '
+set -euo pipefail
+repo_root=$1
+
+printf "\n[%s] post-merge install started in %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$repo_root"
+cd "$repo_root"
+CARGO_HOME=/usr/local cargo install --path . --force
+printf "[%s] post-merge install finished\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+' mempal-post-merge-install "$repo_root" >>"$log_file" 2>&1 </dev/null &
+
+echo "[mempal] Binary update triggered (background install)"


### PR DESCRIPTION
## Summary

Fixes #143 — mempal binary auto-updates after PR merges when source code changes.

- Added `scripts/hooks/post-merge.sh`: detects `src/`, `crates/`, or `Cargo.toml` changes via `git diff-tree`, triggers background `cargo install`
- Registered in `lefthook.yml` under `post-merge` section
- Install runs in background (non-blocking) with log at `/tmp/mempal-post-merge-install.log`
- Silently skips when only docs/tests/configs changed

## Test plan
- [x] Script detects src/ changes and triggers install
- [x] Script skips on docs-only merges
- [x] git merge returns immediately (background install)
- [x] Script handles non-writable CARGO_HOME gracefully

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)