### PR TITLE
feat(ingest): replace/supersede CRUD semantics (#186)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -205,7 +205,7 @@ async fn ingest_handler(
         .await
         .map_err(internal_error)?;
     let db = Database::open(&state.db_path).map_err(internal_error)?;
-    let config = ConfigHandle::current();
+    let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
 
@@ -219,10 +219,14 @@ async fn ingest_handler(
         ));
     }
 
+    let scrubbed_replace_text = request
+        .replace_text
+        .as_deref()
+        .map(|text| config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
     let replacement_target = db
         .resolve_replacement_target(
             request.supersedes.as_deref(),
-            request.replace_text.as_deref(),
+            scrubbed_replace_text.as_deref(),
             &request.wing,
             request.room.as_deref(),
             project_id.as_deref(),
@@ -232,6 +236,7 @@ async fn ingest_handler(
         .as_ref()
         .map(|summary| summary.id.clone());
     let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
+    let mut superseded_response_id: Option<String> = None;
 
     let mut accepted_chunks: Vec<(usize, &String, String, bool)> = Vec::with_capacity(chunks.len());
     let mut fact_check_warnings = Vec::new();
@@ -283,7 +288,7 @@ async fn ingest_handler(
                 drawer_ids: Vec::new(),
                 chunk_count: 0,
                 dropped: true,
-                superseded_drawer_id,
+                superseded_drawer_id: None,
                 fact_check_warnings,
             }),
         ));
@@ -297,6 +302,7 @@ async fn ingest_handler(
         if let Some(old_id) = superseded_drawer_id.as_deref() {
             let replacement_id = drawer_ids.first().map(String::as_str).unwrap_or("existing");
             supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+            superseded_response_id = Some(old_id.to_string());
         }
         let primary_drawer_id = drawer_ids.first().cloned().unwrap_or_default();
         return Ok((
@@ -306,7 +312,7 @@ async fn ingest_handler(
                 drawer_ids,
                 chunk_count: accepted_chunks.len(),
                 dropped: false,
-                superseded_drawer_id,
+                superseded_drawer_id: superseded_response_id,
                 fact_check_warnings,
             }),
         ));
