### PR TITLE
feat(ingest): auto fact-check gate before embedding (#190)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -7,6 +7,7 @@ use crate::core::{
     },
     utils::{build_bootstrap_evidence_drawer_id, iso_timestamp, source_file_or_synthetic},
 };
+use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
 use crate::search::{resolve_route, search_with_vector};
 use axum::{
@@ -87,6 +88,10 @@ struct IngestResponse {
     drawer_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "is_zero")]
     chunk_count: usize,
+    #[serde(default)]
+    dropped: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fact_check_warnings: Vec<String>,
 }
 
 fn is_zero(v: &usize) -> bool {
@@ -207,10 +212,53 @@ async fn ingest_handler(
         ));
     }
 
-    // Embed all chunks in one batch call.
-    let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
+    let mut accepted_chunks: Vec<(usize, &String, String)> = Vec::with_capacity(chunks.len());
+    let mut fact_check_warnings = Vec::new();
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
+        let drawer_id = build_bootstrap_evidence_drawer_id(
+            &request.wing,
+            request.room.as_deref(),
+            chunk,
+            &SourceType::Manual,
+        );
+        if request.wing != "hooks-raw"
+            && let Some(outcome) = evaluate_fact_check_gate(
+                &drawer_id,
+                chunk,
+                &db,
+                project_id.as_deref(),
+                &config.ingest_gating.fact_check,
+            )
+            .map_err(internal_error)?
+        {
+            fact_check_warnings.extend(outcome.warnings);
+            if outcome.decision.is_rejected() {
+                continue;
+            }
+        }
+        accepted_chunks.push((chunk_idx, chunk, drawer_id));
+    }
+
+    if accepted_chunks.is_empty() {
+        return Ok((
+            StatusCode::CREATED,
+            Json(IngestResponse {
+                drawer_id: String::new(),
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
+                dropped: true,
+                fact_check_warnings,
+            }),
+        ));
+    }
+
+    // Embed all accepted chunks in one batch call.
+    let chunk_refs: Vec<&str> = accepted_chunks
+        .iter()
+        .map(|(_, chunk, _)| chunk.as_str())
+        .collect();
     let vectors = embedder.embed(&chunk_refs).await.map_err(internal_error)?;
