### PR TITLE
feat(strata): memory strata + configurable turn storage (#189)

### DIFF
--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -82,6 +82,7 @@ def _load_config(hermes_home: str = "") -> dict:
     config = {
         "base_url": os.environ.get("MEMPAL_BASE_URL", "http://127.0.0.1:3080"),
         "user_id": os.environ.get("MEMPAL_USER_ID", "hermes-user"),
+        "turn_storage_mode": os.environ.get("MEMPAL_TURN_STORAGE_MODE", "raw_evidence"),
     }
     if hermes_home:
         config_path = os.path.join(hermes_home, "mempal.json")
@@ -131,6 +132,21 @@ class MempalMemoryProvider:
         user_id = kwargs.get("user_id") or cfg.get("user_id", "hermes-user")
         self._user_id = user_id
         self._wing = f"hermes-user/{user_id}"
+
+    def _turn_storage_mode(self) -> str:
+        try:
+            status = self._get("/api/status")
+            mode = (
+                status.get("turn_storage", {})
+                .get("storage_mode", "")
+                .strip()
+            )
+            if mode:
+                return mode
+        except Exception as exc:
+            logger.debug("mempal status lookup for turn storage failed: %s", exc)
+        cfg = _load_config(self._hermes_home)
+        return str(cfg.get("turn_storage_mode", "raw_evidence")).strip() or "raw_evidence"
 
     # -- Circuit breaker ----------------------------------------------------
 
@@ -209,7 +225,12 @@ class MempalMemoryProvider:
             try:
                 results = self._get(
                     "/api/search",
-                    {"q": query, "wing": self._wing, "top_k": 5},
+                    {
+                        "q": query,
+                        "wing": self._wing,
+                        "top_k": 5,
+                        "include_raw_turns": False,
+                    },
                 )
                 if results:
                     lines = [r.get("content", "") for r in results if r.get("content")]
@@ -230,6 +251,8 @@ class MempalMemoryProvider:
     ) -> None:
         """Ingest turn summary to mempal (non-blocking)."""
         if self._is_breaker_open():
+            return
+        if self._turn_storage_mode() != "raw_evidence":
             return
 
         content = f"User: {user_content}\nAssistant: {assistant_content}"
@@ -278,7 +301,7 @@ class MempalMemoryProvider:
                     limit = 20
                 entries = self._get(
                     "/api/timeline",
-                    {"wing": self._wing, "limit": limit},
+                    {"wing": self._wing, "limit": limit, "include_raw_turns": False},
                 )
                 self._record_success()
                 if not entries:
@@ -300,7 +323,12 @@ class MempalMemoryProvider:
             try:
                 results = self._get(
                     "/api/search",
-                    {"q": query, "wing": self._wing, "top_k": top_k},
+                    {
+                        "q": query,
+                        "wing": self._wing,
+                        "top_k": top_k,
+                        "include_raw_turns": False,
+                    },
                 )
                 self._record_success()
                 if not results:
@@ -411,6 +439,12 @@ class MempalMemoryProvider:
                 "description": "User identifier for memory scoping",
                 "default": "hermes-user",
                 "env_var": "MEMPAL_USER_ID",
+            },
+            {
+                "key": "turn_storage_mode",
+                "description": "Raw turn storage mode: off, raw_evidence, or summarized",
+                "default": "raw_evidence",
+                "env_var": "MEMPAL_TURN_STORAGE_MODE",
             },
         ]
 

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -2,6 +2,7 @@ use crate::core::{
     config::ConfigHandle,
     db::Database,
     project::{ProjectSearchScope, resolve_project_id},
+    strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
         BootstrapEvidenceArgs, Drawer, RouteDecision, SearchResult, SourceType, TaxonomyEntry,
     },
