### PR TITLE
feat(hermes): scope and session lifecycle isolation (#188)

### DIFF
--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -63,9 +63,10 @@ or `profile`.
 - Session summaries → `room="sessions/{session_id}"`
 - Built-in memory mirrors → `room="facts"`, scoped turns/session rooms, or `room="memory-mirror/{target}"`
 
-When Hermes provides `project_id` (or `cwd` as a fallback), the plugin forwards
-it to `/api/search`, `/api/timeline`, and `/api/ingest` for mempal project
-isolation.
+When Hermes provides `project_id`, the plugin forwards it to `/api/search`,
+`/api/timeline`, and `/api/ingest` for mempal project isolation. When only
+`cwd` is available, the plugin derives the project scope from the directory
+basename.
 
 ## Circuit breaker
 

--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -54,11 +54,18 @@ Replaces mem0 with a fully local BM25 + vector hybrid backend — no cloud API c
 
 ## Memory routing
 
-All memories are stored under `wing="hermes-user/{user_id}"`:
-- Turns → `room="turns"`
-- Explicit facts → `room="facts"`
-- Session summaries → `room="sessions"`
-- Built-in memory mirrors → `room="memory-mirror"`
+All memories are profile-scoped under `wing="hermes-user/{user_id}/{profile}"`.
+The default profile is `default`, and Hermes may pass it as `agent_identity`
+or `profile`.
+
+- Turns → `room="turns"` or `room="turns/{platform}/{chat_id}[/{thread_id}]"`
+- Explicit facts → `room="facts"` shared across chats for the same profile
+- Session summaries → `room="sessions/{session_id}"`
+- Built-in memory mirrors → `room="facts"`, scoped turns/session rooms, or `room="memory-mirror/{target}"`
+
+When Hermes provides `project_id` (or `cwd` as a fallback), the plugin forwards
+it to `/api/search`, `/api/timeline`, and `/api/ingest` for mempal project
+isolation.
 
 ## Circuit breaker
 

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -174,7 +174,10 @@ class MempalMemoryProvider:
             thread_id = self._thread_id if preserve_existing else ""
 
         if "project_id" in context or "cwd" in context:
-            project_id = context.get("project_id") or context.get("cwd", "")
+            project_id = context.get("project_id") or ""
+            if not project_id:
+                cwd = str(context.get("cwd") or "")
+                project_id = os.path.basename(cwd.rstrip("/")) if cwd else ""
         else:
             project_id = self._project_id if preserve_existing else ""
 

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -100,15 +100,27 @@ class MempalMemoryProvider:
 
     def __init__(self):
         self._base_url = "http://127.0.0.1:3080"
+        self._session_id = ""
+        self._hermes_home = ""
         self._user_id = "hermes-user"
-        self._wing = "hermes-user/hermes-user"
+        self._profile = "default"
+        self._platform = "cli"
+        self._chat_id = ""
+        self._thread_id = ""
+        self._wing = "hermes-user/hermes-user/default"
+        self._turns_room = "turns"
+        self._facts_room = "facts"
+        self._project_id: Optional[str] = None
         self._prefetch_result = ""
+        self._prefetch_results: Dict[str, str] = {}
+        self._prefetch_generation = 0
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
+        self._session_end_thread: Optional[threading.Thread] = None
+        self._mirror_thread: Optional[threading.Thread] = None
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
-        self._hermes_home = ""
 
     @property
     def name(self) -> str:
@@ -126,12 +138,89 @@ class MempalMemoryProvider:
             return False
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        self._hermes_home = kwargs.get("hermes_home", "")
+        self._configure_scope(session_id, kwargs, preserve_existing=False)
+
+    def _configure_scope(
+        self,
+        session_id: str,
+        context: Dict[str, Any],
+        *,
+        preserve_existing: bool,
+    ) -> None:
+        self._session_id = session_id
+        if "hermes_home" in context or not preserve_existing:
+            self._hermes_home = str(context.get("hermes_home", ""))
+
         cfg = _load_config(self._hermes_home)
         self._base_url = cfg["base_url"].rstrip("/")
-        user_id = kwargs.get("user_id") or cfg.get("user_id", "hermes-user")
+
+        user_id = context.get("user_id") or (
+            self._user_id if preserve_existing else cfg.get("user_id", "hermes-user")
+        )
+        profile = (
+            context.get("agent_identity")
+            or context.get("profile")
+            or (self._profile if preserve_existing else "default")
+        )
+        platform = context.get("platform") or (self._platform if preserve_existing else "cli")
+
+        if "chat_id" in context:
+            chat_id = str(context.get("chat_id") or "")
+        else:
+            chat_id = self._chat_id if preserve_existing else ""
+        if "thread_id" in context:
+            thread_id = str(context.get("thread_id") or "")
+        else:
+            thread_id = self._thread_id if preserve_existing else ""
+
+        if "project_id" in context or "cwd" in context:
+            project_id = context.get("project_id") or context.get("cwd", "")
+        else:
+            project_id = self._project_id if preserve_existing else ""
+
         self._user_id = user_id
-        self._wing = f"hermes-user/{user_id}"
+        self._profile = str(profile)
+        self._platform = str(platform)
+        self._chat_id = chat_id
+        self._thread_id = thread_id
+        self._wing = f"hermes-user/{user_id}/{self._profile}"
+        self._turns_room = self._derive_turns_room(self._platform, chat_id, thread_id)
+        self._facts_room = "facts"
+        self._project_id = str(project_id) if project_id else None
+
+    @staticmethod
+    def _derive_turns_room(platform: str, chat_id: str, thread_id: str) -> str:
+        if not chat_id:
+            return "turns"
+        if thread_id:
+            return f"turns/{platform}/{chat_id}/{thread_id}"
+        return f"turns/{platform}/{chat_id}"
+
+    def _session_key(self, session_id: str = "") -> str:
+        return session_id or self._session_id
+
+    def _with_project_id(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        scoped = dict(payload)
+        if self._project_id:
+            scoped["project_id"] = self._project_id
+        return scoped
+
+    def _session_room(self) -> str:
+        if self._session_id:
+            return f"sessions/{self._session_id}"
+        return "sessions"
+
+    def _memory_room_for_target(self, target: str) -> str:
+        normalized = (target or "").strip().lower()
+        if normalized in {"fact", "facts", "profile", "user", "global"}:
+            return self._facts_room
+        if normalized in {"turn", "turns", "conversation"}:
+            return self._turns_room
+        if normalized in {"session", "sessions"}:
+            return self._session_room()
+        if normalized:
+            return f"memory-mirror/{normalized.replace('/', '_')}"
+        return "memory-mirror"
 
     def _turn_storage_mode(self) -> str:
         try:
@@ -202,7 +291,8 @@ class MempalMemoryProvider:
     def system_prompt_block(self) -> str:
         return (
             "# Mempal Memory\n"
-            f"Active. User: {self._user_id}. Local BM25+vector backend, zero cloud.\n"
+            f"Active. User: {self._user_id}. Profile: {self._profile}. "
+            "Local BM25+vector backend, zero cloud.\n"
             "Use mempal_search to recall facts, mempal_conclude to store, "
             "mempal_profile for recent overview."
         )
@@ -210,8 +300,11 @@ class MempalMemoryProvider:
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
+        key = self._session_key(session_id)
         with self._prefetch_lock:
-            result = self._prefetch_result
+            result = self._prefetch_results.pop(key, "")
+            if not result and key == self._session_id:
+                result = self._prefetch_result
             self._prefetch_result = ""
         if not result:
             return ""
@@ -220,22 +313,27 @@ class MempalMemoryProvider:
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         if self._is_breaker_open():
             return
+        key = self._session_key(session_id)
+        wing = self._wing
+        generation = self._prefetch_generation
+        params = self._with_project_id({
+            "q": query,
+            "wing": wing,
+            "top_k": 5,
+            "include_raw_turns": False,
+        })
 
         def _run():
             try:
-                results = self._get(
-                    "/api/search",
-                    {
-                        "q": query,
-                        "wing": self._wing,
-                        "top_k": 5,
-                        "include_raw_turns": False,
-                    },
-                )
+                results = self._get("/api/search", params)
                 if results:
                     lines = [r.get("content", "") for r in results if r.get("content")]
                     with self._prefetch_lock:
-                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+                        if generation == self._prefetch_generation:
+                            result = "\n".join(f"- {l}" for l in lines)
+                            self._prefetch_results[key] = result
+                            if key == self._session_id:
+                                self._prefetch_result = result
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
@@ -256,17 +354,15 @@ class MempalMemoryProvider:
             return
 
         content = f"User: {user_content}\nAssistant: {assistant_content}"
+        body = self._with_project_id({
+            "content": content,
+            "wing": self._wing,
+            "room": self._turns_room,
+        })
 
         def _sync():
             try:
-                self._post(
-                    "/api/ingest",
-                    {
-                        "content": content,
-                        "wing": self._wing,
-                        "room": "turns",
-                    },
-                )
+                self._post("/api/ingest", body)
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
@@ -301,7 +397,11 @@ class MempalMemoryProvider:
                     limit = 20
                 entries = self._get(
                     "/api/timeline",
-                    {"wing": self._wing, "limit": limit, "include_raw_turns": False},
+                    self._with_project_id({
+                        "wing": self._wing,
+                        "limit": limit,
+                        "include_raw_turns": False,
+                    }),
                 )
                 self._record_success()
                 if not entries:
@@ -323,12 +423,12 @@ class MempalMemoryProvider:
             try:
                 results = self._get(
                     "/api/search",
-                    {
+                    self._with_project_id({
                         "q": query,
                         "wing": self._wing,
                         "top_k": top_k,
                         "include_raw_turns": False,
-                    },
+                    }),
                 )
                 self._record_success()
                 if not results:
@@ -349,11 +449,11 @@ class MempalMemoryProvider:
             try:
                 self._post(
                     "/api/ingest",
-                    {
+                    self._with_project_id({
                         "content": conclusion,
                         "wing": self._wing,
-                        "room": "facts",
-                    },
+                        "room": self._facts_room,
+                    }),
                 )
                 self._record_success()
                 return json.dumps({"result": "Fact stored."})
@@ -375,23 +475,24 @@ class MempalMemoryProvider:
         if not assistant_msgs:
             return
         summary = assistant_msgs[-1][:2000]
+        body = self._with_project_id({
+            "content": f"[Session summary] {summary}",
+            "wing": self._wing,
+            "room": self._session_room(),
+        })
 
         def _ingest():
             try:
-                self._post(
-                    "/api/ingest",
-                    {
-                        "content": f"[Session summary] {summary}",
-                        "wing": self._wing,
-                        "room": "sessions",
-                    },
-                )
+                self._post("/api/ingest", body)
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
                 logger.warning("mempal on_session_end failed: %s", exc)
 
-        threading.Thread(target=_ingest, daemon=True, name="mempal-session-end").start()
+        self._session_end_thread = threading.Thread(
+            target=_ingest, daemon=True, name="mempal-session-end"
+        )
+        self._session_end_thread.start()
 
     def on_memory_write(
         self,
@@ -403,26 +504,46 @@ class MempalMemoryProvider:
         """Mirror built-in memory writes to mempal."""
         if self._is_breaker_open() or action == "remove":
             return
+        body = self._with_project_id({
+            "content": content,
+            "wing": self._wing,
+            "room": self._memory_room_for_target(target),
+        })
 
         def _mirror():
             try:
-                self._post(
-                    "/api/ingest",
-                    {
-                        "content": content,
-                        "wing": self._wing,
-                        "room": "memory-mirror",
-                    },
-                )
+                self._post("/api/ingest", body)
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
                 logger.debug("mempal on_memory_write failed: %s", exc)
 
-        threading.Thread(target=_mirror, daemon=True, name="mempal-mirror").start()
+        self._mirror_thread = threading.Thread(
+            target=_mirror, daemon=True, name="mempal-mirror"
+        )
+        self._mirror_thread.start()
+
+    def on_session_switch(self, new_session_id: str, reason: str = "", **kwargs) -> None:
+        """Handle reset/new/resume/branch/compression continuation events."""
+        del reason
+        with self._prefetch_lock:
+            self._prefetch_result = ""
+            self._prefetch_results.clear()
+            self._prefetch_generation += 1
+
+        for thread in (self._sync_thread, self._session_end_thread, self._mirror_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+
+        self._configure_scope(new_session_id, kwargs, preserve_existing=True)
 
     def shutdown(self) -> None:
-        for t in (self._prefetch_thread, self._sync_thread):
+        for t in (
+            self._prefetch_thread,
+            self._sync_thread,
+            self._session_end_thread,
+            self._mirror_thread,
+        ):
             if t and t.is_alive():
                 t.join(timeout=5.0)
 

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -1,0 +1,161 @@
+import os
+import sys
+import unittest
+from typing import Any, Dict, List, Optional, Tuple
+
+
+PLUGIN_DIR = os.path.dirname(__file__)
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+from mempal import MempalMemoryProvider  # noqa: E402
+
+
+class RecordingProvider(MempalMemoryProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gets: List[Tuple[str, Optional[Dict[str, Any]]]] = []
+        self.posts: List[Tuple[str, Dict[str, Any]]] = []
+        self.responses: Dict[str, Any] = {}
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        self.gets.append((path, dict(params or {})))
+        return self.responses.get(path, [])
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Any:
+        self.posts.append((path, dict(body)))
+        return {"ok": True}
+
+    def _turn_storage_mode(self) -> str:
+        return "raw_evidence"
+
+
+class MempalProviderScopeTests(unittest.TestCase):
+    def test_two_profiles_use_distinct_wings(self) -> None:
+        work = RecordingProvider()
+        personal = RecordingProvider()
+        work.initialize("session-a", user_id="alice", profile="work")
+        personal.initialize("session-b", user_id="alice", profile="personal")
+
+        work.handle_tool_call("mempal_conclude", {"conclusion": "likes vim"})
+        personal.handle_tool_call("mempal_conclude", {"conclusion": "likes emacs"})
+
+        self.assertEqual(work.posts[-1][1]["wing"], "hermes-user/alice/work")
+        self.assertEqual(personal.posts[-1][1]["wing"], "hermes-user/alice/personal")
+
+    def test_same_profile_facts_are_shared_across_chats(self) -> None:
+        chat_a = RecordingProvider()
+        chat_b = RecordingProvider()
+        chat_a.initialize("session-a", user_id="alice", profile="work", chat_id="chat-a")
+        chat_b.initialize("session-b", user_id="alice", profile="work", chat_id="chat-b")
+
+        chat_a.handle_tool_call("mempal_conclude", {"conclusion": "prefers concise answers"})
+        chat_b.handle_tool_call("mempal_conclude", {"conclusion": "prefers citations"})
+
+        self.assertEqual(chat_a.posts[-1][1]["wing"], chat_b.posts[-1][1]["wing"])
+        self.assertEqual(chat_a.posts[-1][1]["room"], "facts")
+        self.assertEqual(chat_b.posts[-1][1]["room"], "facts")
+
+    def test_chat_and_thread_ids_scope_turn_rooms(self) -> None:
+        chat_only = RecordingProvider()
+        threaded = RecordingProvider()
+        chat_only.initialize("session-a", user_id="alice", profile="work", platform="slack", chat_id="chat-a")
+        threaded.initialize(
+            "session-b",
+            user_id="alice",
+            profile="work",
+            platform="slack",
+            chat_id="chat-a",
+            thread_id="thread-1",
+        )
+
+        chat_only.sync_turn("hello", "hi")
+        threaded.sync_turn("hello", "hi")
+        chat_only._sync_thread.join(timeout=1.0)
+        threaded._sync_thread.join(timeout=1.0)
+
+        self.assertEqual(chat_only.posts[-1][1]["room"], "turns/slack/chat-a")
+        self.assertEqual(threaded.posts[-1][1]["room"], "turns/slack/chat-a/thread-1")
+
+    def test_project_id_passes_through_rest_calls(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize(
+            "session-a",
+            user_id="alice",
+            profile="work",
+            project_id="project-alpha",
+            chat_id="chat-a",
+        )
+
+        provider.responses["/api/timeline"] = [{"content": "fact"}]
+        provider.handle_tool_call("mempal_profile", {"limit": 5})
+        provider.handle_tool_call("mempal_search", {"query": "fact", "top_k": 3})
+        provider.handle_tool_call("mempal_conclude", {"conclusion": "durable fact"})
+        provider.sync_turn("hello", "hi")
+        provider._sync_thread.join(timeout=1.0)
+
+        timeline_params = provider.gets[0][1]
+        search_params = provider.gets[1][1]
+        ingest_bodies = [body for path, body in provider.posts if path == "/api/ingest"]
+
+        self.assertEqual(timeline_params["project_id"], "project-alpha")
+        self.assertEqual(search_params["project_id"], "project-alpha")
+        self.assertTrue(ingest_bodies)
+        self.assertTrue(all(body["project_id"] == "project-alpha" for body in ingest_bodies))
+
+    def test_session_switch_clears_prefetch_results(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        with provider._prefetch_lock:
+            provider._prefetch_result = "stale"
+            provider._prefetch_results["session-a"] = "stale"
+
+        provider.on_session_switch("session-b", reason="reset")
+
+        self.assertEqual(provider.prefetch("anything", session_id="session-a"), "")
+        self.assertEqual(provider.prefetch("anything", session_id="session-b"), "")
+
+    def test_prefetch_is_keyed_by_session_and_project(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work", project_id="project-alpha")
+        provider.responses["/api/search"] = [{"content": "session scoped memory"}]
+
+        provider.queue_prefetch("memory", session_id="session-a")
+        result = provider.prefetch("memory", session_id="session-a")
+
+        self.assertIn("session scoped memory", result)
+        self.assertEqual(provider.gets[-1][1]["project_id"], "project-alpha")
+        self.assertEqual(provider.prefetch("memory", session_id="session-b"), "")
+
+    def test_session_end_uses_session_scoped_room(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work", project_id="project-alpha")
+
+        provider.on_session_end([{"role": "assistant", "content": "summary text"}])
+        provider._session_end_thread.join(timeout=1.0)
+
+        self.assertEqual(provider.posts[-1][1]["room"], "sessions/session-a")
+        self.assertEqual(provider.posts[-1][1]["project_id"], "project-alpha")
+
+    def test_memory_write_routes_by_target(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize(
+            "session-a",
+            user_id="alice",
+            profile="work",
+            project_id="project-alpha",
+            chat_id="chat-a",
+        )
+
+        provider.on_memory_write("set", "profile", "profile fact")
+        provider._mirror_thread.join(timeout=1.0)
+        provider.on_memory_write("set", "turns", "turn content")
+        provider._mirror_thread.join(timeout=1.0)
+
+        self.assertEqual(provider.posts[-2][1]["room"], "facts")
+        self.assertEqual(provider.posts[-1][1]["room"], "turns/cli/chat-a")
+        self.assertEqual(provider.posts[-1][1]["project_id"], "project-alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -103,6 +103,30 @@ class MempalProviderScopeTests(unittest.TestCase):
         self.assertTrue(ingest_bodies)
         self.assertTrue(all(body["project_id"] == "project-alpha" for body in ingest_bodies))
 
+    def test_cwd_fallback_uses_directory_basename_as_project_id(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize(
+            "session-a",
+            user_id="alice",
+            profile="work",
+            cwd="/home/alice/my-project/",
+            chat_id="chat-a",
+        )
+
+        provider.responses["/api/timeline"] = [{"content": "fact"}]
+        provider.handle_tool_call("mempal_profile", {"limit": 5})
+        provider.handle_tool_call("mempal_search", {"query": "fact", "top_k": 3})
+        provider.handle_tool_call("mempal_conclude", {"conclusion": "durable fact"})
+
+        timeline_params = provider.gets[0][1]
+        search_params = provider.gets[1][1]
+        ingest_bodies = [body for path, body in provider.posts if path == "/api/ingest"]
+
+        self.assertEqual(timeline_params["project_id"], "my-project")
+        self.assertEqual(search_params["project_id"], "my-project")
+        self.assertTrue(ingest_bodies)
+        self.assertTrue(all(body["project_id"] == "my-project" for body in ingest_bodies))
+
     def test_session_switch_clears_prefetch_results(self) -> None:
         provider = RecordingProvider()
         provider.initialize("session-a", user_id="alice", profile="work")

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "8cff5050aa93e3034e2343fc237eb430888b05f8"
+commit = "69b62e5aa355e8a153b8cf91a4fed8832ea0aed3"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Hermes MemoryProvider plugin now derives scoped wing (`hermes-user/{user_id}/{profile}`), chat/thread-scoped turns rooms, profile-scoped facts room
- `on_session_switch()` clears prefetch with generation counter to prevent cross-session leakage
- All REST calls pass `project_id` when available (derived from cwd basename, not raw path)
- 8 focused Python unit tests covering isolation scenarios

Closes #188

## Test plan
- [x] `python -m unittest discover -s contrib/hermes-agent-plugin -p 'test_*.py'` — 8 tests OK
- [x] Tier-4 critical review PASS (R1: fixed cwd-as-project_id, R2: clean)
- [x] Pre-commit hooks pass
- [x] Worktree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>