-    if vectors.len() != chunks.len() {
+    if vectors.len() != accepted_chunks.len() {
         return Err(ApiError::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "embedder returned wrong number of vectors",
@@ -218,27 +266,23 @@ async fn ingest_handler(
     }
 
     // Insert each chunk as a separate drawer.
-    let mut drawer_ids: Vec<String> = Vec::with_capacity(chunks.len());
-    for (chunk_idx, (chunk, vector)) in chunks.iter().zip(vectors.iter()).enumerate() {
-        let drawer_id = build_bootstrap_evidence_drawer_id(
-            &request.wing,
-            request.room.as_deref(),
-            chunk,
-            &SourceType::Manual,
-        );
-        let drawer_exists = db.drawer_exists(&drawer_id).map_err(internal_error)?;
+    let mut drawer_ids: Vec<String> = Vec::with_capacity(accepted_chunks.len());
+    for ((chunk_idx, chunk, drawer_id), vector) in accepted_chunks.iter().zip(vectors.iter()) {
+        let drawer_exists = db
+            .drawer_exists(drawer_id.as_str())
+            .map_err(internal_error)?;
 
         if !drawer_exists {
-            let source_file = source_file_or_synthetic(&drawer_id, request.source.as_deref());
+            let source_file = source_file_or_synthetic(drawer_id, request.source.as_deref());
             let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
                 id: drawer_id.clone(),
-                content: chunk.clone(),
+                content: chunk.to_string(),
                 wing: request.wing.clone(),
                 room: request.room.clone(),
                 source_file: Some(source_file),
                 source_type: SourceType::Manual,
                 added_at: iso_timestamp(),
-                chunk_index: Some(chunk_idx as i64),
+                chunk_index: Some(*chunk_idx as i64),
                 importance: 0,
             });
             let drawer = Drawer {
@@ -247,20 +291,22 @@ async fn ingest_handler(
             };
             db.insert_drawer_with_project(&drawer, project_id.as_deref())
                 .map_err(internal_error)?;
-            db.insert_vector_with_project(&drawer_id, vector, project_id.as_deref())
+            db.insert_vector_with_project(drawer_id, vector, project_id.as_deref())
                 .map_err(internal_error)?;
         }
-        drawer_ids.push(drawer_id);
+        drawer_ids.push(drawer_id.clone());
     }
 
     let primary_drawer_id = drawer_ids.first().cloned().unwrap_or_default();
-    let chunk_count = chunks.len();
+    let chunk_count = drawer_ids.len();
     Ok((
         StatusCode::CREATED,
         Json(IngestResponse {
             drawer_id: primary_drawer_id,
             drawer_ids,
             chunk_count,
+            dropped: false,
+            fact_check_warnings,
         }),
     ))
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -942,6 +942,7 @@ pub struct IngestGatingConfig {
     pub tier1_skip_events: Vec<String>,
     pub rules: Vec<GatingRuleConfig>,
     pub embedding_classifier: EmbeddingClassifierConfig,
+    pub fact_check: AutoFactCheckConfig,
     pub novelty: NoveltyConfig,
     pub llm_judge: Option<LlmJudgeConfig>,
 }
@@ -953,8 +954,40 @@ impl Default for IngestGatingConfig {
             tier1_skip_events: default_tier1_skip_events(),
             rules: Vec::new(),
             embedding_classifier: EmbeddingClassifierConfig::default(),
+            fact_check: AutoFactCheckConfig::default(),
             novelty: NoveltyConfig::default(),
             llm_judge: None,
+        }
+    }
+}
+
+fn default_false() -> bool {
+    false
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AutoFactCheckConfig {
+    #[serde(default = "default_false")]
+    pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub reject_on_contradiction: bool,
+    #[serde(default = "default_false")]
+    pub reject_on_stale: bool,
+    #[serde(default = "default_false")]
+    pub reject_on_similar_name: bool,
+}
+
+impl Default for AutoFactCheckConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            reject_on_contradiction: true,
+            reject_on_stale: false,
+            reject_on_similar_name: false,
         }
     }
 }

--- a/src/ingest/gating.rs
+++ b/src/ingest/gating.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
 use crate::core::config::{
-    Config, EmbeddingClassifierConfig, GatingRuleConfig, IngestGatingConfig,
+    AutoFactCheckConfig, Config, EmbeddingClassifierConfig, GatingRuleConfig, IngestGatingConfig,
 };
+use crate::core::db::{Database, DbError};
 use crate::embed::{EmbedError, Embedder, EmbedderFactory, build_backend_from_name};
