### PR TITLE
fix(llm): cancel in-flight worker requests on config hot-reload model change

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1153,9 +1153,25 @@ impl ConfigHandle {
         super::hot_reload::global_hot_reload_state().simulate_notify_failure();
     }
 
+    /// Subscribe to LLM config generation changes.
+    ///
+    /// The counter increments whenever a hot-reloadable LLM field (model,
+    /// retry_interval_secs, enabled_for, max_concurrent) changes via hot-reload.
+    /// LLM workers subscribe here to cancel in-flight requests on config change.
+    pub fn subscribe_llm_gen() -> tokio::sync::watch::Receiver<u64> {
+        super::hot_reload::global_hot_reload_state().subscribe_llm_gen()
+    }
+
     #[doc(hidden)]
     pub fn harness_reload_counter() -> Arc<AtomicUsize> {
         super::hot_reload::global_hot_reload_state().reload_counter_arc()
+    }
+
+    /// Force a config reload from the given path, bypassing the file watcher.
+    /// Intended only for tests that need to trigger `reload_from_disk` directly.
+    #[doc(hidden)]
+    pub fn harness_reload_from_path(path: &std::path::Path) {
+        super::hot_reload::global_hot_reload_state().reload_from_disk_for_test(path);
     }
 }
 

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -94,6 +94,10 @@ pub struct HotReloadState {
     // harness-point: PR0 — counts successful reload applications (version changes)
     reload_count: Arc<AtomicUsize>,
     runtime_prototypes: ArcSwap<Vec<String>>,
+    /// Incremented whenever a hot-reloadable LLM field changes (model,
+    /// retry_interval_secs, enabled_for, max_concurrent). LLM workers subscribe
+    /// to this to cancel in-flight requests and restart with the new config.
+    llm_gen_tx: tokio::sync::watch::Sender<u64>,
 }
 
 impl HotReloadState {
@@ -101,6 +105,7 @@ impl HotReloadState {
         let initial = Config::default();
         let snapshot =
             ConfigSnapshot::from_config(initial.clone()).expect("default config is valid");
+        let (llm_gen_tx, _) = tokio::sync::watch::channel(0u64);
         Self {
             snapshot: ArcSwap::from_pointee(snapshot),
             runtime: Mutex::new(None),
@@ -110,6 +115,7 @@ impl HotReloadState {
             runtime_prototypes: ArcSwap::from_pointee(
                 initial.ingest_gating.embedding_classifier.prototypes,
             ),
+            llm_gen_tx,
         }
     }
 
@@ -204,6 +210,23 @@ impl HotReloadState {
         {
             let _ = runtime.control_tx.send(WatchMessage::NotifyFailed);
         }
+    }
+
+    /// Subscribe to LLM generation changes.
+    ///
+    /// The channel value is a monotonically-increasing counter that is bumped
+    /// whenever a hot-reloadable LLM field (model, retry_interval_secs,
+    /// enabled_for, max_concurrent) changes. LLM workers use this to detect
+    /// config changes and cancel in-flight requests.
+    pub fn subscribe_llm_gen(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.llm_gen_tx.subscribe()
+    }
+
+    /// Trigger a reload from the given path without going through the watcher.
+    /// Only for use in tests via `ConfigHandle::harness_reload_from_path`.
+    #[doc(hidden)]
+    pub fn reload_from_disk_for_test(&self, path: &Path) {
+        self.reload_from_disk(path);
     }
 
     fn start_runtime(
@@ -388,6 +411,12 @@ impl HotReloadState {
             return;
         }
 
+        // Compute LLM gen change before `effective` is consumed by from_config.
+        let llm_hot_changed = previous.config.llm.model != effective.llm.model
+            || previous.config.llm.max_concurrent != effective.llm.max_concurrent
+            || previous.config.llm.retry_interval_secs != effective.llm.retry_interval_secs
+            || previous.config.llm.enabled_for != effective.llm.enabled_for;
+
         let next_snapshot = match ConfigSnapshot::from_config(effective) {
             Ok(snapshot) => snapshot,
             Err(error) => {
@@ -400,6 +429,18 @@ impl HotReloadState {
         self.snapshot.store(Arc::new(next_snapshot));
         // harness-point: PR0 — increment reload counter on successful version change
         self.reload_count.fetch_add(1, Ordering::SeqCst);
+
+        // Notify LLM workers when any hot-reloadable LLM field changes so they
+        // can cancel in-flight requests and restart with the new configuration.
+        if llm_hot_changed {
+            let prev_gen = *self.llm_gen_tx.borrow();
+            let _ = self.llm_gen_tx.send(prev_gen.wrapping_add(1));
+            self.push_event(format!(
+                "config hot-reload: LLM config changed, generation bumped to {}",
+                prev_gen.wrapping_add(1)
+            ));
+        }
+
         self.push_event(format!(
             "config hot-reload: version changed from {} to {}",
             previous.version, next_version

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -352,6 +352,29 @@ impl PendingMessageStore {
         Ok(())
     }
 
+    /// Return a claimed message to pending without counting it as a failure.
+    ///
+    /// Used by LLM workers cancelled due to a config hot-reload so the task is
+    /// retried with the new configuration rather than charged a retry.
+    pub fn release_claim(&self, id: &str) -> Result<()> {
+        let conn = self.open_connection()?;
+        let updated = conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'pending',
+                claim_token = NULL,
+                claimed_at = NULL,
+                heartbeat_at = NULL
+            WHERE id = ?1 AND status = 'claimed'
+            "#,
+            [id],
+        )?;
+        if updated == 0 {
+            return Err(QueueError::MessageNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     pub fn refresh_heartbeat(&self, id: &str, worker_id: &str) -> Result<()> {
         let claim_prefix = format!("{worker_id}:");
         let now = now_secs();

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -54,12 +54,19 @@ pub async fn run_llm_worker(
         }
     }
 
+    // Subscribe to LLM config generation changes. When a hot-reloadable LLM
+    // field changes (e.g. model), the receiver value is bumped and any
+    // in-flight task is cancelled so the worker restarts with the new config.
+    let mut llm_gen_rx = ConfigHandle::subscribe_llm_gen();
+
     loop {
         if crate::daemon::shutdown_requested() {
             tracing::info!("LLM worker: shutdown requested");
             break;
         }
 
+        // Re-read config at the start of each claim cycle so model/timeout
+        // changes are picked up without a full daemon restart.
         let config = ConfigHandle::current();
         if !config.llm.enabled {
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -86,6 +93,10 @@ pub async fn run_llm_worker(
             }
         };
 
+        // Mark the current generation as seen AFTER claiming so that `changed()`
+        // only fires for changes that happen while THIS task is in-flight.
+        let _ = llm_gen_rx.borrow_and_update();
+
         let message_id = message.id.clone();
         tracing::info!("LLM worker claimed task {message_id}");
         let start = Instant::now();
@@ -102,31 +113,54 @@ pub async fn run_llm_worker(
             Ok(())
         });
 
-        let result = process_llm_task_shared(
-            &client,
-            &status,
-            &db,
-            &message.payload,
-            &config,
-            Some(heartbeat.as_ref()),
-        )
-        .await;
+        // Race the LLM task against a config-change signal. If the LLM config
+        // changes while a request is in-flight, the task future is dropped
+        // (reqwest futures are cancel-safe), the task is released back to
+        // pending (no retry count increment), and the worker restarts the loop
+        // with the fresh config snapshot.
+        let task_result = tokio::select! {
+            result = process_llm_task_shared(
+                &client,
+                &status,
+                &db,
+                &message.payload,
+                &config,
+                Some(heartbeat.as_ref()),
+            ) => Some(result),
+            _ = llm_gen_rx.changed() => None,
+        };
 
         let latency_ms = start.elapsed().as_millis();
-        match result {
-            Ok(()) => {
+        match task_result {
+            Some(Ok(())) => {
                 tracing::info!("LLM task {message_id} completed in {latency_ms}ms");
                 store
                     .confirm(&message_id)
                     .with_context(|| format!("failed to confirm LLM task {message_id}"))?;
                 write_observer.record_successful_write();
             }
-            Err(error) => {
+            Some(Err(error)) => {
                 tracing::error!("LLM task {message_id} failed after {latency_ms}ms: {error}");
                 write_observer.record_error(error.to_string());
                 store
                     .mark_failed(&message_id, &error.to_string())
                     .with_context(|| format!("failed to mark_failed LLM task {message_id}"))?;
+            }
+            None => {
+                tracing::info!(
+                    worker_id,
+                    message_id,
+                    "LLM worker restarting due to config change; releasing task back to pending"
+                );
+                if let Err(error) = store.release_claim(&message_id) {
+                    tracing::warn!(
+                        ?error,
+                        message_id,
+                        "failed to release claimed LLM task on config change; \
+                         task will be reclaimed by TTL or next startup"
+                    );
+                }
+                // Continue loop — next iteration picks up the updated config.
             }
         }
     }

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -1,0 +1,255 @@
+//! Tests for fix/llm-worker-hot-reload (issue #176):
+//! LLM workers stuck after config hot-reload model change.
+
+use std::time::Duration;
+
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::core::queue::PendingMessageStore;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_store(db: &Database) -> PendingMessageStore {
+    PendingMessageStore::new(db.path()).expect("open queue")
+}
+
+// ── release_claim ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_release_claim_returns_task_to_pending() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let store = make_store(&db);
+
+    let id = store
+        .enqueue("llm_task", r#"{"type":"test"}"#)
+        .expect("enqueue");
+
+    // Claim the task.
+    let msg = store
+        .claim_next_by_kind("test-worker", 300, "llm_task")
+        .expect("claim_next_by_kind")
+        .expect("claimed message");
+    assert_eq!(msg.id, id);
+
+    let stats_claimed = store.stats().expect("stats");
+    assert_eq!(stats_claimed.claimed, 1);
+    assert_eq!(stats_claimed.pending, 0);
+
+    // Release back to pending — simulates worker cancellation due to config change.
+    store.release_claim(&id).expect("release_claim");
+
+    let stats_after = store.stats().expect("stats after release");
+    assert_eq!(stats_after.claimed, 0, "task must be pending after release");
+    assert_eq!(stats_after.pending, 1, "task must be pending after release");
+    assert_eq!(
+        stats_after.failed, 0,
+        "release_claim must not increment retry count or mark as failed"
+    );
+}
+
+#[test]
+fn test_release_claim_does_not_increment_retry_count() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let store = make_store(&db);
+
+    let id = store.enqueue("llm_task", "{}").expect("enqueue");
+    let msg = store
+        .claim_next_by_kind("worker", 300, "llm_task")
+        .expect("claim_next_by_kind")
+        .expect("message");
+    assert_eq!(msg.retry_count, 0);
+
+    store.release_claim(&id).expect("release_claim");
+
+    // Claim again — retry_count must still be 0.
+    let msg2 = store
+        .claim_next_by_kind("worker", 300, "llm_task")
+        .expect("claim_next_by_kind")
+        .expect("message after release");
+    assert_eq!(
+        msg2.retry_count, 0,
+        "release_claim must not increment retry_count"
+    );
+}
+
+#[test]
+fn test_release_claim_returns_error_for_unknown_id() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let store = make_store(&db);
+
+    let result = store.release_claim("nonexistent-id");
+    assert!(
+        result.is_err(),
+        "release_claim on unknown id must return MessageNotFound"
+    );
+}
+
+// ── LLM generation watch channel ─────────────────────────────────────────────
+
+#[test]
+fn test_llm_gen_increments_on_model_change() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    // Bootstrap with model-a so the global snapshot is set.
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_llm_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    // Write model-b and trigger reload_from_disk directly (bypasses watcher).
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-b"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert!(
+        gen_after > gen_before,
+        "generation must increment when llm.model changes (before={gen_before}, after={gen_after})"
+    );
+}
+
+#[test]
+fn test_llm_gen_does_not_increment_on_unrelated_change() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-stable"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_llm_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    // Change a non-LLM field (search.preview_chars) only.
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-stable"
+
+[search]
+preview_chars = 200
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert_eq!(
+        gen_after, gen_before,
+        "generation must NOT change for non-LLM config changes"
+    );
+}
+
+// ── tokio::select! cancellation ───────────────────────────────────────────────
+
+/// Simulates the worker's tokio::select! pattern: a slow async operation races
+/// against an LLM generation change signal and is cancelled when the signal fires.
+#[tokio::test]
+async fn test_worker_select_cancels_on_gen_change() {
+    let (gen_tx, mut gen_rx) = tokio::sync::watch::channel(0u64);
+
+    // Mark current value as seen so `changed()` only fires for NEW values.
+    let _ = gen_rx.borrow_and_update();
+
+    // Spawn a task that bumps the generation after a short delay.
+    let handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = gen_tx.send(1u64);
+    });
+
+    let slow_op = async {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Ok::<(), anyhow::Error>(())
+    };
+
+    // The slow_op should be cancelled by gen_rx.changed() well before 60s.
+    let result: Option<Result<(), anyhow::Error>> = tokio::select! {
+        r = slow_op => Some(r),
+        _ = gen_rx.changed() => None,
+    };
+
+    assert!(
+        result.is_none(),
+        "slow operation must be cancelled when generation changes"
+    );
+    handle.await.expect("spawned task");
+}
+
+/// Verify that the per-request timeout on LlmClient is set from config.
+#[test]
+fn test_llm_client_has_request_timeout_from_config() {
+    use mempal::core::config::LlmConfig;
+    use mempal::llm::LlmClient;
+
+    let config = LlmConfig {
+        enabled: true,
+        base_url: Some("http://127.0.0.1:19999/v1".to_string()),
+        model: Some("test-model".to_string()),
+        request_timeout_secs: 42,
+        ..Default::default()
+    };
+
+    // LlmClient::from_config must succeed (it builds the reqwest client with
+    // the timeout). The timeout value is baked into the reqwest::Client and
+    // cannot be read back directly, so we just verify construction succeeds
+    // with a non-default timeout.
+    let client = LlmClient::from_config(&config)
+        .expect("LlmClient must build with custom request_timeout_secs");
+
+    // Sanity-check that the client was created (indirectly validates the
+    // timeout parameter was accepted by reqwest without panicking).
+    assert_eq!(
+        client.current_max_concurrent(),
+        config.max_concurrent.max(1)
+    );
+}
+
+// ── queue release idempotency ────────────────────────────────────────────────
+
+#[test]
+fn test_release_claim_on_already_pending_is_error() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let store = make_store(&db);
+
+    let id = store.enqueue("llm_task", "{}").expect("enqueue");
+    // Task is pending (not claimed) — release_claim should return error.
+    let result = store.release_claim(&id);
+    assert!(
+        result.is_err(),
+        "release_claim on a pending (unclaimed) task must fail"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "04c3bbead713e0b90b25a27e97124be6ceb11fbe"
+commit = "2a58a9b7c1101a84fde281f550404ef51fc48ab4"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Fixes #176: LLM daemon workers are no longer stuck after `llm.model` changes in `~/.mempal/config.toml` trigger a hot-reload
- Added a `tokio::sync::watch` generation counter that bumps whenever a hot-reloadable LLM field changes; each worker races its in-flight HTTP request against `llm_gen_rx.changed()` via `tokio::select!`
- On cancellation: `release_claim()` returns the task to `pending` with no retry-count increment, then the worker loops with the updated config snapshot

## Changes

| File | Change |
|------|--------|
| `src/core/queue.rs` | Add `release_claim()` — returns claimed message to pending without touching `retry_count` |
| `src/core/hot_reload.rs` | Add `llm_gen_tx` watch channel; bump generation on `model`, `max_concurrent`, `retry_interval_secs`, or `enabled_for` changes |
| `src/core/config.rs` | Expose `subscribe_llm_gen()` and `harness_reload_from_path()` (doc-hidden test harness) |
| `src/llm/worker.rs` | Subscribe to LLM gen at startup; `tokio::select!` races each task against gen change; calls `release_claim` + continues loop on cancellation |
| `tests/llm_worker_hot_reload.rs` | 8 new integration tests covering queue release semantics, gen channel behaviour, `tokio::select!` cancellation, and per-request timeout construction |

## Test plan

- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all 863 tests pass (8 new tests in `tests/llm_worker_hot_reload.rs`)
- [x] CSA tier-4-critical review: **PASS** (session `01KRCCT4KWBDXCK18QDB2FRDSS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)