### PR TITLE
fix(hooks): checkpoint saves real summary instead of placeholder

### DIFF
--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -83,14 +83,24 @@ before KV cache expires (1h TTL), run this background countdown:
 
 \`\`\`bash
 export MEMPAL_CHECKPOINT_LOCKFILE=$LOCKFILE_SHELL
-export MEMPAL_CHECKPOINT_PROJECT=$PROJECT_NAME_SHELL
-bash -lc 'trap '\''rmdir "\$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; mempal checkpoint save --project "\$MEMPAL_CHECKPOINT_PROJECT" --content "Session checkpoint auto-saved. Summarize current work state here."'
+bash -lc 'trap '\''rmdir "\$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; echo "CHECKPOINT_TIMER_FIRED"'
 \`\`\`
 
 Run the countdown command with run_in_background: true. When the notification fires
-(~50 min), check if the user has been active. If no activity, write a checkpoint
-summarizing: (1) what you were working on, (2) key decisions made, (3) next steps.
-The write itself generates tokens that refresh the KV cache.
+(~50 min), check if the user has been active. If no activity, write a checkpoint:
+
+\`\`\`bash
+echo '<your actual summary here>' | mempal checkpoint save --project $PROJECT_NAME_SHELL
+\`\`\`
+
+IMPORTANT: You MUST replace '<your actual summary here>' with a REAL summary of:
+(1) what you were working on in this session
+(2) key decisions made or problems solved
+(3) open items / next steps
+DO NOT pass placeholder text. The summary should be 3-10 sentences that let a
+future session resume without re-reading the full conversation.
+
+The checkpoint write generates tokens that refresh the KV cache.
 
 CHECKPOINT_PROMPT
 PROMPT_EMITTED=1

--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -90,10 +90,12 @@ Run the countdown command with run_in_background: true. When the notification fi
 (~50 min), check if the user has been active. If no activity, write a checkpoint:
 
 \`\`\`bash
-echo '<your actual summary here>' | mempal checkpoint save --project $PROJECT_NAME_SHELL
+cat <<'EOF' | mempal checkpoint save --project $PROJECT_NAME_SHELL
+<your actual summary here — 3-10 sentences>
+EOF
 \`\`\`
 
-IMPORTANT: You MUST replace '<your actual summary here>' with a REAL summary of:
+IMPORTANT: You MUST replace the heredoc body with a REAL summary of:
 (1) what you were working on in this session
 (2) key decisions made or problems solved
 (3) open items / next steps

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "9c52ac8d4084329f35a068bab91b0245138c5407"
+commit = "20794a3173318de04f262e2fe2d92c084a54f017"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Checkpoint countdown hook previously passed hardcoded placeholder text to `mempal checkpoint save --content`, causing all checkpoints to contain "Session checkpoint auto-saved. Summarize current work state here." instead of actual session state
- Separated timer (background sleep) from content generation — timer only fires a signal, agent must pipe real summary via stdin heredoc
- Used heredoc (`<<'EOF'`) instead of `echo '...'` to avoid single-quote escaping issues in LLM-generated content

## Test plan
- [ ] Trigger a Stop event in a new session, verify the injected prompt shows heredoc syntax
- [ ] Let the 50-min timer fire, verify the resulting checkpoint drawer contains a real summary (not placeholder)
- [ ] Confirm warifu-ce sessions also get the fixed prompt (global hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)