+use crate::factcheck::{self, FactIssue};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -86,6 +88,12 @@ impl GatingDecision {
 pub struct Tier2Outcome {
     pub decision: GatingDecision,
     pub vector: Option<Vec<f32>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FactCheckGateOutcome {
+    pub decision: GatingDecision,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -367,6 +375,149 @@ pub async fn evaluate_tier2<E: Embedder + ?Sized>(
                 vector: None,
             }
         }
+    }
+}
+
+pub fn evaluate_fact_check_gate(
+    candidate_hash: &str,
+    chunk_text: &str,
+    db: &Database,
+    project_id: Option<&str>,
+    config: &AutoFactCheckConfig,
+) -> Result<Option<FactCheckGateOutcome>, DbError> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    let now = match factcheck::resolve_now(None) {
+        Ok(now) => now,
+        Err(error) => {
+            let outcome = fact_check_fail_open_outcome(error.to_string());
+            db.record_gating_audit(
+                candidate_hash,
+                &outcome.decision,
+                project_id,
+                Some(chunk_text),
+            )?;
+            return Ok(Some(outcome));
+        }
+    };
+
+    let report = match factcheck::check(chunk_text, db, now, None) {
+        Ok(report) => report,
+        Err(error) => {
+            let outcome = fact_check_fail_open_outcome(error.to_string());
+            db.record_gating_audit(
+                candidate_hash,
+                &outcome.decision,
+                project_id,
+                Some(chunk_text),
+            )?;
+            return Ok(Some(outcome));
+        }
+    };
+
+    let warnings = report
+        .issues
+        .iter()
+        .map(format_fact_issue_warning)
+        .collect::<Vec<_>>();
+    let decision = fact_check_decision(&report.issues, config);
+    db.record_gating_audit(candidate_hash, &decision, project_id, Some(chunk_text))?;
+    Ok(Some(FactCheckGateOutcome { decision, warnings }))
+}
+
+fn fact_check_decision(issues: &[FactIssue], config: &AutoFactCheckConfig) -> GatingDecision {
+    let rejecting_issue = issues
+        .iter()
+        .find(|issue| fact_issue_rejects(issue, config));
+    if let Some(issue) = rejecting_issue {
+        let label = fact_issue_label(issue).to_string();
+        return GatingDecision {
+            decision: "rejected".to_string(),
+            tier: 3,
+            gating_reason: Some(label.clone()),
+            label: Some(label),
+            score: None,
+            matched_pattern: None,
+        };
+    }
+
+    let label = issues
+        .first()
+        .map(fact_issue_label)
+        .unwrap_or("fact_check.clean")
+        .to_string();
+    GatingDecision {
+        decision: "accepted".to_string(),
+        tier: 3,
+        gating_reason: None,
+        label: Some(label),
+        score: None,
+        matched_pattern: None,
+    }
+}
+
+fn fact_check_fail_open_outcome(error: String) -> FactCheckGateOutcome {
+    FactCheckGateOutcome {
+        decision: GatingDecision {
+            decision: "accepted".to_string(),
+            tier: 3,
+            gating_reason: Some("fact_check.error".to_string()),
+            label: Some("fact_check.error".to_string()),
+            score: None,
+            matched_pattern: None,
+        },
+        warnings: vec![format!("fact_check.error: {error}")],
+    }
+}
+
+fn fact_issue_rejects(issue: &FactIssue, config: &AutoFactCheckConfig) -> bool {
+    match issue {
+        FactIssue::RelationContradiction { .. } => config.reject_on_contradiction,
+        FactIssue::StaleFact { .. } => config.reject_on_stale,
+        FactIssue::SimilarNameConflict { .. } => config.reject_on_similar_name,
+    }
+}
+
+fn fact_issue_label(issue: &FactIssue) -> &'static str {
+    match issue {
+        FactIssue::RelationContradiction { .. } => "fact_check.relation_contradiction",
+        FactIssue::StaleFact { .. } => "fact_check.stale_fact",
+        FactIssue::SimilarNameConflict { .. } => "fact_check.similar_name",
+    }
+}
+
+fn format_fact_issue_warning(issue: &FactIssue) -> String {
+    match issue {
+        FactIssue::SimilarNameConflict {
+            mentioned,
+            known_entity,
+            edit_distance,
+        } => format!(
+            "fact_check.similar_name: mentioned={mentioned} known_entity={known_entity} edit_distance={edit_distance}"
+        ),
+        FactIssue::RelationContradiction {
+            subject,
+            text_claim,
+            kg_fact,
+            triple_id,
+            source_drawer,
+        } => format!(
+            "fact_check.relation_contradiction: subject={subject} text_claim={text_claim} kg_fact={kg_fact} triple_id={triple_id} source_drawer={}",
+            source_drawer.as_deref().unwrap_or("")
+        ),
+        FactIssue::StaleFact {
+            subject,
+            predicate,
+            object,
+            valid_to,
+            triple_id,
+            source_drawer,
+        } => format!(
+            "fact_check.stale_fact: subject={subject} predicate={predicate} object={object} valid_to={valid_to} triple_id={triple_id} source_drawer={}",
+            source_drawer.as_deref().unwrap_or("")
+        ),
     }
 }
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -25,7 +25,9 @@ use crate::core::{
     },
 };
 use crate::embed::{EmbedError, Embedder};
