### PR TITLE
feat(hook): add --target codex/all support for hook install

### DIFF
--- a/src/hook_install.rs
+++ b/src/hook_install.rs
@@ -4,6 +4,7 @@ use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::ValueEnum;
+use serde::Deserialize;
 use serde_json::{Value, json};
 
 const CLAUDE_SETTINGS_RELATIVE: &str = ".claude/settings.json";
@@ -20,6 +21,12 @@ const HOOK_COMMAND_EVENTS: [(&str, &str); 4] = [
     ("UserPromptSubmit", "UserPromptSubmit"),
     ("SessionStart", "SessionStart"),
     ("SessionEnd", "SessionEnd"),
+];
+const LEGACY_ALIASES: [(&str, &str); 4] = [
+    ("hook_post_tool", "PostToolUse"),
+    ("hook_user_prompt", "UserPromptSubmit"),
+    ("hook_session_start", "SessionStart"),
+    ("hook_session_end", "SessionEnd"),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -324,20 +331,21 @@ fn check_codex_feature_flag(home: &Path) -> Result<()> {
     let mut enabled = false;
 
     if path.exists() {
-        let content = fs::read_to_string(&path).unwrap_or_default();
-        for line in content.lines() {
-            let trimmed = line.trim();
-            // Match both "codex_hooks = true" and "[features]\ncodex_hooks = true"
-            if (trimmed.starts_with("codex_hooks") || trimmed.starts_with("\"codex_hooks\""))
-                && trimmed.contains('=')
-            {
-                if let Some(val) = trimmed.split('=').nth(1) {
-                    if val.trim() == "true" {
-                        enabled = true;
-                        break;
-                    }
-                }
-            }
+        let content = fs::read_to_string(&path).context("failed to read Codex config")?;
+
+        #[derive(Deserialize)]
+        struct CodexConfig {
+            codex_hooks: Option<bool>,
+            features: Option<CodexFeatures>,
+        }
+        #[derive(Deserialize)]
+        struct CodexFeatures {
+            codex_hooks: Option<bool>,
+        }
+
+        if let Ok(config) = toml::from_str::<CodexConfig>(&content) {
+            enabled = config.codex_hooks.unwrap_or(false)
+                || config.features.and_then(|f| f.codex_hooks).unwrap_or(false);
         }
     }
 
@@ -558,12 +566,38 @@ fn ensure_hook_event_array<'a>(
 }
 
 fn entry_contains_command(entry: &Value, expected: &str) -> bool {
-    entry
-        .get("hooks")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .any(|hook| hook.get("command").and_then(Value::as_str) == Some(expected))
+    let hooks = match entry.get("hooks").and_then(Value::as_array) {
+        Some(h) => h,
+        None => return false,
+    };
+
+    hooks.iter().any(|hook| {
+        let cmd = match hook.get("command").and_then(Value::as_str) {
+            Some(c) => c,
+            None => return false,
+        };
+
+        if cmd == expected {
+            return true;
+        }
+
+        // Check for aliases. Both cmd and expected should share the same
+        // '.../mempal hook ' prefix for us to consider them related.
+        if let (Some((_base_cmd, sub_cmd)), Some((_base_expected, sub_expected))) =
+            (cmd.rsplit_once(" hook "), expected.rsplit_once(" hook "))
+        {
+            if sub_cmd == sub_expected {
+                return true;
+            }
+            for (old, new) in LEGACY_ALIASES {
+                if sub_expected == new && sub_cmd == old {
+                    return true;
+                }
+            }
+        }
+
+        false
+    })
 }
 
 fn is_symlink(path: &Path) -> Result<bool> {

--- a/src/hook_install.rs
+++ b/src/hook_install.rs
@@ -9,14 +9,17 @@ use serde_json::{Value, json};
 const CLAUDE_SETTINGS_RELATIVE: &str = ".claude/settings.json";
 const CLAUDE_SETTINGS_DIR: &str = ".claude";
 const CLAUDE_SETTINGS_FILE: &str = "settings.json";
+const CODEX_SETTINGS_DIR: &str = ".codex";
+const CODEX_SETTINGS_FILE: &str = "hooks.json";
+const CODEX_HOOKS_RELATIVE: &str = ".codex/hooks.json";
 const USER_MCP_FILE: &str = ".mcp.json";
 const MEMPAL_MCP_SERVER_NAME: &str = "mempal";
 const FORBIDDEN_TARGET_NAMES: [&str; 3] = ["AGENTS.md", "CLAUDE.md", "GEMINI.md"];
 const HOOK_COMMAND_EVENTS: [(&str, &str); 4] = [
-    ("PostToolUse", "hook_post_tool"),
-    ("UserPromptSubmit", "hook_user_prompt"),
-    ("SessionStart", "hook_session_start"),
-    ("SessionEnd", "hook_session_end"),
+    ("PostToolUse", "PostToolUse"),
+    ("UserPromptSubmit", "UserPromptSubmit"),
+    ("SessionStart", "SessionStart"),
+    ("SessionEnd", "SessionEnd"),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -27,6 +30,8 @@ pub enum HookInstallTarget {
     GeminiCli,
     #[value(name = "codex")]
     Codex,
+    #[value(name = "all")]
+    All,
 }
 
 #[derive(Debug, Clone)]
@@ -75,57 +80,76 @@ pub fn install(
     uninstall: bool,
     skip_mcp: bool,
 ) -> Result<()> {
-    match target {
-        HookInstallTarget::ClaudeCode => {
-            let cwd = env::current_dir().context("failed to resolve current working directory")?;
-            let home = home_dir()?;
-            let outcome = install_claude_code(&cwd, &home, dry_run, uninstall)?;
-            if dry_run {
-                println!(
-                    "--- dry run: {} ({}) ---\n{}",
-                    outcome.display_path.display(),
-                    outcome.write_path.display(),
-                    outcome.rendered
-                );
-            } else if uninstall {
-                println!(
-                    "removed {} hook entr{} from {} ({})",
-                    outcome.removed_commands,
-                    if outcome.removed_commands == 1 {
-                        "y"
-                    } else {
-                        "ies"
-                    },
-                    outcome.display_path.display(),
-                    outcome.write_path.display()
-                );
-            } else if outcome.changed {
-                println!(
-                    "updated {} ({})",
-                    outcome.display_path.display(),
-                    outcome.write_path.display()
-                );
-            } else {
-                println!(
-                    "no-op {} ({})",
-                    outcome.display_path.display(),
-                    outcome.write_path.display()
-                );
-            }
+    let home = home_dir()?;
+    let cwd = env::current_dir().context("failed to resolve current working directory")?;
 
-            // Issue #129: ensure mempal MCP server is registered at the user
-            // level so any project (not just the mempal repo) can call
-            // mempal_ingest / mempal_search and reach the daemon-driven
-            // capture pipeline.
-            if !skip_mcp {
-                let mcp_outcome = install_user_mcp(&home, dry_run, uninstall)?;
-                report_mcp_outcome(&mcp_outcome, dry_run);
+    let targets = match target {
+        HookInstallTarget::All => vec![HookInstallTarget::ClaudeCode, HookInstallTarget::Codex],
+        other => vec![other],
+    };
+
+    for t in targets {
+        match t {
+            HookInstallTarget::ClaudeCode => {
+                let outcome = install_claude_code(&cwd, &home, dry_run, uninstall)?;
+                report_install_outcome(&outcome, dry_run, uninstall);
             }
-            Ok(())
+            HookInstallTarget::Codex => {
+                let outcome = install_codex(&cwd, &home, dry_run, uninstall)?;
+                report_install_outcome(&outcome, dry_run, uninstall);
+                if !dry_run && !uninstall {
+                    if let Err(e) = check_codex_feature_flag(&home) {
+                        eprintln!("warning: failed to check Codex feature flag: {}", e);
+                    }
+                }
+            }
+            HookInstallTarget::GeminiCli => {
+                bail!("hook install currently supports only --target claude-code, codex, and all");
+            }
+            HookInstallTarget::All => unreachable!(),
         }
-        HookInstallTarget::GeminiCli | HookInstallTarget::Codex => {
-            bail!("hook install currently supports only --target claude-code");
-        }
+    }
+
+    if !skip_mcp {
+        let mcp_outcome = install_user_mcp(&home, dry_run, uninstall)?;
+        report_mcp_outcome(&mcp_outcome, dry_run);
+    }
+
+    Ok(())
+}
+
+fn report_install_outcome(outcome: &InstallOutcome, dry_run: bool, uninstall: bool) {
+    if dry_run {
+        println!(
+            "--- dry run: {} ({}) ---\n{}",
+            outcome.display_path.display(),
+            outcome.write_path.display(),
+            outcome.rendered
+        );
+    } else if uninstall {
+        println!(
+            "removed {} hook entr{} from {} ({})",
+            outcome.removed_commands,
+            if outcome.removed_commands == 1 {
+                "y"
+            } else {
+                "ies"
+            },
+            outcome.display_path.display(),
+            outcome.write_path.display()
+        );
+    } else if outcome.changed {
+        println!(
+            "updated {} ({})",
+            outcome.display_path.display(),
+            outcome.write_path.display()
+        );
+    } else {
+        println!(
+            "no-op {} ({})",
+            outcome.display_path.display(),
+            outcome.write_path.display()
+        );
     }
 }
 
@@ -228,6 +252,104 @@ pub fn install_claude_code(
         changed,
         removed_commands,
     })
+}
+
+pub fn install_codex(
+    cwd: &Path,
+    home: &Path,
+    dry_run: bool,
+    uninstall: bool,
+) -> Result<InstallOutcome> {
+    let path = home.join(CODEX_HOOKS_RELATIVE);
+    let write_path = canonicalize_if_symlink(&path)?;
+    validate_write_target(cwd, home, &write_path, HookInstallTarget::Codex)?;
+
+    let hook_commands = hook_commands()?;
+    let mut root = read_settings_json(&write_path)?;
+    let mut removed_commands = 0usize;
+    let mut changed = false;
+
+    for (event_name, command) in &hook_commands {
+        let event_array = ensure_hook_event_array(&mut root, event_name)?;
+        let before_len = event_array.len();
+        event_array.retain(|entry| !entry_contains_command(entry, command));
+        let removed = before_len.saturating_sub(event_array.len());
+        removed_commands += removed;
+
+        let inserted = !uninstall
+            && !event_array
+                .iter()
+                .any(|entry| entry_contains_command(entry, command));
+
+        if inserted {
+            event_array.push(json!({
+                "hooks": [{
+                    "type": "command",
+                    "command": command
+                }]
+            }));
+        }
+
+        changed |= removed > 0 || inserted;
+    }
+
+    let rendered =
+        serde_json::to_string_pretty(&root).context("failed to serialize hook settings JSON")?;
+    if !dry_run {
+        if let Some(parent) = write_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create hook settings parent {}", parent.display())
+            })?;
+        }
+        let existing = fs::read_to_string(&write_path).ok();
+        changed = existing.as_deref() != Some(rendered.as_str());
+        if changed {
+            fs::write(&write_path, &rendered).with_context(|| {
+                format!("failed to write hook settings {}", write_path.display())
+            })?;
+        }
+    }
+
+    Ok(InstallOutcome {
+        display_path: path,
+        write_path,
+        rendered,
+        changed,
+        removed_commands,
+    })
+}
+
+fn check_codex_feature_flag(home: &Path) -> Result<()> {
+    let path = home.join(".codex/config.toml");
+    let mut enabled = false;
+
+    if path.exists() {
+        let content = fs::read_to_string(&path).unwrap_or_default();
+        for line in content.lines() {
+            let trimmed = line.trim();
+            // Match both "codex_hooks = true" and "[features]\ncodex_hooks = true"
+            if (trimmed.starts_with("codex_hooks") || trimmed.starts_with("\"codex_hooks\""))
+                && trimmed.contains('=')
+            {
+                if let Some(val) = trimmed.split('=').nth(1) {
+                    if val.trim() == "true" {
+                        enabled = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if !enabled {
+        println!(
+            "warning: Codex hook runtime (codex_hooks) is currently disabled. hooks in {} will be ignored.",
+            home.join(CODEX_HOOKS_RELATIVE).display()
+        );
+        println!("Run `codex features enable codex_hooks` to activate hook support.");
+    }
+
+    Ok(())
 }
 
 fn home_dir() -> Result<PathBuf> {
@@ -384,7 +506,7 @@ fn resolve_claude_settings_path(cwd: &Path, home: &Path) -> Result<ResolvedSetti
     let local_path = cwd.join(CLAUDE_SETTINGS_RELATIVE);
     if local_path.exists() || is_symlink(&local_path)? {
         let write_path = canonicalize_if_symlink(&local_path)?;
-        validate_write_target(cwd, home, &write_path)?;
+        validate_write_target(cwd, home, &write_path, HookInstallTarget::ClaudeCode)?;
         return Ok(ResolvedSettingsPath {
             display_path: local_path,
             write_path,
@@ -393,7 +515,7 @@ fn resolve_claude_settings_path(cwd: &Path, home: &Path) -> Result<ResolvedSetti
 
     let global_path = home.join(CLAUDE_SETTINGS_RELATIVE);
     let write_path = canonicalize_if_symlink(&global_path)?;
-    validate_write_target(cwd, home, &write_path)?;
+    validate_write_target(cwd, home, &write_path, HookInstallTarget::ClaudeCode)?;
     Ok(ResolvedSettingsPath {
         display_path: global_path.clone(),
         write_path,
@@ -461,7 +583,12 @@ fn canonicalize_if_symlink(path: &Path) -> Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-fn validate_write_target(cwd: &Path, home: &Path, path: &Path) -> Result<()> {
+fn validate_write_target(
+    cwd: &Path,
+    home: &Path,
+    path: &Path,
+    target: HookInstallTarget,
+) -> Result<()> {
     if path
         .file_name()
         .and_then(|name| name.to_str())
@@ -487,11 +614,25 @@ fn validate_write_target(cwd: &Path, home: &Path, path: &Path) -> Result<()> {
         .and_then(Path::file_name)
         .and_then(|name| name.to_str());
     let file_name = path.file_name().and_then(|name| name.to_str());
-    if parent_name != Some(CLAUDE_SETTINGS_DIR) || file_name != Some(CLAUDE_SETTINGS_FILE) {
-        bail!(
-            "refusing to edit non-canonical Claude settings target {}",
-            path.display()
-        );
+
+    match target {
+        HookInstallTarget::ClaudeCode => {
+            if parent_name != Some(CLAUDE_SETTINGS_DIR) || file_name != Some(CLAUDE_SETTINGS_FILE) {
+                bail!(
+                    "refusing to edit non-canonical Claude settings target {}",
+                    path.display()
+                );
+            }
+        }
+        HookInstallTarget::Codex => {
+            if parent_name != Some(CODEX_SETTINGS_DIR) || file_name != Some(CODEX_SETTINGS_FILE) {
+                bail!(
+                    "refusing to edit non-canonical Codex settings target {}",
+                    path.display()
+                );
+            }
+        }
+        _ => {}
     }
 
     let allowed_roots = [

--- a/tests/hook_install.rs
+++ b/tests/hook_install.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::os::unix::fs::symlink;
 use std::process::Command;
 
-use mempal::hook_install::{McpInstallStatus, install_claude_code, install_user_mcp};
+use mempal::hook_install::{
+    McpInstallStatus, install_claude_code, install_codex, install_user_mcp,
+};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -15,9 +17,9 @@ fn mempal_bin() -> String {
     env!("CARGO_BIN_EXE_mempal").to_string()
 }
 
-fn expected_hook_command(alias: &str) -> String {
+fn expected_hook_command(name: &str) -> String {
     let binary = fs::canonicalize(mempal_bin()).expect("canonical mempal bin");
-    format!("{} hook {alias}", binary.display())
+    format!("{} hook {name}", binary.display())
 }
 
 #[test]
@@ -34,14 +36,14 @@ fn test_hook_install_writes_claude_code_settings() {
     assert!(outcome.display_path.ends_with(".claude/settings.json"));
     assert!(outcome.changed);
     assert_eq!(outcome.removed_commands, 0);
-    assert!(outcome.rendered.contains("hook_post_tool"));
+    assert!(outcome.rendered.contains("PostToolUse"));
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_post_tool")
+        expected_hook_command("PostToolUse")
     );
     assert_eq!(
         parsed["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_user_prompt")
+        expected_hook_command("UserPromptSubmit")
     );
 }
 
@@ -63,7 +65,7 @@ fn test_hook_install_respects_project_local_settings() {
     assert_eq!(parsed["theme"], "dark");
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_post_tool")
+        expected_hook_command("PostToolUse")
     );
     assert!(
         !home.join(".claude/settings.json").exists(),
@@ -104,7 +106,7 @@ fn test_hook_install_merges_existing_settings() {
     );
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_post_tool")
+        expected_hook_command("PostToolUse")
     );
     assert!(outcome.changed);
 }
@@ -136,10 +138,10 @@ fn test_hook_install_follows_symlink_target() {
     );
     assert_eq!(parsed["theme"], "dark");
     assert_eq!(outcome.write_path, real_target);
-    assert!(outcome.rendered.contains("hook_post_tool"));
+    assert!(outcome.rendered.contains("PostToolUse"));
     assert_eq!(
         parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_post_tool")
+        expected_hook_command("PostToolUse")
     );
 }
 
@@ -175,7 +177,7 @@ fn test_hook_install_coexists_with_upstream_cowork_entry() {
         .flat_map(|entry| entry["hooks"].as_array().expect("hook array").iter())
         .filter_map(|hook| hook["command"].as_str())
         .collect();
-    let expected = expected_hook_command("hook_user_prompt");
+    let expected = expected_hook_command("UserPromptSubmit");
 
     assert!(commands.contains(&".claude/hooks/user-prompt-submit.sh"));
     assert!(commands.iter().any(|command| *command == expected));
@@ -218,7 +220,7 @@ fn test_hook_install_dry_run_does_not_write() {
     assert!(
         outcome
             .rendered
-            .contains(&expected_hook_command("hook_post_tool"))
+            .contains(&expected_hook_command("PostToolUse"))
     );
     assert!(
         !home.join(".claude/settings.json").exists(),
@@ -265,7 +267,7 @@ fn test_hook_install_absolute_path_binary() {
         command.starts_with('/'),
         "hook command must use absolute binary path, got {command}"
     );
-    assert_eq!(command, expected_hook_command("hook_post_tool"));
+    assert_eq!(command, expected_hook_command("PostToolUse"));
 
     let outside = TempDir::new().expect("outside tempdir");
     let outside_target = outside.path().join(".claude/settings.json");
@@ -307,7 +309,7 @@ fn test_hook_install_public_wrapper_uses_home_env() {
     let parsed = parse_json(&home.join(".claude/settings.json"));
     assert_eq!(
         parsed["hooks"]["SessionEnd"][0]["hooks"][0]["command"],
-        expected_hook_command("hook_session_end")
+        expected_hook_command("SessionEnd")
     );
 
     // Issue #129: the same install also seeds `~/.mcp.json` with the mempal
@@ -506,4 +508,129 @@ fn test_hook_install_skip_mcp_does_not_touch_user_mcp() {
         !home.join(".mcp.json").exists(),
         "--skip-mcp must not touch ~/.mcp.json"
     );
+}
+
+#[test]
+fn test_hook_install_writes_codex_hooks() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&home).expect("create home");
+
+    let outcome = install_codex(&cwd, &home, false, false).expect("install codex");
+    let parsed = parse_json(&outcome.write_path);
+
+    assert!(outcome.display_path.ends_with(".codex/hooks.json"));
+    assert!(outcome.changed);
+    assert_eq!(
+        parsed["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+        expected_hook_command("PostToolUse")
+    );
+    assert_eq!(
+        parsed["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        expected_hook_command("UserPromptSubmit")
+    );
+}
+
+#[test]
+fn test_hook_install_codex_merges_existing() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(home.join(".codex")).expect("create .codex");
+    fs::write(
+        home.join(".codex/hooks.json"),
+        r#"{
+          "hooks": {
+            "UserPromptSubmit": [{
+              "hooks": [{
+                "type": "command",
+                "command": "mempal cowork-drain --target codex --format codex-hook-json --cwd-source stdin-json"
+              }]
+            }]
+          }
+        }"#,
+    )
+    .expect("write seed codex hooks");
+
+    let outcome = install_codex(&cwd, &home, false, false).expect("install codex");
+    let parsed = parse_json(&outcome.write_path);
+    let entries = parsed["hooks"]["UserPromptSubmit"]
+        .as_array()
+        .expect("prompt array");
+
+    // Should have 2 entries in UserPromptSubmit array
+    assert_eq!(entries.len(), 2);
+    let commands: Vec<&str> = entries
+        .iter()
+        .flat_map(|entry| entry["hooks"].as_array().expect("hook array").iter())
+        .filter_map(|hook| hook["command"].as_str())
+        .collect();
+
+    assert!(commands.contains(
+        &"mempal cowork-drain --target codex --format codex-hook-json --cwd-source stdin-json"
+    ));
+    assert!(commands.contains(&expected_hook_command("UserPromptSubmit").as_str()));
+}
+
+#[test]
+fn test_hook_install_all_target() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&home).expect("create home");
+
+    let output = Command::new(mempal_bin())
+        .args(["hook", "install", "--target", "all"])
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .output()
+        .expect("install all");
+
+    assert!(output.status.success());
+    assert!(home.join(".claude/settings.json").exists());
+    assert!(home.join(".codex/hooks.json").exists());
+    assert!(home.join(".mcp.json").exists());
+}
+
+#[test]
+fn test_hook_install_codex_warns_on_missing_feature_flag() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&home).expect("create home");
+
+    let output = Command::new(mempal_bin())
+        .args(["hook", "install", "--target", "codex"])
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .output()
+        .expect("install codex");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("warning: Codex hook runtime (codex_hooks) is currently disabled"));
+    assert!(stdout.contains("codex features enable codex_hooks"));
+}
+
+#[test]
+fn test_hook_install_codex_no_warning_when_feature_enabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(home.join(".codex")).expect("create .codex");
+    fs::write(home.join(".codex/config.toml"), "codex_hooks = true").expect("enable hooks");
+
+    let output = Command::new(mempal_bin())
+        .args(["hook", "install", "--target", "codex"])
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .output()
+        .expect("install codex");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("warning: Codex hook runtime (codex_hooks) is currently disabled"));
 }

--- a/tests/hook_install.rs
+++ b/tests/hook_install.rs
@@ -634,3 +634,65 @@ fn test_hook_install_codex_no_warning_when_feature_enabled() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(!stdout.contains("warning: Codex hook runtime (codex_hooks) is currently disabled"));
 }
+
+#[test]
+fn test_hook_install_removes_legacy_aliases() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(cwd.join(".claude")).expect("create local .claude");
+    fs::create_dir_all(&home).expect("create home");
+
+    // Seed with a legacy hook command
+    let legacy_cmd = "/usr/local/bin/mempal hook hook_post_tool";
+    fs::write(
+        cwd.join(".claude/settings.json"),
+        json!({
+          "hooks": {
+            "PostToolUse": [{
+              "hooks": [{
+                "type": "command",
+                "command": legacy_cmd
+              }]
+            }]
+          }
+        })
+        .to_string(),
+    )
+    .expect("write seed settings");
+
+    let outcome = install_claude_code(&cwd, &home, false, false).expect("install");
+    let parsed = parse_json(&outcome.write_path);
+
+    let entries = parsed["hooks"]["PostToolUse"].as_array().expect("array");
+    // Should have only 1 entry (the new one), legacy should be gone
+    assert_eq!(entries.len(), 1);
+    let command = entries[0]["hooks"][0]["command"].as_str().expect("command");
+    assert_ne!(command, legacy_cmd);
+    assert_eq!(command, expected_hook_command("PostToolUse"));
+    assert_eq!(outcome.removed_commands, 1);
+}
+
+#[test]
+fn test_hook_install_codex_no_warning_when_feature_enabled_in_section() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cwd = tmp.path().join("repo");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(home.join(".codex")).expect("create .codex");
+    fs::write(
+        home.join(".codex/config.toml"),
+        "[features]\ncodex_hooks = true",
+    )
+    .expect("enable hooks");
+
+    let output = Command::new(mempal_bin())
+        .args(["hook", "install", "--target", "codex"])
+        .current_dir(&cwd)
+        .env("HOME", &home)
+        .output()
+        .expect("install codex");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("warning: Codex hook runtime (codex_hooks) is currently disabled"));
+}


### PR DESCRIPTION
## Summary
- Adds `--target codex` to write hooks to `~/.codex/hooks.json` (PostToolUse, UserPromptSubmit, SessionEnd)
- Adds `--target all` to iterate all known adapters (claude-code + codex)
- Preserves existing hooks via array append semantics (non-destructive merge)
- Detects and removes legacy hook command aliases on upgrade (hook_post_tool → PostToolUse etc.)
- Checks `codex_hooks` feature flag in `~/.codex/config.toml` and warns if disabled
- Uses proper `toml` crate for config parsing instead of manual string splitting

Closes #147

## Test plan
- [x] All 237 tests pass including 22+ hook_install integration tests
- [x] Legacy alias removal verified by dedicated test
- [x] Multi-target (all) installation verified
- [x] CSA tier-4-critical review passed (2 rounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)