### PR TITLE
feat(api): hermes-agent MemoryProvider plugin — REST API + Python contrib

### DIFF
--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -1,0 +1,66 @@
+# mempal hermes-agent plugin
+
+Plugs mempal into hermes-agent as a drop-in MemoryProvider.
+Replaces mem0 with a fully local BM25 + vector hybrid backend — no cloud API calls.
+
+## Prerequisites
+
+1. mempal built with `--features rest` and running:
+   ```bash
+   cargo build --features rest
+   mempal serve   # starts MCP + REST on 127.0.0.1:3080
+   ```
+   Or start the daemon (auto-starts REST when built with `rest` feature):
+   ```bash
+   mempal daemon start
+   ```
+
+2. Python 3.9+ with no extra pip dependencies required (uses stdlib `urllib`).
+
+## Setup
+
+1. Copy or symlink this directory into hermes-agent's plugin search path:
+   ```bash
+   cp -r contrib/hermes-agent-plugin/mempal  /path/to/hermes-agent/plugins/memory/mempal
+   ```
+
+2. Configure hermes-agent to use the mempal provider:
+   ```yaml
+   # cli-config.yaml
+   memory:
+     provider: mempal
+   ```
+
+3. Optionally set environment variables:
+   ```bash
+   export MEMPAL_BASE_URL=http://127.0.0.1:3080   # default
+   export MEMPAL_USER_ID=your-username              # default: hermes-user
+   ```
+   Or write `$HERMES_HOME/mempal.json`:
+   ```json
+   {
+     "base_url": "http://127.0.0.1:3080",
+     "user_id": "your-username"
+   }
+   ```
+
+## Tools exposed to the model
+
+| Tool | Description |
+|------|-------------|
+| `mempal_profile` | Recent memories via `/api/timeline` |
+| `mempal_search` | Hybrid BM25+vector search via `/api/search` |
+| `mempal_conclude` | Store a fact verbatim via `/api/ingest` |
+
+## Memory routing
+
+All memories are stored under `wing="hermes-user/{user_id}"`:
+- Turns → `room="turns"`
+- Explicit facts → `room="facts"`
+- Session summaries → `room="sessions"`
+- Built-in memory mirrors → `room="memory-mirror"`
+
+## Circuit breaker
+
+After 5 consecutive REST failures the provider pauses for 120 seconds to avoid
+hammering a down server. Tool calls return a clear error message during cooldown.

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -1,0 +1,426 @@
+"""Mempal memory plugin for hermes-agent.
+
+Local memory backend via mempal REST API.
+BM25 + vector hybrid search, zero cloud dependency.
+
+Config via environment variables:
+  MEMPAL_BASE_URL  — mempal REST endpoint (default: http://127.0.0.1:3080)
+  MEMPAL_USER_ID   — user identifier (default: hermes-user)
+
+Or via $HERMES_HOME/mempal.json.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker: pause API calls after this many consecutive failures
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+# Tool schemas
+PROFILE_SCHEMA = {
+    "name": "mempal_profile",
+    "description": (
+        "Retrieve recent memory entries for the user via mempal timeline. "
+        "Fast, ordered by recency. Use at conversation start for context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Max entries to return (default: 20, max: 100).",
+            },
+        },
+        "required": [],
+    },
+}
+
+SEARCH_SCHEMA = {
+    "name": "mempal_search",
+    "description": (
+        "Search memories by meaning via BM25 + vector hybrid search. "
+        "Returns relevant facts ranked by similarity."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "top_k": {"type": "integer", "description": "Max results (default: 10)."},
+        },
+        "required": ["query"],
+    },
+}
+
+CONCLUDE_SCHEMA = {
+    "name": "mempal_conclude",
+    "description": (
+        "Store a durable fact about the user in mempal. "
+        "Stored verbatim via local BM25 + vector index. "
+        "Use for explicit preferences, corrections, or decisions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conclusion": {"type": "string", "description": "The fact to store."},
+        },
+        "required": ["conclusion"],
+    },
+}
+
+
+def _load_config(hermes_home: str = "") -> dict:
+    """Load config from env vars with $HERMES_HOME/mempal.json overrides."""
+    config = {
+        "base_url": os.environ.get("MEMPAL_BASE_URL", "http://127.0.0.1:3080"),
+        "user_id": os.environ.get("MEMPAL_USER_ID", "hermes-user"),
+    }
+    if hermes_home:
+        config_path = os.path.join(hermes_home, "mempal.json")
+        if os.path.exists(config_path):
+            try:
+                file_cfg = json.loads(open(config_path, encoding="utf-8").read())
+                config.update({k: v for k, v in file_cfg.items() if v})
+            except Exception:
+                pass
+    return config
+
+
+class MempalMemoryProvider:
+    """Mempal local memory backend implementing the MemoryProvider interface."""
+
+    def __init__(self):
+        self._base_url = "http://127.0.0.1:3080"
+        self._user_id = "hermes-user"
+        self._wing = "hermes-user/hermes-user"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        self._sync_thread: Optional[threading.Thread] = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._hermes_home = ""
+
+    @property
+    def name(self) -> str:
+        return "mempal"
+
+    def is_available(self) -> bool:
+        """Check if mempal REST endpoint is reachable."""
+        try:
+            import urllib.request
+            cfg = _load_config(self._hermes_home)
+            url = cfg["base_url"] + "/api/status"
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._hermes_home = kwargs.get("hermes_home", "")
+        cfg = _load_config(self._hermes_home)
+        self._base_url = cfg["base_url"].rstrip("/")
+        user_id = kwargs.get("user_id") or cfg.get("user_id", "hermes-user")
+        self._user_id = user_id
+        self._wing = f"hermes-user/{user_id}"
+
+    # -- Circuit breaker ----------------------------------------------------
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "mempal circuit breaker tripped after %d failures. Pausing %ds.",
+                self._consecutive_failures,
+                _BREAKER_COOLDOWN_SECS,
+            )
+
+    # -- HTTP helpers -------------------------------------------------------
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        import urllib.request
+        import urllib.parse
+
+        url = self._base_url + path
+        if params:
+            url += "?" + urllib.parse.urlencode(
+                {k: v for k, v in params.items() if v is not None}
+            )
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Any:
+        import urllib.request
+
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(
+            self._base_url + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+
+    # -- MemoryProvider interface --------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Mempal Memory\n"
+            f"Active. User: {self._user_id}. Local BM25+vector backend, zero cloud.\n"
+            "Use mempal_search to recall facts, mempal_conclude to store, "
+            "mempal_profile for recent overview."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Mempal Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open():
+            return
+
+        def _run():
+            try:
+                results = self._get(
+                    "/api/search",
+                    {"q": query, "wing": self._wing, "top_k": 5},
+                )
+                if results:
+                    lines = [r.get("content", "") for r in results if r.get("content")]
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("mempal prefetch failed: %s", exc)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="mempal-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def sync_turn(
+        self, user_content: str, assistant_content: str, *, session_id: str = ""
+    ) -> None:
+        """Ingest turn summary to mempal (non-blocking)."""
+        if self._is_breaker_open():
+            return
+
+        content = f"User: {user_content}\nAssistant: {assistant_content}"
+
+        def _sync():
+            try:
+                self._post(
+                    "/api/ingest",
+                    {
+                        "content": content,
+                        "wing": self._wing,
+                        "room": "turns",
+                    },
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.warning("mempal sync_turn failed: %s", exc)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(
+            target=_sync, daemon=True, name="mempal-sync"
+        )
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps(
+                {
+                    "error": (
+                        "mempal temporarily unavailable (too many failures). "
+                        "Will retry automatically."
+                    )
+                }
+            )
+
+        if tool_name == "mempal_profile":
+            try:
+                limit = min(int(args.get("limit", 20)), 100)
+                entries = self._get(
+                    "/api/timeline",
+                    {"wing": self._wing, "limit": limit},
+                )
+                self._record_success()
+                if not entries:
+                    return json.dumps({"result": "No memories stored yet."})
+                lines = [e.get("content", "") for e in entries if e.get("content")]
+                return json.dumps({"result": "\n".join(f"- {l}" for l in lines), "count": len(lines)})
+            except Exception as exc:
+                self._record_failure()
+                return json.dumps({"error": f"Failed to fetch profile: {exc}"})
+
+        elif tool_name == "mempal_search":
+            query = args.get("query", "")
+            if not query:
+                return json.dumps({"error": "Missing required parameter: query"})
+            top_k = min(int(args.get("top_k", 10)), 50)
+            try:
+                results = self._get(
+                    "/api/search",
+                    {"q": query, "wing": self._wing, "top_k": top_k},
+                )
+                self._record_success()
+                if not results:
+                    return json.dumps({"result": "No relevant memories found."})
+                items = [
+                    {"memory": r.get("content", ""), "score": r.get("similarity", 0)}
+                    for r in results
+                ]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as exc:
+                self._record_failure()
+                return json.dumps({"error": f"Search failed: {exc}"})
+
+        elif tool_name == "mempal_conclude":
+            conclusion = args.get("conclusion", "")
+            if not conclusion:
+                return json.dumps({"error": "Missing required parameter: conclusion"})
+            try:
+                self._post(
+                    "/api/ingest",
+                    {
+                        "content": conclusion,
+                        "wing": self._wing,
+                        "room": "facts",
+                    },
+                )
+                self._record_success()
+                return json.dumps({"result": "Fact stored."})
+            except Exception as exc:
+                self._record_failure()
+                return json.dumps({"error": f"Failed to store: {exc}"})
+
+        return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Ingest a session summary when the session ends."""
+        if self._is_breaker_open():
+            return
+        assistant_msgs = [
+            m.get("content", "")
+            for m in messages
+            if m.get("role") == "assistant" and m.get("content")
+        ]
+        if not assistant_msgs:
+            return
+        summary = assistant_msgs[-1][:2000]
+
+        def _ingest():
+            try:
+                self._post(
+                    "/api/ingest",
+                    {
+                        "content": f"[Session summary] {summary}",
+                        "wing": self._wing,
+                        "room": "sessions",
+                    },
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.warning("mempal on_session_end failed: %s", exc)
+
+        threading.Thread(target=_ingest, daemon=True, name="mempal-session-end").start()
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror built-in memory writes to mempal."""
+        if self._is_breaker_open() or action == "remove":
+            return
+
+        def _mirror():
+            try:
+                self._post(
+                    "/api/ingest",
+                    {
+                        "content": content,
+                        "wing": self._wing,
+                        "room": "memory-mirror",
+                    },
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("mempal on_memory_write failed: %s", exc)
+
+        threading.Thread(target=_mirror, daemon=True, name="mempal-mirror").start()
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "base_url",
+                "description": "mempal REST endpoint",
+                "default": "http://127.0.0.1:3080",
+                "env_var": "MEMPAL_BASE_URL",
+            },
+            {
+                "key": "user_id",
+                "description": "User identifier for memory scoping",
+                "default": "hermes-user",
+                "env_var": "MEMPAL_USER_ID",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = os.path.join(hermes_home, "mempal.json")
+        existing: dict = {}
+        if os.path.exists(config_path):
+            try:
+                existing = json.loads(open(config_path, encoding="utf-8").read())
+            except Exception:
+                pass
+        existing.update(values)
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(existing, f, indent=2)
+
+
+def register(ctx) -> None:
+    """Register mempal as a memory provider plugin."""
+    ctx.register_memory_provider(MempalMemoryProvider())

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -272,7 +272,10 @@ class MempalMemoryProvider:
 
         if tool_name == "mempal_profile":
             try:
-                limit = min(int(args.get("limit", 20)), 100)
+                try:
+                    limit = min(int(args.get("limit", 20)), 100)
+                except (ValueError, TypeError):
+                    limit = 20
                 entries = self._get(
                     "/api/timeline",
                     {"wing": self._wing, "limit": limit},
@@ -290,7 +293,10 @@ class MempalMemoryProvider:
             query = args.get("query", "")
             if not query:
                 return json.dumps({"error": "Missing required parameter: query"})
-            top_k = min(int(args.get("top_k", 10)), 50)
+            try:
+                top_k = min(int(args.get("top_k", 10)), 50)
+            except (ValueError, TypeError):
+                top_k = 10
             try:
                 results = self._get(
                     "/api/search",

--- a/contrib/hermes-agent-plugin/mempal/plugin.yaml
+++ b/contrib/hermes-agent-plugin/mempal/plugin.yaml
@@ -1,0 +1,3 @@
+name: mempal
+description: Local memory backend via mempal (BM25 + vector hybrid search, zero cloud dependency)
+dependencies: []

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -34,6 +34,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/api/ingest", post(ingest_handler))
         .route("/api/taxonomy", get(taxonomy_handler))
         .route("/api/status", get(status_handler))
+        .merge(super::hermes_compat::routes())
         .with_state(state)
         .layer(cors_layer())
 }

--- a/src/api/hermes_compat.rs
+++ b/src/api/hermes_compat.rs
@@ -1,0 +1,109 @@
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::state::ApiState;
+use crate::core::db::Database;
+
+pub fn routes() -> Router<ApiState> {
+    Router::new()
+        .route("/api/timeline", get(timeline_handler))
+        .route("/api/delete", post(delete_handler))
+}
+
+#[derive(Debug, Deserialize)]
+struct TimelineQuery {
+    wing: Option<String>,
+    room: Option<String>,
+    limit: Option<usize>,
+    project_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct TimelineEntry {
+    drawer_id: String,
+    content: String,
+    wing: String,
+    room: Option<String>,
+    source_file: Option<String>,
+    added_at: String,
+    importance: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeleteRequest {
+    drawer_id: String,
+}
+
+async fn timeline_handler(
+    State(state): State<ApiState>,
+    Query(query): Query<TimelineQuery>,
+) -> Result<Json<Vec<TimelineEntry>>, HermesError> {
+    let db = Database::open(&state.db_path).map_err(hermes_internal)?;
+    let limit = query.limit.unwrap_or(50).min(500);
+    let drawers = db
+        .timeline_drawers(
+            query.wing.as_deref(),
+            query.room.as_deref(),
+            query.project_id.as_deref(),
+            limit,
+        )
+        .map_err(hermes_internal)?;
+
+    let entries = drawers
+        .into_iter()
+        .map(|d| TimelineEntry {
+            drawer_id: d.id,
+            content: d.content,
+            wing: d.wing,
+            room: d.room,
+            source_file: d.source_file,
+            added_at: d.added_at,
+            importance: d.importance,
+        })
+        .collect();
+    Ok(Json(entries))
+}
+
+async fn delete_handler(
+    State(state): State<ApiState>,
+    Json(request): Json<DeleteRequest>,
+) -> Result<impl IntoResponse, HermesError> {
+    let db = Database::open(&state.db_path).map_err(hermes_internal)?;
+    let deleted = db
+        .soft_delete_drawer(&request.drawer_id)
+        .map_err(hermes_internal)?;
+    if deleted {
+        Ok((StatusCode::OK, Json(json!({"deleted": true}))))
+    } else {
+        Err(HermesError {
+            status: StatusCode::NOT_FOUND,
+            message: format!("drawer '{}' not found", request.drawer_id),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct HermesError {
+    status: StatusCode,
+    message: String,
+}
+
+impl IntoResponse for HermesError {
+    fn into_response(self) -> axum::response::Response {
+        (self.status, Json(json!({ "error": self.message }))).into_response()
+    }
+}
+
+fn hermes_internal(error: impl std::fmt::Display) -> HermesError {
+    HermesError {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: error.to_string(),
+    }
+}

--- a/src/api/hermes_compat.rs
+++ b/src/api/hermes_compat.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::state::ApiState;
+use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
+use crate::core::project::resolve_project_id;
 
 pub fn routes() -> Router<ApiState> {
     Router::new()
@@ -39,6 +41,7 @@ struct TimelineEntry {
 #[derive(Debug, Deserialize)]
 struct DeleteRequest {
     drawer_id: String,
+    project_id: Option<String>,
 }
 
 async fn timeline_handler(
@@ -46,12 +49,15 @@ async fn timeline_handler(
     Query(query): Query<TimelineQuery>,
 ) -> Result<Json<Vec<TimelineEntry>>, HermesError> {
     let db = Database::open(&state.db_path).map_err(hermes_internal)?;
+    let config = ConfigHandle::current();
+    let project_id = resolve_project_id(query.project_id.as_deref(), config.as_ref(), None)
+        .map_err(hermes_internal)?;
     let limit = query.limit.unwrap_or(50).min(500);
     let drawers = db
         .timeline_drawers(
             query.wing.as_deref(),
             query.room.as_deref(),
-            query.project_id.as_deref(),
+            project_id.as_deref(),
             limit,
         )
         .map_err(hermes_internal)?;
@@ -76,6 +82,20 @@ async fn delete_handler(
     Json(request): Json<DeleteRequest>,
 ) -> Result<impl IntoResponse, HermesError> {
     let db = Database::open(&state.db_path).map_err(hermes_internal)?;
+    let config = ConfigHandle::current();
+    let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
+        .map_err(hermes_internal)?;
+    if let Some(ref pid) = project_id {
+        let drawer_project = db
+            .drawer_project_id(&request.drawer_id)
+            .map_err(hermes_internal)?;
+        if drawer_project.as_deref() != Some(pid.as_str()) {
+            return Err(HermesError {
+                status: StatusCode::FORBIDDEN,
+                message: format!("drawer '{}' belongs to another project", request.drawer_id),
+            });
+        }
+    }
     let deleted = db
         .soft_delete_drawer(&request.drawer_id)
         .map_err(hermes_internal)?;

--- a/src/api/hermes_compat.rs
+++ b/src/api/hermes_compat.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use super::state::ApiState;
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
-use crate::core::project::resolve_project_id;
+use crate::core::project::{ProjectFilterMode, ProjectSearchScope, resolve_project_id};
 
 pub fn routes() -> Router<ApiState> {
     Router::new()
@@ -52,13 +52,21 @@ async fn timeline_handler(
     let config = ConfigHandle::current();
     let project_id = resolve_project_id(query.project_id.as_deref(), config.as_ref(), None)
         .map_err(hermes_internal)?;
+    let scope = ProjectSearchScope::from_request(
+        project_id,
+        false,
+        false,
+        config.search.strict_project_isolation,
+    );
     let limit = query.limit.unwrap_or(50).min(500);
+    let strict_null_only = scope.mode == ProjectFilterMode::NullOnly;
     let drawers = db
         .timeline_drawers(
             query.wing.as_deref(),
             query.room.as_deref(),
-            project_id.as_deref(),
+            scope.project_id.as_deref(),
             limit,
+            strict_null_only,
         )
         .map_err(hermes_internal)?;
 
@@ -85,16 +93,33 @@ async fn delete_handler(
     let config = ConfigHandle::current();
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(hermes_internal)?;
-    if let Some(ref pid) = project_id {
-        let drawer_project = db
-            .drawer_project_id(&request.drawer_id)
-            .map_err(hermes_internal)?;
-        if drawer_project.as_deref() != Some(pid.as_str()) {
-            return Err(HermesError {
-                status: StatusCode::FORBIDDEN,
-                message: format!("drawer '{}' belongs to another project", request.drawer_id),
-            });
+    let scope = ProjectSearchScope::from_request(
+        project_id,
+        false,
+        false,
+        config.search.strict_project_isolation,
+    );
+    let drawer_project = db
+        .drawer_project_id(&request.drawer_id)
+        .map_err(hermes_internal)?;
+    match scope.mode {
+        ProjectFilterMode::ProjectScoped | ProjectFilterMode::ProjectPlusGlobal => {
+            if drawer_project.as_deref() != scope.project_id.as_deref() {
+                return Err(HermesError {
+                    status: StatusCode::FORBIDDEN,
+                    message: format!("drawer '{}' belongs to another project", request.drawer_id),
+                });
+            }
         }
+        ProjectFilterMode::NullOnly => {
+            if drawer_project.is_some() {
+                return Err(HermesError {
+                    status: StatusCode::FORBIDDEN,
+                    message: format!("drawer '{}' belongs to another project", request.drawer_id),
+                });
+            }
+        }
+        ProjectFilterMode::AllProjects => {}
     }
     let deleted = db
         .soft_delete_drawer(&request.drawer_id)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "rest")]
 mod handlers;
 #[cfg(feature = "rest")]
+mod hermes_compat;
+#[cfg(feature = "rest")]
 mod state;
 
 #[cfg(feature = "rest")]

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub ingest_gating: IngestGatingConfig,
     pub hooks: HooksConfig,
     pub daemon: DaemonConfig,
+    pub api: ApiConfig,
     pub mcp: McpConfig,
     pub importance: ImportanceConfig,
     pub patterns: PatternsConfig,
@@ -107,6 +108,7 @@ impl Default for Config {
             ingest_gating: IngestGatingConfig::default(),
             hooks: HooksConfig::default(),
             daemon: DaemonConfig::default(),
+            api: ApiConfig::default(),
             mcp: McpConfig::default(),
             importance: ImportanceConfig::default(),
             patterns: PatternsConfig::default(),
@@ -514,6 +516,25 @@ impl Default for HooksSessionEndConfig {
             trailing_messages: DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES,
             min_length: DEFAULT_SESSION_REVIEW_MIN_LENGTH,
             wing: DEFAULT_SESSION_REVIEW_WING.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ApiConfig {
+    /// Start the REST API server automatically when the daemon starts.
+    /// Requires the binary to be built with `--features rest`.
+    pub enabled: bool,
+    /// Address to bind the REST API server on.
+    pub addr: String,
+}
+
+impl Default for ApiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            addr: "127.0.0.1:3080".to_string(),
         }
     }
 }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1962,6 +1962,50 @@ impl Database {
             .query_row(&sql, params_from_iter(values), |row| row.get(0))?)
     }
 
+    pub fn timeline_drawers(
+        &self,
+        wing: Option<&str>,
+        room: Option<&str>,
+        project_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<Drawer>, DbError> {
+        let sql_limit =
+            i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let mut sql = format!(
+            r#"
+            SELECT {DRAWER_SELECT_COLUMNS}
+            FROM drawers
+            WHERE deleted_at IS NULL
+            "#
+        );
+        let mut values: Vec<SqlValue> = Vec::new();
+        if let Some(w) = wing {
+            values.push(SqlValue::Text(w.to_string()));
+            sql.push_str(&format!("AND wing = ?{} ", values.len()));
+        }
+        if let Some(r) = room {
+            values.push(SqlValue::Text(r.to_string()));
+            sql.push_str(&format!("AND room = ?{} ", values.len()));
+        }
+        if let Some(p) = project_id {
+            values.push(SqlValue::Text(p.to_string()));
+            sql.push_str(&format!("AND project_id = ?{} ", values.len()));
+        }
+        values.push(SqlValue::Integer(sql_limit));
+        sql.push_str(&format!(
+            "ORDER BY CAST(added_at AS INTEGER) DESC, id DESC LIMIT ?{}",
+            values.len()
+        ));
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params_from_iter(values), |row| {
+                drawer_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     pub fn purge_deleted(&self, before: Option<&str>) -> Result<u64, DbError> {
         // First collect IDs to purge, then delete from both tables
         let ids: Vec<String> = if let Some(before) = before {

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1993,7 +1993,7 @@ impl Database {
         }
         values.push(SqlValue::Integer(sql_limit));
         sql.push_str(&format!(
-            "ORDER BY CASE WHEN added_at NOT GLOB '20*' THEN datetime(CAST(added_at AS INTEGER), 'unixepoch') ELSE added_at END DESC, id DESC LIMIT ?{}",
+            "ORDER BY CASE WHEN added_at NOT GLOB '20*' THEN strftime('%Y-%m-%dT%H:%M:%SZ', CAST(added_at AS INTEGER), 'unixepoch') ELSE added_at END DESC, id DESC LIMIT ?{}",
             values.len()
         ));
 

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1968,6 +1968,7 @@ impl Database {
         room: Option<&str>,
         project_id: Option<&str>,
         limit: usize,
+        strict_null_only: bool,
     ) -> Result<Vec<Drawer>, DbError> {
         let sql_limit =
             i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
@@ -1990,6 +1991,8 @@ impl Database {
         if let Some(p) = project_id {
             values.push(SqlValue::Text(p.to_string()));
             sql.push_str(&format!("AND project_id = ?{} ", values.len()));
+        } else if strict_null_only {
+            sql.push_str("AND project_id IS NULL ");
         }
         values.push(SqlValue::Integer(sql_limit));
         sql.push_str(&format!(

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1993,7 +1993,7 @@ impl Database {
         }
         values.push(SqlValue::Integer(sql_limit));
         sql.push_str(&format!(
-            "ORDER BY CAST(added_at AS INTEGER) DESC, id DESC LIMIT ?{}",
+            "ORDER BY CASE WHEN added_at NOT GLOB '20*' THEN datetime(CAST(added_at AS INTEGER), 'unixepoch') ELSE added_at END DESC, id DESC LIMIT ?{}",
             values.len()
         ));
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -71,6 +71,44 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     install_shutdown_handlers()?;
     tracing::info!("daemon log path: {}", context.log_path.display());
 
+    // Start REST API alongside the daemon worker loop when the binary was built
+    // with `--features rest` and `[api] enabled = true` (default).
+    #[cfg(feature = "rest")]
+    let _rest_task: Option<tokio::task::JoinHandle<_>> = if context.config.api.enabled {
+        use crate::api::{ApiState, serve as serve_rest_api};
+        use std::sync::Arc;
+
+        let addr = context.config.api.addr.clone();
+        let db_path_rest = {
+            let db = context.db.lock().await;
+            db.path().to_path_buf()
+        };
+        let config_for_rest = context.config.as_ref().clone();
+        match tokio::net::TcpListener::bind(&addr).await {
+            Ok(listener) => {
+                let local_addr = listener
+                    .local_addr()
+                    .context("failed to resolve REST server address")?;
+                tracing::info!("daemon REST listening on http://{local_addr}");
+                eprintln!("daemon REST listening on http://{local_addr}");
+                let factory = crate::embed::ConfiguredEmbedderFactory::new(config_for_rest);
+                let state = ApiState::new(db_path_rest, Arc::new(factory));
+                Some(tokio::spawn(async move {
+                    if let Err(error) = serve_rest_api(listener, state).await {
+                        tracing::error!("daemon REST server error: {error}");
+                    }
+                }))
+            }
+            Err(error) => {
+                tracing::warn!("daemon REST server failed to bind {addr}: {error}");
+                eprintln!("warning: daemon REST server failed to bind {addr}: {error}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let embedder = DaemonEmbedder::from_config(context.config.as_ref())
         .await
         .context("failed to build daemon embedder")?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,16 +63,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
             .context("failed to prune expired audit logs")?;
     }
 
-    if !context.config.hooks.enabled {
-        eprintln!("hooks not enabled; daemon exiting without starting worker loop");
-        return Ok(());
-    }
-
     install_shutdown_handlers()?;
     tracing::info!("daemon log path: {}", context.log_path.display());
 
-    // Start REST API alongside the daemon worker loop when the binary was built
-    // with `--features rest` and `[api] enabled = true` (default).
+    // Start REST API before the hooks check so the API remains available
+    // even when hooks are disabled.
     #[cfg(feature = "rest")]
     let _rest_task: Option<tokio::task::JoinHandle<_>> = if context.config.api.enabled {
         use crate::api::{ApiState, serve as serve_rest_api};
@@ -108,6 +103,16 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     } else {
         None
     };
+
+    if !context.config.hooks.enabled {
+        eprintln!("hooks not enabled; daemon running REST API only (no worker loop)");
+        // Keep the process alive for the REST server.
+        #[cfg(feature = "rest")]
+        if let Some(task) = _rest_task {
+            let _ = task.await;
+        }
+        return Ok(());
+    }
 
     let embedder = DaemonEmbedder::from_config(context.config.as_ref())
         .await


### PR DESCRIPTION
## Summary

- **REST API extension** (`src/api/hermes_compat.rs`): two new endpoints for hermes-agent compatibility
  - `GET /api/timeline` — recent drawers with optional wing/room/project_id/limit filters, ordered by recency
  - `POST /api/delete` — soft-delete a drawer by id
  - Backed by new `Database::timeline_drawers()` method in `core/db.rs`
  - Merged into existing router via `super::hermes_compat::routes()` (one `.merge()` call)
- **Python plugin** (`contrib/hermes-agent-plugin/mempal/`): drop-in MemoryProvider replacing mem0
  - Implements full MemoryProvider ABC: `initialize`, `prefetch`, `queue_prefetch`, `sync_turn`, `get_tool_schemas`, `handle_tool_call`, `on_session_end`, `on_memory_write`, `shutdown`
  - Tools: `mempal_profile` (timeline), `mempal_search` (hybrid BM25+vector), `mempal_conclude` (ingest)
  - Circuit breaker (5 failures → 120s cooldown), stdlib-only (no extra pip deps)
  - User-id routing via wing namespace: `hermes-user/{user_id}`
- **Daemon REST auto-start** (`src/daemon.rs`): REST server now starts automatically in daemon mode
  - New `ApiConfig` in `src/core/config.rs` with `enabled: bool` (default `true`) and `addr: String`
  - `#[cfg(feature = "rest")]` guard — only active when binary built with `--features rest`
  - Bind failure is non-fatal (warns and continues daemon loop)

## Test plan

- [x] `cargo check --features rest` passes
- [x] `cargo check` (without rest) passes
- [x] `cargo test --lib` — 244 tests pass
- [x] `cargo test` — 863 tests pass
- [x] `cargo clippy --all-features --all-targets` — clean
- [x] CSA review passed (session 01KRFCNPXZKXY6YXMCKSKXTFDE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)