-use crate::ingest::gating::{PrototypeClassifier, evaluate_tier1, evaluate_tier2};
+use crate::ingest::gating::{
+    PrototypeClassifier, evaluate_fact_check_gate, evaluate_tier1, evaluate_tier2,
+};
 use thiserror::Error;
 
 use crate::ingest::{
@@ -55,6 +57,7 @@ pub struct IngestStats {
     pub skipped: usize,
     pub dropped_by_gate: usize,
     pub drawer_ids: Vec<String>,
+    pub fact_check_warnings: Vec<String>,
     pub noise_bytes_stripped: Option<u64>,
     /// Time waited acquiring the per-source ingest lock (P9-B). `None`
     /// when the lock was bypassed (e.g. dry-run) or when no wait was
@@ -391,6 +394,26 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                         source,
                     })?;
                 if decision.is_rejected() {
+                    stats.dropped_by_gate += 1;
+                    continue;
+                }
+            }
+
+            if wing != "hooks-raw"
+                && let Some(outcome) = evaluate_fact_check_gate(
+                    &drawer_id,
+                    chunk,
+                    db,
+                    options.project_id,
+                    &gating.fact_check,
+                )
+                .map_err(|source| IngestError::InsertDrawer {
+                    drawer_id: drawer_id.clone(),
+                    source,
+                })?
+            {
+                stats.fact_check_warnings.extend(outcome.warnings);
+                if outcome.decision.is_rejected() {
                     stats.dropped_by_gate += 1;
                     continue;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use mempal::ingest::gating::compile_classifier_from_config;
 use mempal::ingest::{
     IngestOptions, IngestStats,
     detect::detect_format,
-    gating::{IngestCandidate, evaluate_tier1, evaluate_tier2},
+    gating::{IngestCandidate, evaluate_fact_check_gate, evaluate_tier1, evaluate_tier2},
     ingest_dir_with_options, ingest_file_with_options,
     normalize::{CURRENT_NORMALIZE_VERSION, NormalizeOptions, normalize_content_with_options},
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
@@ -1726,6 +1726,7 @@ async fn ingest_command(
     )
     .context("failed to append ingest audit log")?;
 
+    print_fact_check_warnings(&stats.fact_check_warnings);
     if options.json {
         let output = IngestJsonOutput {
             dry_run: options.dry_run,
@@ -1734,6 +1735,7 @@ async fn ingest_command(
             skipped: stats.skipped,
             dropped_by_gate: stats.dropped_by_gate,
             drawer_ids: &stats.drawer_ids,
+            fact_check_warnings: stats.fact_check_warnings.clone(),
         };
         println!(
             "{}",
@@ -1782,6 +1784,8 @@ struct StdinIngestStatsJson {
     chunks: usize,
     skipped: usize,
     dropped_by_gate: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fact_check_warnings: Vec<String>,
 }
 
 async fn ingest_stdin_command(
@@ -1888,6 +1892,26 @@ async fn ingest_stdin_command(
                 return Ok(());
             }
         }
+
+        if wing != "hooks-raw"
+            && let Some(outcome) = evaluate_fact_check_gate(
+                &drawer_id,
+                &content,
+                db,
+                project_id.as_deref(),
+                &config.ingest_gating.fact_check,
+            )
+            .with_context(|| format!("failed to record fact-check gate audit for {drawer_id}"))?
+        {
+            stats.fact_check_warnings.extend(outcome.warnings);
+            if outcome.decision.is_rejected() {
+                stats.dropped_by_gate = 1;
+                append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+                    .context("failed to append ingest audit log")?;
+                print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+                return Ok(());
+            }
+        }
     }
 
     let texts = [content.as_str()];
@@ -1972,6 +1996,7 @@ fn normalize_stdin_content(content: &str, no_strip_noise: bool) -> Result<String
 }
 
 fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> Result<()> {
+    print_fact_check_warnings(&stats.fact_check_warnings);
     if json {
         let output = StdinIngestJsonOutput {
             drawer_ids: &stats.drawer_ids,
@@ -1981,6 +2006,7 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
                 chunks: stats.chunks,
                 skipped: stats.skipped,
                 dropped_by_gate: stats.dropped_by_gate,
+                fact_check_warnings: stats.fact_check_warnings.clone(),
             },
         };
         println!(
@@ -1996,6 +2022,12 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
         dry_run, stats.files, stats.chunks, stats.skipped, stats.dropped_by_gate
     );
     Ok(())
+}
+
+fn print_fact_check_warnings(warnings: &[String]) {
+    for warning in warnings {
+        eprintln!("{warning}");
+    }
 }
 
 async fn checkpoint_command(
@@ -2291,6 +2323,8 @@ struct IngestJsonOutput<'a> {
     skipped: usize,
     dropped_by_gate: usize,
     drawer_ids: &'a [String],
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    fact_check_warnings: Vec<String>,
 }
 
 #[derive(Default)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -24,7 +24,10 @@ use crate::embed::{EmbedderFactory, global_embed_status};
 use crate::field_taxonomy::field_taxonomy;
 use crate::ingest::{
     IngestError,
-    gating::{GatingDecision, GatingRuntime, IngestCandidate, evaluate_tier1, evaluate_tier2},
+    gating::{
+        GatingDecision, GatingRuntime, IngestCandidate, evaluate_fact_check_gate, evaluate_tier1,
+        evaluate_tier2,
+    },
     normalize::CURRENT_NORMALIZE_VERSION,
     novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty},
 };
@@ -1771,6 +1774,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
+                fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
         }
@@ -1802,6 +1806,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
+                fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
         }
@@ -1902,6 +1907,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms,
+                fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
         }