@@ -327,7 +333,6 @@ async fn ingest_handler(
 
     // Insert each chunk as a separate drawer.
     let mut drawer_ids: Vec<String> = Vec::with_capacity(accepted_chunks.len());
-    let mut supersede_pending = superseded_drawer_id.clone();
     for ((chunk_idx, chunk, drawer_id, exact_duplicate), vector) in
         accepted_chunks.iter().zip(vectors.iter())
     {
@@ -337,9 +342,6 @@ async fn ingest_handler(
                 .map_err(internal_error)?;
 
         if !drawer_exists {
-            if let Some(old_id) = supersede_pending.take() {
-                supersede_drawer_for_ingest(&db, &old_id, drawer_id)?;
-            }
             let source_file = source_file_or_synthetic(drawer_id, request.source.as_deref());
             let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
                 id: drawer_id.clone(),
@@ -368,6 +370,13 @@ async fn ingest_handler(
         drawer_ids.push(drawer_id.clone());
     }
 
+    if let Some(old_id) = superseded_drawer_id.as_deref()
+        && let Some(replacement_id) = drawer_ids.first()
+    {
+        supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+        superseded_response_id = Some(old_id.to_string());
+    }
+
     let primary_drawer_id = drawer_ids.first().cloned().unwrap_or_default();
     let chunk_count = drawer_ids.len();
     Ok((
@@ -377,7 +386,7 @@ async fn ingest_handler(
             drawer_ids,
             chunk_count,
             dropped: false,
-            superseded_drawer_id,
+            superseded_drawer_id: superseded_response_id,
             fact_check_warnings,
         }),
     ))

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -5,7 +5,10 @@ use crate::core::{
     types::{
         BootstrapEvidenceArgs, Drawer, RouteDecision, SearchResult, SourceType, TaxonomyEntry,
     },
-    utils::{build_bootstrap_evidence_drawer_id, iso_timestamp, source_file_or_synthetic},
+    utils::{
+        build_bootstrap_evidence_drawer_id, iso_timestamp, link_superseded_drawer,
+        source_file_or_synthetic,
+    },
 };
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
@@ -79,6 +82,8 @@ struct IngestRequest {
     room: Option<String>,
     source: Option<String>,
     project_id: Option<String>,
+    supersedes: Option<String>,
+    replace_text: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -90,6 +95,8 @@ struct IngestResponse {
     chunk_count: usize,
     #[serde(default)]
     dropped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    superseded_drawer_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fact_check_warnings: Vec<String>,
 }
@@ -212,15 +219,44 @@ async fn ingest_handler(
         ));
     }
 
-    let mut accepted_chunks: Vec<(usize, &String, String)> = Vec::with_capacity(chunks.len());
+    let replacement_target = db
+        .resolve_replacement_target(
+            request.supersedes.as_deref(),
+            request.replace_text.as_deref(),
+            &request.wing,
+            request.room.as_deref(),
+            project_id.as_deref(),
+        )
+        .map_err(replacement_error)?;
+    let superseded_drawer_id = replacement_target
+        .as_ref()
+        .map(|summary| summary.id.clone());
+    let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
+
+    let mut accepted_chunks: Vec<(usize, &String, String, bool)> = Vec::with_capacity(chunks.len());
     let mut fact_check_warnings = Vec::new();
     for (chunk_idx, chunk) in chunks.iter().enumerate() {
-        let drawer_id = build_bootstrap_evidence_drawer_id(
+        if let Some(existing_id) = exact_duplicate_drawer_id(
+            &db,
+            chunk,
+            &request.wing,
+            request.room.as_deref(),
+            project_id.as_deref(),
+            superseded_drawer_id_ref,
+        )? {
+            accepted_chunks.push((chunk_idx, chunk, existing_id, true));
+            continue;
+        }
+
+        let preferred_drawer_id = build_bootstrap_evidence_drawer_id(
             &request.wing,
             request.room.as_deref(),
             chunk,
             &SourceType::Manual,
         );
+        let drawer_id = db
+            .resolve_available_drawer_id(&preferred_drawer_id)
+            .map_err(internal_error)?;
         if request.wing != "hooks-raw"
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
@@ -236,7 +272,7 @@ async fn ingest_handler(
                 continue;
             }
         }
-        accepted_chunks.push((chunk_idx, chunk, drawer_id));
+        accepted_chunks.push((chunk_idx, chunk, drawer_id, false));
     }
 
     if accepted_chunks.is_empty() {
@@ -247,6 +283,30 @@ async fn ingest_handler(
                 drawer_ids: Vec::new(),
                 chunk_count: 0,
                 dropped: true,
+                superseded_drawer_id,
+                fact_check_warnings,
+            }),
+        ));
+    }
+
+    if accepted_chunks.iter().all(|(_, _, _, exists)| *exists) {
+        let drawer_ids = accepted_chunks
+            .iter()
+            .map(|(_, _, drawer_id, _)| drawer_id.clone())
+            .collect::<Vec<_>>();
+        if let Some(old_id) = superseded_drawer_id.as_deref() {
+            let replacement_id = drawer_ids.first().map(String::as_str).unwrap_or("existing");
+            supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+        }
+        let primary_drawer_id = drawer_ids.first().cloned().unwrap_or_default();
+        return Ok((
+            StatusCode::CREATED,
+            Json(IngestResponse {
+                drawer_id: primary_drawer_id,
+                drawer_ids,
+                chunk_count: accepted_chunks.len(),
+                dropped: false,
+                superseded_drawer_id,
                 fact_check_warnings,
             }),
         ));
@@ -255,7 +315,7 @@ async fn ingest_handler(
     // Embed all accepted chunks in one batch call.
     let chunk_refs: Vec<&str> = accepted_chunks
         .iter()
-        .map(|(_, chunk, _)| chunk.as_str())
+        .map(|(_, chunk, _, _)| chunk.as_str())
         .collect();
     let vectors = embedder.embed(&chunk_refs).await.map_err(internal_error)?;
     if vectors.len() != accepted_chunks.len() {
@@ -267,12 +327,19 @@ async fn ingest_handler(
 
     // Insert each chunk as a separate drawer.
     let mut drawer_ids: Vec<String> = Vec::with_capacity(accepted_chunks.len());
-    for ((chunk_idx, chunk, drawer_id), vector) in accepted_chunks.iter().zip(vectors.iter()) {
-        let drawer_exists = db
-            .drawer_exists(drawer_id.as_str())
-            .map_err(internal_error)?;
+    let mut supersede_pending = superseded_drawer_id.clone();
+    for ((chunk_idx, chunk, drawer_id, exact_duplicate), vector) in
+        accepted_chunks.iter().zip(vectors.iter())
+    {
+        let drawer_exists = *exact_duplicate
+            || db
+                .drawer_exists(drawer_id.as_str())
+                .map_err(internal_error)?;
 
         if !drawer_exists {
+            if let Some(old_id) = supersede_pending.take() {
+                supersede_drawer_for_ingest(&db, &old_id, drawer_id)?;
+            }
             let source_file = source_file_or_synthetic(drawer_id, request.source.as_deref());
             let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
                 id: drawer_id.clone(),
@@ -289,6 +356,10 @@ async fn ingest_handler(
                 normalize_version: CURRENT_NORMALIZE_VERSION,
                 ..drawer
             };
+            let mut drawer = drawer;
+            if let Some(old_id) = superseded_drawer_id.as_deref() {
+                link_superseded_drawer(&mut drawer, old_id);
+            }
             db.insert_drawer_with_project(&drawer, project_id.as_deref())
                 .map_err(internal_error)?;
             db.insert_vector_with_project(drawer_id, vector, project_id.as_deref())
@@ -306,6 +377,7 @@ async fn ingest_handler(
             drawer_ids,
             chunk_count,
             dropped: false,
+            superseded_drawer_id,
             fact_check_warnings,
         }),
     ))
@@ -377,6 +449,41 @@ impl IntoResponse for ApiError {
 
 fn internal_error(error: impl std::fmt::Display) -> ApiError {
     ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+fn replacement_error(error: crate::core::db::DbError) -> ApiError {
+    match error {
+        crate::core::db::DbError::ReplacementTargetConflict
+        | crate::core::db::DbError::SupersededDrawerNotFound { .. }
+        | crate::core::db::DbError::SupersededDrawerProjectMismatch { .. }
+        | crate::core::db::DbError::ReplacementTextNotFound
+        | crate::core::db::DbError::ReplacementTextAmbiguous { .. } => {
+            ApiError::new(StatusCode::BAD_REQUEST, error.to_string())
+        }
+        _ => internal_error(error),
+    }
+}
+
+fn exact_duplicate_drawer_id(
+    db: &Database,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+    excluded_drawer_id: Option<&str>,
+) -> Result<Option<String>, ApiError> {
+    Ok(db
+        .find_active_drawers_by_content(content, wing, room, project_id)
+        .map_err(internal_error)?
+        .into_iter()
+        .find(|summary| Some(summary.id.as_str()) != excluded_drawer_id)
+        .map(|summary| summary.id))
+}
+
+fn supersede_drawer_for_ingest(db: &Database, old_id: &str, new_id: &str) -> Result<(), ApiError> {
+    db.supersede_drawer(old_id, &format!("replaced by {new_id}"))
+        .map_err(internal_error)?;
+    Ok(())
 }
 
 impl From<SearchResult> for SearchResultDto {

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1466,6 +1466,21 @@ impl Database {
         Ok(exists == 1)
     }
 
+    pub fn resolve_available_drawer_id(&self, preferred_id: &str) -> Result<String, DbError> {
+        if !self.drawer_id_in_use(preferred_id)? {
+            return Ok(preferred_id.to_string());
+        }
+
+        let mut suffix = 2usize;
+        loop {
+            let candidate = format!("{preferred_id}_{suffix}");
+            if !self.drawer_id_in_use(&candidate)? {
+                return Ok(candidate);
+            }
+            suffix += 1;
+        }
+    }
+
     fn find_active_drawer_id_by_identity(
         &self,
         wing: &str,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -7,7 +7,8 @@ pub use db_fork_ext::{
     read_fork_ext_version, set_fork_ext_version,
 };
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -22,12 +23,12 @@ use thiserror::Error;
 use super::anchor;
 use super::{
     types::{
-        AnchorKind, ChunkNeighbors, Drawer, DrawerDetails, ExplicitTunnel, KnowledgeCard,
-        KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink,
-        KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
-        NeighborChunk, Provenance, ReindexSource, RuntimeAdoptionEvent, RuntimeAdoptionFilter,
-        RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType, TaxonomyEntry, Triple,
-        TripleStats, TunnelDrawer, TunnelEndpoint, TunnelFollowResult,
+        AnchorKind, ChunkNeighbors, Drawer, DrawerDetails, DrawerSummary, ExplicitTunnel,
+        KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
+        KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
+        MemoryKind, NeighborChunk, Provenance, ReindexSource, RuntimeAdoptionEvent,
+        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
+        TaxonomyEntry, Triple, TripleStats, TunnelDrawer, TunnelEndpoint, TunnelFollowResult,
     },
     utils::{
         build_drawer_id, build_scoped_drawer_id, build_tunnel_id, current_timestamp,
@@ -145,6 +146,18 @@ pub enum DbError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to open audit log {path}")]
+    AuditOpen {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to write audit log {path}")]
+    AuditWrite {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error(transparent)]
     Sqlite(#[from] rusqlite::Error),
     #[error("failed to parse taxonomy keywords JSON")]
@@ -161,6 +174,22 @@ pub enum DbError {
     RegisterVec(String),
     #[error("database schema version {current} is newer than supported version {supported}")]
     UnsupportedSchemaVersion { current: u32, supported: u32 },
+    #[error("supersedes and replace_text are mutually exclusive")]
+    ReplacementTargetConflict,
+    #[error("superseded drawer {drawer_id} was not found or is already deleted")]
+    SupersededDrawerNotFound { drawer_id: String },
+    #[error(
+        "superseded drawer {drawer_id} belongs to project scope {actual:?}, expected {expected:?}"
+    )]
+    SupersededDrawerProjectMismatch {
+        drawer_id: String,
+        expected: Option<String>,
+        actual: Option<String>,
+    },
+    #[error("no matching active fact found for replace_text")]
+    ReplacementTextNotFound,
+    #[error("multiple matching active facts found for replace_text; candidates: {candidate_ids:?}")]
+    ReplacementTextAmbiguous { candidate_ids: Vec<String> },
 }
 
 pub struct Database {
@@ -745,6 +774,97 @@ impl Database {
             |row| row.get::<_, i64>(0),
         )?;
         Ok(exists == 1)
+    }
+
+    pub fn drawer_exists_exact(
+        &self,
+        content: &str,
+        wing: &str,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<bool, DbError> {
+        Ok(!self
+            .find_active_drawers_by_content(content, wing, room, project_id)?
+            .is_empty())
+    }
+
+    pub fn find_active_drawers_by_content(
+        &self,
+        text: &str,
+        wing: &str,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<Vec<DrawerSummary>, DbError> {
+        let content_hash = content_hash_hex(text);
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT id, wing, room, source_file, project_id, added_at
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND content_hash = ?1
+              AND content = ?2
+              AND wing = ?3
+              AND ((room IS NULL AND ?4 IS NULL) OR room = ?4)
+              AND ((project_id IS NULL AND ?5 IS NULL) OR project_id = ?5)
+            ORDER BY added_at DESC, id
+            "#,
+        )?;
+        let rows =
+            statement.query_map(params![content_hash, text, wing, room, project_id], |row| {
+                Ok(DrawerSummary {
+                    id: row.get(0)?,
+                    wing: row.get(1)?,
+                    room: row.get(2)?,
+                    source_file: row.get(3)?,
+                    project_id: row.get(4)?,
+                    added_at: row.get(5)?,
+                })
+            })?;
+
+        let mut summaries = Vec::new();
+        for row in rows {
+            summaries.push(row?);
+        }
+        Ok(summaries)
+    }
+
+    pub fn resolve_replacement_target(
+        &self,
+        supersedes: Option<&str>,
+        replace_text: Option<&str>,
+        wing: &str,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<Option<DrawerSummary>, DbError> {
+        match (supersedes, replace_text) {
+            (Some(_), Some(_)) => Err(DbError::ReplacementTargetConflict),
+            (Some(drawer_id), None) => {
+                let details = self.get_drawer_details(drawer_id)?.ok_or_else(|| {
+                    DbError::SupersededDrawerNotFound {
+                        drawer_id: drawer_id.to_string(),
+                    }
+                })?;
+                if details.project_id.as_deref() != project_id {
+                    return Err(DbError::SupersededDrawerProjectMismatch {
+                        drawer_id: drawer_id.to_string(),
+                        expected: project_id.map(ToOwned::to_owned),
+                        actual: details.project_id,
+                    });
+                }
+                Ok(Some(drawer_summary_from_details(details)))
+            }
+            (None, Some(text)) => {
+                let matches = self.find_active_drawers_by_content(text, wing, room, project_id)?;
+                match matches.len() {
+                    0 => Err(DbError::ReplacementTextNotFound),
+                    1 => Ok(matches.into_iter().next()),
+                    _ => Err(DbError::ReplacementTextAmbiguous {
+                        candidate_ids: matches.into_iter().map(|summary| summary.id).collect(),
+                    }),
+                }
+            }
+            (None, None) => Ok(None),
+        }
     }
 
     pub fn resolve_ingest_drawer_id(
@@ -1916,6 +2036,50 @@ impl Database {
             params![timestamp, drawer_id],
         )?;
         Ok(affected > 0)
+    }
+
+    pub fn supersede_drawer(&self, old_id: &str, reason: &str) -> Result<bool, DbError> {
+        let timestamp = super::utils::current_timestamp();
+        let affected = self.conn.execute(
+            "UPDATE drawers SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            params![timestamp, old_id],
+        )?;
+        if affected > 0 {
+            self.append_supersede_audit_entry(old_id, reason, &timestamp)?;
+        }
+        Ok(affected > 0)
+    }
+
+    fn append_supersede_audit_entry(
+        &self,
+        old_id: &str,
+        reason: &str,
+        timestamp: &str,
+    ) -> Result<(), DbError> {
+        let audit_path = self
+            .path
+            .parent()
+            .map(|parent| parent.join("audit.jsonl"))
+            .unwrap_or_else(|| PathBuf::from("audit.jsonl"));
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&audit_path)
+            .map_err(|source| DbError::AuditOpen {
+                path: audit_path.clone(),
+                source,
+            })?;
+        let entry = serde_json::json!({
+            "timestamp": timestamp,
+            "command": "supersede",
+            "drawer_id": old_id,
+            "reason": reason,
+        });
+        writeln!(file, "{entry}").map_err(|source| DbError::AuditWrite {
+            path: audit_path,
+            source,
+        })?;
+        Ok(())
     }
 
     pub fn soft_delete_drawers_since(
@@ -3940,6 +4104,17 @@ fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {
     })
 }
 
+fn drawer_summary_from_details(details: DrawerDetails) -> DrawerSummary {
+    DrawerSummary {
+        id: details.drawer.id,
+        wing: details.drawer.wing,
+        room: details.drawer.room,
+        source_file: details.drawer.source_file,
+        project_id: details.project_id,
+        added_at: details.drawer.added_at,
+    }
+}
+
 fn parse_keywords(raw: Option<&str>) -> Result<Vec<String>, DbError> {
     let Some(raw) = raw else {
         return Ok(Vec::new());
@@ -3975,6 +4150,99 @@ fn build_fts_match_query(query: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_drawer(id: &str, content: &str) -> Drawer {
+        Drawer::new_bootstrap_evidence(super::super::types::BootstrapEvidenceArgs {
+            id: id.to_string(),
+            content: content.to_string(),
+            wing: "test-wing".to_string(),
+            room: Some("test-room".to_string()),
+            source_file: Some(format!("{id}.md")),
+            source_type: SourceType::Manual,
+            added_at: "2026-05-13T00:00:00Z".to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+        })
+    }
+
+    fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
+        db.insert_drawer_with_project(&test_drawer(id, content), project_id)
+            .expect("insert drawer");
+    }
+
+    #[test]
+    fn test_find_active_drawers_by_content_respects_scope_and_soft_delete() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        insert_test_drawer(&db, "same-project", "same fact", Some("project-a"));
+        insert_test_drawer(&db, "other-project", "same fact", Some("project-b"));
+        insert_test_drawer(&db, "deleted", "same fact", Some("project-a"));
+        db.soft_delete_drawer("deleted").expect("soft delete");
+
+        let matches = db
+            .find_active_drawers_by_content(
+                "same fact",
+                "test-wing",
+                Some("test-room"),
+                Some("project-a"),
+            )
+            .expect("find matches");
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].id, "same-project");
+        assert!(
+            db.drawer_exists_exact(
+                "same fact",
+                "test-wing",
+                Some("test-room"),
+                Some("project-a")
+            )
+            .expect("exists exact")
+        );
+    }
+
+    #[test]
+    fn test_supersede_drawer_soft_deletes_and_writes_audit() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        insert_test_drawer(&db, "old", "old fact", Some("project-a"));
+
+        let superseded = db
+            .supersede_drawer("old", "replaced by new")
+            .expect("supersede");
+
+        assert!(superseded);
+        assert!(!db.drawer_exists("old").expect("drawer exists"));
+        let audit = fs::read_to_string(tempdir.path().join("audit.jsonl")).expect("read audit");
+        assert!(audit.contains("\"command\":\"supersede\""));
+        assert!(audit.contains("\"drawer_id\":\"old\""));
+        assert!(audit.contains("\"reason\":\"replaced by new\""));
+    }
+
+    #[test]
+    fn test_resolve_replacement_target_rejects_project_mismatch() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        insert_test_drawer(&db, "old", "old fact", Some("project-a"));
+
+        let error = db
+            .resolve_replacement_target(
+                Some("old"),
+                None,
+                "test-wing",
+                Some("test-room"),
+                Some("project-b"),
+            )
+            .expect_err("project mismatch");
+
+        assert!(matches!(
+            error,
+            DbError::SupersededDrawerProjectMismatch { .. }
+        ));
+    }
 
     #[test]
     fn test_atomic_migration_rolls_back_partial_schema_changes() {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -379,6 +379,16 @@ pub struct DrawerDetails {
     pub project_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrawerSummary {
+    pub id: String,
+    pub wing: String,
+    pub room: Option<String>,
+    pub source_file: Option<String>,
+    pub project_id: Option<String>,
+    pub added_at: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TunnelDrawer {
     pub drawer: Drawer,

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use super::{
     anchor,
     types::{
-        AnchorKind, BootstrapIdentityParts, KnowledgeStatus, KnowledgeTier, MemoryDomain,
+        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeStatus, KnowledgeTier, MemoryDomain,
         MemoryKind, Provenance, SourceType, TaxonomyEntry, TunnelEndpoint,
     },
 };
@@ -160,6 +160,17 @@ pub fn build_bootstrap_evidence_drawer_id(
             trigger_hints: None,
         },
     )
+}
+
+pub fn link_superseded_drawer(drawer: &mut Drawer, old_id: &str) {
+    let marker = format!("supersedes:{old_id}");
+    match drawer.scope_constraints.as_mut() {
+        Some(existing) if !existing.trim().is_empty() => {
+            existing.push_str("; ");
+            existing.push_str(&marker);
+        }
+        _ => drawer.scope_constraints = Some(marker),
+    }
 }
 
 pub fn build_triple_id(subject: &str, predicate: &str, object: &str) -> String {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -20,7 +20,7 @@ use crate::core::{
     db::Database,
     types::{BootstrapEvidenceArgs, Drawer, SourceType},
     utils::{
-        build_bootstrap_evidence_drawer_id, build_drawer_id, iso_timestamp,
+        build_bootstrap_evidence_drawer_id, build_drawer_id, iso_timestamp, link_superseded_drawer,
         route_room_from_taxonomy,
     },
 };
@@ -59,6 +59,7 @@ pub struct IngestStats {
     pub drawer_ids: Vec<String>,
     pub fact_check_warnings: Vec<String>,
     pub noise_bytes_stripped: Option<u64>,
+    pub superseded_drawer_id: Option<String>,
     /// Time waited acquiring the per-source ingest lock (P9-B). `None`
     /// when the lock was bypassed (e.g. dry-run) or when no wait was
     /// needed and the path took the fast exit before lock acquisition.
@@ -78,6 +79,8 @@ pub struct IngestOptions<'a> {
     pub no_strip_noise: bool,
     pub diary_rollup: bool,
     pub diary_rollup_day: Option<&'a str>,
+    pub supersedes: Option<&'a str>,
+    pub replace_text: Option<&'a str>,
 }
 
 pub type Result<T> = std::result::Result<T, IngestError>;
@@ -123,6 +126,17 @@ pub enum IngestError {
     #[error("failed to replace source drawers for {source_file}")]
     ReplaceSource {
         source_file: String,
+        #[source]
+        source: crate::core::db::DbError,
+    },
+    #[error("failed to resolve replacement target")]
+    ResolveReplacement {
+        #[source]
+        source: crate::core::db::DbError,
+    },
+    #[error("failed to supersede drawer {drawer_id}")]
+    SupersedeDrawer {
+        drawer_id: String,
         #[source]
         source: crate::core::db::DbError,
     },
@@ -207,6 +221,8 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
             no_strip_noise: false,
             diary_rollup: false,
             diary_rollup_day: None,
+            supersedes: None,
+            replace_text: None,
         },
     )
     .await
@@ -341,15 +357,57 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             })?;
     }
 
+    let scrubbed_replace_text = options
+        .replace_text
+        .map(|text| config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
+    let replacement_target = db
+        .resolve_replacement_target(
+            options.supersedes,
+            scrubbed_replace_text.as_deref(),
+            wing,
+            Some(resolved_room.as_str()),
+            options.project_id,
+        )
+        .map_err(|source| IngestError::ResolveReplacement { source })?;
+    stats.superseded_drawer_id = replacement_target
+        .as_ref()
+        .map(|summary| summary.id.clone());
+    let replacement_target_id = stats.superseded_drawer_id.as_deref();
+
     let mut pending = Vec::new();
 
     for (chunk_index, chunk) in chunks.iter().enumerate() {
-        let drawer_id = build_bootstrap_evidence_drawer_id(
+        let exact_duplicate = db
+            .find_active_drawers_by_content(
+                chunk,
+                wing,
+                Some(resolved_room.as_str()),
+                options.project_id,
+            )
+            .map_err(|source| IngestError::CheckDrawer {
+                drawer_id: build_drawer_id(wing, Some(resolved_room.as_str()), chunk),
+                source,
+            })?
+            .into_iter()
+            .find(|summary| Some(summary.id.as_str()) != replacement_target_id);
+        if let Some(existing) = exact_duplicate {
+            stats.skipped += 1;
+            stats.drawer_ids.push(existing.id);
+            continue;
+        }
+
+        let preferred_drawer_id = build_bootstrap_evidence_drawer_id(
             wing,
             Some(resolved_room.as_str()),
             chunk,
             &source_type,
         );
+        let drawer_id = db
+            .resolve_available_drawer_id(&preferred_drawer_id)
+            .map_err(|source| IngestError::CheckDrawer {
+                drawer_id: preferred_drawer_id.clone(),
+                source,
+            })?;
         let exists = db
             .drawer_exists(&drawer_id)
             .map_err(|source| IngestError::CheckDrawer {
@@ -424,6 +482,17 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     }
 
     if options.dry_run || pending.is_empty() {
+        if replacement_target.is_some() && !options.dry_run && pending.is_empty() {
+            supersede_target(
+                db,
+                replacement_target_id.expect("replacement target exists"),
+                stats
+                    .drawer_ids
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or("existing"),
+            )?;
+        }
         return Ok(stats);
     }
 
@@ -469,7 +538,12 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     }
 
     // Stage 7: Storage with all fields from both sides
+    let mut supersede_pending = replacement_target_id.map(ToOwned::to_owned);
     for ((chunk_index, chunk, drawer_id), vector) in pending.into_iter().zip(vectors) {
+        if let Some(old_id) = supersede_pending.take() {
+            supersede_target(db, &old_id, &drawer_id)?;
+        }
+
         let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
             id: drawer_id.clone(),
             content: chunk.to_string(),
@@ -485,6 +559,10 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             normalize_version: CURRENT_NORMALIZE_VERSION,
             ..drawer
         };
+        let mut drawer = drawer;
+        if let Some(old_id) = replacement_target_id {
+            link_superseded_drawer(&mut drawer, old_id);
+        }
 
         db.insert_drawer_with_project(&drawer, options.project_id)
             .map_err(|source| IngestError::InsertDrawer {
@@ -574,6 +652,8 @@ pub async fn ingest_dir<E: Embedder + ?Sized>(
             no_strip_noise: false,
             diary_rollup: false,
             diary_rollup_day: None,
+            supersedes: None,
+            replace_text: None,
         },
     )
     .await
@@ -618,6 +698,9 @@ pub async fn ingest_dir_with_options<E: Embedder + ?Sized>(
                 stats.drawer_ids.extend(file_stats.drawer_ids);
                 stats.noise_bytes_stripped =
                     merge_optional_sum(stats.noise_bytes_stripped, file_stats.noise_bytes_stripped);
+                if stats.superseded_drawer_id.is_none() {
+                    stats.superseded_drawer_id = file_stats.superseded_drawer_id;
+                }
             }
         }
     }
@@ -631,6 +714,15 @@ fn merge_optional_sum(left: Option<u64>, right: Option<u64>) -> Option<u64> {
         (Some(value), None) | (None, Some(value)) => Some(value),
         (None, None) => None,
     }
+}
+
+fn supersede_target(db: &Database, old_id: &str, new_id: &str) -> Result<()> {
+    db.supersede_drawer(old_id, &format!("replaced by {new_id}"))
+        .map_err(|source| IngestError::SupersedeDrawer {
+            drawer_id: old_id.to_string(),
+            source,
+        })?;
+    Ok(())
 }
 
 fn source_type_for(format: Format) -> SourceType {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -369,10 +369,9 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             options.project_id,
         )
         .map_err(|source| IngestError::ResolveReplacement { source })?;
-    stats.superseded_drawer_id = replacement_target
+    let replacement_target_id = replacement_target
         .as_ref()
-        .map(|summary| summary.id.clone());
-    let replacement_target_id = stats.superseded_drawer_id.as_deref();
+        .map(|summary| summary.id.as_str());
 
     let mut pending = Vec::new();
 
@@ -482,16 +481,8 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     }
 
     if options.dry_run || pending.is_empty() {
-        if replacement_target.is_some() && !options.dry_run && pending.is_empty() {
-            supersede_target(
-                db,
-                replacement_target_id.expect("replacement target exists"),
-                stats
-                    .drawer_ids
-                    .first()
-                    .map(String::as_str)
-                    .unwrap_or("existing"),
-            )?;
+        if !options.dry_run {
+            supersede_after_successful_replacement(db, replacement_target_id, &mut stats)?;
         }
         return Ok(stats);
     }
@@ -538,12 +529,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     }
 
     // Stage 7: Storage with all fields from both sides
-    let mut supersede_pending = replacement_target_id.map(ToOwned::to_owned);
     for ((chunk_index, chunk, drawer_id), vector) in pending.into_iter().zip(vectors) {
-        if let Some(old_id) = supersede_pending.take() {
-            supersede_target(db, &old_id, &drawer_id)?;
-        }
-
         let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
             id: drawer_id.clone(),
             content: chunk.to_string(),
@@ -624,6 +610,8 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         stats.drawer_ids.push(drawer_id);
         stats.chunks += 1;
     }
+
+    supersede_after_successful_replacement(db, replacement_target_id, &mut stats)?;
 
     Ok(stats)
 }
@@ -722,6 +710,20 @@ fn supersede_target(db: &Database, old_id: &str, new_id: &str) -> Result<()> {
             drawer_id: old_id.to_string(),
             source,
         })?;
+    Ok(())
+}
+
+fn supersede_after_successful_replacement(
+    db: &Database,
+    replacement_target_id: Option<&str>,
+    stats: &mut IngestStats,
+) -> Result<()> {
+    if let Some(target_id) = replacement_target_id
+        && let Some(replacement_id) = stats.drawer_ids.first()
+    {
+        supersede_target(db, target_id, replacement_id)?;
+        stats.superseded_drawer_id = Some(target_id.to_string());
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1872,13 +1872,22 @@ async fn ingest_stdin_command(
     let project = options.project.or(record.project.as_deref());
     let supersedes = options.supersedes.or(record.supersedes.as_deref());
     let replace_text = options.replace_text.or(record.replace_text.as_deref());
+    let (privacy_config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    let scrubbed_replace_text = replace_text
+        .map(|text| privacy_config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
     let cwd = env::current_dir().ok();
     let project_id = resolve_project_id(project, config, cwd.as_deref())
         .context("failed to resolve stdin ingest project id")?;
 
     let source_type = SourceType::Manual;
     let replacement_target = db
-        .resolve_replacement_target(supersedes, replace_text, wing, room, project_id.as_deref())
+        .resolve_replacement_target(
+            supersedes,
+            scrubbed_replace_text.as_deref(),
+            wing,
+            room,
+            project_id.as_deref(),
+        )
         .context("failed to resolve replacement target")?;
     let superseded_drawer_id = replacement_target
         .as_ref()
@@ -1902,7 +1911,6 @@ async fn ingest_stdin_command(
     };
     let mut stats = IngestStats {
         files: 1,
-        superseded_drawer_id: superseded_drawer_id.clone(),
         ..IngestStats::default()
     };
 
@@ -1921,6 +1929,7 @@ async fn ingest_stdin_command(
         if let Some(old_id) = superseded_drawer_id.as_deref() {
             db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
                 .with_context(|| format!("failed to supersede drawer {old_id}"))?;
+            stats.superseded_drawer_id = Some(old_id.to_string());
         }
         append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
             .context("failed to append ingest audit log")?;
@@ -2008,10 +2017,6 @@ async fn ingest_stdin_command(
         .or(record.source.as_deref())
         .map(&scrub);
     let source_file = source_file_or_synthetic(&drawer_id, source_hint.as_deref());
-    if let Some(old_id) = superseded_drawer_id.as_deref() {
-        db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
-            .with_context(|| format!("failed to supersede drawer {old_id}"))?;
-    }
 
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: drawer_id.clone(),
@@ -2037,6 +2042,12 @@ async fn ingest_stdin_command(
         .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
     db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
+
+    if let Some(old_id) = superseded_drawer_id.as_deref() {
+        db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
+            .with_context(|| format!("failed to supersede drawer {old_id}"))?;
+        stats.superseded_drawer_id = Some(old_id.to_string());
+    }
 
     // Failure detection (P14) — synchronous, lightweight DB write.
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,9 @@ use mempal::core::{
     },
     utils::{
         build_bootstrap_evidence_drawer_id, build_triple_id, current_timestamp,
-        format_tunnel_endpoint, iso_timestamp, normalize_added_at as normalize_added_at_value,
-        normalize_rfc3339_timestamp, source_file_or_synthetic,
+        format_tunnel_endpoint, iso_timestamp, link_superseded_drawer,
+        normalize_added_at as normalize_added_at_value, normalize_rfc3339_timestamp,
+        source_file_or_synthetic,
     },
 };
 use mempal::embed::build_backend_from_name;
@@ -116,6 +117,8 @@ struct IngestCommandOptions<'a> {
     json: bool,
     no_strip_noise: bool,
     diary_rollup: bool,
+    supersedes: Option<&'a str>,
+    replace_text: Option<&'a str>,
 }
 
 struct RollbackCommandOptions<'a> {
@@ -183,6 +186,10 @@ enum Commands {
         no_strip_noise: bool,
         #[arg(long)]
         diary_rollup: bool,
+        #[arg(long)]
+        supersedes: Option<String>,
+        #[arg(long)]
+        replace_text: Option<String>,
     },
     Search {
         query: String,
@@ -1176,6 +1183,8 @@ fn run() -> Result<()> {
             json,
             no_strip_noise,
             diary_rollup,
+            supersedes,
+            replace_text,
         } => block_on_result(ingest_command(
             &db,
             config.as_ref(),
@@ -1191,6 +1200,8 @@ fn run() -> Result<()> {
                 json,
                 no_strip_noise,
                 diary_rollup,
+                supersedes: supersedes.as_deref(),
+                replace_text: replace_text.as_deref(),
             },
         )),
         Commands::Search {
@@ -1640,6 +1651,9 @@ async fn ingest_command(
         }
         (false, Some(_)) => {}
     }
+    if options.supersedes.is_some() || options.replace_text.is_some() {
+        bail!("--supersedes and --replace-text are only supported with --stdin ingest");
+    }
 
     let path = options
         .dir
@@ -1682,6 +1696,8 @@ async fn ingest_command(
         no_strip_noise: options.no_strip_noise,
         diary_rollup: options.diary_rollup,
         diary_rollup_day: None,
+        supersedes: options.supersedes,
+        replace_text: options.replace_text,
     };
 
     let stats = if options.dry_run {
@@ -1712,6 +1728,8 @@ async fn ingest_command(
             no_strip_noise: options.no_strip_noise,
             diary_rollup: options.diary_rollup,
             diary_rollup_day: None,
+            supersedes: options.supersedes,
+            replace_text: options.replace_text,
         };
         ingest_path_with_options(db, &*embedder, path, wing, live_options).await?
     };
@@ -1735,6 +1753,7 @@ async fn ingest_command(
             skipped: stats.skipped,
             dropped_by_gate: stats.dropped_by_gate,
             drawer_ids: &stats.drawer_ids,
+            superseded_drawer_id: stats.superseded_drawer_id.clone(),
             fact_check_warnings: stats.fact_check_warnings.clone(),
         };
         println!(
@@ -1746,14 +1765,15 @@ async fn ingest_command(
     }
 
     println!(
-        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={} noise_bytes_stripped={} lock_wait_ms={}",
+        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={} noise_bytes_stripped={} lock_wait_ms={} superseded_drawer_id={}",
         options.dry_run,
         stats.files,
         stats.chunks,
         stats.skipped,
         stats.dropped_by_gate,
         stats.noise_bytes_stripped.unwrap_or(0),
-        stats.lock_wait_ms.unwrap_or(0)
+        stats.lock_wait_ms.unwrap_or(0),
+        stats.superseded_drawer_id.as_deref().unwrap_or("")
     );
     Ok(())
 }
@@ -1766,6 +1786,8 @@ struct StdinIngestRecord {
     project: Option<String>,
     source: Option<String>,
     source_file: Option<String>,
+    supersedes: Option<String>,
+    replace_text: Option<String>,
     metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
@@ -1786,6 +1808,23 @@ struct StdinIngestStatsJson {
     dropped_by_gate: usize,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fact_check_warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    superseded_drawer_id: Option<String>,
+}
+
+fn exact_duplicate_drawer_id(
+    db: &Database,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+    excluded_drawer_id: Option<&str>,
+) -> Result<Option<String>> {
+    Ok(db
+        .find_active_drawers_by_content(content, wing, room, project_id)?
+        .into_iter()
+        .find(|summary| Some(summary.id.as_str()) != excluded_drawer_id)
+        .map(|summary| summary.id))
 }
 
 async fn ingest_stdin_command(
@@ -1831,20 +1870,58 @@ async fn ingest_stdin_command(
         .context("stdin ingest requires --wing or JSON `wing`")?;
     let room = options.room.or(record.room.as_deref());
     let project = options.project.or(record.project.as_deref());
+    let supersedes = options.supersedes.or(record.supersedes.as_deref());
+    let replace_text = options.replace_text.or(record.replace_text.as_deref());
     let cwd = env::current_dir().ok();
     let project_id = resolve_project_id(project, config, cwd.as_deref())
         .context("failed to resolve stdin ingest project id")?;
 
     let source_type = SourceType::Manual;
-    let drawer_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+    let replacement_target = db
+        .resolve_replacement_target(supersedes, replace_text, wing, room, project_id.as_deref())
+        .context("failed to resolve replacement target")?;
+    let superseded_drawer_id = replacement_target
+        .as_ref()
+        .map(|summary| summary.id.clone());
+    let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
+    let exact_duplicate = exact_duplicate_drawer_id(
+        db,
+        &content,
+        wing,
+        room,
+        project_id.as_deref(),
+        superseded_drawer_id_ref,
+    )
+    .context("failed to check exact duplicate")?;
+    let drawer_id = if let Some(existing_id) = exact_duplicate.as_ref() {
+        existing_id.clone()
+    } else {
+        let preferred_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+        db.resolve_available_drawer_id(&preferred_id)
+            .with_context(|| format!("failed to resolve drawer id for {preferred_id}"))?
+    };
     let mut stats = IngestStats {
         files: 1,
+        superseded_drawer_id: superseded_drawer_id.clone(),
         ..IngestStats::default()
     };
 
     if options.dry_run {
         stats.chunks = 1;
         stats.drawer_ids.push(drawer_id.clone());
+        append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+            .context("failed to append ingest audit log")?;
+        print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+        return Ok(());
+    }
+
+    if exact_duplicate.is_some() {
+        stats.skipped = 1;
+        stats.drawer_ids.push(drawer_id.clone());
+        if let Some(old_id) = superseded_drawer_id.as_deref() {
+            db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
+                .with_context(|| format!("failed to supersede drawer {old_id}"))?;
+        }
         append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
             .context("failed to append ingest audit log")?;
         print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
@@ -1931,6 +2008,11 @@ async fn ingest_stdin_command(
         .or(record.source.as_deref())
         .map(&scrub);
     let source_file = source_file_or_synthetic(&drawer_id, source_hint.as_deref());
+    if let Some(old_id) = superseded_drawer_id.as_deref() {
+        db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
+            .with_context(|| format!("failed to supersede drawer {old_id}"))?;
+    }
+
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: drawer_id.clone(),
         content,
@@ -1946,6 +2028,10 @@ async fn ingest_stdin_command(
         normalize_version: CURRENT_NORMALIZE_VERSION,
         ..drawer
     };
+    let mut drawer = drawer;
+    if let Some(old_id) = superseded_drawer_id.as_deref() {
+        link_superseded_drawer(&mut drawer, old_id);
+    }
 
     db.insert_drawer_with_project(&drawer, project_id.as_deref())
         .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
@@ -2007,6 +2093,7 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
                 skipped: stats.skipped,
                 dropped_by_gate: stats.dropped_by_gate,
                 fact_check_warnings: stats.fact_check_warnings.clone(),
+                superseded_drawer_id: stats.superseded_drawer_id.clone(),
             },
         };
         println!(
@@ -2018,8 +2105,13 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
     }
 
     println!(
-        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={}",
-        dry_run, stats.files, stats.chunks, stats.skipped, stats.dropped_by_gate
+        "dry_run={} files={} chunks={} skipped={} dropped_by_gate={} superseded_drawer_id={}",
+        dry_run,
+        stats.files,
+        stats.chunks,
+        stats.skipped,
+        stats.dropped_by_gate,
+        stats.superseded_drawer_id.as_deref().unwrap_or("")
     );
     Ok(())
 }
@@ -2323,6 +2415,8 @@ struct IngestJsonOutput<'a> {
     skipped: usize,
     dropped_by_gate: usize,
     drawer_ids: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    superseded_drawer_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     fact_check_warnings: Vec<String>,
 }
@@ -2364,7 +2458,7 @@ fn append_ingest_audit_log(
         .append(true)
         .open(&audit_path)
         .with_context(|| format!("failed to open audit log {}", audit_path.display()))?;
-    let entry = serde_json::json!({ "timestamp": current_timestamp(), "command": "ingest", "wing": wing, "dir": dir.to_string_lossy(), "format": format, "dry_run": dry_run, "files": stats.files, "chunks": stats.chunks, "skipped": stats.skipped, "dropped_by_gate": stats.dropped_by_gate });
+    let entry = serde_json::json!({ "timestamp": current_timestamp(), "command": "ingest", "wing": wing, "dir": dir.to_string_lossy(), "format": format, "dry_run": dry_run, "files": stats.files, "chunks": stats.chunks, "skipped": stats.skipped, "dropped_by_gate": stats.dropped_by_gate, "superseded_drawer_id": stats.superseded_drawer_id.as_deref() });
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;
     Ok(())
@@ -2399,12 +2493,15 @@ fn append_ingest_stdin_audit_log(
         "wing": wing,
         "source": source,
         "source_file": source_file,
+        "supersedes": record.supersedes.as_deref().map(&scrub),
+        "replace_text": record.replace_text.as_deref().map(&scrub),
         "metadata": metadata.as_ref(),
         "dry_run": dry_run,
         "files": stats.files,
         "chunks": stats.chunks,
         "skipped": stats.skipped,
         "dropped_by_gate": stats.dropped_by_gate,
+        "superseded_drawer_id": stats.superseded_drawer_id.as_deref(),
     });
     writeln!(file, "{entry}")
         .with_context(|| format!("failed to write audit log {}", audit_path.display()))?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,7 +16,8 @@ use crate::core::{
     },
     utils::{
         build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, iso_timestamp,
-        knowledge_source_file, normalize_rfc3339_timestamp, source_file_or_synthetic,
+        knowledge_source_file, link_superseded_drawer, normalize_rfc3339_timestamp,
+        source_file_or_synthetic,
     },
 };
 use crate::cowork::{PeekError, PeekRequest as CoworkPeekRequest, Tool, peek_partner};
@@ -1743,14 +1744,48 @@ impl MempalMcpServer {
         let chunks =
             crate::ingest::prepare_chunks(&scrubbed_content, &config.chunker, embedder.as_ref());
 
+        let scrubbed_replace_text = request
+            .replace_text
+            .as_deref()
+            .map(|text| config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
+        let replacement_target = db
+            .resolve_replacement_target(
+                request.supersedes.as_deref(),
+                scrubbed_replace_text.as_deref(),
+                &request.wing,
+                room,
+                project_id.as_deref(),
+            )
+            .map_err(replacement_db_error)?;
+        let superseded_drawer_id = replacement_target
+            .as_ref()
+            .map(|summary| summary.id.clone());
+        let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
+
         let mut chunk_drawer_ids: Vec<(usize, String, bool)> = Vec::with_capacity(chunks.len());
         for (idx, chunk) in chunks.iter().enumerate() {
-            let did = build_bootstrap_drawer_id_from_parts(
+            if let Some(existing_id) = exact_duplicate_drawer_id(
+                &db,
+                chunk,
+                &request.wing,
+                room,
+                project_id.as_deref(),
+                superseded_drawer_id_ref,
+                &metadata,
+            )? {
+                chunk_drawer_ids.push((idx, existing_id, true));
+                continue;
+            }
+
+            let preferred_id = build_bootstrap_drawer_id_from_parts(
                 &request.wing,
                 room,
                 chunk,
                 metadata.identity_parts(),
             );
+            let did = db
+                .resolve_available_drawer_id(&preferred_id)
+                .map_err(db_error)?;
             let exists = db.drawer_exists(&did).map_err(db_error)?;
             chunk_drawer_ids.push((idx, did, exists));
         }
@@ -1774,6 +1809,32 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
+                superseded_drawer_id,
+                fact_check_warnings: Vec::new(),
+                system_warnings: current_system_warnings(),
+            }));
+        }
+
+        if chunk_drawer_ids.iter().all(|(_, _, exists)| *exists) {
+            let all_ids = chunk_drawer_ids
+                .iter()
+                .map(|(_, id, _)| id.clone())
+                .collect::<Vec<_>>();
+            if let Some(old_id) = superseded_drawer_id.as_deref() {
+                let replacement_id = all_ids.first().map(String::as_str).unwrap_or("existing");
+                supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+            }
+            return Ok(Json(IngestResponse {
+                drawer_id,
+                drawer_ids: all_ids,
+                chunk_count: chunks.len(),
+                dropped: false,
+                gating_decision: None,
+                novelty_action: None,
+                near_drawer_id: None,
+                duplicate_warning: None,
+                lock_wait_ms: None,
+                superseded_drawer_id,
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -1806,6 +1867,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
+                superseded_drawer_id: superseded_drawer_id.clone(),
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -1852,7 +1914,8 @@ impl MempalMcpServer {
                 first_vector = tier2.vector;
                 // Tier 3: intercept uncertain Tier 2 results ("prototype_below_threshold")
                 // and route to LLM judge when enabled (fail-open: store now, judge async).
-                let llm_judge_active = config.llm.enabled
+                let llm_judge_active = superseded_drawer_id.is_none()
+                    && config.llm.enabled
                     && config.llm.enabled_for.contains(&"gating".to_string())
                     && config
                         .ingest_gating
@@ -1907,6 +1970,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms,
+                superseded_drawer_id: superseded_drawer_id.clone(),
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -1949,6 +2013,7 @@ impl MempalMcpServer {
                     near_drawer_id: None,
                     duplicate_warning: None,
                     lock_wait_ms,
+                    superseded_drawer_id: superseded_drawer_id.clone(),
                     fact_check_warnings,
                     system_warnings: current_system_warnings(),
                 }));
@@ -1996,12 +2061,19 @@ impl MempalMcpServer {
             room: request.room.clone(),
             project_id: project_id.clone(),
         };
-        let novelty = evaluate_novelty(
-            &db,
-            &novelty_candidate,
-            first_vector_ref,
-            &config.ingest_gating.novelty,
-        );
+        let novelty = if superseded_drawer_id.is_some() {
+            crate::ingest::novelty::NoveltyDecision {
+                should_audit: false,
+                ..crate::ingest::novelty::NoveltyDecision::insert()
+            }
+        } else {
+            evaluate_novelty(
+                &db,
+                &novelty_candidate,
+                first_vector_ref,
+                &config.ingest_gating.novelty,
+            )
+        };
         let mut response_drawer_id = drawer_id.clone();
         let (novelty_action, near_drawer_id);
 
@@ -2026,6 +2098,7 @@ impl MempalMcpServer {
                 novelty_action = Some(NoveltyAction::Insert);
                 near_drawer_id = novelty.near_drawer_id.clone();
 
+                let mut supersede_pending = superseded_drawer_id.clone();
                 for ((chunk_idx, chunk_did, chunk_exists), (chunk, vector)) in chunk_drawer_ids
                     .iter()
                     .zip(chunks.iter().zip(vectors.iter()))
@@ -2060,7 +2133,10 @@ impl MempalMcpServer {
                         inserted_drawer_ids.push(chunk_did.clone());
                         continue;
                     }
-                    let drawer = drawer_from_ingest_metadata(
+                    if let Some(old_id) = supersede_pending.take() {
+                        supersede_drawer_for_ingest(&db, &old_id, chunk_did)?;
+                    }
+                    let mut drawer = drawer_from_ingest_metadata(
                         &request,
                         &metadata,
                         chunk_did,
@@ -2068,6 +2144,9 @@ impl MempalMcpServer {
                         *chunk_idx,
                         &source_type,
                     );
+                    if let Some(old_id) = superseded_drawer_id.as_deref() {
+                        link_superseded_drawer(&mut drawer, old_id);
+                    }
                     db.insert_drawer_with_project(&drawer, project_id.as_deref())
                         .map_err(db_error)?;
                     db.insert_vector_with_project(chunk_did, vector, project_id.as_deref())
@@ -2363,6 +2442,7 @@ impl MempalMcpServer {
             near_drawer_id,
             duplicate_warning,
             lock_wait_ms,
+            superseded_drawer_id,
             fact_check_warnings,
             system_warnings: current_system_warnings(),
         }))
@@ -3225,6 +3305,103 @@ impl ServerHandler for MempalMcpServer {
 
 pub(super) fn db_error(error: impl std::fmt::Display) -> ErrorData {
     ErrorData::internal_error(format!("{error}"), None)
+}
+
+fn replacement_db_error(error: crate::core::db::DbError) -> ErrorData {
+    match error {
+        crate::core::db::DbError::ReplacementTargetConflict
+        | crate::core::db::DbError::SupersededDrawerNotFound { .. }
+        | crate::core::db::DbError::SupersededDrawerProjectMismatch { .. }
+        | crate::core::db::DbError::ReplacementTextNotFound
+        | crate::core::db::DbError::ReplacementTextAmbiguous { .. } => {
+            ErrorData::invalid_params(error.to_string(), None)
+        }
+        _ => db_error(error),
+    }
+}
+
+fn exact_duplicate_drawer_id(
+    db: &Database,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+    project_id: Option<&str>,
+    excluded_drawer_id: Option<&str>,
+    metadata: &ValidatedIngestMetadata,
+) -> std::result::Result<Option<String>, ErrorData> {
+    let candidates = db
+        .find_active_drawers_by_content(content, wing, room, project_id)
+        .map_err(db_error)?
+        .into_iter()
+        .filter(|summary| Some(summary.id.as_str()) != excluded_drawer_id)
+        .collect::<Vec<_>>();
+
+    for candidate in candidates {
+        let Some(drawer) = db.get_drawer(&candidate.id).map_err(db_error)? else {
+            continue;
+        };
+        if drawer_matches_ingest_metadata(&drawer, metadata) {
+            return Ok(Some(candidate.id));
+        }
+    }
+
+    Ok(None)
+}
+
+fn supersede_drawer_for_ingest(
+    db: &Database,
+    old_id: &str,
+    new_id: &str,
+) -> std::result::Result<(), ErrorData> {
+    db.supersede_drawer(old_id, &format!("replaced by {new_id}"))
+        .map_err(db_error)?;
+    Ok(())
+}
+
+fn drawer_matches_ingest_metadata(drawer: &Drawer, metadata: &ValidatedIngestMetadata) -> bool {
+    drawer.memory_kind == metadata.memory_kind
+        && drawer.domain == metadata.domain
+        && drawer.field == metadata.field
+        && drawer.anchor_kind == metadata.anchor_kind
+        && drawer.anchor_id == metadata.anchor_id
+        && drawer.parent_anchor_id == metadata.parent_anchor_id
+        && drawer.provenance == metadata.provenance
+        && drawer.statement == metadata.statement
+        && drawer.tier == metadata.tier
+        && drawer.status == metadata.status
+        && normalized_string_sets_match(&drawer.supporting_refs, &metadata.supporting_refs)
+        && normalized_string_sets_match(&drawer.counterexample_refs, &metadata.counterexample_refs)
+        && normalized_string_sets_match(&drawer.teaching_refs, &metadata.teaching_refs)
+        && normalized_string_sets_match(&drawer.verification_refs, &metadata.verification_refs)
+        && drawer.scope_constraints == metadata.scope_constraints
+        && trigger_hints_match(&drawer.trigger_hints, &metadata.trigger_hints)
+}
+
+fn normalized_string_sets_match(left: &[String], right: &[String]) -> bool {
+    fn normalize(values: &[String]) -> Vec<String> {
+        let mut normalized = values
+            .iter()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        normalized.sort();
+        normalized
+    }
+
+    normalize(left) == normalize(right)
+}
+
+fn trigger_hints_match(left: &Option<TriggerHints>, right: &Option<TriggerHints>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => {
+            normalized_string_sets_match(&left.intent_tags, &right.intent_tags)
+                && normalized_string_sets_match(&left.workflow_bias, &right.workflow_bias)
+                && normalized_string_sets_match(&left.tool_needs, &right.tool_needs)
+        }
+        _ => false,
+    }
 }
 
 #[allow(dead_code)]
@@ -5528,6 +5705,229 @@ mod tests {
         );
     }
 
+    async fn ingest_manual(
+        server: &MempalMcpServer,
+        content: &str,
+        project_id: Option<&str>,
+        supersedes: Option<&str>,
+        replace_text: Option<&str>,
+    ) -> IngestResponse {
+        server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: content.to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                project_id: project_id.map(ToOwned::to_owned),
+                supersedes: supersedes.map(ToOwned::to_owned),
+                replace_text: replace_text.map(ToOwned::to_owned),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest should succeed")
+            .0
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_idempotent_exact_duplicate_returns_existing_id() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let first = ingest_manual(&server, "idempotent exact fact", None, None, None).await;
+        let second = ingest_manual(&server, "idempotent exact fact", None, None, None).await;
+
+        assert_eq!(second.drawer_id, first.drawer_id);
+        assert_eq!(second.drawer_ids, vec![first.drawer_id.clone()]);
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_supersedes_soft_deletes_old_and_links_new() {
+        let (_tempdir, db_path, server) = setup_server();
+        let old = ingest_manual(&server, "stale explicit fact", None, None, None).await;
+
+        let new = ingest_manual(
+            &server,
+            "corrected explicit fact",
+            None,
+            Some(&old.drawer_id),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            new.superseded_drawer_id.as_deref(),
+            Some(old.drawer_id.as_str())
+        );
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&old.drawer_id).expect("old lookup").is_none());
+        let new_drawer = db
+            .get_drawer(&new.drawer_id)
+            .expect("new lookup")
+            .expect("new drawer exists");
+        assert!(
+            new_drawer
+                .scope_constraints
+                .as_deref()
+                .unwrap_or_default()
+                .contains(&format!("supersedes:{}", old.drawer_id))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_replace_text_single_match_supersedes() {
+        let (_tempdir, db_path, server) = setup_server();
+        let old = ingest_manual(&server, "replace text old fact", None, None, None).await;
+
+        let new = ingest_manual(
+            &server,
+            "replace text new fact",
+            None,
+            None,
+            Some("replace text old fact"),
+        )
+        .await;
+
+        assert_eq!(
+            new.superseded_drawer_id.as_deref(),
+            Some(old.drawer_id.as_str())
+        );
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&old.drawer_id).expect("old lookup").is_none());
+        assert!(db.get_drawer(&new.drawer_id).expect("new lookup").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_replace_text_zero_matches_errors() {
+        let (_tempdir, _db_path, server) = setup_server();
+
+        let error = match server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "new fact without old".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                replace_text: Some("missing old fact".to_string()),
+                ..IngestRequest::default()
+            }))
+            .await
+        {
+            Ok(_) => panic!("missing replace_text target should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("no matching active fact found"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_replace_text_multiple_matches_errors_with_candidates() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "replace_candidate_a",
+            "ambiguous old fact",
+            "mempal",
+            Some("replace"),
+            "a.md",
+            0,
+        );
+        insert_drawer(
+            &db_path,
+            "replace_candidate_b",
+            "ambiguous old fact",
+            "mempal",
+            Some("replace"),
+            "b.md",
+            0,
+        );
+
+        let error = match server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "new ambiguous replacement".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                replace_text: Some("ambiguous old fact".to_string()),
+                ..IngestRequest::default()
+            }))
+            .await
+        {
+            Ok(_) => panic!("ambiguous replace_text target should fail"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("multiple matching active facts"));
+        assert!(message.contains("replace_candidate_a"));
+        assert!(message.contains("replace_candidate_b"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_superseded_drawer_excluded_from_search() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let old = ingest_manual(&server, "retired-search-token old fact", None, None, None).await;
+        let new = ingest_manual(
+            &server,
+            "replacement visible fact",
+            None,
+            Some(&old.drawer_id),
+            None,
+        )
+        .await;
+
+        let results = server
+            .mempal_search(Parameters(SearchRequest {
+                query: "retired-search-token".to_string(),
+                wing: Some("mempal".to_string()),
+                room: Some("replace".to_string()),
+                top_k: Some(10),
+                ..SearchRequest::default()
+            }))
+            .await
+            .expect("search should succeed")
+            .0
+            .results;
+
+        assert!(
+            !results
+                .iter()
+                .any(|result| result.drawer_id == old.drawer_id)
+        );
+        assert!(
+            results
+                .iter()
+                .all(|result| result.drawer_id != old.drawer_id)
+        );
+        assert_ne!(new.drawer_id, old.drawer_id);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_cannot_supersede_different_project_scope() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let old = ingest_manual(
+            &server,
+            "project scoped old fact",
+            Some("project-a"),
+            None,
+            None,
+        )
+        .await;
+
+        let error = match server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "project scoped new fact".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                project_id: Some("project-b".to_string()),
+                supersedes: Some(old.drawer_id),
+                ..IngestRequest::default()
+            }))
+            .await
+        {
+            Ok(_) => panic!("project mismatch should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("expected Some(\"project-b\")"));
+    }
+
     #[tokio::test]
     async fn test_mcp_ingest_response_exposes_lock_wait() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -5541,6 +5941,8 @@ mod tests {
                 importance: None,
                 dry_run: None,
                 diary_rollup: None,
+                supersedes: None,
+                replace_text: None,
                 memory_kind: None,
                 domain: None,
                 field: None,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1761,6 +1761,7 @@ impl MempalMcpServer {
             .as_ref()
             .map(|summary| summary.id.clone());
         let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
+        let mut superseded_response_id: Option<String> = None;
 
         let mut chunk_drawer_ids: Vec<(usize, String, bool)> = Vec::with_capacity(chunks.len());
         for (idx, chunk) in chunks.iter().enumerate() {
@@ -1823,6 +1824,7 @@ impl MempalMcpServer {
             if let Some(old_id) = superseded_drawer_id.as_deref() {
                 let replacement_id = all_ids.first().map(String::as_str).unwrap_or("existing");
                 supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+                superseded_response_id = Some(old_id.to_string());
             }
             return Ok(Json(IngestResponse {
                 drawer_id,
@@ -1834,7 +1836,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
-                superseded_drawer_id,
+                superseded_drawer_id: superseded_response_id,
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -1867,7 +1869,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms: None,
-                superseded_drawer_id: superseded_drawer_id.clone(),
+                superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -1970,7 +1972,7 @@ impl MempalMcpServer {
                 near_drawer_id: None,
                 duplicate_warning: None,
                 lock_wait_ms,
-                superseded_drawer_id: superseded_drawer_id.clone(),
+                superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
                 system_warnings: current_system_warnings(),
             }));
@@ -2013,7 +2015,7 @@ impl MempalMcpServer {
                     near_drawer_id: None,
                     duplicate_warning: None,
                     lock_wait_ms,
-                    superseded_drawer_id: superseded_drawer_id.clone(),
+                    superseded_drawer_id: None,
                     fact_check_warnings,
                     system_warnings: current_system_warnings(),
                 }));
@@ -2098,7 +2100,6 @@ impl MempalMcpServer {
                 novelty_action = Some(NoveltyAction::Insert);
                 near_drawer_id = novelty.near_drawer_id.clone();
 
-                let mut supersede_pending = superseded_drawer_id.clone();
                 for ((chunk_idx, chunk_did, chunk_exists), (chunk, vector)) in chunk_drawer_ids
                     .iter()
                     .zip(chunks.iter().zip(vectors.iter()))
@@ -2132,9 +2133,6 @@ impl MempalMcpServer {
                         // newly_created_drawer_ids so LLM reject cannot delete it.
                         inserted_drawer_ids.push(chunk_did.clone());
                         continue;
-                    }
-                    if let Some(old_id) = supersede_pending.take() {
-                        supersede_drawer_for_ingest(&db, &old_id, chunk_did)?;
                     }
                     let mut drawer = drawer_from_ingest_metadata(
                         &request,
@@ -2302,6 +2300,13 @@ impl MempalMcpServer {
             }
         }
 
+        if let Some(old_id) = superseded_drawer_id.as_deref()
+            && let Some(replacement_id) = inserted_drawer_ids.first()
+        {
+            supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
+            superseded_response_id = Some(old_id.to_string());
+        }
+
         drop(lock_guard);
 
         // Apply session-ingest boost to previously searched drawers (P13).
@@ -2442,7 +2447,7 @@ impl MempalMcpServer {
             near_drawer_id,
             duplicate_warning,
             lock_wait_ms,
-            superseded_drawer_id,
+            superseded_drawer_id: superseded_response_id,
             fact_check_warnings,
             system_warnings: current_system_warnings(),
         }))

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1743,6 +1743,12 @@ impl MempalMcpServer {
         })?;
         let chunks =
             crate::ingest::prepare_chunks(&scrubbed_content, &config.chunker, embedder.as_ref());
+        if chunks.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "content produced no chunks",
+                None,
+            ));
+        }
 
         let scrubbed_replace_text = request
             .replace_text
@@ -5776,6 +5782,31 @@ mod tests {
                 .unwrap_or_default()
                 .contains(&format!("supersedes:{}", old.drawer_id))
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_supersedes_empty_chunks_errors_without_retiring_old() {
+        let (_tempdir, db_path, server) = setup_server();
+        let old = ingest_manual(&server, "empty replacement old fact", None, None, None).await;
+
+        let error = match server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "   \n\t  ".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                supersedes: Some(old.drawer_id.clone()),
+                ..IngestRequest::default()
+            }))
+            .await
+        {
+            Ok(_) => panic!("empty replacement should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("content produced no chunks"));
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&old.drawer_id).expect("old lookup").is_some());
+        assert_eq!(db.drawer_count().expect("drawer count"), 1);
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -781,6 +781,12 @@ pub struct IngestRequest {
     pub room: Option<String>,
     pub source: Option<String>,
     pub project_id: Option<String>,
+    /// Drawer ID to replace. The old drawer must be active and in the
+    /// same project scope as this ingest.
+    pub supersedes: Option<String>,
+    /// Exact active content to replace within the same wing/room/project
+    /// scope. Must match exactly; ambiguous matches return candidate IDs.
+    pub replace_text: Option<String>,
 
     /// If true, return the drawer_id that WOULD be created without actually
     /// writing to the database. Use this to preview before committing.
@@ -885,6 +891,8 @@ pub struct IngestResponse {
     /// concurrent ingest of the same content serialized with this call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lock_wait_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_drawer_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fact_check_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/tests/auto_fact_check_gate.rs
+++ b/tests/auto_fact_check_gate.rs
@@ -218,6 +218,119 @@ async fn test_fact_check_engine_error_fails_open_with_warning() {
 }
 
 #[tokio::test]
+async fn test_rejected_replacement_does_not_supersede_old_drawer() {
+    let (tmp, db) = new_test_db();
+    let old_path = write_input(tmp.path(), "old fact remains active");
+    let old = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &old_path,
+        "mempal",
+        IngestOptions {
+            room: Some("decision"),
+            project_id: Some("test-project"),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest old drawer");
+    let old_id = old.drawer_ids.first().expect("old drawer id").clone();
+
+    insert_triple(&db, "Bob", "husband_of", "Alice");
+    let replacement_path = write_input(tmp.path(), "Bob is Alice's brother.");
+    let gating = gating(enabled_fact_check(true));
+
+    let stats = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &replacement_path,
+        "mempal",
+        IngestOptions {
+            room: Some("decision"),
+            gating: Some(&gating),
+            project_id: Some("test-project"),
+            supersedes: Some(&old_id),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest rejected replacement");
+
+    assert_eq!(stats.dropped_by_gate, 1);
+    assert!(stats.drawer_ids.is_empty());
+    assert!(stats.superseded_drawer_id.is_none());
+    assert!(
+        db.get_drawer(&old_id).expect("old lookup").is_some(),
+        "old drawer must remain active when every replacement chunk is rejected"
+    );
+}
+
+#[tokio::test]
+async fn test_duplicate_replacement_supersedes_old_drawer() {
+    let (tmp, db) = new_test_db();
+    let old_path = write_input(tmp.path(), "stale duplicate replacement source");
+    let old = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &old_path,
+        "mempal",
+        IngestOptions {
+            room: Some("decision"),
+            project_id: Some("test-project"),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest old drawer");
+    let old_id = old.drawer_ids.first().expect("old drawer id").clone();
+
+    let canonical_path = write_input(tmp.path(), "canonical replacement fact");
+    let canonical = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &canonical_path,
+        "mempal",
+        IngestOptions {
+            room: Some("decision"),
+            project_id: Some("test-project"),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest canonical drawer");
+    let canonical_id = canonical
+        .drawer_ids
+        .first()
+        .expect("canonical drawer id")
+        .clone();
+
+    let replacement_path = write_input(tmp.path(), "canonical replacement fact");
+    let stats = ingest_file_with_options(
+        &db,
+        &StubEmbedder,
+        &replacement_path,
+        "mempal",
+        IngestOptions {
+            room: Some("decision"),
+            project_id: Some("test-project"),
+            supersedes: Some(&old_id),
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest duplicate replacement");
+
+    assert_eq!(stats.drawer_ids, vec![canonical_id.clone()]);
+    assert_eq!(stats.superseded_drawer_id.as_deref(), Some(old_id.as_str()));
+    assert!(db.get_drawer(&old_id).expect("old lookup").is_none());
+    assert!(
+        db.get_drawer(&canonical_id)
+            .expect("canonical lookup")
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn test_fact_check_config_disabled_skips_gate_entirely() {
     let (tmp, db) = new_test_db();
     insert_triple(&db, "Bob", "husband_of", "Alice");

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -405,6 +405,138 @@ async fn test_ingest_stdin_scrubs_source_fields_in_audit_and_drawer() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stdin_replace_text_uses_scrubbed_text_for_lookup() {
+    let tmp = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config_with_privacy(tmp.path(), &format!("http://{addr}/v1"), true);
+
+    let raw_old = "old <private>hidden</private> fact";
+    let old_payload = serde_json::json!({
+        "content": raw_old,
+        "wing": "privacy-wing",
+        "room": "privacy-room",
+        "project": "privacy-project"
+    })
+    .to_string();
+    let old_output = run_ingest_stdin_json(tmp.path(), &old_payload, &["--no-gate", "--json"]);
+    assert!(
+        old_output.status.success(),
+        "old ingest must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&old_output.stdout),
+        String::from_utf8_lossy(&old_output.stderr)
+    );
+    let old_json: Value =
+        serde_json::from_slice(&old_output.stdout).expect("parse old ingest JSON");
+    let old_id = old_json["drawer_ids"][0]
+        .as_str()
+        .expect("old drawer id")
+        .to_string();
+
+    let replacement_payload = serde_json::json!({
+        "content": "new scrubbed replacement fact",
+        "wing": "privacy-wing",
+        "room": "privacy-room",
+        "project": "privacy-project"
+    })
+    .to_string();
+    let replacement_output = run_ingest_stdin_json(
+        tmp.path(),
+        &replacement_payload,
+        &["--no-gate", "--json", "--replace-text", raw_old],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        replacement_output.status.success(),
+        "replacement ingest must match scrubbed replace_text, stdout={}, stderr={}",
+        String::from_utf8_lossy(&replacement_output.stdout),
+        String::from_utf8_lossy(&replacement_output.stderr)
+    );
+    let replacement_json: Value =
+        serde_json::from_slice(&replacement_output.stdout).expect("parse replacement JSON");
+    assert_eq!(
+        replacement_json["stats"]["superseded_drawer_id"],
+        Value::String(old_id.clone())
+    );
+
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    assert!(db.get_drawer(&old_id).expect("old lookup").is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_stdin_replacement_insert_failure_preserves_old_drawer() {
+    let tmp = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    write_embed_config(tmp.path(), &format!("http://{addr}/v1"));
+
+    let old_payload = serde_json::json!({
+        "content": "old durable replacement fact",
+        "wing": "replace-wing",
+        "room": "replace-room",
+        "project": "replace-project"
+    })
+    .to_string();
+    let old_output = run_ingest_stdin_json(tmp.path(), &old_payload, &["--no-gate", "--json"]);
+    assert!(
+        old_output.status.success(),
+        "old ingest must succeed, stdout={}, stderr={}",
+        String::from_utf8_lossy(&old_output.stdout),
+        String::from_utf8_lossy(&old_output.stderr)
+    );
+    let old_json: Value =
+        serde_json::from_slice(&old_output.stdout).expect("parse old ingest JSON");
+    let old_id = old_json["drawer_ids"][0]
+        .as_str()
+        .expect("old drawer id")
+        .to_string();
+
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    db.conn()
+        .execute_batch(
+            r#"
+            CREATE TRIGGER fail_replacement_drawer_insert
+            BEFORE INSERT ON drawers
+            BEGIN
+                SELECT RAISE(FAIL, 'forced replacement drawer insert failure');
+            END;
+            "#,
+        )
+        .expect("install failure trigger");
+
+    let replacement_payload = serde_json::json!({
+        "content": "new replacement fact that cannot be stored",
+        "wing": "replace-wing",
+        "room": "replace-room",
+        "project": "replace-project"
+    })
+    .to_string();
+    let replacement_output = run_ingest_stdin_json(
+        tmp.path(),
+        &replacement_payload,
+        &["--no-gate", "--json", "--supersedes", &old_id],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        !replacement_output.status.success(),
+        "replacement ingest must fail, stdout={}, stderr={}",
+        String::from_utf8_lossy(&replacement_output.stdout),
+        String::from_utf8_lossy(&replacement_output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&replacement_output.stderr);
+    assert!(
+        stderr.contains("forced replacement drawer insert failure"),
+        "stderr must include forced failure, got: {stderr}"
+    );
+    assert!(
+        db.get_drawer(&old_id).expect("old lookup").is_some(),
+        "old drawer must remain active when replacement storage fails"
+    );
+}
+
 #[test]
 fn test_ingest_stdin_rejects_invalid_json() {
     let tmp = setup_home();


### PR DESCRIPTION
## Summary

- Add deterministic replace/supersede semantics to all ingest paths (MCP, REST, CLI)
- New params: `supersedes` (drawer_id) and `replace_text` (exact text match) on ingest
- Idempotent add: exact duplicate content in same scope returns existing drawer_id
- Superseded drawers excluded from search/timeline (existing soft-delete mechanism)
- Project isolation enforced: can't supersede drawers from different projects
- Empty-chunks guard on all paths prevents data loss during replacement

## Test plan

- [x] `cargo test` — all tests pass (new + existing)
- [x] `cargo clippy` — no warnings
- [x] Tier-4 review: PASS after 3 rounds (R1: data-loss in file-ingest path, R2: data-loss in MCP path, R3: clean)

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)