### PR TITLE
feat(search): temporal decay and drawer validity windows (#198)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -75,6 +75,7 @@ struct SearchQuery {
     include_global: Option<bool>,
     all_projects: Option<bool>,
     include_raw_turns: Option<bool>,
+    include_expired: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -86,6 +87,8 @@ struct IngestRequest {
     project_id: Option<String>,
     supersedes: Option<String>,
     replace_text: Option<String>,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -107,11 +110,24 @@ fn is_zero(v: &usize) -> bool {
     *v == 0
 }
 
+fn validate_temporal_param(name: &str, value: Option<&str>) -> Result<(), ApiError> {
+    if let Some(raw) = value
+        && crate::core::decay::parse_temporal_timestamp_secs(raw).is_none()
+    {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            format!("{name} must be a Unix timestamp or RFC3339 timestamp"),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Serialize)]
 struct StatusResponse {
     drawer_count: i64,
     taxonomy_count: i64,
     db_size_bytes: u64,
+    search_decay_mode: String,
     wings: Vec<ScopeCount>,
     turn_storage: TurnStorageStatus,
 }
@@ -200,6 +216,7 @@ async fn search_handler(
         &scope,
         SearchOptions {
             include_raw_turns: query.include_raw_turns.unwrap_or(false),
+            include_expired: query.include_expired.unwrap_or(false),
             ..SearchOptions::default()
         },
         query.top_k.unwrap_or(10),
@@ -222,6 +239,8 @@ async fn ingest_handler(
         .map_err(internal_error)?;
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+    validate_temporal_param("valid_from", request.valid_from.as_deref())?;
+    validate_temporal_param("valid_until", request.valid_until.as_deref())?;
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
     let raw_turn = is_raw_turn(&request.wing, request.room.as_deref(), &config.turns);
@@ -394,8 +413,13 @@ async fn ingest_handler(
             if let Some(old_id) = superseded_drawer_id.as_deref() {
                 link_superseded_drawer(&mut drawer, old_id);
             }
-            db.insert_drawer_with_project(&drawer, project_id.as_deref())
-                .map_err(internal_error)?;
+            db.insert_drawer_with_project_validity(
+                &drawer,
+                project_id.as_deref(),
+                request.valid_from.as_deref(),
+                request.valid_until.as_deref(),
+            )
+            .map_err(internal_error)?;
             db.insert_vector_with_project(drawer_id, vector, project_id.as_deref())
                 .map_err(internal_error)?;
         }
@@ -459,6 +483,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         drawer_count,
         taxonomy_count,
         db_size_bytes,
+        search_decay_mode: config.search.decay.mode.to_string(),
         wings,
         turn_storage: TurnStorageStatus {
             storage_mode: config.turns.storage_mode.to_string(),

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,6 +27,9 @@ const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
 const DEFAULT_SEARCH_TUNNEL_FANOUT_CAP: usize = 5;
 const DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP: usize = 8;
 const DEFAULT_SEARCH_TUNNEL_PENALTY: f32 = 0.7;
+const DEFAULT_SEARCH_DECAY_HALF_LIFE_DAYS: u64 = 90;
+const DEFAULT_SEARCH_DECAY_STEP_FULL_DAYS: u64 = 30;
+const DEFAULT_SEARCH_DECAY_STEP_REDUCED_WEIGHT: f64 = 0.5;
 const DEFAULT_TURN_STORAGE_MODE: TurnStorageMode = TurnStorageMode::RawEvidence;
 const DEFAULT_TURN_IMPORTANCE: i32 = 0;
 const DEFAULT_ALERT_EVERY_N_FAILURES: u64 = 100;
@@ -211,6 +214,18 @@ impl Config {
         {
             return Err(ConfigError::InvalidConfig(
                 "search.tunnel_penalty must be a finite value in 0.0..=1.0".to_string(),
+            ));
+        }
+        if self.search.decay.half_life_days == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "search.decay.half_life_days must be greater than 0".to_string(),
+            ));
+        }
+        if !self.search.decay.step_reduced_weight.is_finite()
+            || !(0.0..=1.0).contains(&self.search.decay.step_reduced_weight)
+        {
+            return Err(ConfigError::InvalidConfig(
+                "search.decay.step_reduced_weight must be a finite value in 0.0..=1.0".to_string(),
             ));
         }
         if !(0..=5).contains(&self.hotpatch.min_importance_stars) {
@@ -897,6 +912,7 @@ pub struct SearchConfig {
     /// `1.0` disables the penalty. Default `0.7` deprioritizes cross-project rows
     /// when their raw embedding score clusters near direct in-project matches.
     pub tunnel_penalty: f32,
+    pub decay: DecayConfig,
 }
 
 impl Default for SearchConfig {
@@ -909,7 +925,50 @@ impl Default for SearchConfig {
             tunnel_fanout_cap: DEFAULT_SEARCH_TUNNEL_FANOUT_CAP,
             tunnel_hints_display_cap: DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP,
             tunnel_penalty: DEFAULT_SEARCH_TUNNEL_PENALTY,
+            decay: DecayConfig::default(),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DecayConfig {
+    pub mode: DecayMode,
+    pub half_life_days: u64,
+    pub step_full_days: u64,
+    pub step_reduced_weight: f64,
+}
+
+impl Default for DecayConfig {
+    fn default() -> Self {
+        Self {
+            mode: DecayMode::None,
+            half_life_days: DEFAULT_SEARCH_DECAY_HALF_LIFE_DAYS,
+            step_full_days: DEFAULT_SEARCH_DECAY_STEP_FULL_DAYS,
+            step_reduced_weight: DEFAULT_SEARCH_DECAY_STEP_REDUCED_WEIGHT,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecayMode {
+    #[default]
+    None,
+    Exponential,
+    Linear,
+    Step,
+}
+
+impl std::fmt::Display for DecayMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::None => "none",
+            Self::Exponential => "exponential",
+            Self::Linear => "linear",
+            Self::Step => "step",
+        };
+        f.write_str(value)
     }
 }
 
@@ -1470,5 +1529,65 @@ impl Default for SkillsConfig {
             skill_min_sessions: DEFAULT_SKILLS_MIN_SESSIONS,
             skill_surfacing_threshold: DEFAULT_SKILLS_SURFACING_THRESHOLD,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, DecayMode};
+
+    #[test]
+    fn search_decay_defaults_to_none() {
+        let config = Config::parse("").expect("empty config should parse");
+        assert_eq!(config.search.decay.mode, DecayMode::None);
+        assert_eq!(config.search.decay.half_life_days, 90);
+        assert_eq!(config.search.decay.step_full_days, 30);
+        assert_eq!(config.search.decay.step_reduced_weight, 0.5);
+    }
+
+    #[test]
+    fn search_decay_config_parses_nested_section() {
+        let config = Config::parse(
+            r#"
+            [search.decay]
+            mode = "exponential"
+            half_life_days = 45
+            step_full_days = 10
+            step_reduced_weight = 0.25
+            "#,
+        )
+        .expect("decay config should parse");
+
+        assert_eq!(config.search.decay.mode, DecayMode::Exponential);
+        assert_eq!(config.search.decay.half_life_days, 45);
+        assert_eq!(config.search.decay.step_full_days, 10);
+        assert_eq!(config.search.decay.step_reduced_weight, 0.25);
+    }
+
+    #[test]
+    fn search_decay_config_rejects_invalid_values() {
+        let err = Config::parse(
+            r#"
+            [search.decay]
+            half_life_days = 0
+            "#,
+        )
+        .expect_err("zero half-life must be rejected");
+        assert!(
+            err.to_string().contains("search.decay.half_life_days"),
+            "unexpected error: {err}"
+        );
+
+        let err = Config::parse(
+            r#"
+            [search.decay]
+            step_reduced_weight = 1.5
+            "#,
+        )
+        .expect_err("step weight above one must be rejected");
+        assert!(
+            err.to_string().contains("search.decay.step_reduced_weight"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -38,7 +38,7 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-const CURRENT_SCHEMA_VERSION: u32 = 9;
+const CURRENT_SCHEMA_VERSION: u32 = 10;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
@@ -291,6 +291,16 @@ impl Database {
         drawer: &Drawer,
         project_id: Option<&str>,
     ) -> Result<(), DbError> {
+        self.insert_drawer_with_project_validity(drawer, project_id, None, None)
+    }
+
+    pub fn insert_drawer_with_project_validity(
+        &self,
+        drawer: &Drawer,
+        project_id: Option<&str>,
+        valid_from: Option<&str>,
+        valid_until: Option<&str>,
+    ) -> Result<(), DbError> {
         let content_hash = content_hash_hex(&drawer.content);
         anchor::validate_anchor_domain(&drawer.domain, &drawer.anchor_kind)
             .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
@@ -325,9 +335,11 @@ impl Database {
                 teaching_refs,
                 verification_refs,
                 scope_constraints,
-                trigger_hints
+                trigger_hints,
+                valid_from,
+                valid_until
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30)
             "#,
             params![
                 drawer.id.as_str(),
@@ -358,6 +370,8 @@ impl Database {
                 encode_json(&drawer.verification_refs)?,
                 drawer.scope_constraints.as_deref(),
                 encode_optional_json(drawer.trigger_hints.as_ref())?,
+                valid_from.unwrap_or(drawer.added_at.as_str()),
+                valid_until,
             ],
         )?;
 
@@ -989,7 +1003,9 @@ impl Database {
                     verification_refs = ?24,
                     scope_constraints = ?25,
                     trigger_hints = ?26,
-                    content_hash = ?27
+                    content_hash = ?27,
+                    valid_from = ?28,
+                    valid_until = NULL
                 WHERE id = ?1 AND deleted_at IS NULL
                 "#,
                 params![
@@ -1020,6 +1036,7 @@ impl Database {
                     drawer.scope_constraints.as_deref(),
                     encode_optional_json(drawer.trigger_hints.as_ref())?,
                     content_hash,
+                    drawer.added_at.as_str(),
                 ],
             )?;
 
@@ -1362,7 +1379,7 @@ impl Database {
         ))?;
         let mut rows = statement.query_map([drawer_id], |row| {
             let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-            // DRAWER_SELECT_COLUMNS now has 27 columns (indices 0-26), so
+            // DRAWER_SELECT_COLUMNS has 27 columns (indices 0-26), so
             // the extra columns appended here start at index 27.
             let updated_at = row.get::<_, Option<String>>(27)?;
             let merge_count = row.get::<_, u32>(28)?;
@@ -2056,7 +2073,7 @@ impl Database {
     pub fn supersede_drawer(&self, old_id: &str, reason: &str) -> Result<bool, DbError> {
         let timestamp = super::utils::current_timestamp();
         let affected = self.conn.execute(
-            "UPDATE drawers SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            "UPDATE drawers SET deleted_at = ?1, valid_until = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             params![timestamp, old_id],
         )?;
         if affected > 0 {
@@ -3122,6 +3139,10 @@ fn apply_migrations(conn: &Connection) -> Result<(), DbError> {
             apply_migration_atomic(conn, &V7_ALREADY_APPLIED_MIGRATION)?;
             continue;
         }
+        if migration.version == 10 {
+            ensure_v10_drawers_schema(conn, read_user_version(conn)?)?;
+            continue;
+        }
         apply_migration_atomic(conn, migration)?;
     }
 
@@ -3178,6 +3199,33 @@ fn ensure_v5_drawers_schema(conn: &Connection, current_version: u32) -> Result<(
     // Keep the large content_hash rewrite outside the schema transaction so
     // the WAL stays bounded on legacy installs with many historical rows.
     backfill_content_hash(conn)?;
+    Ok(())
+}
+
+fn ensure_v10_drawers_schema(conn: &Connection, current_version: u32) -> Result<(), DbError> {
+    let existing_columns = drawers_column_names(conn)?;
+    let missing_columns = V10_DRAWER_COLUMN_MIGRATIONS
+        .iter()
+        .filter(|column| !existing_columns.contains(column.name))
+        .copied()
+        .collect::<Vec<_>>();
+
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    if let Err(error) = (|| -> Result<(), DbError> {
+        for column in missing_columns {
+            conn.execute_batch(column.sql)?;
+        }
+        conn.execute_batch(V10_VALIDITY_BACKFILL_SQL)?;
+        if current_version < 10 {
+            set_user_version(conn, 10)?;
+        }
+        conn.execute_batch("COMMIT;")?;
+        Ok(())
+    })() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return Err(error);
+    }
+
     Ok(())
 }
 
@@ -3625,6 +3673,40 @@ CREATE INDEX IF NOT EXISTS idx_runtime_adoption_events_signal
     ON runtime_adoption_events(signal);
 "#;
 
+const V10_MIGRATION_SQL: &str = r#"
+ALTER TABLE drawers ADD COLUMN valid_from TEXT;
+ALTER TABLE drawers ADD COLUMN valid_until TEXT;
+
+UPDATE drawers
+SET valid_from = added_at
+WHERE valid_from IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drawers_validity
+    ON drawers(valid_from, valid_until)
+    WHERE deleted_at IS NULL;
+"#;
+
+const V10_DRAWER_COLUMN_MIGRATIONS: &[DrawerColumnMigration] = &[
+    DrawerColumnMigration {
+        name: "valid_from",
+        sql: "ALTER TABLE drawers ADD COLUMN valid_from TEXT;",
+    },
+    DrawerColumnMigration {
+        name: "valid_until",
+        sql: "ALTER TABLE drawers ADD COLUMN valid_until TEXT;",
+    },
+];
+
+const V10_VALIDITY_BACKFILL_SQL: &str = r#"
+UPDATE drawers
+SET valid_from = added_at
+WHERE valid_from IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drawers_validity
+    ON drawers(valid_from, valid_until)
+    WHERE deleted_at IS NULL;
+"#;
+
 fn migrations() -> &'static [Migration] {
     static MIGRATIONS: &[Migration] = &[
         Migration {
@@ -3662,6 +3744,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 9,
             sql: V9_MIGRATION_SQL,
+        },
+        Migration {
+            version: 10,
+            sql: V10_MIGRATION_SQL,
         },
     ];
     MIGRATIONS
@@ -4218,7 +4304,33 @@ mod tests {
     }
 
     #[test]
-    fn test_supersede_drawer_soft_deletes_and_writes_audit() {
+    fn test_insert_drawer_defaults_valid_from_to_added_at() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+
+        insert_test_drawer(&db, "valid-default", "valid fact", Some("project-a"));
+
+        let validity = db
+            .conn()
+            .query_row(
+                "SELECT added_at, valid_from, valid_until FROM drawers WHERE id = 'valid-default'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .expect("read validity");
+        assert_eq!(validity.1.as_deref(), Some(validity.0.as_str()));
+        assert_eq!(validity.2, None);
+    }
+
+    #[test]
+    fn test_supersede_drawer_soft_deletes_sets_valid_until_and_writes_audit() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
@@ -4230,6 +4342,15 @@ mod tests {
 
         assert!(superseded);
         assert!(!db.drawer_exists("old").expect("drawer exists"));
+        let valid_until = db
+            .conn()
+            .query_row(
+                "SELECT valid_until FROM drawers WHERE id = 'old'",
+                [],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .expect("read valid_until");
+        assert!(valid_until.is_some());
         let audit = fs::read_to_string(tempdir.path().join("audit.jsonl")).expect("read audit");
         assert!(audit.contains("\"command\":\"supersede\""));
         assert!(audit.contains("\"drawer_id\":\"old\""));
@@ -4301,6 +4422,57 @@ mod tests {
             !columns.iter().any(|column| column == "memory_kind"),
             "failed migration must not leave partial columns behind"
         );
+    }
+
+    #[test]
+    fn test_v10_migration_adds_validity_windows_and_backfills_valid_from() {
+        let conn = Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE drawers (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                wing TEXT NOT NULL,
+                room TEXT,
+                source_file TEXT,
+                source_type TEXT NOT NULL CHECK(source_type IN ('project', 'conversation', 'manual')),
+                added_at TEXT NOT NULL,
+                chunk_index INTEGER,
+                deleted_at TEXT
+            );
+            INSERT INTO drawers (
+                id, content, wing, room, source_file, source_type, added_at, chunk_index, deleted_at
+            ) VALUES (
+                'legacy', 'legacy body', 'code', NULL, 'legacy.md', 'manual', '2026-04-29T00:00:00Z', 0, NULL
+            );
+            PRAGMA user_version = 9;
+            "#,
+        )
+        .expect("create legacy schema");
+
+        apply_migrations(&conn).expect("apply migration");
+
+        assert_eq!(
+            read_user_version(&conn).expect("user_version"),
+            CURRENT_SCHEMA_VERSION
+        );
+        let columns = drawers_column_names(&conn).expect("drawer columns");
+        assert!(columns.contains("valid_from"));
+        assert!(columns.contains("valid_until"));
+        let validity = conn
+            .query_row(
+                "SELECT valid_from, valid_until FROM drawers WHERE id = 'legacy'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                    ))
+                },
+            )
+            .expect("read validity");
+        assert_eq!(validity.0.as_deref(), Some("2026-04-29T00:00:00Z"));
+        assert_eq!(validity.1, None);
     }
 
     #[test]

--- a/src/core/decay.rs
+++ b/src/core/decay.rs
@@ -1,9 +1,12 @@
-//! Pure importance-decay and retrieval-boost functions (P13, LLM-free).
+//! Pure importance-decay, retrieval-boost, and search temporal scoring functions.
 //!
 //! Implements heuristic effective_importance = base * decay(days) + capped_boost.
 //! All parameters come from `ImportanceConfig` which is hot-reload whitelisted.
 
-use crate::core::config::ImportanceConfig;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::core::config::{DecayConfig, DecayMode, ImportanceConfig};
+use crate::cowork::peek::parse_rfc3339;
 
 /// Compute `effective_importance` from components.
 ///
@@ -40,10 +43,76 @@ pub fn elapsed_days(now_ms: i64, reference_ms: i64) -> f64 {
     diff_ms / 86_400_000.0
 }
 
+/// Parse mempal temporal fields as Unix seconds or RFC3339 timestamps.
+pub fn parse_temporal_timestamp_secs(value: &str) -> Option<i64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<i64>().ok().or_else(|| parse_rfc3339(value))
+}
+
+/// Compute the search relevance decay factor for a drawer timestamp.
+///
+/// Invalid timestamps fail open with factor `1.0` so search recall is not lost
+/// because of legacy or externally supplied metadata.
+pub fn search_decay_factor(added_at: &str, config: &DecayConfig) -> f64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0);
+    search_decay_factor_at(added_at, config, now)
+}
+
+/// Deterministic variant of [`search_decay_factor`] for tests and callers that
+/// already captured a request-level clock.
+pub fn search_decay_factor_at(added_at: &str, config: &DecayConfig, now_secs: i64) -> f64 {
+    let Some(added_at_secs) = parse_temporal_timestamp_secs(added_at) else {
+        return 1.0;
+    };
+    let age_days = ((now_secs - added_at_secs).max(0) as f64) / 86_400.0;
+    match config.mode {
+        DecayMode::None => 1.0,
+        DecayMode::Exponential => (-0.693 * age_days / config.half_life_days as f64).exp(),
+        DecayMode::Linear => (1.0 - age_days / config.half_life_days as f64).max(0.0),
+        DecayMode::Step => {
+            if age_days <= config.step_full_days as f64 {
+                1.0
+            } else {
+                config.step_reduced_weight
+            }
+        }
+    }
+}
+
+/// Return whether a validity window contains `now_secs`.
+///
+/// Unset or unparseable bounds are treated as open so malformed legacy
+/// metadata does not silently hide otherwise searchable memories.
+pub fn validity_window_contains_at(
+    valid_from: Option<&str>,
+    valid_until: Option<&str>,
+    now_secs: i64,
+) -> bool {
+    if valid_from
+        .and_then(parse_temporal_timestamp_secs)
+        .is_some_and(|from| from > now_secs)
+    {
+        return false;
+    }
+    if valid_until
+        .and_then(parse_temporal_timestamp_secs)
+        .is_some_and(|until| until < now_secs)
+    {
+        return false;
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::config::ImportanceConfig;
+    use crate::core::config::{DecayConfig, DecayMode, ImportanceConfig};
 
     fn default_cfg() -> ImportanceConfig {
         ImportanceConfig::default()
@@ -136,5 +205,88 @@ mod tests {
     fn test_elapsed_days_clamps_negative_to_zero() {
         // reference > now → should clamp to 0 days
         assert!((elapsed_days(0, 1_000_000)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_search_decay_none_is_noop() {
+        let cfg = DecayConfig::default();
+        let factor = search_decay_factor_at("1710000000", &cfg, 1710000000 + 365 * 86_400);
+        assert_eq!(factor, 1.0);
+    }
+
+    #[test]
+    fn test_search_decay_exponential_halves_at_half_life() {
+        let cfg = DecayConfig {
+            mode: DecayMode::Exponential,
+            half_life_days: 90,
+            ..DecayConfig::default()
+        };
+        let factor = search_decay_factor_at("1710000000", &cfg, 1710000000 + 90 * 86_400);
+        assert!((factor - 0.500_073_6).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_search_decay_linear_reaches_zero_at_half_life() {
+        let cfg = DecayConfig {
+            mode: DecayMode::Linear,
+            half_life_days: 90,
+            ..DecayConfig::default()
+        };
+        let factor = search_decay_factor_at("1710000000", &cfg, 1710000000 + 45 * 86_400);
+        assert!((factor - 0.5).abs() < 1e-9);
+
+        let zero = search_decay_factor_at("1710000000", &cfg, 1710000000 + 91 * 86_400);
+        assert_eq!(zero, 0.0);
+    }
+
+    #[test]
+    fn test_search_decay_step_uses_reduced_weight_after_full_window() {
+        let cfg = DecayConfig {
+            mode: DecayMode::Step,
+            step_full_days: 30,
+            step_reduced_weight: 0.25,
+            ..DecayConfig::default()
+        };
+        assert_eq!(
+            search_decay_factor_at("1710000000", &cfg, 1710000000 + 30 * 86_400),
+            1.0
+        );
+        assert_eq!(
+            search_decay_factor_at("1710000000", &cfg, 1710000000 + 31 * 86_400),
+            0.25
+        );
+    }
+
+    #[test]
+    fn test_search_decay_accepts_rfc3339_and_fails_open() {
+        let cfg = DecayConfig {
+            mode: DecayMode::Linear,
+            half_life_days: 10,
+            ..DecayConfig::default()
+        };
+        let factor = search_decay_factor_at("2026-05-01T00:00:00Z", &cfg, 1_777_852_800);
+        assert!((factor - 0.7).abs() < 1e-9);
+        assert_eq!(
+            search_decay_factor_at("not-a-time", &cfg, 1_777_930_400),
+            1.0
+        );
+    }
+
+    #[test]
+    fn test_validity_window_excludes_future_and_expired() {
+        let now = 1_710_000_000;
+        assert!(validity_window_contains_at(None, None, now));
+        assert!(validity_window_contains_at(
+            Some("1709999900"),
+            Some("1710000100"),
+            now
+        ));
+        assert!(!validity_window_contains_at(Some("1710000100"), None, now));
+        assert!(!validity_window_contains_at(None, Some("1709999900"), now));
+        assert!(validity_window_contains_at(
+            Some("not-a-time"),
+            Some("also-not-a-time"),
+            now
+        ));
     }
 }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -528,10 +528,10 @@ mod tests {
     }
 
     #[test]
-    fn protocol_schema_version_matches_phase3_runtime_events() {
+    fn protocol_schema_version_matches_temporal_validity_windows() {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 9);
+        assert_eq!(db.schema_version().expect("schema version"), 10);
     }
 }

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -82,6 +82,8 @@ pub struct IngestOptions<'a> {
     pub diary_rollup_day: Option<&'a str>,
     pub supersedes: Option<&'a str>,
     pub replace_text: Option<&'a str>,
+    pub valid_from: Option<&'a str>,
+    pub valid_until: Option<&'a str>,
 }
 
 pub type Result<T> = std::result::Result<T, IngestError>;
@@ -224,6 +226,8 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
             diary_rollup_day: None,
             supersedes: None,
             replace_text: None,
+            valid_from: None,
+            valid_until: None,
         },
     )
     .await
@@ -562,11 +566,16 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             link_superseded_drawer(&mut drawer, old_id);
         }
 
-        db.insert_drawer_with_project(&drawer, options.project_id)
-            .map_err(|source| IngestError::InsertDrawer {
-                drawer_id: drawer.id.clone(),
-                source,
-            })?;
+        db.insert_drawer_with_project_validity(
+            &drawer,
+            options.project_id,
+            options.valid_from,
+            options.valid_until,
+        )
+        .map_err(|source| IngestError::InsertDrawer {
+            drawer_id: drawer.id.clone(),
+            source,
+        })?;
         db.insert_vector_with_project(&drawer_id, &vector, options.project_id)
             .map_err(|source| IngestError::InsertVector {
                 drawer_id: drawer.id.clone(),
@@ -654,6 +663,8 @@ pub async fn ingest_dir<E: Embedder + ?Sized>(
             diary_rollup_day: None,
             supersedes: None,
             replace_text: None,
+            valid_from: None,
+            valid_until: None,
         },
     )
     .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -2702,6 +2702,7 @@ async fn search_command(
             filters: options.filters,
             with_neighbors: options.with_neighbors,
             include_raw_turns: options.include_raw_turns,
+            include_expired: false,
         },
         options.top_k,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ struct SearchCommandOptions<'a> {
     json: bool,
     with_neighbors: bool,
     include_raw_turns: bool,
+    include_expired: bool,
 }
 
 struct IngestCommandOptions<'a> {
@@ -121,6 +122,8 @@ struct IngestCommandOptions<'a> {
     diary_rollup: bool,
     supersedes: Option<&'a str>,
     replace_text: Option<&'a str>,
+    valid_from: Option<&'a str>,
+    valid_until: Option<&'a str>,
 }
 
 struct RollbackCommandOptions<'a> {
@@ -192,6 +195,10 @@ enum Commands {
         supersedes: Option<String>,
         #[arg(long)]
         replace_text: Option<String>,
+        #[arg(long = "valid-from")]
+        valid_from: Option<String>,
+        #[arg(long = "valid-until")]
+        valid_until: Option<String>,
     },
     Search {
         query: String,
@@ -225,6 +232,8 @@ enum Commands {
         with_neighbors: bool,
         #[arg(long)]
         include_raw_turns: bool,
+        #[arg(long = "include-expired")]
+        include_expired: bool,
     },
     Context {
         query: String,
@@ -1189,6 +1198,8 @@ fn run() -> Result<()> {
             diary_rollup,
             supersedes,
             replace_text,
+            valid_from,
+            valid_until,
         } => block_on_result(ingest_command(
             &db,
             config.as_ref(),
@@ -1206,6 +1217,8 @@ fn run() -> Result<()> {
                 diary_rollup,
                 supersedes: supersedes.as_deref(),
                 replace_text: replace_text.as_deref(),
+                valid_from: valid_from.as_deref(),
+                valid_until: valid_until.as_deref(),
             },
         )),
         Commands::Search {
@@ -1225,6 +1238,7 @@ fn run() -> Result<()> {
             json,
             with_neighbors,
             include_raw_turns,
+            include_expired,
         } => block_on_result(search_command(
             &db,
             config.as_ref(),
@@ -1247,6 +1261,7 @@ fn run() -> Result<()> {
                 json,
                 with_neighbors,
                 include_raw_turns,
+                include_expired,
             },
         )),
         Commands::Context {
@@ -1686,6 +1701,8 @@ async fn ingest_command(
 
     let project_id = resolve_project_id(options.project, config, Some(path))
         .context("failed to resolve ingest project id")?;
+    let valid_from = validate_temporal_bound("--valid-from", options.valid_from)?;
+    let valid_until = validate_temporal_bound("--valid-until", options.valid_until)?;
     let base_options = IngestOptions {
         room: options.room,
         source_root: if path.is_file() {
@@ -1704,6 +1721,8 @@ async fn ingest_command(
         diary_rollup_day: None,
         supersedes: options.supersedes,
         replace_text: options.replace_text,
+        valid_from,
+        valid_until,
     };
 
     let stats = if options.dry_run {
@@ -1736,6 +1755,8 @@ async fn ingest_command(
             diary_rollup_day: None,
             supersedes: options.supersedes,
             replace_text: options.replace_text,
+            valid_from,
+            valid_until,
         };
         ingest_path_with_options(db, &*embedder, path, wing, live_options).await?
     };
@@ -1794,6 +1815,8 @@ struct StdinIngestRecord {
     source_file: Option<String>,
     supersedes: Option<String>,
     replace_text: Option<String>,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
     metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
@@ -1831,6 +1854,15 @@ fn exact_duplicate_drawer_id(
         .into_iter()
         .find(|summary| Some(summary.id.as_str()) != excluded_drawer_id)
         .map(|summary| summary.id))
+}
+
+fn validate_temporal_bound<'a>(field: &str, value: Option<&'a str>) -> Result<Option<&'a str>> {
+    if let Some(raw) = value {
+        if mempal::core::decay::parse_temporal_timestamp_secs(raw).is_none() {
+            bail!("{field} must be a Unix timestamp or RFC3339 timestamp");
+        }
+    }
+    Ok(value)
 }
 
 async fn ingest_stdin_command(
@@ -1878,6 +1910,14 @@ async fn ingest_stdin_command(
     let project = options.project.or(record.project.as_deref());
     let supersedes = options.supersedes.or(record.supersedes.as_deref());
     let replace_text = options.replace_text.or(record.replace_text.as_deref());
+    let valid_from = validate_temporal_bound(
+        "valid_from",
+        options.valid_from.or(record.valid_from.as_deref()),
+    )?;
+    let valid_until = validate_temporal_bound(
+        "valid_until",
+        options.valid_until.or(record.valid_until.as_deref()),
+    )?;
     let raw_turn = is_raw_turn(wing, room, &config.turns);
     let mut stats = IngestStats {
         files: 1,
@@ -2050,7 +2090,7 @@ async fn ingest_stdin_command(
         link_superseded_drawer(&mut drawer, old_id);
     }
 
-    db.insert_drawer_with_project(&drawer, project_id.as_deref())
+    db.insert_drawer_with_project_validity(&drawer, project_id.as_deref(), valid_from, valid_until)
         .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
     db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
@@ -2702,7 +2742,7 @@ async fn search_command(
             filters: options.filters,
             with_neighbors: options.with_neighbors,
             include_raw_turns: options.include_raw_turns,
-            include_expired: false,
+            include_expired: options.include_expired,
         },
         options.top_k,
     )
@@ -5236,6 +5276,7 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         .context("failed to query daemon heartbeat")?;
     println!("schema_version: {schema_version}");
     println!("fork_ext_version: {fork_ext_version}");
+    println!("search_decay_mode: {}", config.search.decay.mode);
     println!("drawer_count: {drawer_count}");
     match project_breakdown {
         Some(breakdown) => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1019,6 +1019,7 @@ impl MempalMcpServer {
             },
             with_neighbors: request.with_neighbors.unwrap_or(false),
             include_raw_turns: request.include_raw_turns.unwrap_or(false),
+            include_expired: false,
         };
         let mut extra_warnings = Vec::new();
         let embedder = self.embedder_factory.build().await.map_err(|error| {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -393,8 +393,13 @@ impl MempalMcpServer {
                 &source_type,
                 importance,
             );
-            db.insert_drawer_with_project(&drawer, project_id)
-                .map_err(db_error)?;
+            db.insert_drawer_with_project_validity(
+                &drawer,
+                project_id,
+                request.valid_from.as_deref(),
+                request.valid_until.as_deref(),
+            )
+            .map_err(db_error)?;
             db.insert_vector_with_project(chunk_did, vector, project_id)
                 .map_err(db_error)?;
             inserted_drawer_ids.push(chunk_did.clone());
@@ -461,6 +466,9 @@ fn validate_ingest_request(
     request: &IngestRequest,
     source_type: &SourceType,
 ) -> std::result::Result<ValidatedIngestMetadata, ErrorData> {
+    validate_temporal_param("valid_from", request.valid_from.as_deref())?;
+    validate_temporal_param("valid_until", request.valid_until.as_deref())?;
+
     let memory_kind =
         parse_memory_kind(request.memory_kind.as_deref())?.unwrap_or(MemoryKind::Evidence);
     let domain = parse_domain(request.domain.as_deref())?.unwrap_or(MemoryDomain::Project);
@@ -579,6 +587,18 @@ fn validate_ingest_request(
             })
         }
     }
+}
+
+fn validate_temporal_param(name: &str, value: Option<&str>) -> std::result::Result<(), ErrorData> {
+    if let Some(raw) = value
+        && crate::core::decay::parse_temporal_timestamp_secs(raw).is_none()
+    {
+        return Err(ErrorData::invalid_params(
+            format!("{name} must be a Unix timestamp or RFC3339 timestamp"),
+            None,
+        ));
+    }
+    Ok(())
 }
 
 fn drawer_from_ingest_metadata(
@@ -920,6 +940,7 @@ impl MempalMcpServer {
             schema_version,
             normalize_version_current: CURRENT_NORMALIZE_VERSION,
             stale_drawer_count,
+            search_decay_mode: config.search.decay.mode.to_string(),
             drawer_count,
             taxonomy_count,
             db_size_bytes,
@@ -1019,7 +1040,7 @@ impl MempalMcpServer {
             },
             with_neighbors: request.with_neighbors.unwrap_or(false),
             include_raw_turns: request.include_raw_turns.unwrap_or(false),
-            include_expired: false,
+            include_expired: request.include_expired.unwrap_or(false),
         };
         let mut extra_warnings = Vec::new();
         let embedder = self.embedder_factory.build().await.map_err(|error| {
@@ -2201,8 +2222,13 @@ impl MempalMcpServer {
                     if let Some(old_id) = superseded_drawer_id.as_deref() {
                         link_superseded_drawer(&mut drawer, old_id);
                     }
-                    db.insert_drawer_with_project(&drawer, project_id.as_deref())
-                        .map_err(db_error)?;
+                    db.insert_drawer_with_project_validity(
+                        &drawer,
+                        project_id.as_deref(),
+                        request.valid_from.as_deref(),
+                        request.valid_until.as_deref(),
+                    )
+                    .map_err(db_error)?;
                     db.insert_vector_with_project(chunk_did, vector, project_id.as_deref())
                         .map_err(db_error)?;
                     inserted_drawer_ids.push(chunk_did.clone());
@@ -4046,6 +4072,7 @@ mod tests {
                 all_projects: None,
                 disable_progressive: None,
                 include_raw_turns: None,
+                include_expired: None,
             }))
             .await
             .expect("search should succeed")
@@ -5806,6 +5833,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_ingest_valid_until_is_respected_by_search_include_expired() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let ingested = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "temporal expired fact".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("temporal".to_string()),
+                valid_until: Some("1".to_string()),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest should succeed")
+            .0;
+
+        let hidden = run_search(
+            &server,
+            "temporal expired fact",
+            Some("mempal"),
+            Some("temporal"),
+            10,
+        )
+        .await;
+        assert!(
+            hidden
+                .results
+                .iter()
+                .all(|result| result.drawer_id != ingested.drawer_id),
+            "expired drawer should be hidden by default"
+        );
+
+        let visible = server
+            .mempal_search(Parameters(SearchRequest {
+                query: "temporal expired fact".to_string(),
+                wing: Some("mempal".to_string()),
+                room: Some("temporal".to_string()),
+                top_k: Some(10),
+                include_expired: Some(true),
+                ..SearchRequest::default()
+            }))
+            .await
+            .expect("include expired search should succeed")
+            .0;
+        assert!(
+            visible
+                .results
+                .iter()
+                .any(|result| result.drawer_id == ingested.drawer_id),
+            "include_expired should return the expired drawer"
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_ingest_supersedes_soft_deletes_old_and_links_new() {
         let (_tempdir, db_path, server) = setup_server();
         let old = ingest_manual(&server, "stale explicit fact", None, None, None).await;
@@ -6033,6 +6112,8 @@ mod tests {
                 diary_rollup: None,
                 supersedes: None,
                 replace_text: None,
+                valid_from: None,
+                valid_until: None,
                 memory_kind: None,
                 domain: None,
                 field: None,
@@ -6623,6 +6704,7 @@ mod tests_duplicate_conflict_artifact {
                 all_projects: None,
                 disable_progressive: None,
                 include_raw_turns: None,
+                include_expired: None,
             }))
             .await
             .expect("search should succeed")
@@ -8695,6 +8777,10 @@ mod tests_duplicate_conflict_artifact {
                 importance: None,
                 dry_run: None,
                 diary_rollup: None,
+                supersedes: None,
+                replace_text: None,
+                valid_from: None,
+                valid_until: None,
                 memory_kind: None,
                 domain: None,
                 field: None,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -82,6 +82,9 @@ pub struct SearchRequest {
 
     /// Include low-importance raw dialogue turns that are excluded by default.
     pub include_raw_turns: Option<bool>,
+
+    /// Include drawers outside their validity window. Defaults to false.
+    pub include_expired: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -790,6 +793,12 @@ pub struct IngestRequest {
     /// Exact active content to replace within the same wing/room/project
     /// scope. Must match exactly; ambiguous matches return candidate IDs.
     pub replace_text: Option<String>,
+    /// Optional validity start timestamp for the new drawer.
+    /// Accepts Unix seconds or RFC3339. Defaults to the drawer's added_at.
+    pub valid_from: Option<String>,
+    /// Optional validity end timestamp for the new drawer.
+    /// Accepts Unix seconds or RFC3339. Null means still valid.
+    pub valid_until: Option<String>,
 
     /// If true, return the drawer_id that WOULD be created without actually
     /// writing to the database. Use this to preview before committing.
@@ -918,6 +927,7 @@ pub struct StatusResponse {
     pub schema_version: u32,
     pub normalize_version_current: u32,
     pub stale_drawer_count: u64,
+    pub search_decay_mode: String,
     pub drawer_count: i64,
     pub taxonomy_count: i64,
     pub db_size_bytes: u64,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all)]
 
+use crate::core::decay::{search_decay_factor_at, validity_window_contains_at};
 use crate::core::{
     db::Database,
     project::{ProjectSearchScope, SearchResultSource},
@@ -13,7 +14,7 @@ use crate::embed::{EmbedError, Embedder};
 use thiserror::Error;
 
 use crate::search::filter::{build_filter_clause, build_vector_search_sql};
-use rusqlite::OptionalExtension;
+use rusqlite::{OptionalExtension, params_from_iter};
 
 pub mod filter;
 pub mod preview;
@@ -40,6 +41,7 @@ pub struct SearchOptions {
     pub filters: SearchFilters,
     pub with_neighbors: bool,
     pub include_raw_turns: bool,
+    pub include_expired: bool,
 }
 
 #[derive(Debug, Error)]
@@ -70,6 +72,8 @@ pub enum SearchError {
     LoadNeighbors(#[source] crate::core::db::DbError),
     #[error("failed to load search result drawer metadata")]
     LoadDrawer(#[source] crate::core::db::DbError),
+    #[error("failed to load temporal search metadata")]
+    LoadTemporalMetadata(#[source] rusqlite::Error),
     #[error(
         "embedding dimension mismatch: drawer_vectors uses {current_dim}d but embedder returned {new_dim}d; run `mempal reindex --embedder <name>` before searching with this backend"
     )]
@@ -246,7 +250,12 @@ pub fn search_with_vector_and_scope_options(
 
     let config = crate::core::config::ConfigHandle::current();
     let exclude_raw_turns = config.search.exclude_raw_turns && !options.include_raw_turns;
-    let has_filters = !options.filters.is_empty() || exclude_raw_turns;
+    let has_temporal_post_process = !options.include_expired
+        || !matches!(
+            config.search.decay.mode,
+            crate::core::config::DecayMode::None
+        );
+    let has_filters = !options.filters.is_empty() || exclude_raw_turns || has_temporal_post_process;
     let candidate_top_k = if has_filters {
         top_k.saturating_mul(20).max(100)
     } else {
@@ -274,13 +283,11 @@ pub fn search_with_vector_and_scope_options(
     };
     if !options.filters.is_empty() {
         results.retain(|result| matches_filters(result, &options.filters));
-        results.truncate(top_k);
     }
     if exclude_raw_turns {
         results.retain(|result| {
             !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
         });
-        results.truncate(top_k);
     }
 
     // Inject tunnel hints: for each result, check if its room exists in other wings
@@ -289,23 +296,132 @@ pub fn search_with_vector_and_scope_options(
         results.retain(|result| {
             !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
         });
-        results.truncate(top_k);
     }
+
+    let now_secs = current_unix_secs();
+    let temporal_metadata = load_temporal_metadata(db, &results)?;
+    if !options.include_expired {
+        retain_currently_valid_results(&mut results, &temporal_metadata, now_secs);
+    }
+
+    // Pattern boosting (P13): boost exemplar drawers of active patterns that
+    // match the query vector. Fire-and-forget on error.
+    apply_pattern_boost(db, query_vector, scope.project_id.as_deref(), &mut results);
+    apply_temporal_decay(
+        &mut results,
+        &temporal_metadata,
+        &config.search.decay,
+        now_secs,
+    );
+
+    // Post-RRF secondary reranking by effective_importance (P13).
+    // Does NOT alter the similarity field; purely reorders within the final set.
+    rerank_by_effective_importance(&mut results);
+    results.truncate(top_k);
 
     // Chunk neighbors hydration (upstream feature)
     if options.with_neighbors && top_k <= 10 {
         inject_chunk_neighbors(db, &mut results)?;
     }
 
-    // Pattern boosting (P13): boost exemplar drawers of active patterns that
-    // match the query vector. Fire-and-forget on error.
-    apply_pattern_boost(db, query_vector, scope.project_id.as_deref(), &mut results);
-
-    // Post-RRF secondary reranking by effective_importance (P13).
-    // Does NOT alter the similarity field; purely reorders within the final set.
-    rerank_by_effective_importance(&mut results);
-
     Ok(results)
+}
+
+#[derive(Debug, Clone)]
+struct TemporalMetadata {
+    added_at: String,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
+}
+
+fn current_unix_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn load_temporal_metadata(
+    db: &Database,
+    results: &[SearchResult],
+) -> Result<std::collections::HashMap<String, TemporalMetadata>> {
+    let ids = results
+        .iter()
+        .map(|result| result.drawer_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    if ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    let placeholders = (1..=ids.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT id, added_at, valid_from, valid_until FROM drawers WHERE id IN ({placeholders})"
+    );
+    let mut statement = db
+        .conn()
+        .prepare(&sql)
+        .map_err(SearchError::LoadTemporalMetadata)?;
+    let rows = statement
+        .query_map(params_from_iter(ids.iter().map(String::as_str)), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                TemporalMetadata {
+                    added_at: row.get(1)?,
+                    valid_from: row.get(2)?,
+                    valid_until: row.get(3)?,
+                },
+            ))
+        })
+        .map_err(SearchError::LoadTemporalMetadata)?
+        .collect::<std::result::Result<std::collections::HashMap<_, _>, _>>()
+        .map_err(SearchError::LoadTemporalMetadata)?;
+
+    Ok(rows)
+}
+
+fn retain_currently_valid_results(
+    results: &mut Vec<SearchResult>,
+    metadata: &std::collections::HashMap<String, TemporalMetadata>,
+    now_secs: i64,
+) {
+    results.retain(|result| {
+        metadata.get(&result.drawer_id).is_none_or(|temporal| {
+            validity_window_contains_at(
+                temporal.valid_from.as_deref(),
+                temporal.valid_until.as_deref(),
+                now_secs,
+            )
+        })
+    });
+}
+
+fn apply_temporal_decay(
+    results: &mut [SearchResult],
+    metadata: &std::collections::HashMap<String, TemporalMetadata>,
+    config: &crate::core::config::DecayConfig,
+    now_secs: i64,
+) {
+    if matches!(config.mode, crate::core::config::DecayMode::None) {
+        return;
+    }
+
+    for result in results.iter_mut() {
+        let factor = metadata
+            .get(&result.drawer_id)
+            .map(|temporal| search_decay_factor_at(&temporal.added_at, config, now_secs))
+            .unwrap_or(1.0);
+        result.similarity *= factor as f32;
+        result.effective_importance *= factor;
+    }
+    results.sort_by(|a, b| {
+        b.similarity
+            .partial_cmp(&a.similarity)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 }
 
 /// Apply active-pattern score boost to matching exemplar drawers.
@@ -437,7 +553,12 @@ pub fn search_bm25_only_with_options(
 
     let config = crate::core::config::ConfigHandle::current();
     let exclude_raw_turns = config.search.exclude_raw_turns && !options.include_raw_turns;
-    let candidate_top_k = if exclude_raw_turns {
+    let has_temporal_post_process = !options.include_expired
+        || !matches!(
+            config.search.decay.mode,
+            crate::core::config::DecayMode::None
+        );
+    let candidate_top_k = if exclude_raw_turns || has_temporal_post_process {
         top_k.saturating_mul(20).max(100)
     } else {
         top_k
@@ -458,15 +579,25 @@ pub fn search_bm25_only_with_options(
         results.retain(|result| {
             !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
         });
-        results.truncate(top_k);
     }
     inject_tunnel_hints_and_results(db, &mut results, scope);
     if exclude_raw_turns {
         results.retain(|result| {
             !crate::core::strata::is_excluded_raw_turn_result(result, &config.turns)
         });
-        results.truncate(top_k);
     }
+    let now_secs = current_unix_secs();
+    let temporal_metadata = load_temporal_metadata(db, &results)?;
+    if !options.include_expired {
+        retain_currently_valid_results(&mut results, &temporal_metadata, now_secs);
+    }
+    apply_temporal_decay(
+        &mut results,
+        &temporal_metadata,
+        &config.search.decay,
+        now_secs,
+    );
+    results.truncate(top_k);
     Ok(results)
 }
 
@@ -1307,6 +1438,15 @@ mod tests {
         }
     }
 
+    fn route() -> RouteDecision {
+        RouteDecision {
+            wing: None,
+            room: None,
+            confidence: 0.0,
+            reason: "test".to_string(),
+        }
+    }
+
     fn seed_cross_project(db: &Database, source: &Drawer, beta_count: usize) {
         db.insert_drawer_with_project(source, Some("proj-a"))
             .expect("insert source");
@@ -1320,6 +1460,78 @@ mod tests {
 
     fn scoped_to_proj_a() -> ProjectSearchScope {
         ProjectSearchScope::from_request(Some("proj-a".to_string()), false, false, false)
+    }
+
+    #[test]
+    fn search_excludes_expired_drawers_by_default_and_include_expired_returns_them() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+        let mut active = make_drawer("active", "alpha", "decision");
+        active.content = "needle active".to_string();
+        let mut expired = make_drawer("expired", "alpha", "decision");
+        expired.content = "needle expired".to_string();
+
+        db.insert_drawer_with_project_validity(&active, None, None, None)
+            .expect("insert active");
+        db.insert_drawer_with_project_validity(&expired, None, Some("0"), Some("1"))
+            .expect("insert expired");
+
+        let results = search_bm25_only_with_options(
+            &db,
+            "needle",
+            route(),
+            &ProjectSearchScope::all_projects(),
+            SearchOptions::default(),
+            10,
+        )
+        .expect("search");
+        let ids = results
+            .iter()
+            .map(|result| result.drawer_id.as_str())
+            .collect::<Vec<_>>();
+        assert!(ids.contains(&"active"));
+        assert!(!ids.contains(&"expired"));
+
+        let results = search_bm25_only_with_options(
+            &db,
+            "needle",
+            route(),
+            &ProjectSearchScope::all_projects(),
+            SearchOptions {
+                include_expired: true,
+                ..SearchOptions::default()
+            },
+            10,
+        )
+        .expect("search include expired");
+        let ids = results
+            .iter()
+            .map(|result| result.drawer_id.as_str())
+            .collect::<Vec<_>>();
+        assert!(ids.contains(&"active"));
+        assert!(ids.contains(&"expired"));
+    }
+
+    #[test]
+    fn search_excludes_future_valid_from_by_default() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+        let mut future = make_drawer("future", "alpha", "decision");
+        future.content = "needle future".to_string();
+
+        db.insert_drawer_with_project_validity(&future, None, Some("4102444800"), None)
+            .expect("insert future");
+
+        let results = search_bm25_only_with_options(
+            &db,
+            "needle",
+            route(),
+            &ProjectSearchScope::all_projects(),
+            SearchOptions::default(),
+            10,
+        )
+        .expect("search");
+        assert!(results.is_empty(), "future-valid drawer must be hidden");
     }
 
     #[test]

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -986,10 +986,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 9);
+    assert_eq!(db.schema_version().expect("schema"), 10);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 9);
+    assert_eq!(db.schema_version().expect("schema"), 10);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -245,10 +245,10 @@ fn insert_event(
 }
 
 #[test]
-fn test_new_database_schema_version_is_9() {
+fn test_new_database_schema_version_is_10() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
     for table in [
         "knowledge_cards",
         "knowledge_evidence_links",
@@ -260,14 +260,14 @@ fn test_new_database_schema_version_is_9() {
 }
 
 #[test]
-fn test_migration_v7_to_v9_adds_phase2_and_phase3_tables_without_data_loss() {
+fn test_migration_v7_to_v10_adds_phase2_phase3_and_validity_without_data_loss() {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     create_v7_db(&db_path);
 
     let db = Database::open(&db_path).expect("migrate v7 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let taxonomy_count: i64 = db

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -557,7 +557,7 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
 
     let drawer = db
         .get_drawer("drawer_legacy_001")

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -2113,7 +2113,7 @@ async fn test_search_filters_by_domain_field_status_and_anchor_kind() {
             "wing": "mempal",
             "room": "bootstrap",
             "anchor_kind": "repo",
-            "top_k": 5
+            "top_k": 10
         }))
         .await
         .expect("anchor-filtered search should succeed");

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -245,7 +245,7 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -30,7 +30,7 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
 
     let event = RuntimeAdoptionEvent {
         id: "adoption_test".to_string(),

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -293,7 +293,7 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -203,7 +203,7 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 9);
+    assert_eq!(db.schema_version().expect("schema version"), 10);
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db


### PR DESCRIPTION
## Summary
- Added `valid_from`/`valid_until` columns to drawers with schema migration
- Configurable decay modes: `none` (default), `exponential`, `linear`, `step`
- Search excludes expired drawers by default; `include_expired` param to override
- Supersede automatically sets `valid_until` on old drawer
- MCP/CLI/REST ingest accept `valid_from`/`valid_until` params
- `mempal_status` reports current decay config

Closes #198

## Test plan
- [x] 4 atomic commits, each compilable
- [x] Tier-4 critical review PASS (zero findings)
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>