### PR TITLE
fix(llm): cancel in-flight worker requests on config hot-reload

### DIFF
--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -1,11 +1,16 @@
 //! Tests for fix/llm-worker-hot-reload (issue #176):
 //! LLM workers stuck after config hot-reload model change.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use mempal::core::config::ConfigHandle;
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
+
+// Tests in this file share the global HotReloadState (OnceLock singleton).
+// Serialize them to prevent cross-test config snapshot contamination.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 
@@ -91,6 +96,7 @@ fn test_release_claim_returns_error_for_unknown_id() {
 
 #[test]
 fn test_llm_gen_increments_on_model_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config_path = tmp.path().join("config.toml");
 
@@ -132,6 +138,7 @@ model = "model-b"
 
 #[test]
 fn test_llm_gen_does_not_increment_on_unrelated_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config_path = tmp.path().join("config.toml");
 


### PR DESCRIPTION
## Summary

- When `llm.model` (or other hot-reloadable LLM fields) change via config hot-reload, in-flight worker HTTP requests are now cancelled via `tokio::select!` + watch channel generation counter
- Workers release claimed tasks back to pending on cancellation, then restart with new config
- Per-request timeout enforced from `llm.request_timeout_secs` to prevent indefinite hangs
- Test isolation fix: serialized config-dependent tests via Mutex to prevent flaky failures from shared global HotReloadState

Closes #176

## Test plan

- [x] `test_llm_gen_increments_on_model_change` — generation bumps on model change
- [x] `test_llm_gen_does_not_increment_on_unrelated_change` — no bump for non-LLM fields
- [x] `test_worker_select_cancels_on_gen_change` — tokio::select! cancellation pattern
- [x] `test_release_claim_returns_task_to_pending` — claimed tasks go back to pending
- [x] `test_llm_client_has_request_timeout_from_config` — timeout wired from config
- [x] 863 tests pass (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)