@@ -1913,6 +1919,40 @@ impl MempalMcpServer {
                 Some(&candidate.content),
             )
             .map_err(db_error)?;
+        }
+
+        let mut fact_check_warnings = Vec::new();
+        if request.wing != "hooks-raw"
+            && let Some(outcome) = evaluate_fact_check_gate(
+                &drawer_id,
+                &candidate.content,
+                &db,
+                project_id.as_deref(),
+                &config.ingest_gating.fact_check,
+            )
+            .map_err(db_error)?
+        {
+            fact_check_warnings = outcome.warnings;
+            gating_decision = Some(outcome.decision);
+            if gating_decision
+                .as_ref()
+                .is_some_and(GatingDecision::is_rejected)
+            {
+                drop(lock_guard);
+                return Ok(Json(IngestResponse {
+                    drawer_id,
+                    drawer_ids: Vec::new(),
+                    chunk_count: 0,
+                    dropped: true,
+                    gating_decision,
+                    novelty_action: None,
+                    near_drawer_id: None,
+                    duplicate_warning: None,
+                    lock_wait_ms,
+                    fact_check_warnings,
+                    system_warnings: current_system_warnings(),
+                }));
+            }
         }
 
         let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
@@ -2323,6 +2363,7 @@ impl MempalMcpServer {
             near_drawer_id,
             duplicate_warning,
             lock_wait_ms,
+            fact_check_warnings,
             system_warnings: current_system_warnings(),
         }))
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -886,6 +886,8 @@ pub struct IngestResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lock_wait_ms: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fact_check_warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
 }
 

