### PR TITLE
feat(checkpoint): add enable/disable/status toggle

### DIFF
--- a/scripts/hooks/checkpoint-countdown.sh
+++ b/scripts/hooks/checkpoint-countdown.sh
@@ -14,6 +14,10 @@
 # Debug log: /tmp/mempal-checkpoint-debug.log
 set -eu
 
+# Kill switch: `mempal checkpoint disable` creates this file, `enable` removes it.
+DISABLE_FLAG="$HOME/.mempal/checkpoint-disabled"
+[ -f "$DISABLE_FLAG" ] && exit 0
+
 LOG="/tmp/mempal-checkpoint-debug.log"
 log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*" >> "$LOG"; }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,6 +505,12 @@ enum CheckpointCommands {
         #[arg(long, default_value_t = 1)]
         last: usize,
     },
+    /// Enable automatic checkpoint on Stop hook.
+    Enable,
+    /// Disable automatic checkpoint on Stop hook.
+    Disable,
+    /// Show whether automatic checkpoint is enabled or disabled.
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -2127,6 +2133,41 @@ async fn checkpoint_command(
             }
             if assistant_texts.is_empty() {
                 eprintln!("no assistant messages found in {}", path.display());
+            }
+        }
+        CheckpointCommands::Enable | CheckpointCommands::Disable | CheckpointCommands::Status => {
+            let flag = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .expect("HOME not set")
+                .join(".mempal")
+                .join("checkpoint-disabled");
+            match command {
+                CheckpointCommands::Enable => {
+                    if flag.exists() {
+                        std::fs::remove_file(&flag)
+                            .with_context(|| format!("failed to remove {}", flag.display()))?;
+                        println!("checkpoint enabled");
+                    } else {
+                        println!("checkpoint already enabled");
+                    }
+                }
+                CheckpointCommands::Disable => {
+                    if !flag.exists() {
+                        std::fs::write(&flag, "disabled by mempal checkpoint disable\n")
+                            .with_context(|| format!("failed to create {}", flag.display()))?;
+                        println!("checkpoint disabled");
+                    } else {
+                        println!("checkpoint already disabled");
+                    }
+                }
+                CheckpointCommands::Status => {
+                    if flag.exists() {
+                        println!("checkpoint: disabled");
+                    } else {
+                        println!("checkpoint: enabled");
+                    }
+                }
+                _ => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
## Summary

- `mempal checkpoint disable` — creates `~/.mempal/checkpoint-disabled` flag, Stop hook exits immediately
- `mempal checkpoint enable` — removes the flag
- `mempal checkpoint status` — shows current state
- Manual `mempal checkpoint save` still works when disabled (intentional)

## Test plan

- [x] `mempal checkpoint disable` → `status` shows disabled → hook exits immediately
- [x] `mempal checkpoint enable` → `status` shows enabled → hook saves normally
- [x] Idempotent: double disable/enable prints "already" message
- [x] Clippy + 242 tests pass
- [x] CSA review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)