### PR TITLE
fix(audit): open database read-write for cleanup command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1432,14 +1432,16 @@ fn run() -> Result<()> {
 }
 
 fn is_dashboard_command(command: &Commands) -> bool {
-    matches!(
-        command,
+    match command {
         Commands::Tail { .. }
-            | Commands::Timeline { .. }
-            | Commands::Stats { .. }
-            | Commands::View { .. }
-            | Commands::Audit { .. }
-    )
+        | Commands::Timeline { .. }
+        | Commands::Stats { .. }
+        | Commands::View { .. } => true,
+        Commands::Audit { command, .. } => {
+            !matches!(command, Some(AuditCommands::Cleanup { dry_run: false, .. }))
+        }
+        _ => false,
+    }
 }
 
 fn open_dashboard_database(path: &Path) -> Result<Database> {


### PR DESCRIPTION
## Summary

- Cleanup subcommand needs write access to soft-delete drawers
- `is_dashboard_command` classified all Audit variants as read-only, causing "readonly database" error
- Now excludes non-dry-run `Cleanup` from dashboard mode so it opens with write access

## Test plan

- [x] All 242 unit tests pass
- [x] clippy clean
- [ ] `mempal audit cleanup` no longer returns "attempt to write a readonly database"

🤖 Generated with [Claude Code](https://claude.com/claude-code)