### PR TITLE
fix(config): allow llm.model to hot-reload without restart

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -386,9 +386,8 @@ impl Config {
         if self.llm.base_url != other.llm.base_url {
             fields.push("llm.base_url");
         }
-        if self.llm.model != other.llm.model {
-            fields.push("llm.model");
-        }
+        // llm.model is just a request parameter — safe to hot-reload
+
         if self.llm.api_key != other.llm.api_key {
             fields.push("llm.api_key");
         }
@@ -414,7 +413,7 @@ impl Config {
         effective.embed.api_model = self.embed.api_model.clone();
         effective.embed.openai_compat = self.embed.openai_compat.clone();
         effective.llm.base_url = self.llm.base_url.clone();
-        effective.llm.model = self.llm.model.clone();
+        // llm.model is hot-reloadable — don't pin it
         effective.llm.api_key = self.llm.api_key.clone();
         effective.llm.api_key_env = self.llm.api_key_env.clone();
         effective.daemon.log_path = self.daemon.log_path.clone();

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -90,7 +90,8 @@ fn test_llm_restart_required_fields() {
     let fields = config.restart_required_fields_changed(&changed);
 
     assert!(fields.contains(&"llm.base_url"));
-    assert!(fields.contains(&"llm.model"));
+    // llm.model is now hot-reloadable
+    assert!(!fields.contains(&"llm.model"));
     assert!(fields.contains(&"llm.api_key_env"));
 }
 
@@ -111,7 +112,8 @@ fn test_llm_runtime_allowed_fields_hot_reload() {
     let effective = current.merge_runtime_allowed(&candidate);
 
     assert_eq!(effective.llm.base_url, current.llm.base_url);
-    assert_eq!(effective.llm.model, current.llm.model);
+    // llm.model is hot-reloadable — candidate value takes effect
+    assert_eq!(effective.llm.model, candidate.llm.model);
     assert_eq!(effective.llm.api_key_env, current.llm.api_key_env);
     assert_eq!(effective.llm.max_concurrent, 4);
     assert_eq!(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "da85105c9af51faa5949f11e955a6fd096c69447"
+commit = "04c3bbead713e0b90b25a27e97124be6ceb11fbe"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Remove `llm.model` from the restart-required blacklist in `config.rs`
- Remove the corresponding pin in `merge_runtime_allowed()` so new model value takes effect on hot-reload
- Update `llm_config` integration tests to match new behavior

`llm.model` is a stateless request parameter — no connection pool or session state depends on it. This lets operators switch gating models (e.g. `qwen35-35b-a3b` → `gpt-5.4-mini`) without restarting all MCP serve processes.

## Test plan
- [x] `cargo test --test llm_config` — 6/6 pass
- [x] `just quality-gates` — clippy clean, full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)