### PR TITLE
perf(status): skip endpoint health probe unless --full

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5013,8 +5013,14 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
     let scrub_stats = ConfigHandle::scrub_stats();
     let runtime_warnings = ConfigHandle::collect_runtime_warnings();
-    let endpoint_health = mempal::endpoint_health::probe_endpoints_blocking(config)
-        .context("failed to probe endpoint health")?;
+    let endpoint_health = if full {
+        Some(
+            mempal::endpoint_health::probe_endpoints_blocking(config)
+                .context("failed to probe endpoint health")?,
+        )
+    } else {
+        None
+    };
     let embed_status = global_embed_status().snapshot();
     let queue_stats = mempal::core::queue::PendingMessageStore::new(db.path())
         .context("failed to open pending message store")?
@@ -5118,9 +5124,14 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     if let Some(last_success_at) = embed_status.last_success_at_unix_ms {
         println!("embed_last_success_at_unix_ms: {last_success_at}");
     }
-    println!("Endpoints:");
-    println!("  embedding: {}", endpoint_health.embedding.display());
-    println!("  llm: {}", endpoint_health.llm.display());
+    match &endpoint_health {
+        Some(health) => {
+            println!("Endpoints:");
+            println!("  embedding: {}", health.embedding.display());
+            println!("  llm: {}", health.llm.display());
+        }
+        None => println!("Endpoints: (use --full to probe)"),
+    }
     println!("Daemon:");
     println!("  running: {daemon_running}");
     match daemon_pid {


### PR DESCRIPTION
## Summary

- Move HTTP endpoint health probes (3s PROBE_TIMEOUT each for embedding + LLM) behind `--full` flag
- Default `mempal status` now runs only fast local queries (SQLite + config snapshot)
- Combined with PR #180 (per-project breakdown behind `--full`), total speedup: ~8s → sub-second

Refs #178

## Test plan

- [x] `mempal status` returns fast (no HTTP probes)
- [x] `mempal status --full` includes endpoint health + per-project breakdown
- [x] 863 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)