@@ -12,7 +13,7 @@ use crate::core::{
 };
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
-use crate::search::{resolve_route, search_with_vector};
+use crate::search::{SearchOptions, resolve_route, search_with_vector_and_scope_options};
 use axum::{
     Json, Router,
     extract::{Query, State},
@@ -73,6 +74,7 @@ struct SearchQuery {
     project_id: Option<String>,
     include_global: Option<bool>,
     all_projects: Option<bool>,
+    include_raw_turns: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -111,6 +113,16 @@ struct StatusResponse {
     taxonomy_count: i64,
     db_size_bytes: u64,
     wings: Vec<ScopeCount>,
+    turn_storage: TurnStorageStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct TurnStorageStatus {
+    storage_mode: String,
+    default_importance: i32,
+    raw_turn_count: i64,
+    raw_turn_wings: Vec<String>,
+    raw_turn_rooms: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -180,12 +192,16 @@ async fn search_handler(
         query.all_projects.unwrap_or(false),
         config.search.strict_project_isolation,
     );
-    let results = search_with_vector(
+    let results = search_with_vector_and_scope_options(
         &db,
         &query.q,
         &query_vector,
         route,
         &scope,
+        SearchOptions {
+            include_raw_turns: query.include_raw_turns.unwrap_or(false),
+            ..SearchOptions::default()
+        },
         query.top_k.unwrap_or(10),
     )
     .map_err(internal_error)?;
@@ -208,6 +224,22 @@ async fn ingest_handler(
     let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
+    let raw_turn = is_raw_turn(&request.wing, request.room.as_deref(), &config.turns);
+    if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+        return Ok((
+            StatusCode::CREATED,
+            Json(IngestResponse {
+                drawer_id: String::new(),
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
+                dropped: false,
+                superseded_drawer_id: None,
+                fact_check_warnings: Vec::new(),
+            }),
+        ));
+    }
+    let drawer_importance =
+        raw_turn_importance(&request.wing, request.room.as_deref(), &config.turns).unwrap_or(0);
 
     // Chunk the content using the token-aware chunker (issue #57).
     let chunks =
@@ -262,7 +294,7 @@ async fn ingest_handler(
         let drawer_id = db
             .resolve_available_drawer_id(&preferred_drawer_id)
             .map_err(internal_error)?;
-        if request.wing != "hooks-raw"
+        if !raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
                 chunk,
@@ -352,7 +384,7 @@ async fn ingest_handler(
                 source_type: SourceType::Manual,
                 added_at: iso_timestamp(),
                 chunk_index: Some(*chunk_idx as i64),
-                importance: 0,
+                importance: drawer_importance,
             });
             let drawer = Drawer {
                 normalize_version: CURRENT_NORMALIZE_VERSION,
@@ -408,6 +440,8 @@ async fn taxonomy_handler(
 async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResponse>, ApiError> {
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let drawer_count = db.drawer_count().map_err(internal_error)?;
+    let config = ConfigHandle::current();
+    let raw_turn_count = count_raw_turn_drawers(&db, &config.turns).map_err(internal_error)?;
     let taxonomy_count = db.taxonomy_count().map_err(internal_error)?;
     let db_size_bytes = db.database_size_bytes().map_err(internal_error)?;
     let wings = db
@@ -426,6 +460,13 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         taxonomy_count,
         db_size_bytes,
         wings,
+        turn_storage: TurnStorageStatus {
+            storage_mode: config.turns.storage_mode.to_string(),
+            default_importance: config.turns.default_importance,
+            raw_turn_count,
+            raw_turn_wings: config.turns.raw_turn_wings.clone(),
+            raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
+        },
     }))
 }
 

--- a/src/api/hermes_compat.rs
+++ b/src/api/hermes_compat.rs
@@ -12,6 +12,7 @@ use super::state::ApiState;
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
 use crate::core::project::{ProjectFilterMode, ProjectSearchScope, resolve_project_id};
+use crate::core::strata::is_excluded_raw_turn_drawer;
 
 pub fn routes() -> Router<ApiState> {
     Router::new()
@@ -25,6 +26,7 @@ struct TimelineQuery {
     room: Option<String>,
     limit: Option<usize>,
     project_id: Option<String>,
+    include_raw_turns: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -70,8 +72,11 @@ async fn timeline_handler(
         )
         .map_err(hermes_internal)?;
 
+    let exclude_raw_turns =
+        config.search.exclude_raw_turns && !query.include_raw_turns.unwrap_or(false);
     let entries = drawers
         .into_iter()
+        .filter(|drawer| !exclude_raw_turns || !is_excluded_raw_turn_drawer(drawer, &config.turns))
         .map(|d| TimelineEntry {
             drawer_id: d.id,
             content: d.content,

--- a/src/context.rs
+++ b/src/context.rs
@@ -385,6 +385,7 @@ fn search_t2_hybrid(
             SearchOptions {
                 filters,
                 with_neighbors: false,
+                ..SearchOptions::default()
             },
             50,
         )
@@ -808,6 +809,7 @@ fn search_context_candidates(
         SearchOptions {
             filters,
             with_neighbors: false,
+            ..SearchOptions::default()
         },
         query.top_k,
     )

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,6 +27,8 @@ const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
 const DEFAULT_SEARCH_TUNNEL_FANOUT_CAP: usize = 5;
 const DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP: usize = 8;
 const DEFAULT_SEARCH_TUNNEL_PENALTY: f32 = 0.7;
+const DEFAULT_TURN_STORAGE_MODE: TurnStorageMode = TurnStorageMode::RawEvidence;
+const DEFAULT_TURN_IMPORTANCE: i32 = 0;
 const DEFAULT_ALERT_EVERY_N_FAILURES: u64 = 100;
 const DEFAULT_DEGRADE_AFTER_N_FAILURES: u64 = 10;
 const DEFAULT_HOOK_WING: &str = "agent-diary";
@@ -79,6 +81,7 @@ pub struct Config {
     pub privacy: PrivacyConfig,
     pub config_hot_reload: ConfigHotReloadConfig,
     pub search: SearchConfig,
+    pub turns: TurnsConfig,
     pub hotpatch: HotpatchConfig,
     #[serde(alias = "gating")]
     pub ingest_gating: IngestGatingConfig,
@@ -104,6 +107,7 @@ impl Default for Config {
             privacy: PrivacyConfig::default(),
             config_hot_reload: ConfigHotReloadConfig::default(),
             search: SearchConfig::default(),
+            turns: TurnsConfig::default(),
             hotpatch: HotpatchConfig::default(),
             ingest_gating: IngestGatingConfig::default(),
             hooks: HooksConfig::default(),
@@ -195,6 +199,11 @@ impl Config {
         if self.search.preview_chars == 0 {
             return Err(ConfigError::InvalidConfig(
                 "search.preview_chars must be greater than 0".to_string(),
+            ));
+        }
+        if !(0..=5).contains(&self.turns.default_importance) {
+            return Err(ConfigError::InvalidConfig(
+                "turns.default_importance must be between 0 and 5".to_string(),
             ));
         }
         if !self.search.tunnel_penalty.is_finite()
@@ -877,6 +886,7 @@ impl Default for ConfigHotReloadConfig {
 pub struct SearchConfig {
     pub strict_project_isolation: bool,
     pub progressive_disclosure: bool,
+    pub exclude_raw_turns: bool,
     pub preview_chars: usize,
     pub tunnel_fanout_cap: usize,
     /// Maximum wing names shown per result in `tunnel_hints`. Excess entries are
@@ -894,10 +904,56 @@ impl Default for SearchConfig {
         Self {
             strict_project_isolation: false,
             progressive_disclosure: true,
+            exclude_raw_turns: true,
             preview_chars: DEFAULT_SEARCH_PREVIEW_CHARS,
             tunnel_fanout_cap: DEFAULT_SEARCH_TUNNEL_FANOUT_CAP,
             tunnel_hints_display_cap: DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP,
             tunnel_penalty: DEFAULT_SEARCH_TUNNEL_PENALTY,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStorageMode {
+    Off,
+    RawEvidence,
+    Summarized,
+}
+
+impl Default for TurnStorageMode {
+    fn default() -> Self {
+        DEFAULT_TURN_STORAGE_MODE
+    }
+}
+
+impl std::fmt::Display for TurnStorageMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Off => "off",
+            Self::RawEvidence => "raw_evidence",
+            Self::Summarized => "summarized",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TurnsConfig {
+    pub storage_mode: TurnStorageMode,
+    pub default_importance: i32,
+    pub raw_turn_wings: Vec<String>,
+    pub raw_turn_rooms: Vec<String>,
+}
+
+impl Default for TurnsConfig {
+    fn default() -> Self {
+        Self {
+            storage_mode: TurnStorageMode::default(),
+            default_importance: DEFAULT_TURN_IMPORTANCE,
+            raw_turn_wings: vec!["hooks-raw".to_string(), "hermes-user".to_string()],
+            raw_turn_rooms: vec!["turns".to_string(), "turns/raw".to_string()],
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,6 +12,7 @@ pub mod protocol;
 pub mod queue;
 pub mod reindex;
 pub mod skills;
+pub mod strata;
 pub mod timeline;
 pub mod types;
 pub mod utils;

--- a/src/core/strata.rs
+++ b/src/core/strata.rs
@@ -1,0 +1,92 @@
+use super::config::{TurnStorageMode, TurnsConfig};
+use super::db::{Database, DbError};
+use super::types::{Drawer, SearchResult};
+
+pub fn is_raw_turn(wing: &str, room: Option<&str>, config: &TurnsConfig) -> bool {
+    config
+        .raw_turn_wings
+        .iter()
+        .filter(|prefix| !prefix.is_empty())
+        .any(|prefix| wing.starts_with(prefix))
+        || room.is_some_and(|room| {
+            config
+                .raw_turn_rooms
+                .iter()
+                .filter(|candidate| !candidate.is_empty())
+                .any(|candidate| candidate == room)
+        })
+}
+
+pub fn should_store_raw_turns(mode: &TurnStorageMode) -> bool {
+    matches!(mode, TurnStorageMode::RawEvidence)
+}
+
+pub fn raw_turn_importance(wing: &str, room: Option<&str>, config: &TurnsConfig) -> Option<i32> {
+    is_raw_turn(wing, room, config).then_some(config.default_importance)
+}
+
+pub fn is_excluded_raw_turn(
+    wing: &str,
+    room: Option<&str>,
+    importance: i32,
+    config: &TurnsConfig,
+) -> bool {
+    importance == 0 && is_raw_turn(wing, room, config)
+}
+
+pub fn is_excluded_raw_turn_result(result: &SearchResult, config: &TurnsConfig) -> bool {
+    is_excluded_raw_turn(
+        &result.wing,
+        result.room.as_deref(),
+        result.importance,
+        config,
+    )
+}
+
+pub fn is_excluded_raw_turn_drawer(drawer: &Drawer, config: &TurnsConfig) -> bool {
+    is_excluded_raw_turn(
+        &drawer.wing,
+        drawer.room.as_deref(),
+        drawer.importance,
+        config,
+    )
+}
+
+pub fn count_raw_turn_drawers(db: &Database, config: &TurnsConfig) -> Result<i64, DbError> {
+    Ok(db
+        .scope_counts()?
+        .into_iter()
+        .filter(|(wing, room, _)| is_raw_turn(wing, room.as_deref(), config))
+        .map(|(_, _, count)| count)
+        .sum())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_by_wing_prefix_or_room() {
+        let config = TurnsConfig {
+            raw_turn_wings: vec!["hooks-raw".to_string(), "hermes-user".to_string()],
+            raw_turn_rooms: vec!["turns".to_string(), "turns/raw".to_string()],
+            ..TurnsConfig::default()
+        };
+
+        assert!(is_raw_turn("hooks-raw", Some("user-prompt"), &config));
+        assert!(is_raw_turn("hermes-user/alice", Some("facts"), &config));
+        assert!(is_raw_turn("project", Some("turns"), &config));
+        assert!(!is_raw_turn("project", Some("decision"), &config));
+    }
+
+    #[test]
+    fn empty_prefixes_do_not_match_everything() {
+        let config = TurnsConfig {
+            raw_turn_wings: vec![String::new()],
+            raw_turn_rooms: vec![String::new()],
+            ..TurnsConfig::default()
+        };
+
+        assert!(!is_raw_turn("project", Some("decision"), &config));
+    }
+}

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -464,6 +464,10 @@ pub struct SearchResult {
     pub anchor_kind: AnchorKind,
     pub anchor_id: String,
     pub parent_anchor_id: Option<String>,
+    /// Static importance ranking (0-5). Raw-turn exclusion uses this field so
+    /// access boosts cannot accidentally promote transcript storage into
+    /// durable recall.
+    pub importance: i32,
     pub similarity: f32,
     pub route: RouteDecision,
     #[serde(skip)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,6 +11,7 @@ use crate::core::{
     db::Database,
     project::resolve_project_id,
     queue::{ClaimedMessage, PendingMessageStore},
+    strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{BootstrapEvidenceArgs, Drawer, SourceType},
     utils::{current_timestamp, route_room_from_taxonomy, synthetic_source_file},
 };
@@ -449,10 +450,18 @@ fn build_drawer_records(
     config: &crate::core::config::Config,
     mempal_home: &Path,
 ) -> Result<Vec<DrawerRecord>> {
-    let audit_record = build_audit_drawer_record(envelope, config, mempal_home)?;
-    let mut records = vec![audit_record.clone()];
+    let mut audit_record = build_audit_drawer_record(envelope, config, mempal_home)?;
+    apply_turn_strata(&mut audit_record, config);
+    let mut records = Vec::new();
+    if should_keep_drawer_record(&audit_record, config) {
+        records.push(audit_record.clone());
+    }
     if let Some(record) = build_user_prompt_project_record(db, envelope, config, &audit_record)? {
-        records.push(record);
+        let mut record = record;
+        apply_turn_strata(&mut record, config);
+        if should_keep_drawer_record(&record, config) {
+            records.push(record);
+        }
     }
     if envelope.event == crate::hook::HookEvent::SessionEnd.display_name() {
         let session_review_payload = if config.hooks.session_end.extract_self_review {
@@ -502,7 +511,12 @@ fn build_drawer_records(
         })();
 
         match review_record {
-            Ok(Some(record)) => records.push(record),
+            Ok(Some(mut record)) => {
+                apply_turn_strata(&mut record, config);
+                if should_keep_drawer_record(&record, config) {
+                    records.push(record);
+                }
+            }
             Ok(None) => {}
             Err(error) => {
                 record_session_review_rejection(db);
@@ -518,6 +532,19 @@ fn build_drawer_records(
     }
 
     Ok(records)
+}
+
+fn apply_turn_strata(record: &mut DrawerRecord, config: &crate::core::config::Config) {
+    if let Some(importance) =
+        raw_turn_importance(&record.wing, Some(record.room.as_str()), &config.turns)
+    {
+        record.importance = importance;
+    }
+}
+
+fn should_keep_drawer_record(record: &DrawerRecord, config: &crate::core::config::Config) -> bool {
+    !is_raw_turn(&record.wing, Some(record.room.as_str()), &config.turns)
+        || should_store_raw_turns(&config.turns.storage_mode)
 }
 
 fn wing_from_cwd(cwd: &str) -> Option<String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -543,8 +543,12 @@ fn apply_turn_strata(record: &mut DrawerRecord, config: &crate::core::config::Co
 }
 
 fn should_keep_drawer_record(record: &DrawerRecord, config: &crate::core::config::Config) -> bool {
-    !is_raw_turn(&record.wing, Some(record.room.as_str()), &config.turns)
-        || should_store_raw_turns(&config.turns.storage_mode)
+    !raw_turn_storage_disabled(&record.wing, &record.room, config)
+}
+
+fn raw_turn_storage_disabled(wing: &str, room: &str, config: &crate::core::config::Config) -> bool {
+    is_raw_turn(wing, Some(room), &config.turns)
+        && !should_store_raw_turns(&config.turns.storage_mode)
 }
 
 fn wing_from_cwd(cwd: &str) -> Option<String> {
@@ -675,8 +679,13 @@ fn build_audit_drawer_record(
     }
 
     let raw_payload = envelope.payload.as_deref().unwrap_or_default();
+    let (wing, room) = audit_target_for_event(&envelope.event, raw_payload, config);
     let preview = config.scrub_content(&preview_for_event(&envelope.event, raw_payload));
-    let payload_path = persist_raw_payload(raw_payload, mempal_home)?;
+    let payload_path = if raw_turn_storage_disabled(&wing, &room, config) {
+        synthetic_source_file("hook-payload-skipped")
+    } else {
+        persist_raw_payload(raw_payload, mempal_home)?
+    };
     let content = serde_json::to_string(&json!({
         "event": envelope.event,
         "agent": envelope.agent,
@@ -694,7 +703,6 @@ fn build_audit_drawer_record(
         hook_payload_session_id(raw_payload).as_deref(),
         Some(envelope.captured_at.as_str()),
     );
-    let (wing, room) = audit_target_for_event(&envelope.event, raw_payload, config);
 
     Ok(DrawerRecord {
         wing,
@@ -1307,7 +1315,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::core::{
-        config::Config,
+        config::{Config, TurnStorageMode},
         db::Database,
         queue::{ClaimedMessage, PendingMessageStore, QueueError},
     };
@@ -1315,8 +1323,8 @@ mod tests {
     use crate::hook::{CapturedHookEnvelope, HookEvent};
 
     use super::{
-        ClaimNextSource, ClaimPollResult, DaemonIngestContext, poll_claim_next,
-        process_claimed_message_with_embedder, wing_from_cwd,
+        ClaimNextSource, ClaimPollResult, DaemonIngestContext, build_drawer_records,
+        poll_claim_next, process_claimed_message_with_embedder, wing_from_cwd,
     };
 
     struct StubClaimSource {
@@ -1467,6 +1475,47 @@ mod tests {
             )
             .expect("query drawer added_at");
         assert_eq!(added_at, captured_at);
+    }
+
+    #[test]
+    fn test_storage_mode_off_skips_hook_payload_file_for_raw_audit() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        let db_path = tmp.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        let raw_payload = serde_json::json!({
+            "session_id": "sess-raw-off",
+            "tool_name": "Bash",
+            "input": "printf secret",
+            "output": "raw payload must not be written",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(raw_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: raw_payload.len(),
+            truncated: false,
+        };
+        let mut config = Config::default();
+        config.turns.storage_mode = TurnStorageMode::Off;
+        config.turns.raw_turn_wings = vec!["hooks-raw".to_string()];
+        config.turns.raw_turn_rooms = Vec::new();
+
+        let records =
+            build_drawer_records(&db, &envelope, &config, &mempal_home).expect("drawer records");
+
+        assert!(records.is_empty());
+        assert!(
+            !mempal_home.join("hook-payloads").exists(),
+            "raw hook payload directory must not be created when turn storage is off"
+        );
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,9 +4,10 @@ use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use crate::core::{
-    config::{Config, default_config_path},
+    config::{Config, ConfigHandle, TurnStorageMode, default_config_path},
     db::Database,
     queue::PendingMessageStore,
+    strata::is_raw_turn,
     utils::current_timestamp,
 };
 use anyhow::{Context, Result};
@@ -68,10 +69,10 @@ pub struct CapturedHookEnvelope {
 
 pub fn run_command(command: HookCommands) -> Result<()> {
     match command {
-        HookCommands::PostToolUse => enqueue_from_stdin(HookEvent::PostToolUse),
-        HookCommands::UserPromptSubmit => enqueue_from_stdin(HookEvent::UserPromptSubmit),
-        HookCommands::SessionStart => enqueue_from_stdin(HookEvent::SessionStart),
-        HookCommands::SessionEnd => enqueue_from_stdin(HookEvent::SessionEnd),
+        HookCommands::PostToolUse => run_capture_command(HookEvent::PostToolUse),
+        HookCommands::UserPromptSubmit => run_capture_command(HookEvent::UserPromptSubmit),
+        HookCommands::SessionStart => run_capture_command(HookEvent::SessionStart),
+        HookCommands::SessionEnd => run_capture_command(HookEvent::SessionEnd),
         HookCommands::Install {
             target,
             dry_run,
@@ -81,14 +82,24 @@ pub fn run_command(command: HookCommands) -> Result<()> {
     }
 }
 
+fn run_capture_command(event: HookEvent) -> Result<()> {
+    ConfigHandle::bootstrap(default_config_path()).context("failed to bootstrap config")?;
+    enqueue_from_stdin(event)
+}
+
 pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
-    let config = Config::load_from(&default_config_path()).context("failed to load config")?;
+    let config = ConfigHandle::current();
+    let stdin = stdin_bytes()?;
+    if should_drop_hook_capture(event, &stdin, config.as_ref()) {
+        return Ok(());
+    }
+
     let db_path = expand_home_path(&config.db_path);
     let db = Database::open(&db_path).context("failed to open database for hook enqueue")?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     let mempal_home = mempal_home_from_db(db.path());
 
-    let captured = capture_stdin_payload(stdin_bytes()?, &mempal_home)?;
+    let captured = capture_stdin_payload(stdin, &mempal_home)?;
     let envelope = CapturedHookEnvelope {
         event: event.display_name().to_string(),
         kind: event.queue_kind().to_string(),
@@ -122,6 +133,33 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
         .enqueue(event.queue_kind(), &payload)
         .context("failed to enqueue hook payload")?;
     Ok(())
+}
+
+fn should_drop_hook_capture(event: HookEvent, bytes: &[u8], config: &Config) -> bool {
+    matches!(config.turns.storage_mode, TurnStorageMode::Off)
+        && is_raw_turn_for_hook_event(event, bytes, config)
+}
+
+fn is_raw_turn_for_hook_event(event: HookEvent, bytes: &[u8], config: &Config) -> bool {
+    let (wing, room) = raw_turn_target_for_hook_event(event, bytes);
+    is_raw_turn(wing, Some(room.as_str()), &config.turns)
+}
+
+fn raw_turn_target_for_hook_event(event: HookEvent, bytes: &[u8]) -> (&'static str, String) {
+    let room = match event {
+        HookEvent::PostToolUse => serde_json::from_slice::<serde_json::Value>(bytes)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("tool_name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_else(|| "unknown-tool".to_string()),
+        HookEvent::UserPromptSubmit => "user-prompt".to_string(),
+        HookEvent::SessionStart | HookEvent::SessionEnd => "session-lifecycle".to_string(),
+    };
+    ("hooks-raw", room)
 }
 
 fn stdin_bytes() -> Result<Vec<u8>> {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -18,6 +18,7 @@ use crate::core::{
     config::ConfigHandle,
     config::IngestGatingConfig,
     db::Database,
+    strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{BootstrapEvidenceArgs, Drawer, SourceType},
     utils::{
         build_bootstrap_evidence_drawer_id, build_drawer_id, iso_timestamp, link_superseded_drawer,
@@ -301,6 +302,17 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             route_room_from_taxonomy(&scrubbed, wing, &taxonomy)
         }
     };
+    let raw_turn = is_raw_turn(wing, Some(resolved_room.as_str()), &config.turns);
+    if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+        return Ok(IngestStats {
+            files: 1,
+            skipped: 1,
+            noise_bytes_stripped,
+            ..IngestStats::default()
+        });
+    }
+    let drawer_importance =
+        raw_turn_importance(wing, Some(resolved_room.as_str()), &config.turns).unwrap_or(0);
     let source_display = path.to_string_lossy();
     let chunker_config = &config.chunker;
 
@@ -456,7 +468,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                 }
             }
 
-            if wing != "hooks-raw"
+            if !raw_turn
                 && let Some(outcome) = evaluate_fact_check_gate(
                     &drawer_id,
                     chunk,
@@ -539,7 +551,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             source_type: source_type.clone(),
             added_at: iso_timestamp(),
             chunk_index: Some(chunk_index as i64),
-            importance: 0,
+            importance: drawer_importance,
         });
         let drawer = Drawer {
             normalize_version: CURRENT_NORMALIZE_VERSION,

--- a/src/knowledge_card_retrieval.rs
+++ b/src/knowledge_card_retrieval.rs
@@ -117,6 +117,7 @@ pub fn retrieve_knowledge_cards_with_vector(
             SearchOptions {
                 filters,
                 with_neighbors: false,
+                ..SearchOptions::default()
             },
             request.evidence_top_k.max(request.top_k),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use mempal::core::{
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     reindex::ReindexProgressStore,
+    strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
         AnchorKind, BootstrapEvidenceArgs, Drawer, KnowledgeCard, KnowledgeCardEvent,
         KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
@@ -103,6 +104,7 @@ struct SearchCommandOptions<'a> {
     all_projects: bool,
     json: bool,
     with_neighbors: bool,
+    include_raw_turns: bool,
 }
 
 struct IngestCommandOptions<'a> {
@@ -221,6 +223,8 @@ enum Commands {
         json: bool,
         #[arg(long)]
         with_neighbors: bool,
+        #[arg(long)]
+        include_raw_turns: bool,
     },
     Context {
         query: String,
@@ -1220,6 +1224,7 @@ fn run() -> Result<()> {
             all_projects,
             json,
             with_neighbors,
+            include_raw_turns,
         } => block_on_result(search_command(
             &db,
             config.as_ref(),
@@ -1241,6 +1246,7 @@ fn run() -> Result<()> {
                 all_projects,
                 json,
                 with_neighbors,
+                include_raw_turns,
             },
         )),
         Commands::Context {
@@ -1872,6 +1878,17 @@ async fn ingest_stdin_command(
     let project = options.project.or(record.project.as_deref());
     let supersedes = options.supersedes.or(record.supersedes.as_deref());
     let replace_text = options.replace_text.or(record.replace_text.as_deref());
+    let raw_turn = is_raw_turn(wing, room, &config.turns);
+    let mut stats = IngestStats {
+        files: 1,
+        ..IngestStats::default()
+    };
+    if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+        stats.skipped = 1;
+        print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+        return Ok(());
+    }
+    let drawer_importance = raw_turn_importance(wing, room, &config.turns).unwrap_or(0);
     let (privacy_config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
     let scrubbed_replace_text = replace_text
         .map(|text| privacy_config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
@@ -1909,11 +1926,6 @@ async fn ingest_stdin_command(
         db.resolve_available_drawer_id(&preferred_id)
             .with_context(|| format!("failed to resolve drawer id for {preferred_id}"))?
     };
-    let mut stats = IngestStats {
-        files: 1,
-        ..IngestStats::default()
-    };
-
     if options.dry_run {
         stats.chunks = 1;
         stats.drawer_ids.push(drawer_id.clone());
@@ -1979,7 +1991,7 @@ async fn ingest_stdin_command(
             }
         }
 
-        if wing != "hooks-raw"
+        if !raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
                 &content,
@@ -2027,7 +2039,7 @@ async fn ingest_stdin_command(
         source_type,
         added_at: iso_timestamp(),
         chunk_index: Some(0),
-        importance: 0,
+        importance: drawer_importance,
     });
     let drawer = Drawer {
         normalize_version: CURRENT_NORMALIZE_VERSION,
@@ -2689,6 +2701,7 @@ async fn search_command(
         SearchOptions {
             filters: options.filters,
             with_neighbors: options.with_neighbors,
+            include_raw_turns: options.include_raw_turns,
         },
         options.top_k,
     )
@@ -5181,6 +5194,8 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         .and_then(|v| v.parse::<u32>().ok())
         .unwrap_or(0);
     let drawer_count = db.drawer_count().context("failed to count drawers")?;
+    let raw_turn_count =
+        count_raw_turn_drawers(db, &config.turns).context("failed to count raw turn drawers")?;
     let project_breakdown: Option<Vec<(Option<String>, i64)>> = if full {
         Some(
             db.project_breakdown()
@@ -5253,6 +5268,18 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("triples: {triple_count}");
     }
     println!("db_size_bytes: {db_size_bytes}");
+    println!("Turns:");
+    println!("  storage_mode: {}", config.turns.storage_mode);
+    println!("  default_importance: {}", config.turns.default_importance);
+    println!("  raw_turn_count: {raw_turn_count}");
+    println!(
+        "  raw_turn_wings: {}",
+        display_list_or_none(&config.turns.raw_turn_wings)
+    );
+    println!(
+        "  raw_turn_rooms: {}",
+        display_list_or_none(&config.turns.raw_turn_rooms)
+    );
     println!(
         "config: version={} loaded_unix_ms={}",
         cfg_meta.version, cfg_meta.loaded_at_unix_ms
@@ -5375,6 +5402,14 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("scopes: (use --full for breakdown)");
     }
     Ok(())
+}
+
+fn display_list_or_none(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values.join(", ")
+    }
 }
 
 fn gating_command(db: &Database, config: &Config, command: GatingCommands) -> Result<()> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,6 +9,7 @@ use crate::core::{
     config::ConfigHandle,
     db::Database,
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
+    strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType,
@@ -49,8 +50,8 @@ use crate::knowledge_lifecycle::{
     promote_knowledge,
 };
 use crate::search::{
-    SearchFilters, SearchOptions, dispatch_access_update, resolve_route, search_bm25_only,
-    search_with_vector_and_scope_options,
+    SearchFilters, SearchOptions, dispatch_access_update, resolve_route,
+    search_bm25_only_with_options, search_with_vector_and_scope_options,
 };
 use anyhow::Context;
 use rmcp::{
@@ -78,7 +79,7 @@ use super::tools::{
     RollbackResponse, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto,
     SkillDto, SkillRequest, SkillResponse, SkillSummaryDto, StatusResponse, SystemWarning,
     TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto,
-    TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
 #[derive(Clone)]
@@ -339,6 +340,7 @@ impl MempalMcpServer {
         near_target_id: &str,
         novelty: &crate::ingest::novelty::NoveltyDecision,
         audit_decision: Option<&str>,
+        importance: i32,
         inserted_drawer_ids: &mut Vec<String>,
         newly_created_drawer_ids: &mut Vec<String>,
     ) -> std::result::Result<(), ErrorData> {
@@ -389,6 +391,7 @@ impl MempalMcpServer {
                 chunk,
                 *chunk_idx,
                 &source_type,
+                importance,
             );
             db.insert_drawer_with_project(&drawer, project_id)
                 .map_err(db_error)?;
@@ -585,6 +588,7 @@ fn drawer_from_ingest_metadata(
     content: &str,
     chunk_idx: usize,
     source_type: &SourceType,
+    importance: i32,
 ) -> Drawer {
     let source_file = match metadata.memory_kind {
         MemoryKind::Knowledge => Some(knowledge_source_file(
@@ -612,7 +616,7 @@ fn drawer_from_ingest_metadata(
         added_at: iso_timestamp(),
         chunk_index: Some(chunk_idx as i64),
         normalize_version: CURRENT_NORMALIZE_VERSION,
-        importance: request.importance.unwrap_or(0),
+        importance,
         memory_kind: metadata.memory_kind.clone(),
         domain: metadata.domain.clone(),
         field: metadata.field.clone(),
@@ -629,7 +633,7 @@ fn drawer_from_ingest_metadata(
         verification_refs: metadata.verification_refs.clone(),
         scope_constraints: metadata.scope_constraints.clone(),
         trigger_hints: metadata.trigger_hints.clone(),
-        effective_importance: request.importance.unwrap_or(0) as f64,
+        effective_importance: importance as f64,
     }
 }
 
@@ -885,6 +889,7 @@ impl MempalMcpServer {
             .stale_drawer_count(CURRENT_NORMALIZE_VERSION)
             .map_err(db_error)? as u64;
         let drawer_count = db.drawer_count().map_err(db_error)?;
+        let raw_turn_count = count_raw_turn_drawers(&db, &config.turns).map_err(db_error)?;
         let null_project_backfill_pending =
             db.null_project_backfill_pending_count().map_err(db_error)?;
         let taxonomy_count = db.taxonomy_count().map_err(db_error)?;
@@ -964,6 +969,13 @@ impl MempalMcpServer {
                 model: config.llm.model.clone(),
                 max_concurrent: config.llm.max_concurrent,
             },
+            turn_storage: TurnStorageStatusDto {
+                storage_mode: config.turns.storage_mode.to_string(),
+                default_importance: config.turns.default_importance,
+                raw_turn_count,
+                raw_turn_wings: config.turns.raw_turn_wings.clone(),
+                raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
+            },
             system_warnings,
         }))
     }
@@ -1006,6 +1018,7 @@ impl MempalMcpServer {
                 anchor_kind: request.anchor_kind.clone(),
             },
             with_neighbors: request.with_neighbors.unwrap_or(false),
+            include_raw_turns: request.include_raw_turns.unwrap_or(false),
         };
         let mut extra_warnings = Vec::new();
         let embedder = self.embedder_factory.build().await.map_err(|error| {
@@ -1040,7 +1053,15 @@ impl MempalMcpServer {
                     message: "vector unavailable, BM25 fallback".to_string(),
                     source: "embed".to_string(),
                 });
-                search_bm25_only(&db, &request.query, route, &scope, top_k).map_err(|bm25_error| {
+                search_bm25_only_with_options(
+                    &db,
+                    &request.query,
+                    route,
+                    &scope,
+                    search_options.clone(),
+                    top_k,
+                )
+                .map_err(|bm25_error| {
                     ErrorData::internal_error(
                         format!(
                             "search failed after vector fallback: {error}; bm25 fallback failed: {bm25_error}"
@@ -1055,7 +1076,15 @@ impl MempalMcpServer {
                     message: "vector unavailable, BM25 fallback".to_string(),
                     source: "embed".to_string(),
                 });
-                search_bm25_only(&db, &request.query, route, &scope, top_k).map_err(|error| {
+                search_bm25_only_with_options(
+                    &db,
+                    &request.query,
+                    route,
+                    &scope,
+                    search_options.clone(),
+                    top_k,
+                )
+                .map_err(|error| {
                     ErrorData::internal_error(
                         format!("search deadline fallback failed: {error}"),
                         None,
@@ -1731,6 +1760,25 @@ impl MempalMcpServer {
         let room = request.room.as_deref();
         let db = self.open_db()?;
         let dry_run = request.dry_run.unwrap_or(false);
+        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
+        if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+            return Ok(Json(IngestResponse {
+                drawer_id: String::new(),
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
+                dropped: false,
+                gating_decision: None,
+                novelty_action: None,
+                near_drawer_id: None,
+                duplicate_warning: None,
+                lock_wait_ms: None,
+                superseded_drawer_id: None,
+                fact_check_warnings: Vec::new(),
+                system_warnings: current_system_warnings(),
+            }));
+        }
+        let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
+            .unwrap_or_else(|| request.importance.unwrap_or(0));
         let source_type = SourceType::Manual;
         let metadata = validate_ingest_request(&request, &source_type)?;
 
@@ -1994,7 +2042,7 @@ impl MempalMcpServer {
         }
 
         let mut fact_check_warnings = Vec::new();
-        if request.wing != "hooks-raw"
+        if !raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
                 &candidate.content,
@@ -2147,6 +2195,7 @@ impl MempalMcpServer {
                         chunk,
                         *chunk_idx,
                         &source_type,
+                        drawer_importance,
                     );
                     if let Some(old_id) = superseded_drawer_id.as_deref() {
                         link_superseded_drawer(&mut drawer, old_id);
@@ -2220,6 +2269,7 @@ impl MempalMcpServer {
                         &target_id,
                         &novelty,
                         Some("insert_due_to_merge_cap"),
+                        drawer_importance,
                         &mut inserted_drawer_ids,
                         &mut newly_created_drawer_ids,
                     )?;
@@ -2270,6 +2320,7 @@ impl MempalMcpServer {
                                     &target_id,
                                     &novelty,
                                     Some("insert_due_to_embed_error"),
+                                    drawer_importance,
                                     &mut inserted_drawer_ids,
                                     &mut newly_created_drawer_ids,
                                 )?;
@@ -2295,6 +2346,7 @@ impl MempalMcpServer {
                                 &target_id,
                                 &novelty,
                                 Some("insert_due_to_embed_error"),
+                                drawer_importance,
                                 &mut inserted_drawer_ids,
                                 &mut newly_created_drawer_ids,
                             )?;
@@ -3992,6 +4044,7 @@ mod tests {
                 include_global: None,
                 all_projects: None,
                 disable_progressive: None,
+                include_raw_turns: None,
             }))
             .await
             .expect("search should succeed")
@@ -6568,6 +6621,7 @@ mod tests_duplicate_conflict_artifact {
                 include_global: None,
                 all_projects: None,
                 disable_progressive: None,
+                include_raw_turns: None,
             }))
             .await
             .expect("search should succeed")

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -79,6 +79,9 @@ pub struct SearchRequest {
 
     /// If true and top_k <= 10, include previous/next chunks from the same source.
     pub with_neighbors: Option<bool>,
+
+    /// Include low-importance raw dialogue turns that are excluded by default.
+    pub include_raw_turns: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -930,8 +933,18 @@ pub struct StatusResponse {
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,
+    pub turn_storage: TurnStorageStatusDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct TurnStorageStatusDto {
+    pub storage_mode: String,
+    pub default_importance: i32,
+    pub raw_turn_count: i64,
+    pub raw_turn_wings: Vec<String>,
+    pub raw_turn_rooms: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
@@ -1333,6 +1346,7 @@ impl SearchResultDto {
             anchor_kind,
             anchor_id,
             parent_anchor_id,
+            importance: _,
             similarity,
             route,
             chunk_index: _,
@@ -1789,6 +1803,7 @@ mod tests {
             anchor_kind: AnchorKind::Repo,
             anchor_id: "repo://signals".to_string(),
             parent_anchor_id: None,
+            importance: 3,
             similarity: 0.91,
             route: RouteDecision {
                 wing: Some("mempal".to_string()),

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -39,6 +39,7 @@ pub struct SearchFilters {
 pub struct SearchOptions {
     pub filters: SearchFilters,
     pub with_neighbors: bool,
+    pub include_raw_turns: bool,
 }
 
 #[derive(Debug, Error)]
@@ -243,7 +244,9 @@ pub fn search_with_vector_and_scope_options(
         return Ok(Vec::new());
     }
 
-    let has_filters = !options.filters.is_empty();
+    let config = crate::core::config::ConfigHandle::current();
+    let exclude_raw_turns = config.search.exclude_raw_turns && !options.include_raw_turns;
+    let has_filters = !options.filters.is_empty() || exclude_raw_turns;
     let candidate_top_k = if has_filters {
         top_k.saturating_mul(20).max(100)
     } else {
@@ -269,13 +272,25 @@ pub fn search_with_vector_and_scope_options(
     } else {
         rrf_merge(vector_results, &fts_ids, &route, scope, db, candidate_top_k)
     };
-    if has_filters {
+    if !options.filters.is_empty() {
         results.retain(|result| matches_filters(result, &options.filters));
+        results.truncate(top_k);
+    }
+    if exclude_raw_turns {
+        results.retain(|result| {
+            !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
+        });
         results.truncate(top_k);
     }
 
     // Inject tunnel hints: for each result, check if its room exists in other wings
     inject_tunnel_hints_and_results(db, &mut results, scope);
+    if exclude_raw_turns {
+        results.retain(|result| {
+            !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
+        });
+        results.truncate(top_k);
+    }
 
     // Chunk neighbors hydration (upstream feature)
     if options.with_neighbors && top_k <= 10 {
@@ -404,10 +419,29 @@ pub fn search_bm25_only(
     scope: &ProjectSearchScope,
     top_k: usize,
 ) -> Result<Vec<SearchResult>> {
+    search_bm25_only_with_options(db, query, route, scope, SearchOptions::default(), top_k)
+}
+
+/// BM25-only search path with raw-turn filtering options.
+pub fn search_bm25_only_with_options(
+    db: &Database,
+    query: &str,
+    route: RouteDecision,
+    scope: &ProjectSearchScope,
+    options: SearchOptions,
+    top_k: usize,
+) -> Result<Vec<SearchResult>> {
     if top_k == 0 {
         return Ok(Vec::new());
     }
 
+    let config = crate::core::config::ConfigHandle::current();
+    let exclude_raw_turns = config.search.exclude_raw_turns && !options.include_raw_turns;
+    let candidate_top_k = if exclude_raw_turns {
+        top_k.saturating_mul(20).max(100)
+    } else {
+        top_k
+    };
     let fts_ids = db
         .search_fts(
             query,
@@ -415,12 +449,24 @@ pub fn search_bm25_only(
             route.room.as_deref(),
             scope.mode_param(),
             scope.project_id.as_deref(),
-            top_k,
+            candidate_top_k,
         )
         .map_err(SearchError::KeywordSearch)?;
 
-    let mut results = rrf_merge(Vec::new(), &fts_ids, &route, scope, db, top_k);
+    let mut results = rrf_merge(Vec::new(), &fts_ids, &route, scope, db, candidate_top_k);
+    if exclude_raw_turns {
+        results.retain(|result| {
+            !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
+        });
+        results.truncate(top_k);
+    }
     inject_tunnel_hints_and_results(db, &mut results, scope);
+    if exclude_raw_turns {
+        results.retain(|result| {
+            !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
+        });
+        results.truncate(top_k);
+    }
     Ok(results)
 }
 
@@ -636,6 +682,7 @@ fn result_from_drawer(
         anchor_kind: drawer.anchor_kind,
         anchor_id: drawer.anchor_id,
         parent_anchor_id: drawer.parent_anchor_id,
+        importance: drawer.importance,
         similarity,
         route,
         chunk_index: drawer.chunk_index,
@@ -860,6 +907,7 @@ pub fn search_by_vector(
                     anchor_kind: AnchorKind::Global,
                     anchor_id: String::new(),
                     parent_anchor_id: None,
+                    importance: 0,
                     similarity: (1.0_f64 - distance) as f32,
                     route: route.clone(),
                     chunk_index: None,
@@ -969,6 +1017,7 @@ fn search_by_vector_scoped_exact(
                     anchor_kind: AnchorKind::Global,
                     anchor_id: String::new(),
                     parent_anchor_id: None,
+                    importance: 0,
                     similarity: (1.0_f64 - distance) as f32,
                     route: route.clone(),
                     chunk_index: None,
@@ -1242,6 +1291,7 @@ mod tests {
             anchor_kind: AnchorKind::Global,
             anchor_id: String::new(),
             parent_anchor_id: None,
+            importance: drawer.importance,
             similarity: 0.9,
             route: RouteDecision {
                 wing: None,

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -12,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use mempal::core::config::ConfigHandle;
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_FORK_EXT_VERSION, Database};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::ingest::gating::{IngestCandidate, evaluate_tier1};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
@@ -597,7 +597,7 @@ async fn test_status_prints_config_version_and_loaded_at() {
     assert!(
         stdout
             .lines()
-            .any(|line| line.trim() == "fork_ext_version: 13"),
+            .any(|line| line.trim() == format!("fork_ext_version: {CURRENT_FORK_EXT_VERSION}")),
         "fork_ext_version line missing from status: {stdout}"
     );
     let line = stdout

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -13,6 +13,10 @@ fn mempal_bin() -> String {
 }
 
 fn setup_home() -> (TempDir, PathBuf) {
+    setup_home_with_extra_config("")
+}
+
+fn setup_home_with_extra_config(extra_config: &str) -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
     let mempal_home = tmp.path().join(".mempal");
     fs::create_dir_all(&mempal_home).expect("create mempal home");
@@ -26,12 +30,39 @@ db_path = "{}"
 
 [hooks]
 enabled = true
+{extra_config}
 "#,
             db_path.display()
         ),
     )
     .expect("write config");
     (tmp, db_path)
+}
+
+fn run_hook(home: &TempDir, command: &str, payload: &[u8]) -> std::process::Output {
+    let mut child = Command::new(mempal_bin())
+        .args(["hook", command])
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook command");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload)
+        .expect("write payload");
+    child.wait_with_output().expect("wait output")
+}
+
+fn pending_message_count(db_path: &PathBuf) -> i64 {
+    let conn = Connection::open(db_path).expect("open sqlite");
+    conn.query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
+        row.get(0)
+    })
+    .expect("query pending count")
 }
 
 #[test]
@@ -169,4 +200,54 @@ fn test_hook_envelopes_oversized_payload() {
             .expect("payload path string"),
     );
     assert!(payload_path.exists(), "oversized payload file must exist");
+}
+
+#[test]
+fn test_hook_storage_mode_off_skips_raw_turn_enqueue() {
+    let (home, db_path) = setup_home_with_extra_config(
+        r#"
+[turns]
+storage_mode = "off"
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = []
+"#,
+    );
+    let payload = r#"{"prompt":"do not persist raw turn"}"#;
+
+    let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(pending_message_count(&db_path), 0);
+}
+
+#[test]
+fn test_hook_storage_mode_off_skips_oversize_payload_file() {
+    let (home, db_path) = setup_home_with_extra_config(
+        r#"
+[turns]
+storage_mode = "off"
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = []
+"#,
+    );
+    let oversized = vec![b'a'; 11 * 1024 * 1024];
+
+    let output = run_hook(&home, "hook_user_prompt", &oversized);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(pending_message_count(&db_path), 0);
+    assert!(
+        !home.path().join(".mempal").join("hook-oversize").exists(),
+        "off-mode raw turn capture must not write oversize files"
+    );
 }

--- a/tests/memory_strata.rs
+++ b/tests/memory_strata.rs
@@ -1,0 +1,311 @@
+#![cfg(feature = "integration")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use mempal::core::config::ConfigHandle;
+use mempal::core::db::Database;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer, SearchRequest};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+async fn config_guard() -> OwnedMutexGuard<()> {
+    static GUARD: OnceLock<Arc<AsyncMutex<()>>> = OnceLock::new();
+    GUARD
+        .get_or_init(|| Arc::new(AsyncMutex::new(())))
+        .clone()
+        .lock_owned()
+        .await
+}
+
+#[derive(Clone)]
+struct StaticEmbedderFactory;
+
+struct StaticEmbedder;
+
+#[async_trait]
+impl EmbedderFactory for StaticEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(StaticEmbedder))
+    }
+}
+
+#[async_trait]
+impl Embedder for StaticEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        3
+    }
+
+    fn name(&self) -> &str {
+        "static"
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+    server: MempalMcpServer,
+}
+
+impl TestEnv {
+    fn new(turns_section: &str) -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let config_path = mempal_home.join("config.toml");
+        let db_path = mempal_home.join("palace.db");
+        fs::write(&config_path, config_text(&db_path, turns_section)).expect("write config");
+        Database::open(&db_path).expect("open db");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        let server =
+            MempalMcpServer::new_with_factory(db_path.clone(), Arc::new(StaticEmbedderFactory));
+        Self {
+            _tmp: tmp,
+            db_path,
+            server,
+        }
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+}
+
+fn config_text(db_path: &Path, turns_section: &str) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embedder]
+backend = "api"
+base_url = "http://127.0.0.1:9/v1/"
+api_model = "test-model"
+
+[config_hot_reload]
+enabled = false
+
+[search]
+strict_project_isolation = false
+progressive_disclosure = false
+preview_chars = 200
+exclude_raw_turns = true
+
+{turns_section}
+"#,
+        db_path.display()
+    )
+}
+
+async fn ingest(
+    server: &MempalMcpServer,
+    content: &str,
+    wing: &str,
+    room: &str,
+    importance: i32,
+) -> mempal::mcp::IngestResponse {
+    server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: content.to_string(),
+            wing: wing.to_string(),
+            room: Some(room.to_string()),
+            importance: Some(importance),
+            ..IngestRequest::default()
+        }))
+        .await
+        .expect("ingest")
+        .0
+}
+
+#[tokio::test]
+async fn storage_mode_off_skips_raw_turn_ingest() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(
+        r#"
+[turns]
+storage_mode = "off"
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = ["turns"]
+"#,
+    );
+
+    let response = ingest(
+        &env.server,
+        "needle raw turn should not persist",
+        "hooks-raw",
+        "user-prompt",
+        5,
+    )
+    .await;
+
+    assert!(!response.dropped);
+    assert!(response.drawer_ids.is_empty());
+    assert_eq!(response.chunk_count, 0);
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 0);
+}
+
+#[tokio::test]
+async fn raw_evidence_forces_low_importance() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(
+        r#"
+[turns]
+storage_mode = "raw_evidence"
+default_importance = 0
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = ["turns"]
+"#,
+    );
+
+    let response = ingest(
+        &env.server,
+        "needle raw turn persists as evidence",
+        "hooks-raw",
+        "user-prompt",
+        5,
+    )
+    .await;
+    let drawer_id = response.drawer_ids.first().expect("drawer id");
+    let drawer = env
+        .db()
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("stored drawer");
+
+    assert_eq!(drawer.importance, 0);
+}
+
+#[tokio::test]
+async fn default_search_excludes_raw_turns_until_requested() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(
+        r#"
+[turns]
+storage_mode = "raw_evidence"
+default_importance = 0
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = ["turns"]
+"#,
+    );
+    ingest(
+        &env.server,
+        "needle durable project fact",
+        "mempal",
+        "facts",
+        4,
+    )
+    .await;
+    ingest(
+        &env.server,
+        "needle raw transcript turn",
+        "hooks-raw",
+        "user-prompt",
+        5,
+    )
+    .await;
+
+    let default_search = env
+        .server
+        .mempal_search(Parameters(SearchRequest {
+            query: "needle".to_string(),
+            top_k: Some(10),
+            ..SearchRequest::default()
+        }))
+        .await
+        .expect("default search")
+        .0;
+    assert!(
+        default_search
+            .results
+            .iter()
+            .all(|result| result.wing != "hooks-raw")
+    );
+
+    let include_raw = env
+        .server
+        .mempal_search(Parameters(SearchRequest {
+            query: "needle".to_string(),
+            top_k: Some(10),
+            include_raw_turns: Some(true),
+            ..SearchRequest::default()
+        }))
+        .await
+        .expect("include raw search")
+        .0;
+    assert!(
+        include_raw
+            .results
+            .iter()
+            .any(|result| result.wing == "hooks-raw")
+    );
+}
+
+#[tokio::test]
+async fn non_raw_ingest_ignores_turn_storage_off() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(
+        r#"
+[turns]
+storage_mode = "off"
+raw_turn_wings = ["hooks-raw"]
+raw_turn_rooms = ["turns"]
+"#,
+    );
+
+    let response = ingest(
+        &env.server,
+        "durable fact still persists",
+        "mempal",
+        "facts",
+        4,
+    )
+    .await;
+    let drawer_id = response.drawer_ids.first().expect("drawer id");
+    let drawer = env
+        .db()
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("stored drawer");
+
+    assert_eq!(drawer.importance, 4);
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 1);
+}
+
+#[tokio::test]
+async fn custom_raw_turn_room_prefixes_are_honored() {
+    let _guard = config_guard().await;
+    let env = TestEnv::new(
+        r#"
+[turns]
+storage_mode = "off"
+raw_turn_wings = ["custom-raw"]
+raw_turn_rooms = ["conversation"]
+"#,
+    );
+
+    ingest(
+        &env.server,
+        "custom room raw turn should skip",
+        "ordinary-wing",
+        "conversation",
+        5,
+    )
+    .await;
+    ingest(
+        &env.server,
+        "custom wing raw turn should skip",
+        "custom-raw-agent",
+        "events",
+        5,
+    )
+    .await;
+
+    assert_eq!(env.db().drawer_count().expect("drawer count"), 0);
+}

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -143,6 +143,7 @@ async fn search_neighbors(
         SearchOptions {
             filters: SearchFilters::default(),
             with_neighbors,
+            ..SearchOptions::default()
         },
         top_k,
     )
@@ -267,6 +268,7 @@ async fn test_neighbors_limited_to_same_wing() {
         SearchOptions {
             filters: SearchFilters::default(),
             with_neighbors: true,
+            ..SearchOptions::default()
         },
         4,
     )

--- a/tests/tiered_retrieval.rs
+++ b/tests/tiered_retrieval.rs
@@ -319,6 +319,7 @@ fn test_search_unaffected_by_tiered_context_config() {
         SearchOptions {
             filters: SearchFilters::default(),
             with_neighbors: false,
+            ..SearchOptions::default()
         },
         10,
     )

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "de76e642a2c182dd03df9bc7ee1712716438b760"
+commit = "8cff5050aa93e3034e2343fc237eb430888b05f8"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add memory strata system separating raw turns from durable facts
- New config `[turns]` with `storage_mode` (off / raw_evidence), `default_importance`, `raw_turn_wings`, `raw_turn_rooms`
- Raw turns deprioritized in search (excluded by default, `include_raw_turns` param to override)
- Hook-level enforcement: `storage_mode = "off"` skips enqueue + oversize write + daemon payload persistence
- Hermes plugin updated: `sync_turn()` respects storage mode, search/profile exclude raw turns
- `mempal status` reports turn storage mode and raw turn stats

## Test plan

- [x] `cargo test` — all tests pass (311-line new test file + existing)
- [x] Tier-4 review: PASS after 3 rounds
  - R1: daemon persisted payload despite off-mode → fixed
  - R2: hook enqueue + oversize write persisted before daemon filter → fixed
  - R3: clean (1 MEDIUM — search under-fill, non-blocking)

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)