### PR TITLE
feat: add memory intelligence LLM modes

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,10 +1,12 @@
 use std::env;
 use std::fs;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use regex::Regex;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -214,6 +216,9 @@ impl Config {
             return Err(ConfigError::InvalidConfig(
                 "memory_intelligence.llm.timeout_secs must be greater than 0".to_string(),
             ));
+        }
+        for warning in self.llm_base_url_locality_warnings() {
+            tracing::warn!(source = warning.source, "{}", warning.message);
         }
         if self.search.preview_chars == 0 {
             return Err(ConfigError::InvalidConfig(
@@ -516,8 +521,61 @@ impl Config {
                 message: "hooks capture is enabled while tier-2 gating is fail-open on embedder errors; review warnings before trusting passive captures.".to_string(),
             });
         }
+        warnings.extend(self.llm_base_url_locality_warnings());
         warnings
     }
+
+    fn llm_base_url_locality_warnings(&self) -> Vec<RuntimeWarning> {
+        [
+            ("llm.base_url", self.llm.base_url.as_deref()),
+            (
+                "memory_intelligence.llm.base_url",
+                self.memory_intelligence.llm.base_url.as_deref(),
+            ),
+        ]
+        .into_iter()
+        .filter_map(|(setting, base_url)| {
+            let base_url = base_url?.trim();
+            if base_url.is_empty() || llm_base_url_is_local_or_lan(base_url) {
+                return None;
+            }
+            let host = llm_base_url_host(base_url)
+                .map(|host| format!(" host `{host}`"))
+                .unwrap_or_default();
+            Some(RuntimeWarning {
+                level: "warn",
+                source: "llm",
+                message: format!(
+                    "{setting}{host} appears outside localhost/LAN; mempal assumes user-configured LLM endpoints are local or private network and does not block operation"
+                ),
+            })
+        })
+        .collect()
+    }
+}
+
+fn llm_base_url_is_local_or_lan(base_url: &str) -> bool {
+    let Some(host) = llm_base_url_host(base_url) else {
+        return false;
+    };
+    if host.eq_ignore_ascii_case("localhost") || !host.contains('.') {
+        return true;
+    }
+    if let Ok(addr) = host.parse::<Ipv4Addr>() {
+        let octets = addr.octets();
+        return octets[0] == 10
+            || octets[0] == 127
+            || (octets[0] == 192 && octets[1] == 168)
+            || (octets[0] == 172 && (16..=31).contains(&octets[1]));
+    }
+    host.parse::<Ipv6Addr>()
+        .is_ok_and(|addr| addr.is_loopback() || addr.is_unique_local())
+}
+
+fn llm_base_url_host(base_url: &str) -> Option<String> {
+    Url::parse(base_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
 }
 
 pub(crate) fn scrub_sensitive_text(input: &str) -> String {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -8,6 +8,8 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::types::IntelligenceMode;
+
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
 const DEFAULT_EMBED_BACKEND: &str = "openai_compat";
 const DEFAULT_CHUNKER_MAX_TOKENS: usize = 1024;
@@ -22,6 +24,7 @@ const DEFAULT_LLM_BACKEND: &str = "openai_compat";
 const DEFAULT_LLM_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_LLM_RETRY_INTERVAL_SECS: u64 = 2;
 const DEFAULT_LLM_MAX_CONCURRENT: usize = 16;
+const DEFAULT_MEMORY_INTELLIGENCE_TIMEOUT_SECS: u64 = 1800;
 const DEFAULT_SEARCH_DEADLINE_SECS: u64 = 5;
 const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
 const DEFAULT_SEARCH_TUNNEL_FANOUT_CAP: usize = 5;
@@ -83,6 +86,7 @@ pub struct Config {
     #[serde(alias = "embedder")]
     pub embed: EmbedConfig,
     pub llm: LlmConfig,
+    pub memory_intelligence: MemoryIntelligenceConfig,
     pub chunker: ChunkerConfig,
     pub project: ProjectConfig,
     pub privacy: PrivacyConfig,
@@ -110,6 +114,7 @@ impl Default for Config {
             db_path: DEFAULT_DB_PATH.to_string(),
             embed: EmbedConfig::default(),
             llm: LlmConfig::default(),
+            memory_intelligence: MemoryIntelligenceConfig::default(),
             chunker: ChunkerConfig::default(),
             project: ProjectConfig::default(),
             privacy: PrivacyConfig::default(),
@@ -203,6 +208,11 @@ impl Config {
         {
             return Err(ConfigError::Validation(
                 "llm.base_url must be set when llm.enabled is true".to_string(),
+            ));
+        }
+        if self.memory_intelligence.llm.timeout_secs == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "memory_intelligence.llm.timeout_secs must be greater than 0".to_string(),
             ));
         }
         if self.search.preview_chars == 0 {
@@ -452,6 +462,9 @@ impl Config {
         if self.llm.api_key_env != other.llm.api_key_env {
             fields.push("llm.api_key_env");
         }
+        if self.llm.extra_body != other.llm.extra_body {
+            fields.push("llm.extra_body");
+        }
         if self.daemon.log_path != other.daemon.log_path {
             fields.push("daemon.log_path");
         }
@@ -474,6 +487,7 @@ impl Config {
         // llm.model is hot-reloadable — don't pin it
         effective.llm.api_key = self.llm.api_key.clone();
         effective.llm.api_key_env = self.llm.api_key_env.clone();
+        effective.llm.extra_body = self.llm.extra_body.clone();
         effective.daemon.log_path = self.daemon.log_path.clone();
         effective.mcp.log_path = self.mcp.log_path.clone();
         effective
@@ -705,7 +719,7 @@ impl EmbedConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct LlmConfig {
     pub enabled: bool,
@@ -714,6 +728,8 @@ pub struct LlmConfig {
     pub model: Option<String>,
     pub api_key: Option<String>,
     pub api_key_env: Option<String>,
+    pub extra_body: Option<serde_json::Value>,
+    #[serde(alias = "timeout_secs")]
     pub request_timeout_secs: u64,
     pub retry_interval_secs: u64,
     pub max_concurrent: usize,
@@ -729,10 +745,91 @@ impl Default for LlmConfig {
             model: None,
             api_key: None,
             api_key_env: None,
+            extra_body: None,
             request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
             retry_interval_secs: DEFAULT_LLM_RETRY_INTERVAL_SECS,
             max_concurrent: DEFAULT_LLM_MAX_CONCURRENT,
             enabled_for: vec!["gating".to_string()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct MemoryIntelligenceConfig {
+    pub mode: IntelligenceMode,
+    pub llm: MemoryIntelligenceLlmConfig,
+}
+
+impl Default for MemoryIntelligenceConfig {
+    fn default() -> Self {
+        Self {
+            mode: IntelligenceMode::Deterministic,
+            llm: MemoryIntelligenceLlmConfig::default(),
+        }
+    }
+}
+
+impl MemoryIntelligenceConfig {
+    pub fn effective_llm_config(&self, base: &LlmConfig) -> LlmConfig {
+        let mut config = base.clone();
+        config.enabled = self.mode.uses_llm();
+        if self.llm.base_url.is_some() {
+            config.base_url = self.llm.base_url.clone();
+        }
+        if self.llm.model.is_some() {
+            config.model = self.llm.model.clone();
+        }
+        if self.llm.api_key.is_some() {
+            config.api_key = self.llm.api_key.clone();
+        }
+        if self.llm.api_key_env.is_some() {
+            config.api_key_env = self.llm.api_key_env.clone();
+        }
+        if self.llm.extra_body.is_some() {
+            config.extra_body = self.llm.extra_body.clone();
+        }
+        config.request_timeout_secs = self.llm.timeout_secs;
+        config
+    }
+
+    pub fn has_effective_llm_endpoint(&self, base: &LlmConfig) -> bool {
+        self.mode.uses_llm()
+            && self
+                .llm
+                .base_url
+                .as_deref()
+                .or(base.base_url.as_deref())
+                .is_some_and(|value| !value.trim().is_empty())
+            && self
+                .llm
+                .model
+                .as_deref()
+                .or(base.model.as_deref())
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct MemoryIntelligenceLlmConfig {
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub api_key_env: Option<String>,
+    pub timeout_secs: u64,
+    pub extra_body: Option<serde_json::Value>,
+}
+
+impl Default for MemoryIntelligenceLlmConfig {
+    fn default() -> Self {
+        Self {
+            base_url: None,
+            model: None,
+            api_key: None,
+            api_key_env: None,
+            timeout_secs: DEFAULT_MEMORY_INTELLIGENCE_TIMEOUT_SECS,
+            extra_body: None,
         }
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -12,7 +12,6 @@ pub enum IntelligenceMode {
     #[default]
     Deterministic,
     LocalLlm,
-    CloudLlm,
     Auto,
 }
 
@@ -21,7 +20,6 @@ impl IntelligenceMode {
         match self {
             Self::Deterministic => "deterministic",
             Self::LocalLlm => "local_llm",
-            Self::CloudLlm => "cloud_llm",
             Self::Auto => "auto",
         }
     }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -8,6 +8,37 @@ use crate::core::project::SearchResultSource;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum IntelligenceMode {
+    #[default]
+    Deterministic,
+    LocalLlm,
+    CloudLlm,
+    Auto,
+}
+
+impl IntelligenceMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Deterministic => "deterministic",
+            Self::LocalLlm => "local_llm",
+            Self::CloudLlm => "cloud_llm",
+            Self::Auto => "auto",
+        }
+    }
+
+    pub fn uses_llm(self) -> bool {
+        !matches!(self, Self::Deterministic)
+    }
+}
+
+impl fmt::Display for IntelligenceMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SourceType {
     #[default]
     AgentInference,

--- a/src/endpoint_health.rs
+++ b/src/endpoint_health.rs
@@ -76,11 +76,19 @@ async fn probe_embedding(config: &Config) -> ProbeStatus {
 }
 
 async fn probe_llm(config: &Config) -> ProbeStatus {
-    if !config.llm.enabled {
+    let effective_llm = if config.memory_intelligence.mode.uses_llm()
+        && config
+            .memory_intelligence
+            .has_effective_llm_endpoint(&config.llm)
+    {
+        config.memory_intelligence.effective_llm_config(&config.llm)
+    } else {
+        config.llm.clone()
+    };
+    if !effective_llm.enabled {
         return ProbeStatus::unreachable("disabled".to_string());
     }
-    let Some(base_url) = config
-        .llm
+    let Some(base_url) = effective_llm
         .base_url
         .as_deref()
         .filter(|value| !value.trim().is_empty())
@@ -89,8 +97,8 @@ async fn probe_llm(config: &Config) -> ProbeStatus {
     };
     probe_models_endpoint(
         base_url,
-        config.llm.api_key_env.as_deref(),
-        config.llm.api_key.as_deref(),
+        effective_llm.api_key_env.as_deref(),
+        effective_llm.api_key.as_deref(),
     )
     .await
 }

--- a/src/intelligence.rs
+++ b/src/intelligence.rs
@@ -1,0 +1,618 @@
+use std::collections::HashSet;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::core::config::Config;
+use crate::core::types::{IntelligenceMode, SearchResult, Triple};
+use crate::core::utils::{build_triple_id, current_timestamp};
+use crate::llm::{LlmClient, LlmMessage, LlmRequest};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnhancedContent {
+    pub raw_content: String,
+    pub candidate_facts: Vec<String>,
+    pub tags: Vec<String>,
+    pub used_llm: bool,
+    pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnhancedSearchResult {
+    pub drawer_id: String,
+    pub summary: String,
+    pub relevance_boost: f32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EnhancedResults {
+    pub items: Vec<EnhancedSearchResult>,
+    pub used_llm: bool,
+    pub fallback_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntelligenceHealthSnapshot {
+    pub failure_count: u64,
+    pub last_error: Option<String>,
+    pub last_success_at_unix_ms: Option<u64>,
+}
+
+pub struct IntelligenceStatus {
+    failure_count: AtomicU64,
+    last_success_at_unix_ms: AtomicU64,
+    last_error: std::sync::Mutex<Option<String>>,
+}
+
+impl IntelligenceStatus {
+    fn new() -> Self {
+        Self {
+            failure_count: AtomicU64::new(0),
+            last_success_at_unix_ms: AtomicU64::new(0),
+            last_error: std::sync::Mutex::new(None),
+        }
+    }
+
+    pub fn record_success(&self) {
+        self.failure_count.store(0, Ordering::SeqCst);
+        self.last_success_at_unix_ms
+            .store(current_unix_ms(), Ordering::SeqCst);
+        if let Ok(mut guard) = self.last_error.lock() {
+            *guard = None;
+        }
+    }
+
+    pub fn record_failure(&self, error: &impl std::fmt::Display) {
+        self.failure_count.fetch_add(1, Ordering::SeqCst);
+        let message = crate::core::config::scrub_sensitive_text(&error.to_string());
+        if let Ok(mut guard) = self.last_error.lock() {
+            *guard = Some(message);
+        }
+    }
+
+    pub fn snapshot(&self) -> IntelligenceHealthSnapshot {
+        let success = self.last_success_at_unix_ms.load(Ordering::SeqCst);
+        IntelligenceHealthSnapshot {
+            failure_count: self.failure_count.load(Ordering::SeqCst),
+            last_error: self.last_error.lock().ok().and_then(|guard| guard.clone()),
+            last_success_at_unix_ms: (success > 0).then_some(success),
+        }
+    }
+}
+
+pub fn global_intelligence_status() -> &'static IntelligenceStatus {
+    static STATUS: OnceLock<IntelligenceStatus> = OnceLock::new();
+    STATUS.get_or_init(IntelligenceStatus::new)
+}
+
+#[derive(Debug, Error)]
+pub enum IntelligenceError {
+    #[error("LLM call failed: {0}")]
+    Llm(#[from] crate::llm::LlmError),
+    #[error("LLM output was not valid JSON: {0}")]
+    InvalidSchema(String),
+    #[error("LLM output included unsupported fact: {0}")]
+    UnsupportedFact(String),
+    #[error("LLM output did not preserve source reference: {0}")]
+    MissingSourceRef(String),
+    #[error("LLM output marked a contradiction without marking it as a correction")]
+    UnmarkedContradiction,
+}
+
+pub type Result<T> = std::result::Result<T, IntelligenceError>;
+
+#[async_trait]
+pub trait IntelligenceEnhancer: Send + Sync {
+    async fn enhance_ingest(&self, raw_content: &str) -> Result<EnhancedContent>;
+    async fn enhance_search(&self, results: &[SearchResult]) -> Result<EnhancedResults>;
+    async fn extract_kg_triples(&self, content: &str) -> Result<Vec<Triple>>;
+    async fn explain_contradiction(&self, a: &str, b: &str) -> Result<String>;
+}
+
+pub struct IntelligenceRouter {
+    mode: IntelligenceMode,
+    llm: Option<LlmIntelligenceEnhancer>,
+}
+
+impl IntelligenceRouter {
+    pub fn from_config(config: &Config) -> Self {
+        let mode = config.memory_intelligence.mode;
+        let llm = if config
+            .memory_intelligence
+            .has_effective_llm_endpoint(&config.llm)
+        {
+            let llm_config = config.memory_intelligence.effective_llm_config(&config.llm);
+            LlmClient::from_config(&llm_config)
+                .ok()
+                .map(LlmIntelligenceEnhancer::new)
+        } else {
+            None
+        };
+        Self { mode, llm }
+    }
+
+    pub fn mode(&self) -> IntelligenceMode {
+        self.mode
+    }
+
+    pub fn llm_configured(&self) -> bool {
+        self.llm.is_some()
+    }
+
+    pub async fn enhance_ingest(&self, raw_content: &str) -> EnhancedContent {
+        if !self.mode.uses_llm() {
+            return deterministic_enhance_ingest(raw_content);
+        }
+        let Some(llm) = self.llm.as_ref() else {
+            return deterministic_enhance_ingest_with_reason(
+                raw_content,
+                "memory intelligence LLM is not configured",
+            );
+        };
+        match llm.enhance_ingest(raw_content).await {
+            Ok(mut enhanced) => {
+                enhanced.used_llm = true;
+                global_intelligence_status().record_success();
+                enhanced
+            }
+            Err(error) => {
+                global_intelligence_status().record_failure(&error);
+                deterministic_enhance_ingest_with_reason(raw_content, &error.to_string())
+            }
+        }
+    }
+
+    pub async fn enhance_search(&self, results: &[SearchResult]) -> EnhancedResults {
+        if results.is_empty() || !self.mode.uses_llm() {
+            return EnhancedResults::default();
+        }
+        let Some(llm) = self.llm.as_ref() else {
+            return EnhancedResults {
+                fallback_reason: Some("memory intelligence LLM is not configured".to_string()),
+                ..EnhancedResults::default()
+            };
+        };
+        match llm.enhance_search(results).await {
+            Ok(mut enhanced) => {
+                enhanced.used_llm = true;
+                global_intelligence_status().record_success();
+                enhanced
+            }
+            Err(error) => {
+                global_intelligence_status().record_failure(&error);
+                EnhancedResults {
+                    fallback_reason: Some(error.to_string()),
+                    ..EnhancedResults::default()
+                }
+            }
+        }
+    }
+
+    pub async fn extract_kg_triples(&self, content: &str) -> Vec<Triple> {
+        if !self.mode.uses_llm() {
+            return Vec::new();
+        }
+        let Some(llm) = self.llm.as_ref() else {
+            return Vec::new();
+        };
+        match llm.extract_kg_triples(content).await {
+            Ok(triples) => {
+                global_intelligence_status().record_success();
+                triples
+            }
+            Err(error) => {
+                global_intelligence_status().record_failure(&error);
+                Vec::new()
+            }
+        }
+    }
+
+    pub async fn explain_contradiction(&self, a: &str, b: &str) -> String {
+        if !self.mode.uses_llm() {
+            return deterministic_explanation(a, b);
+        }
+        let Some(llm) = self.llm.as_ref() else {
+            return deterministic_explanation(a, b);
+        };
+        match llm.explain_contradiction(a, b).await {
+            Ok(explanation) => {
+                global_intelligence_status().record_success();
+                explanation
+            }
+            Err(error) => {
+                global_intelligence_status().record_failure(&error);
+                deterministic_explanation(a, b)
+            }
+        }
+    }
+}
+
+pub struct DeterministicIntelligenceEnhancer;
+
+#[async_trait]
+impl IntelligenceEnhancer for DeterministicIntelligenceEnhancer {
+    async fn enhance_ingest(&self, raw_content: &str) -> Result<EnhancedContent> {
+        Ok(deterministic_enhance_ingest(raw_content))
+    }
+
+    async fn enhance_search(&self, _results: &[SearchResult]) -> Result<EnhancedResults> {
+        Ok(EnhancedResults::default())
+    }
+
+    async fn extract_kg_triples(&self, _content: &str) -> Result<Vec<Triple>> {
+        Ok(Vec::new())
+    }
+
+    async fn explain_contradiction(&self, a: &str, b: &str) -> Result<String> {
+        Ok(deterministic_explanation(a, b))
+    }
+}
+
+pub struct LlmIntelligenceEnhancer {
+    client: LlmClient,
+}
+
+impl LlmIntelligenceEnhancer {
+    pub fn new(client: LlmClient) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
+    async fn enhance_ingest(&self, raw_content: &str) -> Result<EnhancedContent> {
+        let response = self
+            .client
+            .chat_completion(&LlmRequest {
+                messages: vec![
+                    LlmMessage {
+                        role: "system".to_string(),
+                        content: "Return strict JSON with keys candidate_facts, tags, contradiction, correction. Every candidate_fact must be directly supported by the input text.".to_string(),
+                    },
+                    LlmMessage {
+                        role: "user".to_string(),
+                        content: raw_content.to_string(),
+                    },
+                ],
+                model: None,
+                temperature: Some(0.0),
+                max_tokens: Some(512),
+            })
+            .await?;
+        let decoded: LlmEnhancedContent = parse_llm_json(&response.content)?;
+        validate_enhanced_content(raw_content, decoded)
+    }
+
+    async fn enhance_search(&self, results: &[SearchResult]) -> Result<EnhancedResults> {
+        let payload = results
+            .iter()
+            .map(|result| {
+                format!(
+                    "drawer_id: {}\nsource_file: {}\ncontent: {}",
+                    result.drawer_id, result.source_file, result.content
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n---\n");
+        let response = self
+            .client
+            .chat_completion(&LlmRequest {
+                messages: vec![
+                    LlmMessage {
+                        role: "system".to_string(),
+                        content: "Return strict JSON: {\"results\":[{\"drawer_id\":\"...\",\"summary\":\"...\",\"relevance_boost\":0.0,\"source_refs\":[\"drawer_id\"]}]}. Preserve source_refs.".to_string(),
+                    },
+                    LlmMessage {
+                        role: "user".to_string(),
+                        content: payload,
+                    },
+                ],
+                model: None,
+                temperature: Some(0.0),
+                max_tokens: Some(1024),
+            })
+            .await?;
+        let decoded: LlmEnhancedResults = parse_llm_json(&response.content)?;
+        validate_search_results(results, decoded)
+    }
+
+    async fn extract_kg_triples(&self, content: &str) -> Result<Vec<Triple>> {
+        let response = self
+            .client
+            .chat_completion(&LlmRequest {
+                messages: vec![
+                    LlmMessage {
+                        role: "system".to_string(),
+                        content: "Return strict JSON: {\"triples\":[{\"subject\":\"...\",\"predicate\":\"...\",\"object\":\"...\",\"confidence\":0.0}]}. Only extract triples directly supported by the input text.".to_string(),
+                    },
+                    LlmMessage {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                    },
+                ],
+                model: None,
+                temperature: Some(0.0),
+                max_tokens: Some(512),
+            })
+            .await?;
+        let decoded: LlmTriples = parse_llm_json(&response.content)?;
+        validate_triples(content, decoded)
+    }
+
+    async fn explain_contradiction(&self, a: &str, b: &str) -> Result<String> {
+        let response = self
+            .client
+            .chat_completion(&LlmRequest {
+                messages: vec![
+                    LlmMessage {
+                        role: "system".to_string(),
+                        content: "Return strict JSON: {\"explanation\":\"...\"}. Do not invent facts outside the two inputs.".to_string(),
+                    },
+                    LlmMessage {
+                        role: "user".to_string(),
+                        content: format!("A:\n{a}\n\nB:\n{b}"),
+                    },
+                ],
+                model: None,
+                temperature: Some(0.0),
+                max_tokens: Some(256),
+            })
+            .await?;
+        let decoded: LlmExplanation = parse_llm_json(&response.content)?;
+        let explanation = decoded.explanation.trim();
+        if explanation.is_empty() {
+            return Err(IntelligenceError::InvalidSchema(
+                "explanation must not be empty".to_string(),
+            ));
+        }
+        Ok(explanation.to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmEnhancedContent {
+    #[serde(default)]
+    candidate_facts: Vec<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    contradiction: bool,
+    #[serde(default)]
+    correction: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmEnhancedResults {
+    #[serde(default)]
+    results: Vec<LlmSearchItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmSearchItem {
+    drawer_id: String,
+    summary: String,
+    #[serde(default)]
+    relevance_boost: f32,
+    #[serde(default)]
+    source_refs: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmTriples {
+    #[serde(default)]
+    triples: Vec<LlmTriple>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmTriple {
+    subject: String,
+    predicate: String,
+    object: String,
+    #[serde(default = "default_confidence")]
+    confidence: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct LlmExplanation {
+    explanation: String,
+}
+
+fn default_confidence() -> f64 {
+    0.5
+}
+
+fn deterministic_enhance_ingest(raw_content: &str) -> EnhancedContent {
+    EnhancedContent {
+        raw_content: raw_content.to_string(),
+        candidate_facts: Vec::new(),
+        tags: deterministic_tags(raw_content),
+        used_llm: false,
+        fallback_reason: None,
+    }
+}
+
+fn deterministic_enhance_ingest_with_reason(raw_content: &str, reason: &str) -> EnhancedContent {
+    let mut enhanced = deterministic_enhance_ingest(raw_content);
+    enhanced.fallback_reason = Some(reason.to_string());
+    enhanced
+}
+
+fn deterministic_tags(raw_content: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    raw_content
+        .split_whitespace()
+        .filter_map(|token| {
+            let tag = token
+                .trim_end_matches(|c: char| c.is_ascii_punctuation())
+                .strip_prefix('#')?;
+            normalize_tag(tag)
+        })
+        .filter(|tag| seen.insert(tag.clone()))
+        .collect()
+}
+
+fn normalize_tag(tag: &str) -> Option<String> {
+    let normalized = tag
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn deterministic_explanation(a: &str, b: &str) -> String {
+    format!(
+        "Deterministic contradiction context: `{}` conflicts with `{}`.",
+        one_line(a),
+        one_line(b)
+    )
+}
+
+fn one_line(value: &str) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    const MAX_LEN: usize = 160;
+    let mut chars = compact.chars();
+    let truncated = chars.by_ref().take(MAX_LEN).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+fn parse_llm_json<T: for<'de> Deserialize<'de>>(content: &str) -> Result<T> {
+    serde_json::from_str(json_payload(content))
+        .map_err(|error| IntelligenceError::InvalidSchema(error.to_string()))
+}
+
+fn json_payload(content: &str) -> &str {
+    let trimmed = content.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+    let Some((_, rest)) = trimmed.split_once('\n') else {
+        return trimmed;
+    };
+    rest.trim()
+        .strip_suffix("```")
+        .map(str::trim)
+        .unwrap_or_else(|| rest.trim())
+}
+
+fn validate_enhanced_content(
+    raw_content: &str,
+    decoded: LlmEnhancedContent,
+) -> Result<EnhancedContent> {
+    if decoded.contradiction && !decoded.correction {
+        return Err(IntelligenceError::UnmarkedContradiction);
+    }
+    let mut candidate_facts = Vec::new();
+    for fact in decoded.candidate_facts {
+        let fact = fact.trim();
+        if fact.is_empty() {
+            continue;
+        }
+        if !raw_content.contains(fact) {
+            return Err(IntelligenceError::UnsupportedFact(fact.to_string()));
+        }
+        candidate_facts.push(fact.to_string());
+    }
+    let tags = decoded
+        .tags
+        .iter()
+        .filter_map(|tag| normalize_tag(tag.trim_start_matches('#')))
+        .collect::<Vec<_>>();
+    Ok(EnhancedContent {
+        raw_content: raw_content.to_string(),
+        candidate_facts,
+        tags,
+        used_llm: true,
+        fallback_reason: None,
+    })
+}
+
+fn validate_search_results(
+    source_results: &[SearchResult],
+    decoded: LlmEnhancedResults,
+) -> Result<EnhancedResults> {
+    let known_ids = source_results
+        .iter()
+        .map(|result| result.drawer_id.as_str())
+        .collect::<HashSet<_>>();
+    let mut items = Vec::new();
+    for item in decoded.results {
+        if !known_ids.contains(item.drawer_id.as_str()) {
+            return Err(IntelligenceError::MissingSourceRef(item.drawer_id));
+        }
+        if !item.source_refs.iter().any(|id| id == &item.drawer_id) {
+            return Err(IntelligenceError::MissingSourceRef(item.drawer_id));
+        }
+        let summary = item.summary.trim();
+        if summary.is_empty() {
+            return Err(IntelligenceError::InvalidSchema(
+                "summary must not be empty".to_string(),
+            ));
+        }
+        if !item.relevance_boost.is_finite() || !(-1.0..=1.0).contains(&item.relevance_boost) {
+            return Err(IntelligenceError::InvalidSchema(
+                "relevance_boost must be finite and in -1.0..=1.0".to_string(),
+            ));
+        }
+        items.push(EnhancedSearchResult {
+            drawer_id: item.drawer_id,
+            summary: summary.to_string(),
+            relevance_boost: item.relevance_boost,
+        });
+    }
+    Ok(EnhancedResults {
+        items,
+        used_llm: true,
+        fallback_reason: None,
+    })
+}
+
+fn validate_triples(content: &str, decoded: LlmTriples) -> Result<Vec<Triple>> {
+    let mut triples = Vec::new();
+    for triple in decoded.triples {
+        let subject = triple.subject.trim();
+        let predicate = triple.predicate.trim();
+        let object = triple.object.trim();
+        if subject.is_empty() || predicate.is_empty() || object.is_empty() {
+            return Err(IntelligenceError::InvalidSchema(
+                "triple subject, predicate, and object must not be empty".to_string(),
+            ));
+        }
+        if !content.contains(subject) || !content.contains(object) {
+            return Err(IntelligenceError::UnsupportedFact(format!(
+                "{subject} {predicate} {object}"
+            )));
+        }
+        if !triple.confidence.is_finite() || !(0.0..=1.0).contains(&triple.confidence) {
+            return Err(IntelligenceError::InvalidSchema(
+                "triple confidence must be finite and in 0.0..=1.0".to_string(),
+            ));
+        }
+        triples.push(Triple {
+            id: build_triple_id(subject, predicate, object),
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: Some(current_timestamp()),
+            valid_to: None,
+            confidence: triple.confidence,
+            source_drawer: None,
+        });
+    }
+    Ok(triples)
+}
+
+fn current_unix_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hotpatch;
 pub mod importance;
 pub mod ingest;
 pub mod integrations;
+pub mod intelligence;
 pub mod knowledge_anchor;
 pub mod knowledge_card_backfill;
 pub mod knowledge_card_lifecycle;

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -6,6 +6,7 @@ use reqwest::StatusCode;
 use reqwest::Url;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, RETRY_AFTER};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 use tokio::sync::Semaphore;
 
@@ -77,6 +78,7 @@ pub struct LlmClient {
     http: reqwest::Client,
     base_url: String,
     model: String,
+    extra_body: Option<Value>,
     semaphore: Arc<Semaphore>,
     current_max: Arc<AtomicUsize>,
 }
@@ -128,6 +130,7 @@ impl LlmClient {
             http,
             base_url,
             model,
+            extra_body: config.extra_body.clone(),
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
             current_max: Arc::new(AtomicUsize::new(max_concurrent)),
         })
@@ -165,16 +168,30 @@ impl LlmClient {
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
         let endpoint = format!("{}/chat/completions", self.base_url);
         let model = request.model.as_deref().unwrap_or(&self.model);
+        let mut body = serde_json::Map::new();
+        body.insert("model".to_string(), Value::String(model.to_string()));
+        body.insert(
+            "messages".to_string(),
+            serde_json::to_value(&request.messages)
+                .map_err(|error| LlmError::DecodeResponse(error.to_string()))?,
+        );
+        if let Some(temperature) = request.temperature {
+            let temperature = serde_json::Number::from_f64(temperature).ok_or_else(|| {
+                LlmError::DecodeResponse("temperature must be finite".to_string())
+            })?;
+            body.insert("temperature".to_string(), Value::Number(temperature));
+        }
+        if let Some(max_tokens) = request.max_tokens {
+            body.insert(
+                "max_tokens".to_string(),
+                Value::Number(serde_json::Number::from(max_tokens)),
+            );
+        }
+        merge_extra_body(&mut body, self.extra_body.as_ref())?;
         let response = self
             .http
             .post(&endpoint)
-            .json(&OpenAiChatRequest {
-                model,
-                messages: &request.messages,
-                temperature: request.temperature,
-                max_tokens: request.max_tokens,
-                chat_template_kwargs: None,
-            })
+            .json(&Value::Object(body))
             .send()
             .await
             .map_err(map_reqwest_error)?;
@@ -215,6 +232,30 @@ impl LlmClient {
             model: response.model,
         })
     }
+}
+
+fn merge_extra_body(
+    body: &mut serde_json::Map<String, Value>,
+    extra_body: Option<&Value>,
+) -> Result<(), LlmError> {
+    let Some(extra_body) = extra_body else {
+        return Ok(());
+    };
+    let Value::Object(extra) = extra_body else {
+        return Err(LlmError::MissingConfiguration(
+            "llm.extra_body must be a JSON object".to_string(),
+        ));
+    };
+    for (key, value) in extra {
+        if matches!(
+            key.as_str(),
+            "model" | "messages" | "temperature" | "max_tokens"
+        ) {
+            continue;
+        }
+        body.insert(key.clone(), value.clone());
+    }
+    Ok(())
 }
 
 fn resolve_api_key(
@@ -286,23 +327,6 @@ fn map_decode_error(source: reqwest::Error) -> LlmError {
     } else {
         LlmError::DecodeResponse(source.to_string())
     }
-}
-
-#[derive(Debug, Serialize)]
-struct OpenAiChatRequest<'a> {
-    model: &'a str,
-    messages: &'a [LlmMessage],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    chat_template_kwargs: Option<ChatTemplateKwargs>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct ChatTemplateKwargs {
-    enable_thinking: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,10 @@ enum Commands {
         #[arg(long)]
         trigger: Option<String>,
     },
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
     Project {
         #[command(subcommand)]
         command: ProjectCommands,
@@ -588,6 +592,12 @@ enum DaemonSubcommand {
     Restart,
     /// Show daemon status, PID, and queue stats.
     Status,
+}
+
+#[derive(Subcommand)]
+enum ConfigCommands {
+    /// Show current memory intelligence mode and effective LLM settings.
+    Intelligence,
 }
 
 #[derive(Subcommand)]
@@ -1149,6 +1159,11 @@ fn run() -> Result<()> {
                 .unwrap_or_else(|| PathBuf::from("."));
             return mempal::hotpatch::run_command(&config, &mempal_home, command.clone());
         }
+        Commands::Config { command } => {
+            let config = Config::load_from(&config_path)
+                .with_context(|| format!("failed to load config {}", config_path.display()))?;
+            return config_command(&config, command);
+        }
         Commands::Daemon {
             command,
             foreground,
@@ -1329,6 +1344,7 @@ fn run() -> Result<()> {
             },
         )),
         Commands::Project { command } => project_command(&db, command),
+        Commands::Config { .. } => unreachable!(),
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
         Commands::Rollback {
             since,
@@ -5419,6 +5435,48 @@ fn fact_check_command(
     Ok(())
 }
 
+fn config_command(config: &Config, command: &ConfigCommands) -> Result<()> {
+    match command {
+        ConfigCommands::Intelligence => config_intelligence_command(config),
+    }
+}
+
+fn config_intelligence_command(config: &Config) -> Result<()> {
+    let effective_llm = config.memory_intelligence.effective_llm_config(&config.llm);
+    let llm_state = if !config.memory_intelligence.mode.uses_llm() {
+        "disabled"
+    } else if config
+        .memory_intelligence
+        .has_effective_llm_endpoint(&config.llm)
+    {
+        "healthy"
+    } else {
+        "disabled"
+    };
+    println!("memory_intelligence:");
+    println!("  mode: {}", config.memory_intelligence.mode);
+    println!("  llm_state: {llm_state}");
+    println!("  llm_backend: {}", effective_llm.backend);
+    match effective_llm.model.as_deref() {
+        Some(model) => println!("  llm_model: {model}"),
+        None => println!("  llm_model: none"),
+    }
+    match effective_llm.base_url.as_deref() {
+        Some(base_url) => println!("  llm_base_url: {base_url}"),
+        None => println!("  llm_base_url: none"),
+    }
+    println!("  timeout_secs: {}", effective_llm.request_timeout_secs);
+    println!(
+        "  extra_body: {}",
+        if effective_llm.extra_body.is_some() {
+            "configured"
+        } else {
+            "none"
+        }
+    );
+    Ok(())
+}
+
 fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
     let scrub_stats = ConfigHandle::scrub_stats();
@@ -5432,6 +5490,7 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         None
     };
     let embed_status = global_embed_status().snapshot();
+    let intelligence_status = mempal::intelligence::global_intelligence_status().snapshot();
     let queue_stats = mempal::core::queue::queue_stats_readonly(db.path())
         .context("failed to query pending message stats")?;
     let schema_version = db
@@ -5658,6 +5717,30 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("  max_concurrent: {}", config.llm.max_concurrent);
         let llm_pending = queue_stats.pending;
         println!("  queue_pending: {llm_pending}");
+    }
+    println!("Intelligence:");
+    println!("  mode: {}", config.memory_intelligence.mode);
+    let intelligence_llm_state = if !config.memory_intelligence.mode.uses_llm() {
+        "disabled"
+    } else if config
+        .memory_intelligence
+        .has_effective_llm_endpoint(&config.llm)
+    {
+        match &endpoint_health {
+            Some(health) if !health.llm.reachable => "degraded",
+            _ => "healthy",
+        }
+    } else {
+        "disabled"
+    };
+    println!("  llm_state: {intelligence_llm_state}");
+    match intelligence_status.last_success_at_unix_ms {
+        Some(last_success) => println!("  last_success_at_unix_ms: {last_success}"),
+        None => println!("  last_success_at_unix_ms: none"),
+    }
+    println!("  failure_count: {}", intelligence_status.failure_count);
+    if let Some(last_error) = intelligence_status.last_error.as_deref() {
+        println!("  last_error: {last_error}");
     }
     if !runtime_warnings.is_empty() {
         println!("Warnings:");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -68,18 +68,19 @@ use super::tools::{
     ChunkerStatsDto, ContextRequest, ContextResponse, CoworkPushRequest, CoworkPushResponse,
     DeleteRequest, DeleteResponse, DuplicateWarning, EmbedStatusDto, EndpointHealthDto,
     FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto, FieldTaxonomyResponse,
-    IngestRequest, IngestResponse, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
-    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
-    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
-    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
-    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
-    LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, PeekMessageDto,
-    PeekPartnerRequest, PeekPartnerResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse,
-    ReadDrawersRequest, ReadDrawersResponse, RetrievedKnowledgeCardDto, RollbackRequest,
-    RollbackResponse, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto,
-    SkillDto, SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, StatusResponse,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
-    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto,
+    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
+    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
+    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
+    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
+    KnowledgePublishAnchorResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
+    MAX_READ_DRAWERS_REQUEST_IDS, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
+    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    RetrievedKnowledgeCardDto, RollbackRequest, RollbackResponse, ScopeCount, ScrubStatsDto,
+    SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
+    SkillSummaryDto, SourceTypeCount, StatusResponse, SystemWarning, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
 #[derive(Clone)]
@@ -944,6 +945,7 @@ impl MempalMcpServer {
             })?;
         let endpoint_health = crate::endpoint_health::probe_endpoints(config.as_ref()).await;
         let embed_snapshot = global_embed_status().snapshot();
+        let intelligence_snapshot = crate::intelligence::global_intelligence_status().snapshot();
         let schema_version = db.schema_version().map_err(db_error)?;
         let stale_drawer_count = db
             .stale_drawer_count(CURRENT_NORMALIZE_VERSION)
@@ -1043,6 +1045,13 @@ impl MempalMcpServer {
                 backend: Some(config.llm.backend.clone()),
                 model: config.llm.model.clone(),
                 max_concurrent: config.llm.max_concurrent,
+            },
+            intelligence_status: IntelligenceStatusDto {
+                mode: config.memory_intelligence.mode.to_string(),
+                llm_state: intelligence_llm_state(config.as_ref(), endpoint_health.llm.reachable),
+                last_success_at_unix_ms: intelligence_snapshot.last_success_at_unix_ms,
+                failure_count: intelligence_snapshot.failure_count,
+                last_error: intelligence_snapshot.last_error,
             },
             turn_storage: TurnStorageStatusDto {
                 storage_mode: config.turns.storage_mode.to_string(),
@@ -3728,6 +3737,23 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
             }),
     );
     warnings
+}
+
+fn intelligence_llm_state(config: &crate::core::config::Config, reachable: bool) -> String {
+    if !config.memory_intelligence.mode.uses_llm() {
+        return "disabled".to_string();
+    }
+    if !config
+        .memory_intelligence
+        .has_effective_llm_endpoint(&config.llm)
+    {
+        return "disabled".to_string();
+    }
+    if reachable {
+        "healthy".to_string()
+    } else {
+        "degraded".to_string()
+    }
 }
 
 fn read_drawer_response(details: crate::core::types::DrawerDetails) -> ReadDrawerResponse {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -951,6 +951,7 @@ pub struct StatusResponse {
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,
+    pub intelligence_status: IntelligenceStatusDto,
     pub turn_storage: TurnStorageStatusDto,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
@@ -989,6 +990,17 @@ pub struct LlmStatusDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     pub max_concurrent: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct IntelligenceStatusDto {
+    pub mode: String,
+    pub llm_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_success_at_unix_ms: Option<u64>,
+    pub failure_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]

--- a/tests/intelligence.rs
+++ b/tests/intelligence.rs
@@ -40,7 +40,6 @@ fn test_intelligence_mode_config_parsing() {
     for (raw, expected) in [
         ("deterministic", IntelligenceMode::Deterministic),
         ("local_llm", IntelligenceMode::LocalLlm),
-        ("cloud_llm", IntelligenceMode::CloudLlm),
         ("auto", IntelligenceMode::Auto),
     ] {
         let config = Config::parse(&format!(

--- a/tests/intelligence.rs
+++ b/tests/intelligence.rs
@@ -1,0 +1,129 @@
+use mempal::core::config::Config;
+use mempal::core::types::IntelligenceMode;
+use mempal::intelligence::IntelligenceRouter;
+use mockito::Server;
+
+fn llm_response(content: &str) -> String {
+    serde_json::json!({
+        "model": "local-test-model",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content
+                }
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn config_for(server: &Server, mode: &str) -> Config {
+    Config::parse(&format!(
+        r#"
+[memory_intelligence]
+mode = "{mode}"
+
+[memory_intelligence.llm]
+base_url = "{}/v1"
+model = "local-test-model"
+timeout_secs = 1
+extra_body = {{ chat_template_kwargs = {{ enable_thinking = false }} }}
+"#,
+        server.url()
+    ))
+    .expect("parse config")
+}
+
+#[test]
+fn test_intelligence_mode_config_parsing() {
+    for (raw, expected) in [
+        ("deterministic", IntelligenceMode::Deterministic),
+        ("local_llm", IntelligenceMode::LocalLlm),
+        ("cloud_llm", IntelligenceMode::CloudLlm),
+        ("auto", IntelligenceMode::Auto),
+    ] {
+        let config = Config::parse(&format!(
+            r#"
+[memory_intelligence]
+mode = "{raw}"
+"#
+        ))
+        .expect("parse mode");
+
+        assert_eq!(config.memory_intelligence.mode, expected);
+    }
+}
+
+#[tokio::test]
+async fn test_deterministic_mode_no_llm_calls() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .expect(0)
+        .with_status(500)
+        .create();
+    let config = config_for(&server, "deterministic");
+    let router = IntelligenceRouter::from_config(&config);
+
+    let enhanced = router
+        .enhance_ingest("Remember #architecture decision")
+        .await;
+
+    mock.assert();
+    assert!(!enhanced.used_llm);
+    assert_eq!(enhanced.tags, vec!["architecture".to_string()]);
+    assert!(enhanced.candidate_facts.is_empty());
+    assert!(enhanced.fallback_reason.is_none());
+}
+
+#[tokio::test]
+async fn test_auto_mode_fallback() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("unavailable")
+        .create();
+    let config = config_for(&server, "auto");
+    let router = IntelligenceRouter::from_config(&config);
+
+    let enhanced = router.enhance_ingest("Alice works at Acme").await;
+
+    mock.assert();
+    assert!(!enhanced.used_llm);
+    assert_eq!(enhanced.raw_content, "Alice works at Acme");
+    assert!(enhanced.candidate_facts.is_empty());
+    assert!(enhanced.fallback_reason.is_some());
+}
+
+#[tokio::test]
+async fn test_llm_output_gate_rejects_hallucination() {
+    let mut server = Server::new_async().await;
+    let hallucinated = serde_json::json!({
+        "candidate_facts": ["Bob works at Acme"],
+        "tags": ["employment"],
+        "contradiction": false,
+        "correction": false
+    })
+    .to_string();
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(llm_response(&hallucinated))
+        .create();
+    let config = config_for(&server, "local_llm");
+    let router = IntelligenceRouter::from_config(&config);
+
+    let enhanced = router.enhance_ingest("Alice works at Acme").await;
+
+    mock.assert();
+    assert!(!enhanced.used_llm);
+    assert!(enhanced.candidate_facts.is_empty());
+    assert!(
+        enhanced
+            .fallback_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("unsupported fact"))
+    );
+}

--- a/tests/llm_client.rs
+++ b/tests/llm_client.rs
@@ -116,6 +116,32 @@ async fn test_llm_client_chat_completion_success() {
 }
 
 #[tokio::test]
+async fn test_llm_client_sends_extra_body() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "model": "local-test-model",
+            "chat_template_kwargs": {
+                "enable_thinking": false
+            }
+        })))
+        .with_status(200)
+        .with_body(success_body("extra"))
+        .create();
+    let config = config_for(
+        &server,
+        r#"extra_body = { chat_template_kwargs = { enable_thinking = false } }"#,
+    );
+    let client = LlmClient::from_config(&config).expect("build client");
+
+    let response = client.chat_completion(&request()).await.expect("chat");
+
+    mock.assert();
+    assert_eq!(response.content, "extra");
+}
+
+#[tokio::test]
 async fn test_llm_client_4xx_not_retryable() {
     let mut server = Server::new_async().await;
     let mock = server

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -62,6 +62,43 @@ enabled_for = ["gating", "distill", "compress"]
 }
 
 #[test]
+fn test_memory_intelligence_config_parse_full() {
+    let config = Config::parse(
+        r#"
+[memory_intelligence]
+mode = "local_llm"
+
+[memory_intelligence.llm]
+base_url = "http://127.0.0.1:18009/v1"
+model = "qwen3.6-27b-decensor-by-aeon"
+timeout_secs = 1800
+extra_body = { chat_template_kwargs = { enable_thinking = false } }
+"#,
+    )
+    .expect("memory intelligence config should parse");
+
+    assert_eq!(config.memory_intelligence.mode.to_string(), "local_llm");
+    let effective = config.memory_intelligence.effective_llm_config(&config.llm);
+    assert_eq!(
+        effective.base_url.as_deref(),
+        Some("http://127.0.0.1:18009/v1")
+    );
+    assert_eq!(
+        effective.model.as_deref(),
+        Some("qwen3.6-27b-decensor-by-aeon")
+    );
+    assert_eq!(effective.request_timeout_secs, 1800);
+    assert_eq!(
+        effective
+            .extra_body
+            .as_ref()
+            .and_then(|body| body.pointer("/chat_template_kwargs/enable_thinking"))
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+}
+
+#[test]
 fn test_llm_config_missing_base_url_when_enabled() {
     let err = Config::parse(
         r#"

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -99,6 +99,49 @@ extra_body = { chat_template_kwargs = { enable_thinking = false } }
 }
 
 #[test]
+fn test_cloud_llm_memory_intelligence_mode_is_rejected() {
+    let err = Config::parse(
+        r#"
+[memory_intelligence]
+mode = "cloud_llm"
+"#,
+    )
+    .expect_err("cloud_llm mode must not parse");
+
+    match err {
+        ConfigError::Parse(source) => {
+            assert!(source.to_string().contains("cloud_llm"), "{source}");
+        }
+        other => panic!("expected ConfigError::Parse, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_external_llm_base_url_warns_but_does_not_block_config() {
+    let config = Config::parse(
+        r#"
+[memory_intelligence]
+mode = "local_llm"
+
+[memory_intelligence.llm]
+base_url = "https://api.example.com/v1"
+model = "operator-owned-model"
+"#,
+    )
+    .expect("external LLM endpoint warning must not block config parsing");
+
+    let warnings = config.collect_runtime_warnings();
+    assert!(
+        warnings.iter().any(|warning| {
+            warning.source == "llm"
+                && warning.message.contains("memory_intelligence.llm.base_url")
+                && warning.message.contains("api.example.com")
+        }),
+        "{warnings:?}"
+    );
+}
+
+#[test]
 fn test_llm_config_missing_base_url_when_enabled() {
     let err = Config::parse(
         r#"


### PR DESCRIPTION
## Summary
- add memory intelligence LLM mode infrastructure while keeping deterministic as the default
- remove the explicit cloud_llm mode and reject that config value
- warn, without blocking, when configured LLM base URLs look outside localhost/LAN

## Verification
- cargo test -j 1
- pre-commit: just clippy; just test
- CSA review gate passed for 10b045f9c97

## Notes
- Pre-existing local changes left untouched: weave.lock and docs/plans/2026-05-13-all-open-issues.md