### PR TITLE
feat(audit): operational observability for embed failures, gating, and novelty

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -2,9 +2,9 @@
 // harness-point: PR0 — re-export MigrationHook trait + hooked migration runner for tests
 pub use db_fork_ext::{
     CURRENT_FORK_EXT_VERSION, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
-    FORK_EXT_V3_SCHEMA_SQL, FORK_EXT_V13_SCHEMA_SQL, MigrationHook, apply_fork_ext_migrations,
-    apply_fork_ext_migrations_to, apply_fork_ext_migrations_with_hook, read_fork_ext_version,
-    set_fork_ext_version,
+    FORK_EXT_V3_SCHEMA_SQL, FORK_EXT_V13_SCHEMA_SQL, FORK_EXT_V14_SCHEMA_SQL, MigrationHook,
+    apply_fork_ext_migrations, apply_fork_ext_migrations_to, apply_fork_ext_migrations_with_hook,
+    read_fork_ext_version, set_fork_ext_version,
 };
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
@@ -39,12 +39,23 @@ use crate::ingest::novelty::NoveltyAction;
 
 const CURRENT_SCHEMA_VERSION: u32 = 9;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
+const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
 const CONTENT_HASH_BACKFILL_BATCH: usize = 1_000;
 
 fn content_hash_hex(content: &str) -> String {
     blake3::hash(content.as_bytes()).to_hex().to_string()
 }
+
+fn truncate_preview(content: &str, max_chars: usize) -> String {
+    let mut chars = content.chars();
+    let mut preview = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        preview.push('…');
+    }
+    preview
+}
+
 const DRAWER_SELECT_COLUMNS: &str = r#"
     id,
     content,
@@ -329,12 +340,13 @@ impl Database {
         candidate_hash: &str,
         decision: &GatingDecision,
         project_id: Option<&str>,
+        content: Option<&str>,
     ) -> Result<(), DbError> {
         let explain_json = serde_json::to_string(decision)?;
         let created_at = super::utils::current_timestamp()
             .parse::<i64>()
             .unwrap_or_default();
-        let retained_until = created_at + 7 * 24 * 60 * 60;
+        let retained_until = created_at + AUDIT_RETENTION_SECS;
         let unique_nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_nanos())
@@ -350,6 +362,10 @@ impl Database {
             "keep"
         };
         let drawer_id = (!decision.is_rejected()).then_some(candidate_hash);