--- a/tests/auto_fact_check_gate.rs
+++ b/tests/auto_fact_check_gate.rs
@@ -1,0 +1,233 @@
+//! Integration tests for the automatic ingest fact-check gate.
+
+use std::fs;
+use std::path::Path;
+
+use mempal::core::config::{AutoFactCheckConfig, IngestGatingConfig};
+use mempal::core::db::Database;
+use mempal::core::types::Triple;
+use mempal::core::utils::build_triple_id;
+use mempal::embed::{Embedder, Result as EmbedResult};
+use mempal::ingest::{IngestOptions, ingest_file_with_options};
+use tempfile::TempDir;
+
+#[derive(Default)]
+struct StubEmbedder;
+
+#[async_trait::async_trait]
+impl Embedder for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> EmbedResult<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "stub"
+    }
+}
+
+fn new_test_db() -> (TempDir, Database) {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    (tmp, db)
+}
+
+fn write_input(dir: &Path, content: &str) -> std::path::PathBuf {
+    let path = dir.join("input.md");
+    fs::write(&path, content).expect("write input");
+    path
+}
+
+fn insert_triple(db: &Database, subject: &str, predicate: &str, object: &str) {
+    let triple = Triple {
+        id: build_triple_id(subject, predicate, object),
+        subject: subject.to_string(),
+        predicate: predicate.to_string(),
+        object: object.to_string(),
+        valid_from: Some("1700000000".to_string()),
+        valid_to: None,
+        confidence: 1.0,
+        source_drawer: None,
+    };
+    db.insert_triple(&triple).expect("insert triple");
+}
+
+fn gating(fact_check: AutoFactCheckConfig) -> IngestGatingConfig {
+    IngestGatingConfig {
+        fact_check,
+        ..IngestGatingConfig::default()
+    }
+}
+
+fn enabled_fact_check(reject_on_contradiction: bool) -> AutoFactCheckConfig {
+    AutoFactCheckConfig {
+        enabled: true,
+        reject_on_contradiction,
+        reject_on_stale: false,
+        reject_on_similar_name: false,
+    }
+}
+
+async fn ingest_with_gating(
+    db: &Database,
+    path: &Path,
+    wing: &str,
+    gating: &IngestGatingConfig,
+) -> mempal::ingest::IngestStats {
+    ingest_file_with_options(
+        db,
+        &StubEmbedder,
+        path,
+        wing,
+        IngestOptions {
+            room: Some("decision"),
+            gating: Some(gating),
+            project_id: Some("test-project"),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest")
+}
+
+fn fact_audit_rows(db: &Database) -> Vec<(String, Option<String>, Option<String>)> {
+    let mut stmt = db
+        .conn()
+        .prepare(
+            "SELECT decision, label, reason FROM gating_audit WHERE label LIKE 'fact_check.%' ORDER BY created_at, id",
+        )
+        .expect("prepare audit query");
+    stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .expect("query audit")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect audit")
+}
+
+#[tokio::test]
+async fn test_fact_check_contradiction_rejects_when_enabled() {
+    let (tmp, db) = new_test_db();
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(enabled_fact_check(true));
+
+    let stats = ingest_with_gating(&db, &path, "mempal", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 1);
+    assert!(stats.drawer_ids.is_empty());
+    assert!(
+        stats
+            .fact_check_warnings
+            .iter()
+            .any(|w| w.contains("fact_check.relation_contradiction"))
+    );
+    assert_eq!(db.drawer_count().expect("drawer count"), 0);
+    let rows = fact_audit_rows(&db);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "skip");
+    assert_eq!(
+        rows[0].1.as_deref(),
+        Some("fact_check.relation_contradiction")
+    );
+}
+
+#[tokio::test]
+async fn test_fact_check_contradiction_warns_when_rejection_disabled() {
+    let (tmp, db) = new_test_db();
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(enabled_fact_check(false));
+
+    let stats = ingest_with_gating(&db, &path, "mempal", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 0);
+    assert_eq!(stats.drawer_ids.len(), 1);
+    assert!(
+        stats
+            .fact_check_warnings
+            .iter()
+            .any(|w| w.contains("fact_check.relation_contradiction"))
+    );
+    let rows = fact_audit_rows(&db);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "keep");
+    assert_eq!(
+        rows[0].1.as_deref(),
+        Some("fact_check.relation_contradiction")
+    );
+}
+
+#[tokio::test]
+async fn test_fact_check_clean_passes_without_warnings() {
+    let (tmp, db) = new_test_db();
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let path = write_input(tmp.path(), "Bob is Alice's husband.");
+    let gating = gating(enabled_fact_check(true));
+
+    let stats = ingest_with_gating(&db, &path, "mempal", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 0);
+    assert_eq!(stats.drawer_ids.len(), 1);
+    assert!(stats.fact_check_warnings.is_empty());
+    let rows = fact_audit_rows(&db);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "keep");
+    assert_eq!(rows[0].1.as_deref(), Some("fact_check.clean"));
+}
+
+#[tokio::test]
+async fn test_hooks_raw_bypasses_fact_check_gate() {
+    let (tmp, db) = new_test_db();
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(enabled_fact_check(true));
+
+    let stats = ingest_with_gating(&db, &path, "hooks-raw", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 0);
+    assert_eq!(stats.drawer_ids.len(), 1);
+    assert!(stats.fact_check_warnings.is_empty());
+    assert!(fact_audit_rows(&db).is_empty());
+}
+
+#[tokio::test]
+async fn test_fact_check_engine_error_fails_open_with_warning() {
+    let (tmp, db) = new_test_db();
+    db.conn()
+        .execute_batch("DROP TABLE triples;")
+        .expect("drop triples");
+    let path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(enabled_fact_check(true));
+
+    let stats = ingest_with_gating(&db, &path, "mempal", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 0);
+    assert_eq!(stats.drawer_ids.len(), 1);
+    assert!(
+        stats
+            .fact_check_warnings
+            .iter()
+            .any(|w| w.contains("fact_check.error"))
+    );
+    let rows = fact_audit_rows(&db);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "keep");
+    assert_eq!(rows[0].1.as_deref(), Some("fact_check.error"));
+}
+
+#[tokio::test]
+async fn test_fact_check_config_disabled_skips_gate_entirely() {
+    let (tmp, db) = new_test_db();
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(AutoFactCheckConfig::default());
+
+    let stats = ingest_with_gating(&db, &path, "mempal", &gating).await;
+
+    assert_eq!(stats.dropped_by_gate, 0);
+    assert_eq!(stats.drawer_ids.len(), 1);
+    assert!(stats.fact_check_warnings.is_empty());
+    assert!(fact_audit_rows(&db).is_empty());
+}


### PR DESCRIPTION
## Summary

- Add automatic fact-check gate on the ingest path (Stage 5.5) — runs existing deterministic `factcheck::check()` engine before embedding
- New config: `[ingest_gating.auto_fact_check]` with per-issue-type toggles (`reject_on_contradiction`, `reject_on_stale`, `reject_on_similar_name`)
- Fail-open: engine errors → accepted with warning (never blocks ingest)
- `hooks-raw` wing bypasses gate automatically
- Warnings propagated to all consumers: MCP `mempal_ingest`, REST `/api/ingest`, CLI `mempal ingest`
- 6 new integration tests covering: conflict rejection, warning-only mode, clean pass-through, hooks-raw bypass, engine error fail-open, disabled config

## Test plan

- [x] `cargo test` — all 6 new + existing tests pass
- [x] `cargo clippy` — no warnings
- [x] Tier-4 review: PASS (1 LOW finding — R2-001 directory warning aggregation, non-blocking)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)