### PR TITLE
fix(hook): checkpoint Stop hook saves directly instead of emitting agent prompt

### DIFF
--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# Session checkpoint countdown hook (SessionStop trigger).
+# Session checkpoint Stop hook.
 #
-# Injected into the main Claude Code agent's prompt via session stop hook.
-# The agent reads this output, then runs a background sleep 3000 (50 min)
-# countdown. When it fires, the agent checks for user activity and writes
-# a checkpoint to mempal if idle — this also refreshes KV cache TTL.
+# Fires on Claude Code SessionStop. Directly saves the last assistant message
+# from the current session JSONL as a mempal checkpoint — no agent involvement
+# required (Stop hook output is not injected back into agent context).
 #
 # Guards:
 #   - Sub-agents (CLAUDE_CODE_ENTRY_POINT=task) skip
 #   - CSA sessions (CSA_SESSION_ID set) skip
 #   - Non-interactive (no TERM, no CLAUDE_CODE_SESSION_ID) skip
-#   - Dedup via flag file prevents stacked countdowns
+#   - Dedup via atomic mkdir lock (TTL: 300s — Stop-event dedup window)
 set -euo pipefail
 
 # Guard: sub-agents should not trigger checkpoints
@@ -32,32 +31,28 @@ fi
 
 PROJECT_HASH=$(echo -n "$(pwd)" | sha256sum | cut -c1-12)
 LOCKFILE="/tmp/mempal-checkpoint-${PROJECT_HASH}.lock"
-LOCK_TTL_SECS=3600
+LOCK_TTL_SECS=300
 LOCK_HELD=0
-PROMPT_EMITTED=0
+SAVED=0
 
 cleanup_lock() {
-    if [ "$LOCK_HELD" -eq 1 ]; then
+    # Release lock only when no checkpoint was saved, so the 300s dedup window
+    # suppresses duplicate Stop events after a successful save.
+    if [ "$LOCK_HELD" -eq 1 ] && [ "$SAVED" -eq 0 ]; then
         rmdir "$LOCKFILE" 2>/dev/null || true
         LOCK_HELD=0
     fi
 }
 
 lock_is_stale() {
-    local now mtime age
+    local mtime now age
     mtime=$(stat -c %Y "$LOCKFILE" 2>/dev/null) || return 1
     now=$(date +%s)
     age=$((now - mtime))
     [ "$age" -ge "$LOCK_TTL_SECS" ]
 }
 
-on_exit() {
-    if [ "$PROMPT_EMITTED" -eq 0 ]; then
-        cleanup_lock
-    fi
-}
-
-trap on_exit EXIT INT TERM
+trap cleanup_lock EXIT INT TERM
 
 # Dedup: mkdir is atomic — if it succeeds, we hold the lock
 if ! mkdir "$LOCKFILE" 2>/dev/null; then
@@ -73,36 +68,29 @@ fi
 LOCK_HELD=1
 
 PROJECT_NAME="${MEMPAL_PROJECT:-$(basename "$(pwd)")}"
-LOCKFILE_SHELL=$(printf '%q' "$LOCKFILE")
-PROJECT_NAME_SHELL=$(printf '%q' "$PROJECT_NAME")
 
-cat <<CHECKPOINT_PROMPT
+# Locate session JSONL via CLAUDE_CODE_SESSION_ID env var
+SESSION_JSONL=""
+if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+    SESSION_JSONL=$(find ~/.claude/projects -maxdepth 2 \
+        -name "${CLAUDE_CODE_SESSION_ID}.jsonl" 2>/dev/null | head -1)
+fi
 
-[SESSION CHECKPOINT] A tool stop was detected. To preserve your session state
-before KV cache expires (1h TTL), run this background countdown:
+if [ -z "$SESSION_JSONL" ] || [ ! -f "$SESSION_JSONL" ]; then
+    exit 0
+fi
 
-\`\`\`bash
-export MEMPAL_CHECKPOINT_LOCKFILE=$LOCKFILE_SHELL
-bash -lc 'trap '\''rmdir "\$MEMPAL_CHECKPOINT_LOCKFILE" 2>/dev/null || true'\'' EXIT; sleep 3000; echo "CHECKPOINT_TIMER_FIRED"'
-\`\`\`
+# Extract last assistant message; exit silently if empty or extraction fails
+CONTENT=$(mempal checkpoint extract "$SESSION_JSONL" --last 1 2>/dev/null) || exit 0
+if [ -z "$CONTENT" ]; then
+    exit 0
+fi
 
-Run the countdown command with run_in_background: true. When the notification fires
-(~50 min), check if the user has been active. If no activity, write a checkpoint:
-
-\`\`\`bash
-cat <<'EOF' | mempal checkpoint save --project $PROJECT_NAME_SHELL
-<your actual summary here — 3-10 sentences>
-EOF
-\`\`\`
-
-IMPORTANT: You MUST replace the heredoc body with a REAL summary of:
-(1) what you were working on in this session
-(2) key decisions made or problems solved
-(3) open items / next steps
-DO NOT pass placeholder text. The summary should be 3-10 sentences that let a
-future session resume without re-reading the full conversation.
-
-The checkpoint write generates tokens that refresh the KV cache.
-
-CHECKPOINT_PROMPT
-PROMPT_EMITTED=1
+# Save checkpoint directly; 10s timeout prevents blocking next session start.
+# Hold lock for 300s after success to suppress duplicate Stop events.
+if printf '%s' "$CONTENT" | timeout 10s mempal checkpoint save \
+        --project "$PROJECT_NAME" >/dev/null 2>&1; then
+    SAVED=1
+else
+    printf 'mempal checkpoint save failed for project %s\n' "$PROJECT_NAME" >&2
+fi

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "20794a3173318de04f262e2fe2d92c084a54f017"
+commit = "da85105c9af51faa5949f11e955a6fd096c69447"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Rewrote `scripts/hooks/checkpoint-countdown.sh` to directly save session checkpoints on `Stop` event
- **Root cause**: Stop hook output is NOT injected back into agent conversation — the previous approach (emit prompt text asking agent to start 50-min countdown) resulted in 0 checkpoints in 12+ hours of monitoring
- Now uses `mempal checkpoint extract <session.jsonl> --last 1` to get last assistant message, pipes to `mempal checkpoint save`
- All guards preserved (sub-agent, CSA, non-interactive, dedup lock)
- Lock TTL reduced from 3600s to 300s (dedup window for rapid Stop events)
- 10s timeout prevents blocking next session start

## Test plan

- [ ] Verify hook fires on session stop: `CLAUDE_CODE_SESSION_ID` must be set
- [ ] Verify checkpoint appears in `mempal checkpoint latest`
- [ ] Verify dedup: rapid Stop events don't create duplicate checkpoints
- [ ] Monitor across projects (mempal, warifu-ce) for automatic checkpoint creation

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)