+        let content_preview = decision
+            .is_rejected()
+            .then(|| content.map(|text| truncate_preview(text, 500)))
+            .flatten();
         self.conn.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> Result<(), DbError> {
             self.conn.execute(
@@ -366,9 +382,10 @@ impl Database {
                     explain_json,
                     retained_until,
                     created_at,
-                    project_id
+                    project_id,
+                    content_preview
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
                 "#,
                 params![
                     id,
@@ -383,6 +400,7 @@ impl Database {
                     retained_until,
                     created_at,
                     project_id,
+                    content_preview.as_deref(),
                 ],
             )?;
             if let Some(reason) = decision.drop_reason() {
@@ -401,6 +419,67 @@ impl Database {
                 Err(error)
             }
         }
+    }
+
+    pub fn record_embed_failure(
+        &self,
+        error_message: &str,
+        endpoint: Option<&str>,
+        consecutive_failures: u64,
+        duration_ms: Option<u64>,
+    ) -> Result<(), DbError> {
+        let timestamp = super::utils::current_timestamp()
+            .parse::<i64>()
+            .unwrap_or_default();
+        let retained_until = timestamp + AUDIT_RETENTION_SECS;
+        let unique_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let id_seed = format!("{timestamp}:{unique_nanos}:{consecutive_failures}:{error_message}");
+        let id = format!(
+            "embed_failure_{}",
+            blake3::hash(id_seed.as_bytes()).to_hex()
+        );
+        self.conn.execute(
+            r#"
+            INSERT INTO embed_failure_log (
+                id,
+                timestamp,
+                error_message,
+                endpoint,
+                consecutive_failures,
+                duration_ms,
+                retained_until
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![
+                id,
+                timestamp,
+                error_message,
+                endpoint,
+                i64::try_from(consecutive_failures).unwrap_or(i64::MAX),
+                duration_ms.map(|value| i64::try_from(value).unwrap_or(i64::MAX)),
+                retained_until,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn prune_expired_audit_logs(&self) -> Result<(), DbError> {
+        let now = super::utils::current_timestamp()
+            .parse::<i64>()
+            .unwrap_or_default();
+        self.conn.execute(
+            "DELETE FROM gating_audit WHERE retained_until < ?1",
+            params![now],
+        )?;
+        self.conn.execute(
+            "DELETE FROM embed_failure_log WHERE retained_until < ?1",
+            params![now],
+        )?;
+        Ok(())
     }
 
     pub fn upsert_llm_verdict(

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,24 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 13;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 14;
+
+pub const FORK_EXT_V14_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS embed_failure_log (
+    id TEXT PRIMARY KEY,
+    timestamp INTEGER NOT NULL,
+    error_message TEXT NOT NULL,
+    endpoint TEXT,
+    consecutive_failures INTEGER,
+    duration_ms INTEGER,
+    retained_until INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_embed_failure_log_timestamp
+    ON embed_failure_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_embed_failure_log_retained_until
+    ON embed_failure_log(retained_until);
+"#;
 
 pub const FORK_EXT_V13_SCHEMA_SQL: &str = r#"
 CREATE TABLE IF NOT EXISTS skills (
@@ -283,6 +300,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 13,
             up: apply_v13,
         },
+        Migration {
+            version: 14,
+            up: apply_v14,
+        },
     ]
 }
 
@@ -383,6 +404,11 @@ fn apply_v13(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V13_SCHEMA_SQL)
 }
 
+fn apply_v14(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V14_SCHEMA_SQL)?;
+    ensure_gating_audit_content_preview_column(conn)
+}
+
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {
     // Each ALTER TABLE must succeed idempotently — use ensure_* helpers.
     ensure_nullable_column(conn, "drawers", "last_accessed_at", "INTEGER")?;
@@ -457,6 +483,21 @@ fn ensure_gating_audit_llm_columns(conn: &Connection) -> rusqlite::Result<()> {
         (true, true) => {}
     }
     Ok(())
+}
+
+fn ensure_gating_audit_content_preview_column(conn: &Connection) -> rusqlite::Result<()> {
+    if conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='gating_audit'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?
+        == 0
+    {
+        return Ok(());
+    }
+
+    ensure_nullable_column(conn, "gating_audit", "content_preview", "TEXT")
 }
 
 fn backfill_gating_audit_from_explain_json(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -52,6 +52,12 @@ pub fn run_command_with_bootstrap_events(
 }
 
 async fn run_loop(context: &DaemonContext) -> Result<()> {
+    global_embed_status().set_audit_db_path(Some(context.db.path().to_path_buf()));
+    context
+        .db
+        .prune_expired_audit_logs()
+        .context("failed to prune expired audit logs")?;
+
     if !context.config.hooks.enabled {
         eprintln!("hooks not enabled; daemon exiting without starting worker loop");
         return Ok(());
@@ -638,7 +644,12 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     {
         context
             .db
-            .record_gating_audit(&drawer_id, decision, record.project_id.as_deref())
+            .record_gating_audit(
+                &drawer_id,
+                decision,
+                record.project_id.as_deref(),
+                Some(&candidate.content),
+            )
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         return Ok(drawer_id);
     }
@@ -675,7 +686,12 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         );
         context
             .db
-            .record_gating_audit(&drawer_id, &decision, record.project_id.as_deref())
+            .record_gating_audit(
+                &drawer_id,
+                &decision,
+                record.project_id.as_deref(),
+                Some(&candidate.content),
+            )
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
         gating_audit_recorded = true;
         if decision.is_rejected() {
@@ -687,7 +703,12 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
         context
             .db
-            .record_gating_audit(&drawer_id, decision, record.project_id.as_deref())
+            .record_gating_audit(
+                &drawer_id,
+                decision,
+                record.project_id.as_deref(),
+                Some(&candidate.content),
+            )
             .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
     }
 

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -129,6 +129,15 @@ impl EmbedError {
                 | Self::ReadApiKeyEnv { .. }
         )
     }
+
+    pub fn endpoint(&self) -> Option<&str> {
+        match self {
+            Self::HttpRequest { endpoint, .. }
+            | Self::HttpStatus { endpoint, .. }
+            | Self::DecodeResponse { endpoint, .. } => Some(endpoint.as_str()),
+            _ => None,
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/embed/retry.rs
+++ b/src/embed/retry.rs
@@ -15,11 +15,14 @@ where
     Fut: Future<Output = Result<Vec<Vec<f32>>>>,
 {
     loop {
+        let attempt_started = tokio::time::Instant::now();
         match operation().await {
             Ok(vectors) => return Ok(vectors),
             Err(error) => {
                 let config = status.retry_config_snapshot();
-                status.record_failure_with_snapshot(&error, &config);
+                let duration_ms = attempt_started.elapsed().as_millis();
+                let duration_ms = u64::try_from(duration_ms).unwrap_or(u64::MAX);
+                status.record_failure_with_snapshot(&error, &config, Some(duration_ms));
                 if !error.is_retryable() {
                     return Err(error);
                 }

--- a/src/embed/status.rs
+++ b/src/embed/status.rs
@@ -6,6 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use arc_swap::{ArcSwap, ArcSwapOption};
 
 use crate::core::config::ConfigHandle;
+use crate::core::db::Database;
 
 use super::alerting;
 
@@ -46,6 +47,7 @@ pub struct EmbedStatus {
     last_error: ArcSwapOption<String>,
     last_success_at_unix_ms: AtomicU64,
     fallback_warning: ArcSwapOption<String>,
+    audit_db_path: ArcSwapOption<PathBuf>,
 }
 
 impl Default for EmbedStatus {
@@ -73,6 +75,7 @@ impl EmbedStatus {
             last_error: ArcSwapOption::from(None),
             last_success_at_unix_ms: AtomicU64::new(0),
             fallback_warning: ArcSwapOption::from(None),
+            audit_db_path: ArcSwapOption::from(None),
         }
     }
 
@@ -134,13 +137,15 @@ impl EmbedStatus {
         if fail_count >= degrade_after {
             self.degraded.store(true, Ordering::SeqCst);
         }
+        self.persist_failure_event(&message, None, fail_count, None);
         self.maybe_fire_alert(fail_count, &message);
     }
 
     pub fn record_failure_with_snapshot(
         &self,
-        error: &impl std::fmt::Display,
+        error: &super::EmbedError,
         snapshot: &RetryConfigSnapshot,
+        duration_ms: Option<u64>,
     ) {
         let message = crate::core::config::scrub_sensitive_text(&error.to_string());
         self.last_error
@@ -149,6 +154,10 @@ impl EmbedStatus {
         if fail_count >= snapshot.degrade_threshold {
             self.degraded.store(true, Ordering::SeqCst);
         }
+        let endpoint = error
+            .endpoint()
+            .map(crate::core::config::scrub_sensitive_text);
+        self.persist_failure_event(&message, endpoint.as_deref(), fail_count, duration_ms);
         self.maybe_fire_alert_with_snapshot(snapshot, fail_count, &message);
     }
 
@@ -222,6 +231,11 @@ impl EmbedStatus {
         self.last_error.store(None);
         self.last_success_at_unix_ms.store(0, Ordering::SeqCst);
         self.fallback_warning.store(None);
+        self.audit_db_path.store(None);
+    }
+
+    pub fn set_audit_db_path(&self, db_path: Option<PathBuf>) {
+        self.audit_db_path.store(db_path.map(std::sync::Arc::new));
     }
 
     fn maybe_fire_alert(&self, fail_count: u64, error_message: &str) {
@@ -254,6 +268,23 @@ impl EmbedStatus {
             return;
         };
         alerting::fire_alert(path, fail_count, error_message);
+    }
+
+    fn persist_failure_event(
+        &self,
+        error_message: &str,
+        endpoint: Option<&str>,
+        fail_count: u64,
+        duration_ms: Option<u64>,
+    ) {
+        let Some(db_path) = self.audit_db_path.load_full() else {
+            return;
+        };
+        if let Err(error) = Database::open(db_path.as_ref()).and_then(|db| {
+            db.record_embed_failure(error_message, endpoint, fail_count, duration_ms)
+        }) {
+            tracing::warn!(error = %error, "failed to persist embed failure audit log");
+        }
     }
 }
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -384,7 +384,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                 gating_decision = Some(tier2.decision);
             }
             if let Some(decision) = gating_decision.as_ref() {
-                db.record_gating_audit(&drawer_id, decision, options.project_id)
+                db.record_gating_audit(&drawer_id, decision, options.project_id, Some(chunk))
                     .map_err(|source| IngestError::InsertDrawer {
                         drawer_id: drawer_id.clone(),
                         source,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1733,7 +1733,7 @@ async fn ingest_stdin_command(
             gating_decision = Some(tier2.decision);
         }
         if let Some(decision) = gating_decision.as_ref() {
-            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
+            db.record_gating_audit(&drawer_id, decision, project_id.as_deref(), Some(&content))
                 .with_context(|| format!("failed to record gating audit for {drawer_id}"))?;
             if decision.is_rejected() {
                 stats.dropped_by_gate = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,17 +382,8 @@ enum Commands {
         raw: bool,
     },
     Audit {
-        #[arg(long)]
-        kind: Option<String>,
-        #[arg(
-            long,
-            help = "Filter to audit records created after this point. \
-                    Duration: '10s', '15m', '2h', '3d'. \
-                    ISO 8601: '2026-04-25T20:00:00Z' or '2026-04-25T20:00:00+08:00'."
-        )]
-        since: Option<String>,
-        #[arg(long, default_value_t = false)]
-        raw: bool,
+        #[command(subcommand)]
+        command: Option<AuditCommands>,
         /// List drawers whose effective_importance is below this threshold (P13).
         #[arg(long, default_value_t = false)]
         stale: bool,
@@ -513,6 +504,52 @@ enum CheckpointCommands {
         /// Only show the last N assistant messages. Default: 1.
         #[arg(long, default_value_t = 1)]
         last: usize,
+    },
+}
+
+#[derive(Subcommand)]
+enum AuditCommands {
+    /// Show gating decisions (keep/skip) with optional filters.
+    Gating {
+        /// Filter by decision: keep or skip.
+        #[arg(long)]
+        decision: Option<String>,
+        /// Filter by time: '10m', '2h', '24h', '3d'.
+        #[arg(long)]
+        since: Option<String>,
+        /// Filter by project ID.
+        #[arg(long)]
+        project: Option<String>,
+        /// Output format: text (default) or json.
+        #[arg(long, default_value = "text")]
+        format: String,
+        /// Show raw (unescaped) text in text format.
+        #[arg(long, default_value_t = false)]
+        raw: bool,
+    },
+    /// Show embedding failure logs.
+    Embed {
+        /// Filter by time: '10m', '2h', '24h', '3d'.
+        #[arg(long)]
+        since: Option<String>,
+        /// Output format: text (default) or json.
+        #[arg(long, default_value = "text")]
+        format: String,
+        /// Show raw (unescaped) text in text format.
+        #[arg(long, default_value_t = false)]
+        raw: bool,
+    },
+    /// Show novelty (de-duplication) decisions.
+    Novelty {
+        /// Filter by time: '10m', '2h', '24h', '3d'.
+        #[arg(long)]
+        since: Option<String>,
+        /// Output format: text (default) or json.
+        #[arg(long, default_value = "text")]
+        format: String,
+        /// Show raw (unescaped) text in text format.
+        #[arg(long, default_value_t = false)]
+        raw: bool,
     },
 }
 
@@ -1293,24 +1330,50 @@ fn run() -> Result<()> {
             },
         ),
         Commands::Audit {
-            kind,
-            since,
-            raw,
+            command,
             stale,
             threshold,
         } => {
             if stale {
                 audit_stale_command(&db, threshold)
-            } else {
-                observability::audit_command(
-                    &db,
-                    config.as_ref(),
-                    observability::AuditOptions {
-                        kind: kind.as_deref(),
-                        since: since.as_deref(),
+            } else if let Some(cmd) = command {
+                match cmd {
+                    AuditCommands::Gating {
+                        decision,
+                        since,
+                        project,
+                        format,
                         raw,
-                    },
-                )
+                    } => observability::audit_gating_command(
+                        &db,
+                        config.as_ref(),
+                        decision,
+                        since.as_deref(),
+                        project.as_deref(),
+                        &format,
+                        raw,
+                    ),
+                    AuditCommands::Embed { since, format, raw } => {
+                        observability::audit_embed_command(
+                            &db,
+                            config.as_ref(),
+                            since.as_deref(),
+                            &format,
+                            raw,
+                        )
+                    }
+                    AuditCommands::Novelty { since, format, raw } => {
+                        observability::audit_novelty_command(
+                            &db,
+                            config.as_ref(),
+                            since.as_deref(),
+                            &format,
+                            raw,
+                        )
+                    }
+                }
+            } else {
+                bail!("`mempal audit` requires a subcommand (gating, embed, novelty) or --stale");
             }
         }
         Commands::RecomputeImportance => recompute_effective_importance_command(&db),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1784,8 +1784,13 @@ impl MempalMcpServer {
         if let Some(decision) = gating_decision.as_ref()
             && decision.is_rejected()
         {
-            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
-                .map_err(db_error)?;
+            db.record_gating_audit(
+                &drawer_id,
+                decision,
+                project_id.as_deref(),
+                Some(&candidate.content),
+            )
+            .map_err(db_error)?;
             return Ok(Json(IngestResponse {
                 drawer_id,
                 drawer_ids: Vec::new(),
@@ -1853,14 +1858,24 @@ impl MempalMcpServer {
                 if llm_judge_active && is_unclassified {
                     let llm_decision =
                         GatingDecision::accepted(0, Some("llm_pending".to_string()), None);
-                    db.record_gating_audit(&drawer_id, &llm_decision, project_id.as_deref())
-                        .map_err(db_error)?;
+                    db.record_gating_audit(
+                        &drawer_id,
+                        &llm_decision,
+                        project_id.as_deref(),
+                        Some(&candidate.content),
+                    )
+                    .map_err(db_error)?;
                     gating_audit_recorded = true;
                     gating_decision = Some(llm_decision);
                     should_enqueue_llm_task = true;
                 } else {
-                    db.record_gating_audit(&drawer_id, &tier2.decision, project_id.as_deref())
-                        .map_err(db_error)?;
+                    db.record_gating_audit(
+                        &drawer_id,
+                        &tier2.decision,
+                        project_id.as_deref(),
+                        Some(&candidate.content),
+                    )
+                    .map_err(db_error)?;
                     gating_audit_recorded = true;
                     gating_decision = Some(tier2.decision);
                 }
@@ -1890,8 +1905,13 @@ impl MempalMcpServer {
             }));
         }
         if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
-            db.record_gating_audit(&drawer_id, decision, project_id.as_deref())
-                .map_err(db_error)?;
+            db.record_gating_audit(
+                &drawer_id,
+                decision,
+                project_id.as_deref(),
+                Some(&candidate.content),
+            )
+            .map_err(db_error)?;
         }
 
         let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -44,12 +44,6 @@ pub struct ViewOptions<'a> {
     pub raw: bool,
 }
 
-pub struct AuditOptions<'a> {
-    pub kind: Option<&'a str>,
-    pub since: Option<&'a str>,
-    pub raw: bool,
-}
-
 pub struct GatingStatsOptions<'a> {
     pub since: Option<&'a str>,
 }
@@ -102,8 +96,42 @@ struct GatingAuditDetail {
     tier: u8,
     label: Option<String>,
     reason: Option<String>,
+    score: Option<f32>,
+    content_preview: Option<String>,
     created_at: i64,
     project_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EmbedFailureRecord {
+    pub id: String,
+    pub timestamp: i64,
+    pub error_message: String,
+    pub endpoint: Option<String>,
+    pub consecutive_failures: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NoveltyAuditRecord {
+    pub id: String,
+    pub candidate_hash: String,
+    pub decision: String,
+    pub near_drawer_id: Option<String>,
+    pub cosine: Option<f32>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatingAuditRecord {
+    pub audit_id: String,
+    pub candidate_hash: String,
+    pub decision: String,
+    pub tier: u8,
+    pub label: Option<String>,
+    pub reason: Option<String>,
+    pub score: Option<f32>,
+    pub content_preview: Option<String>,
+    pub created_at: i64,
 }
 
 struct GatingExplainFields {
@@ -401,39 +429,198 @@ pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) ->
     Ok(())
 }
 
-pub fn audit_command(db: &Database, config: &Config, options: AuditOptions<'_>) -> Result<()> {
+pub fn audit_gating_command(
+    db: &Database,
+    config: &Config,
+    decision_filter: Option<String>,
+    since: Option<&str>,
+    project_filter: Option<&str>,
+    format: &str,
+    raw: bool,
+) -> Result<()> {
     let scope = dashboard_scope(config)?;
-    let since_cutoff = parse_since_cutoff(options.since)?;
-    match options.kind.unwrap_or("all") {
-        "all" => {
-            print_audit_section(
-                "gating",
-                &load_audit_records(db, "gating", &scope, since_cutoff)?,
-                options.raw,
-            );
-            print_audit_section(
-                "novelty",
-                &load_audit_records(db, "novelty", &scope, since_cutoff)?,
-                options.raw,
-            );
+    let since_cutoff = parse_since_cutoff(since)?;
+    let rows = load_gating_audit_details(db, &scope, since_cutoff)?;
+
+    let filtered: Vec<_> = rows
+        .into_iter()
+        .filter(|row| {
+            decision_filter.as_deref().is_none_or(|d| row.decision == d)
+                && project_filter.is_none_or(|p| row.project_id.as_deref() == Some(p))
+        })
+        .collect();
+
+    if format == "json" {
+        let json_rows: Vec<_> = filtered
+            .into_iter()
+            .map(|row| GatingAuditRecord {
+                audit_id: row.audit_id,
+                candidate_hash: row.candidate_hash,
+                decision: row.decision,
+                tier: row.tier,
+                label: row.label,
+                reason: row.reason,
+                score: row.score,
+                content_preview: row.content_preview,
+                created_at: row.created_at,
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_rows).context("failed to serialize gating audit")?
+        );
+    } else {
+        println!("gating_audit:");
+        if filtered.is_empty() {
+            println!("  none");
+        } else {
+            for row in filtered {
+                let score_str = row
+                    .score
+                    .map(|s| format!(" score={:.3}", s))
+                    .unwrap_or_default();
+                let preview = row
+                    .content_preview
+                    .as_deref()
+                    .map(|p| {
+                        let truncated = if p.len() > 80 {
+                            format!("{}...", &p[..77])
+                        } else {
+                            p.to_string()
+                        };
+                        format!(" preview={:?}", maybe_escape(&truncated, raw))
+                    })
+                    .unwrap_or_default();
+                println!(
+                    "  {} decision={} label={:?} reason={:?}{} candidate_hash={} audit_id={}{}",
+                    format_created_at(row.created_at),
+                    row.decision,
+                    row.label.as_deref().unwrap_or("none"),
+                    row.reason.as_deref().unwrap_or("none"),
+                    score_str,
+                    maybe_escape(&row.candidate_hash, raw),
+                    maybe_escape(&row.audit_id, raw),
+                    preview
+                );
+            }
         }
-        "gating" => {
-            print_audit_section(
-                "gating",
-                &load_audit_records(db, "gating", &scope, since_cutoff)?,
-                options.raw,
-            );
-        }
-        "novelty" => {
-            print_audit_section(
-                "novelty",
-                &load_audit_records(db, "novelty", &scope, since_cutoff)?,
-                options.raw,
-            );
-        }
-        other => bail!("unsupported audit kind: {other}"),
     }
     Ok(())
+}
+
+pub fn audit_embed_command(
+    db: &Database,
+    config: &Config,
+    since: Option<&str>,
+    format: &str,
+    raw: bool,
+) -> Result<()> {
+    let _scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(since)?;
+    let rows = load_embed_failure_records(db, since_cutoff)?;
+
+    if format == "json" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&rows).context("failed to serialize embed audit")?
+        );
+    } else {
+        println!("embed_failure_log:");
+        if rows.is_empty() {
+            println!("  none");
+        } else {
+            for row in rows {
+                let endpoint = row.endpoint.as_deref().unwrap_or("unknown");
+                let consecutive = row.consecutive_failures.unwrap_or(1);
+                let truncated_error = if row.error_message.len() > 80 {
+                    format!("{}...", &row.error_message[..77])
+                } else {
+                    row.error_message.clone()
+                };
+                println!(
+                    "  {} endpoint={} consecutive={} error={:?} id={}",
+                    format_created_at(row.timestamp),
+                    maybe_escape(endpoint, raw),
+                    consecutive,
+                    maybe_escape(&truncated_error, raw),
+                    maybe_escape(&row.id, raw)
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn audit_novelty_command(
+    db: &Database,
+    config: &Config,
+    since: Option<&str>,
+    format: &str,
+    raw: bool,
+) -> Result<()> {
+    let scope = dashboard_scope(config)?;
+    let since_cutoff = parse_since_cutoff(since)?;
+    let records = load_audit_records(db, "novelty", &scope, since_cutoff)?;
+
+    if format == "json" {
+        let json_rows: Vec<_> = records
+            .into_iter()
+            .map(|row| NoveltyAuditRecord {
+                id: row.audit_id,
+                candidate_hash: row.candidate_drawer_id,
+                decision: row.decision,
+                near_drawer_id: row.near_drawer_id,
+                cosine: row.similarity_score,
+                created_at: row.created_at,
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json_rows)
+                .context("failed to serialize novelty audit")?
+        );
+    } else {
+        print_audit_section("novelty", &records, raw);
+    }
+    Ok(())
+}
+
+fn load_embed_failure_records(
+    db: &Database,
+    since_cutoff: Option<i64>,
+) -> Result<Vec<EmbedFailureRecord>> {
+    if db.conn().query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='embed_failure_log'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )? == 0
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = db.conn().prepare(
+        r#"
+        SELECT id, timestamp, error_message, endpoint, consecutive_failures
+        FROM embed_failure_log
+        ORDER BY timestamp DESC
+        "#,
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(EmbedFailureRecord {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                error_message: row.get(2)?,
+                endpoint: row.get(3)?,
+                consecutive_failures: row.get(4)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows
+        .into_iter()
+        .filter(|row| since_cutoff.is_none_or(|cutoff| row.timestamp >= cutoff))
+        .collect())
 }
 
 pub fn gating_stats(
@@ -825,11 +1012,21 @@ fn load_gating_audit_details(
         .into_iter()
         .all(|column| columns.iter().any(|name| name == column));
 
+    let has_score = columns.iter().any(|name| name == "score");
+    let has_content_preview = columns.iter().any(|name| name == "content_preview");
+
     let rows = if modern {
+        let score_expr = if has_score { "a.score" } else { "NULL" };
+        let preview_expr = if has_content_preview {
+            "a.content_preview"
+        } else {
+            "NULL"
+        };
+
         let sql = format!(
             r#"
             SELECT a.id, a.candidate_hash, a.decision, a.tier, a.label, a.reason,
-                   a.explain_json, a.created_at, {project_expr}
+                   a.explain_json, a.created_at, {project_expr}, {score_expr}, {preview_expr}
             FROM gating_audit a
             LEFT JOIN drawers d ON d.id = COALESCE(a.drawer_id, a.candidate_hash)
             ORDER BY a.created_at DESC, a.id DESC
@@ -860,6 +1057,8 @@ fn load_gating_audit_details(
                 reason,
                 created_at: row.get::<_, i64>(7)?,
                 project_id: row.get::<_, Option<String>>(8)?,
+                score: row.get::<_, Option<f32>>(9)?,
+                content_preview: row.get::<_, Option<String>>(10)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?
@@ -888,6 +1087,8 @@ fn load_gating_audit_details(
                 reason: parsed.and_then(|value| value.reason),
                 created_at: row.get::<_, i64>(4)?,
                 project_id: row.get::<_, Option<String>>(5)?,
+                score: None,
+                content_preview: None,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?
@@ -1339,5 +1540,17 @@ mod tests {
         assert_eq!(try_parse_duration_secs("2026-04-25T20:00:00Z"), None);
         assert_eq!(try_parse_duration_secs("not-a-duration"), None);
         assert_eq!(try_parse_duration_secs(""), None);
+    }
+
+    #[test]
+    fn test_parse_since_24_hours() {
+        let cutoff = parse_since_str("24h", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 86400);
+    }
+
+    #[test]
+    fn test_parse_since_7_days() {
+        let cutoff = parse_since_str("7d", FIXED_NOW).unwrap();
+        assert_eq!(cutoff, FIXED_NOW - 7 * 86400);
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -483,8 +483,8 @@ pub fn audit_gating_command(
                     .content_preview
                     .as_deref()
                     .map(|p| {
-                        let truncated = if p.len() > 80 {
-                            format!("{}...", &p[..77])
+                        let truncated = if p.chars().count() > 80 {
+                            format!("{}...", p.chars().take(77).collect::<String>())
                         } else {
                             p.to_string()
                         };
@@ -532,8 +532,11 @@ pub fn audit_embed_command(
             for row in rows {
                 let endpoint = row.endpoint.as_deref().unwrap_or("unknown");
                 let consecutive = row.consecutive_failures.unwrap_or(1);
-                let truncated_error = if row.error_message.len() > 80 {
-                    format!("{}...", &row.error_message[..77])
+                let truncated_error = if row.error_message.chars().count() > 80 {
+                    format!(
+                        "{}...",
+                        row.error_message.chars().take(77).collect::<String>()
+                    )
                 } else {
                     row.error_message.clone()
                 };

--- a/tests/audit_observability.rs
+++ b/tests/audit_observability.rs
@@ -1,0 +1,166 @@
+use mempal::core::db::{CURRENT_FORK_EXT_VERSION, Database, read_fork_ext_version};
+use mempal::embed::EmbedError;
+use mempal::embed::status::{EmbedStatus, RetryConfigSnapshot};
+use mempal::ingest::gating::GatingDecision;
+use rusqlite::params;
+use tempfile::TempDir;
+
+fn new_test_db() -> (TempDir, std::path::PathBuf, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    (tmp, db_path, db)
+}
+
+fn table_columns(db: &Database, table: &str) -> Vec<(String, String)> {
+    let mut statement = db
+        .conn()
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table info");
+    statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        })
+        .expect("query table info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table info")
+}
+
+fn has_column(columns: &[(String, String)], name: &str, ty: &str) -> bool {
+    columns
+        .iter()
+        .any(|(column_name, column_ty)| column_name == name && column_ty.eq_ignore_ascii_case(ty))
+}
+
+#[test]
+fn test_audit_observability_schema_exists_after_current_migration() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    assert_eq!(
+        read_fork_ext_version(db.conn()).expect("read fork_ext_version"),
+        CURRENT_FORK_EXT_VERSION
+    );
+
+    let embed_columns = table_columns(&db, "embed_failure_log");
+    assert!(has_column(&embed_columns, "id", "TEXT"));
+    assert!(has_column(&embed_columns, "timestamp", "INTEGER"));
+    assert!(has_column(&embed_columns, "error_message", "TEXT"));
+    assert!(has_column(&embed_columns, "endpoint", "TEXT"));
+    assert!(has_column(
+        &embed_columns,
+        "consecutive_failures",
+        "INTEGER"
+    ));
+    assert!(has_column(&embed_columns, "duration_ms", "INTEGER"));
+    assert!(has_column(&embed_columns, "retained_until", "INTEGER"));
+
+    let gating_columns = table_columns(&db, "gating_audit");
+    assert!(has_column(&gating_columns, "content_preview", "TEXT"));
+}
+
+#[test]
+fn test_record_gating_audit_stores_preview_for_skip_decision() {
+    let (_tmp, _db_path, db) = new_test_db();
+    let content = format!("{}b", "a".repeat(500));
+    let decision = GatingDecision::rejected(1, Some("low_signal".to_string()), None, None);
+
+    db.record_gating_audit("candidate-hash", &decision, None, Some(&content))
+        .expect("record gating audit");
+
+    let preview = db
+        .conn()
+        .query_row(
+            "SELECT content_preview FROM gating_audit WHERE candidate_hash = ?1",
+            params!["candidate-hash"],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read content preview");
+
+    assert_eq!(preview, format!("{}…", "a".repeat(500)));
+}
+
+#[test]
+fn test_embed_status_records_failure_with_snapshot_to_db() {
+    let (_tmp, db_path, db) = new_test_db();
+    let status = EmbedStatus::new();
+    status.set_audit_db_path(Some(db_path));
+    let snapshot = RetryConfigSnapshot {
+        retry_interval_secs: 2,
+        alert_threshold: 100,
+        degrade_threshold: 10,
+        alert_script: None,
+        alert_enabled: false,
+    };
+    let error = EmbedError::Runtime("backend unavailable".to_string());
+
+    status.record_failure_with_snapshot(&error, &snapshot, Some(123));
+
+    let (message, consecutive_failures, duration_ms, timestamp, retained_until) = db
+        .conn()
+        .query_row(
+            r#"
+            SELECT error_message, consecutive_failures, duration_ms, timestamp, retained_until
+            FROM embed_failure_log
+            "#,
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .expect("read embed failure log");
+
+    assert!(message.contains("backend unavailable"));
+    assert_eq!(consecutive_failures, 1);
+    assert_eq!(duration_ms, 123);
+    assert_eq!(retained_until, timestamp + 7 * 24 * 60 * 60);
+}
+
+#[test]
+fn test_prune_expired_audit_logs_removes_expired_rows() {
+    let (_tmp, db_path, db) = new_test_db();
+    let status = EmbedStatus::new();
+    status.set_audit_db_path(Some(db_path));
+    let snapshot = RetryConfigSnapshot {
+        retry_interval_secs: 2,
+        alert_threshold: 100,
+        degrade_threshold: 10,
+        alert_script: None,
+        alert_enabled: false,
+    };
+    let error = EmbedError::Runtime("backend unavailable".to_string());
+    status.record_failure_with_snapshot(&error, &snapshot, Some(1));
+
+    let decision = GatingDecision::rejected(1, Some("low_signal".to_string()), None, None);
+    db.record_gating_audit("candidate-hash", &decision, None, Some("candidate"))
+        .expect("record gating audit");
+    db.conn()
+        .execute("UPDATE embed_failure_log SET retained_until = 0", [])
+        .expect("expire embed failure");
+    db.conn()
+        .execute("UPDATE gating_audit SET retained_until = 0", [])
+        .expect("expire gating audit");
+
+    db.prune_expired_audit_logs().expect("prune audit logs");
+
+    let embed_count = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM embed_failure_log", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count embed failures");
+    let gating_count = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM gating_audit", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count gating audit");
+
+    assert_eq!(embed_count, 0);
+    assert_eq!(gating_count, 0);
+}

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -381,11 +381,7 @@ fn test_audit_novelty_lists_decisions() {
         );
     }
 
-    let output = run_mempal(
-        &env.home,
-        env.cwd(),
-        &["audit", "--kind", "novelty", "--since", "7d"],
-    );
+    let output = run_mempal(&env.home, env.cwd(), &["audit", "novelty", "--since", "7d"]);
     assert!(
         output.status.success(),
         "stderr={}",
@@ -505,7 +501,7 @@ fn test_observability_subcommands_readonly() {
         vec!["timeline", "--format", "json"],
         vec!["stats"],
         vec!["view", "readonly-1"],
-        vec!["audit", "--kind", "novelty", "--since", "7d"],
+        vec!["audit", "novelty", "--since", "7d"],
     ] {
         let output = run_mempal(&env.home, env.cwd(), &args);
         assert!(
@@ -1162,11 +1158,7 @@ fn test_audit_filters_by_project_when_isolation_strict() {
         now_unix_secs(),
     );
 
-    let output = run_mempal(
-        &env.home,
-        env.cwd(),
-        &["audit", "--kind", "novelty", "--since", "7d"],
-    );
+    let output = run_mempal(&env.home, env.cwd(), &["audit", "novelty", "--since", "7d"]);
     assert!(
         output.status.success(),
         "stderr={}",

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -144,8 +144,13 @@ fn record_gating_audit(db_path: &Path, drawer_id: &str, accepted: bool) {
     } else {
         GatingDecision::rejected(1, Some("drop".to_string()), None, None)
     };
-    db.record_gating_audit(drawer_id, &decision, None)
-        .expect("record gating audit");
+    db.record_gating_audit(
+        drawer_id,
+        &decision,
+        None,
+        Some("dashboard audit candidate"),
+    )
+    .expect("record gating audit");
 }
 
 fn record_novelty_audit(db_path: &Path, drawer_id: &str, action: NoveltyAction, created_at: i64) {

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -1157,7 +1157,12 @@ fn test_tier1_skips_read_tool() {
     )
     .expect("tier1 decision");
     env.db()
-        .record_gating_audit("read-tool-candidate", &decision, None)
+        .record_gating_audit(
+            "read-tool-candidate",
+            &decision,
+            None,
+            Some("long enough content to hit tool rule"),
+        )
         .expect("record gating audit");
     let rows = gating_rows(&env.db());
 


### PR DESCRIPTION
## Summary
- **#154**: Persist embedding failure events to `embed_failure_log` table with 7-day retention. Best-effort write from `EmbedStatus::record_failure_with_snapshot` — doesn't block retry loop. Auto-prune on daemon startup.
- **#155**: Store first 500 chars of rejected content in `gating_audit.content_preview` for post-hoc review of gating decisions.
- **#156**: `mempal audit gating/embed/novelty` CLI subcommands with `--since`, `--decision`, `--project`, `--format text|json` filters.
- Fix UTF-8 panic in audit text rendering (char-safe truncation for CJK content).

Closes #154, closes #155, closes #156

## Test plan
- [x] 834 tests pass (cargo test)
- [x] `mempal audit gating --since 7d` shows real data
- [x] CSA tier-4-critical review passed (schema + persist commit)
- [x] Second review found UTF-8 panic → fixed → verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)