### PR TITLE
fix(daemon): share database connection to eliminate lock contention stall

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -576,7 +576,7 @@ impl Database {
     }
 
     pub fn update_drawer_after_merge(
-        &mut self,
+        &self,
         drawer_id: &str,
         merged_content: &str,
         updated_at: &str,
@@ -584,29 +584,41 @@ impl Database {
     ) -> Result<(), DbError> {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
-        let transaction = self.conn.transaction()?;
-        transaction.execute(
-            r#"
-            UPDATE drawers
-            SET content = ?2,
-                updated_at = ?3,
-                merge_count = COALESCE(merge_count, 0) + 1
-            WHERE id = ?1
-            "#,
-            params![drawer_id, merged_content, updated_at],
-        )?;
-        transaction.execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
-        let project_id = transaction.query_row(
-            "SELECT project_id FROM drawers WHERE id = ?1",
-            [drawer_id],
-            |row| row.get::<_, Option<String>>(0),
-        )?;
-        transaction.execute(
-            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
-            params![drawer_id, vector_json, project_id],
-        )?;
-        transaction.commit()?;
-        Ok(())
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> Result<(), DbError> {
+            self.conn.execute(
+                r#"
+                UPDATE drawers
+                SET content = ?2,
+                    updated_at = ?3,
+                    merge_count = COALESCE(merge_count, 0) + 1
+                WHERE id = ?1
+                "#,
+                params![drawer_id, merged_content, updated_at],
+            )?;
+            self.conn
+                .execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
+            let project_id = self.conn.query_row(
+                "SELECT project_id FROM drawers WHERE id = ?1",
+                [drawer_id],
+                |row| row.get::<_, Option<String>>(0),
+            )?;
+            self.conn.execute(
+                "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+                params![drawer_id, vector_json, project_id],
+            )?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
     }
 
     pub fn record_novelty_audit(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -52,11 +52,16 @@ pub fn run_command_with_bootstrap_events(
 }
 
 async fn run_loop(context: &DaemonContext) -> Result<()> {
-    global_embed_status().set_audit_db_path(Some(context.db.path().to_path_buf()));
-    context
-        .db
-        .prune_expired_audit_logs()
-        .context("failed to prune expired audit logs")?;
+    let db_path = {
+        let db = context.db.lock().await;
+        db.path().to_path_buf()
+    };
+    global_embed_status().set_audit_db_path(Some(db_path));
+    {
+        let db = context.db.lock().await;
+        db.prune_expired_audit_logs()
+            .context("failed to prune expired audit logs")?;
+    }
 
     if !context.config.hooks.enabled {
         eprintln!("hooks not enabled; daemon exiting without starting worker loop");
@@ -82,6 +87,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .reclaim_stale(claim_ttl_secs)
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
+    let stall_watchdog_handle = spawn_stall_watchdog(
+        context.write_observer.clone(),
+        context.store.clone(),
+        Duration::from_secs(60),
+    );
 
     let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
         match crate::llm::LlmClient::from_config(&context.config.llm) {
@@ -90,18 +100,21 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                 let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
                 let llm_store = std::sync::Arc::new(context.store.clone());
                 let llm_client = std::sync::Arc::new(llm_client);
-                let db_path = context.db.path().to_path_buf();
+                let shared_db = context.db.clone();
+                let write_observer = context.write_observer.clone();
                 tracing::info!("spawning {num_workers} LLM worker tasks");
                 (0..num_workers)
                     .map(|i| {
                         let store = llm_store.clone();
                         let client = llm_client.clone();
                         let status = llm_status.clone();
-                        let path = db_path.clone();
+                        let db = shared_db.clone();
+                        let observer = write_observer.clone();
                         tokio::spawn(async move {
-                            if let Err(e) =
-                                crate::llm::worker::run_llm_worker(store, client, status, path)
-                                    .await
+                            if let Err(e) = crate::llm::worker::run_llm_worker(
+                                store, client, status, db, observer,
+                            )
+                            .await
                             {
                                 tracing::error!("LLM worker {i} fatal error: {e:#}");
                             }
@@ -120,6 +133,8 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     };
 
     loop {
+        context.write_observer.maybe_log_stall(&context.store);
+
         if shutdown_requested() {
             tracing::info!("shutdown requested; stopping daemon loop");
             break;
@@ -132,19 +147,22 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         {
             ClaimPollResult::Claimed(message) => {
                 let message_id = message.id.clone();
-                let result = process_claimed_message_with_embedder(
-                    &context.db,
-                    &context.store,
-                    &worker_id,
-                    &message,
-                    &embedder,
-                    DaemonIngestContext {
-                        prototype_classifier: prototype_classifier.as_ref(),
-                        config: context.config.as_ref(),
-                        mempal_home: &context.mempal_home,
-                    },
-                )
-                .await;
+                let result = {
+                    let db = context.db.lock().await;
+                    process_claimed_message_with_embedder(
+                        &db,
+                        &context.store,
+                        &worker_id,
+                        &message,
+                        &embedder,
+                        DaemonIngestContext {
+                            prototype_classifier: prototype_classifier.as_ref(),
+                            config: context.config.as_ref(),
+                            mempal_home: &context.mempal_home,
+                        },
+                    )
+                    .await
+                };
 
                 match result {
                     Ok(_) => {
@@ -152,9 +170,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                             .store
                             .confirm(&message_id)
                             .with_context(|| format!("failed to confirm {message_id}"))?;
+                        context.write_observer.record_successful_write();
                     }
                     Err(error) => {
                         tracing::error!("daemon message {message_id} failed: {error}");
+                        context.write_observer.record_error(error.to_string());
                         context
                             .store
                             .mark_failed(&message_id, &error.to_string())
@@ -174,8 +194,28 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         let _ = handle.await;
     }
     tracing::info!("LLM workers stopped");
+    stall_watchdog_handle.abort();
+    let _ = stall_watchdog_handle.await;
 
     Ok(())
+}
+
+fn spawn_stall_watchdog(
+    observer: crate::daemon_bootstrap::DaemonWriteObserver,
+    store: PendingMessageStore,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if shutdown_requested() {
+                break;
+            }
+            observer.maybe_log_stall(&store);
+        }
+    })
 }
 
 trait ClaimNextSource {
@@ -898,9 +938,8 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         record.project_id.as_deref(),
                     )
                     .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-                let mut db_for_merge = Database::open(context.db.path())
-                    .with_context(|| format!("failed to reopen db for merge {}", target_id))?;
-                db_for_merge
+                context
+                    .db
                     .update_drawer_after_merge(
                         &target_id,
                         &merged_content,

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -1,6 +1,11 @@
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
@@ -9,16 +14,143 @@ use crate::core::{
     queue::PendingMessageStore,
 };
 use anyhow::{Context, Result};
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+
+const DAEMON_STALL_SECONDS: u64 = 5 * 60;
+const DAEMON_STALL_LOG_THROTTLE_SECONDS: u64 = 60;
+
+pub type SharedDatabase = Arc<AsyncMutex<Database>>;
+
+#[derive(Clone)]
+pub struct DaemonWriteObserver {
+    inner: Arc<DaemonWriteObserverInner>,
+}
+
+struct DaemonWriteObserverInner {
+    started_at: Instant,
+    last_successful_write_secs: AtomicU64,
+    last_stall_log_secs: AtomicU64,
+    last_error: Mutex<Option<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DaemonStallDiagnostic {
+    queued_count: u64,
+    seconds_since_successful_write: u64,
+    last_error: String,
+    uptime_secs: u64,
+}
 
 pub struct DaemonContext {
     pub runtime: tokio::runtime::Runtime,
-    pub db: Database,
+    pub db: SharedDatabase,
     pub store: PendingMessageStore,
+    pub write_observer: DaemonWriteObserver,
     pub config: std::sync::Arc<crate::core::config::Config>,
     pub mempal_home: PathBuf,
     pub log_path: PathBuf,
     _pid_guard: PidFileGuard,
+}
+
+impl DaemonWriteObserver {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(DaemonWriteObserverInner {
+                started_at: Instant::now(),
+                last_successful_write_secs: AtomicU64::new(unix_secs()),
+                last_stall_log_secs: AtomicU64::new(0),
+                last_error: Mutex::new(None),
+            }),
+        }
+    }
+
+    pub fn record_successful_write(&self) {
+        self.inner
+            .last_successful_write_secs
+            .store(unix_secs(), Ordering::Relaxed);
+    }
+
+    pub fn record_error(&self, error: impl Into<String>) {
+        if let Ok(mut last_error) = self.inner.last_error.lock() {
+            *last_error = Some(error.into());
+        }
+    }
+
+    pub fn maybe_log_stall(&self, store: &PendingMessageStore) {
+        let now = unix_secs();
+        let Some(diagnostic) = self.stall_diagnostic(store, now) else {
+            return;
+        };
+        let last_log = self.inner.last_stall_log_secs.load(Ordering::Relaxed);
+        if now.saturating_sub(last_log) < DAEMON_STALL_LOG_THROTTLE_SECONDS {
+            return;
+        }
+        if self
+            .inner
+            .last_stall_log_secs
+            .compare_exchange(last_log, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+
+        tracing::error!(
+            queued_count = diagnostic.queued_count,
+            seconds_since_successful_write = diagnostic.seconds_since_successful_write,
+            last_error = %diagnostic.last_error,
+            uptime_secs = diagnostic.uptime_secs,
+            "daemon write stall detected: queued messages exist but no successful write has completed for at least 5 minutes"
+        );
+    }
+
+    fn stall_diagnostic(
+        &self,
+        store: &PendingMessageStore,
+        now_secs: u64,
+    ) -> Option<DaemonStallDiagnostic> {
+        let stats = match store.stats() {
+            Ok(stats) => stats,
+            Err(error) => {
+                tracing::warn!(?error, "daemon stall detector failed to read queue stats");
+                return None;
+            }
+        };
+        let queued_count = stats.pending.saturating_add(stats.claimed);
+        if queued_count == 0 {
+            return None;
+        }
+
+        let last_successful_write = self
+            .inner
+            .last_successful_write_secs
+            .load(Ordering::Relaxed);
+        let seconds_since_successful_write = now_secs.saturating_sub(last_successful_write);
+        if seconds_since_successful_write < DAEMON_STALL_SECONDS {
+            return None;
+        }
+
+        let last_error = self
+            .inner
+            .last_error
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| "none recorded".to_string());
+
+        Some(DaemonStallDiagnostic {
+            queued_count,
+            seconds_since_successful_write,
+            last_error,
+            uptime_secs: self.inner.started_at.elapsed().as_secs(),
+        })
+    }
+
+    #[cfg(test)]
+    fn force_last_successful_write_for_test(&self, timestamp_secs: u64) {
+        self.inner
+            .last_successful_write_secs
+            .store(timestamp_secs, Ordering::Relaxed);
+    }
 }
 
 impl DaemonContext {
@@ -75,6 +207,8 @@ fn bootstrap_inner(
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::DbOpen);
     let db = Database::open(&db_path).context("failed to open daemon database")?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
+    let db = Arc::new(AsyncMutex::new(db));
+    let write_observer = DaemonWriteObserver::new();
 
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::TracingInit);
@@ -88,11 +222,19 @@ fn bootstrap_inner(
         runtime,
         db,
         store,
+        write_observer,
         config,
         mempal_home,
         log_path,
         _pid_guard: pid_guard,
     })
+}
+
+fn unix_secs() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(_) => 0,
+    }
 }
 
 fn init_tracing_subscriber() {
@@ -227,4 +369,46 @@ fn redirect_stdin_to_dev_null() -> Result<()> {
         return Err(std::io::Error::last_os_error()).context("failed to redirect daemon stdin");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_observer_reports_stall_when_queue_has_work_and_no_recent_writes() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let store = PendingMessageStore::new(&db_path).expect("open queue");
+        store
+            .enqueue("hook:user-prompt-submit", "{}")
+            .expect("enqueue pending message");
+
+        let observer = DaemonWriteObserver::new();
+        let now = unix_secs();
+        observer.force_last_successful_write_for_test(now.saturating_sub(DAEMON_STALL_SECONDS));
+        observer.record_error("failed to merge drawer");
+
+        let diagnostic = observer
+            .stall_diagnostic(&store, now)
+            .expect("stall diagnostic");
+        assert_eq!(diagnostic.queued_count, 1);
+        assert!(diagnostic.seconds_since_successful_write >= DAEMON_STALL_SECONDS);
+        assert_eq!(diagnostic.last_error, "failed to merge drawer");
+    }
+
+    #[test]
+    fn write_observer_ignores_empty_queue() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let store = PendingMessageStore::new(&db_path).expect("open queue");
+
+        let observer = DaemonWriteObserver::new();
+        let now = unix_secs();
+        observer.force_last_successful_write_for_test(now.saturating_sub(DAEMON_STALL_SECONDS));
+
+        assert_eq!(observer.stall_diagnostic(&store, now), None);
+    }
 }

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
 use crate::core::queue::PendingMessageStore;
+use crate::daemon_bootstrap::{DaemonWriteObserver, SharedDatabase};
 
 use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest};
 use super::retry::{self, HeartbeatCallback};
@@ -35,7 +36,8 @@ pub async fn run_llm_worker(
     store: Arc<PendingMessageStore>,
     client: Arc<LlmClient>,
     status: Arc<LlmStatus>,
-    db_path: std::path::PathBuf,
+    db: SharedDatabase,
+    write_observer: DaemonWriteObserver,
 ) -> Result<()> {
     use std::sync::atomic::{AtomicUsize, Ordering};
     static WORKER_INDEX: AtomicUsize = AtomicUsize::new(0);
@@ -100,10 +102,10 @@ pub async fn run_llm_worker(
             Ok(())
         });
 
-        let result = process_llm_task(
+        let result = process_llm_task_shared(
             &client,
             &status,
-            &db_path,
+            &db,
             &message.payload,
             &config,
             Some(heartbeat.as_ref()),
@@ -117,9 +119,11 @@ pub async fn run_llm_worker(
                 store
                     .confirm(&message_id)
                     .with_context(|| format!("failed to confirm LLM task {message_id}"))?;
+                write_observer.record_successful_write();
             }
             Err(error) => {
                 tracing::error!("LLM task {message_id} failed after {latency_ms}ms: {error}");
+                write_observer.record_error(error.to_string());
                 store
                     .mark_failed(&message_id, &error.to_string())
                     .with_context(|| format!("failed to mark_failed LLM task {message_id}"))?;
@@ -130,10 +134,10 @@ pub async fn run_llm_worker(
     Ok(())
 }
 
-pub async fn process_llm_task(
+async fn process_llm_task_shared(
     client: &LlmClient,
     status: &LlmStatus,
-    db_path: &std::path::Path,
+    db: &SharedDatabase,
     payload: &str,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
@@ -142,7 +146,7 @@ pub async fn process_llm_task(
         serde_json::from_str(payload).context("failed to decode LLM task payload")?;
 
     match task.task_type.as_str() {
-        "gating" => process_gating_task(client, status, db_path, &task, config, heartbeat).await,
+        "gating" => process_gating_task(client, status, db, &task, config, heartbeat).await,
         other => anyhow::bail!("unknown LLM task type: {other}"),
     }
 }
@@ -150,11 +154,44 @@ pub async fn process_llm_task(
 async fn process_gating_task(
     client: &LlmClient,
     status: &LlmStatus,
-    db_path: &std::path::Path,
+    db: &SharedDatabase,
     task: &LlmTaskPayload,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<()> {
+    let (verdict, score) = request_gating_verdict(client, status, task, config, heartbeat).await?;
+    let db = db.lock().await;
+    apply_gating_verdict(&db, task, config, &verdict, score)
+}
+
+pub async fn process_llm_task(
+    client: &LlmClient,
+    status: &LlmStatus,
+    db: &Database,
+    payload: &str,
+    config: &crate::core::config::Config,
+    heartbeat: Option<&HeartbeatCallback>,
+) -> Result<()> {
+    let task: LlmTaskPayload =
+        serde_json::from_str(payload).context("failed to decode LLM task payload")?;
+
+    match task.task_type.as_str() {
+        "gating" => {
+            let (verdict, score) =
+                request_gating_verdict(client, status, &task, config, heartbeat).await?;
+            apply_gating_verdict(db, &task, config, &verdict, score)
+        }
+        other => anyhow::bail!("unknown LLM task type: {other}"),
+    }
+}
+
+async fn request_gating_verdict(
+    client: &LlmClient,
+    status: &LlmStatus,
+    task: &LlmTaskPayload,
+    config: &crate::core::config::Config,
+    heartbeat: Option<&HeartbeatCallback>,
+) -> Result<(String, f64)> {
     let system_prompt = task
         .system_prompt
         .as_deref()
@@ -185,49 +222,56 @@ async fn process_gating_task(
     match response {
         Ok(response) => {
             status.record_success();
-            let (verdict, score) = parse_gating_verdict(&response.content);
-            let db = Database::open(db_path).context("failed to open database for LLM verdict")?;
-
-            // The gating_audit row exists only for the primary drawer_id (recorded during ingest
-            // before chunking). Record the verdict there; the remaining chunk IDs have no audit
-            // row and updating them would violate the NOT NULL explain_json constraint.
-            db.upsert_llm_verdict(&task.drawer_id, &verdict, Some(score))
-                .context("failed to upsert LLM verdict")?;
-
-            let threshold = config
-                .ingest_gating
-                .llm_judge
-                .as_ref()
-                .map(|judge| judge.threshold)
-                .unwrap_or(0.3);
-
-            if score < threshold {
-                // Resolve all drawer IDs: prefer the multi-chunk list when present,
-                // fall back to the single drawer_id for backward-compat queue tasks.
-                let all_ids: Vec<&str> = if task.drawer_ids.is_empty() {
-                    vec![task.drawer_id.as_str()]
-                } else {
-                    task.drawer_ids.iter().map(String::as_str).collect()
-                };
-                tracing::info!(
-                    drawer_ids = ?all_ids,
-                    score,
-                    threshold,
-                    "LLM rejected drawers, executing soft-delete for all chunks"
-                );
-                for id in &all_ids {
-                    db.soft_delete_drawer(id)
-                        .context("failed to soft-delete rejected drawer")?;
-                }
-            }
-
-            Ok(())
+            Ok(parse_gating_verdict(&response.content))
         }
         Err(error) => {
             status.record_failure(&error);
             Err(error).context("LLM gating request failed")
         }
     }
+}
+
+fn apply_gating_verdict(
+    db: &Database,
+    task: &LlmTaskPayload,
+    config: &crate::core::config::Config,
+    verdict: &str,
+    score: f64,
+) -> Result<()> {
+    // The gating_audit row exists only for the primary drawer_id (recorded during ingest
+    // before chunking). Record the verdict there; the remaining chunk IDs have no audit
+    // row and updating them would violate the NOT NULL explain_json constraint.
+    db.upsert_llm_verdict(&task.drawer_id, verdict, Some(score))
+        .context("failed to upsert LLM verdict")?;
+
+    let threshold = config
+        .ingest_gating
+        .llm_judge
+        .as_ref()
+        .map(|judge| judge.threshold)
+        .unwrap_or(0.3);
+
+    if score < threshold {
+        // Resolve all drawer IDs: prefer the multi-chunk list when present,
+        // fall back to the single drawer_id for backward-compat queue tasks.
+        let all_ids: Vec<&str> = if task.drawer_ids.is_empty() {
+            vec![task.drawer_id.as_str()]
+        } else {
+            task.drawer_ids.iter().map(String::as_str).collect()
+        };
+        tracing::info!(
+            drawer_ids = ?all_ids,
+            score,
+            threshold,
+            "LLM rejected drawers, executing soft-delete for all chunks"
+        );
+        for id in &all_ids {
+            db.soft_delete_drawer(id)
+                .context("failed to soft-delete rejected drawer")?;
+        }
+    }
+
+    Ok(())
 }
 
 fn parse_gating_verdict(content: &str) -> (String, f64) {

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -1750,6 +1750,7 @@ threshold = 0.5
     };
     let client = LlmClient::from_config(&llm_config).expect("build LLM client");
     let status = LlmStatus::new(5);
+    let db = env.db();
     let judge_config = Config {
         ingest_gating: IngestGatingConfig {
             llm_judge: Some(LlmJudgeConfig {
@@ -1761,16 +1762,9 @@ threshold = 0.5
         },
         ..Default::default()
     };
-    mempal::llm::process_llm_task(
-        &client,
-        &status,
-        &env.db_path,
-        &claimed.payload,
-        &judge_config,
-        None,
-    )
-    .await
-    .expect("process LLM task");
+    mempal::llm::process_llm_task(&client, &status, &db, &claimed.payload, &judge_config, None)
+        .await
+        .expect("process LLM task");
 
     // All chunk drawers must be soft-deleted after rejection.
     assert_eq!(


### PR DESCRIPTION
## Summary
- Root cause: daemon LLM workers and merge path each reopened `Database::open()` per operation, causing WAL write lock contention under concurrent load → cascading "failed to reopen db" errors → complete processing stall
- Fix: `DaemonContext` now holds `Arc<tokio::sync::Mutex<Database>>` shared across all workers and the main loop — zero `Database::open()` calls remain in daemon/worker code
- LLM workers acquire the mutex only for verdict writes (not during the LLM request wait), minimizing lock hold time
- Added stall detection watchdog: logs ERROR with diagnostics (queued_count, seconds_since_write, last_error, uptime) when no successful write occurs in 5 minutes while messages are pending

Closes #158

## Test plan
- [x] cargo test passes (all 834 tests)
- [x] `rg "Database::open" src/daemon.rs src/llm/worker.rs` returns zero matches
- [x] CSA tier-4-critical review passed
- [x] Pre-commit hooks (clippy + test) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)