### PR TITLE
feat: typed ingest and canonical pinned facts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -746,7 +746,7 @@ fn context_anchors(request: &ContextRequest) -> Result<Vec<AnchorCandidate>> {
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Worktree,
         anchor_id: derived.anchor_id,
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
 
     let repo_anchor_id = derived
@@ -755,7 +755,7 @@ fn context_anchors(request: &ContextRequest) -> Result<Vec<AnchorCandidate>> {
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Repo,
         anchor_id: repo_anchor_id,
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
 
     // P12 backfilled existing drawers to repo://legacy. Keep it as a fallback
@@ -763,7 +763,7 @@ fn context_anchors(request: &ContextRequest) -> Result<Vec<AnchorCandidate>> {
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Repo,
         anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
 
     anchors.push(AnchorCandidate {
@@ -829,7 +829,7 @@ fn context_item_from_result(db: &Database, result: SearchResult) -> Result<Conte
             .filter(|value| !value.is_empty())
             .unwrap_or(result.content.as_str())
             .to_string(),
-        MemoryKind::Evidence => result.content,
+        MemoryKind::Evidence | MemoryKind::ProfileFact => result.content,
     };
     Ok(ContextItem {
         drawer_id: result.drawer_id,
@@ -865,7 +865,7 @@ fn append_card_context_items(
                 .list_knowledge_cards(&KnowledgeCardFilter {
                     tier: Some(tier.clone()),
                     status: Some(status.clone()),
-                    domain: Some(anchor.domain.clone()),
+                    domain: Some(anchor.domain),
                     field: Some(request.field.clone()),
                     anchor_kind: Some(anchor.anchor_kind.clone()),
                     anchor_id: Some(anchor.anchor_id.clone()),
@@ -943,12 +943,14 @@ fn memory_kind_slug(value: &MemoryKind) -> &'static str {
     match value {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
 fn domain_slug(value: &MemoryDomain) -> &'static str {
     match value {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -967,6 +969,8 @@ fn tier_slug(value: &KnowledgeTier) -> &'static str {
 fn status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
         KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
         KnowledgeStatus::Demoted => "demoted",

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -39,7 +39,7 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-const CURRENT_SCHEMA_VERSION: u32 = 12;
+const CURRENT_SCHEMA_VERSION: u32 = 13;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
@@ -58,6 +58,10 @@ fn truncate_preview(content: &str, max_chars: usize) -> String {
     preview
 }
 
+fn truncate_to_char_budget(content: &str, max_chars: usize) -> String {
+    content.chars().take(max_chars).collect()
+}
+
 const DRAWER_SELECT_COLUMNS: &str = r#"
     id,
     content,
@@ -72,7 +76,7 @@ const DRAWER_SELECT_COLUMNS: &str = r#"
     COALESCE(importance, 0) as importance,
     memory_kind,
     domain,
-    field,
+    COALESCE(field, 'general') as field,
     anchor_kind,
     anchor_id,
     parent_anchor_id,
@@ -86,6 +90,9 @@ const DRAWER_SELECT_COLUMNS: &str = r#"
     verification_refs,
     scope_constraints,
     trigger_hints,
+    COALESCE(is_pinned, 0) as is_pinned,
+    pin_order,
+    supersedes,
     COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) as effective_importance,
     compacted_into
 "#;
@@ -347,10 +354,13 @@ impl Database {
                 verification_refs,
                 scope_constraints,
                 trigger_hints,
+                is_pinned,
+                pin_order,
+                supersedes,
                 valid_from,
                 valid_until
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34)
             "#,
             params![
                 drawer.id.as_str(),
@@ -382,6 +392,9 @@ impl Database {
                 encode_json(&drawer.verification_refs)?,
                 drawer.scope_constraints.as_deref(),
                 encode_optional_json(drawer.trigger_hints.as_ref())?,
+                drawer.is_pinned,
+                drawer.pin_order,
+                drawer.supersedes.as_deref(),
                 valid_from.unwrap_or(drawer.added_at.as_str()),
                 valid_until,
             ],
@@ -1016,8 +1029,11 @@ impl Database {
                     verification_refs = ?25,
                     scope_constraints = ?26,
                     trigger_hints = ?27,
-                    content_hash = ?28,
-                    valid_from = ?29,
+                    is_pinned = ?28,
+                    pin_order = ?29,
+                    supersedes = ?30,
+                    content_hash = ?31,
+                    valid_from = ?32,
                     valid_until = NULL
                 WHERE id = ?1 AND deleted_at IS NULL
                 "#,
@@ -1049,6 +1065,9 @@ impl Database {
                     encode_json(&drawer.verification_refs)?,
                     drawer.scope_constraints.as_deref(),
                     encode_optional_json(drawer.trigger_hints.as_ref())?,
+                    drawer.is_pinned,
+                    drawer.pin_order,
+                    drawer.supersedes.as_deref(),
                     content_hash,
                     drawer.added_at.as_str(),
                 ],
@@ -1223,6 +1242,157 @@ impl Database {
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+
+    pub fn pinned_fact_counts_by_project(&self) -> Result<Vec<(Option<String>, i64)>, DbError> {
+        if !drawers_column_exists(&self.conn, "project_id")? {
+            let count = self.conn.query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM drawers
+                WHERE deleted_at IS NULL
+                  AND is_pinned = 1
+                  AND COALESCE(status, 'active') IN ('active', 'canonical')
+                "#,
+                [],
+                |row| row.get::<_, i64>(0),
+            )?;
+            return Ok(vec![(None, count)]);
+        }
+
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT project_id, COUNT(*)
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND is_pinned = 1
+              AND COALESCE(status, 'active') IN ('active', 'canonical')
+            GROUP BY project_id
+            ORDER BY project_id IS NOT NULL DESC, project_id
+            "#,
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn pin_drawer(&self, drawer_id: &str, pin_order: Option<i64>) -> Result<bool, DbError> {
+        let resolved_order = match pin_order {
+            Some(order) => Some(order),
+            None => self.conn.query_row(
+                "SELECT COALESCE(MAX(pin_order), -1) + 1 FROM drawers WHERE is_pinned = 1",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )?,
+        };
+        let affected = self.conn.execute(
+            "UPDATE drawers SET is_pinned = 1, pin_order = COALESCE(?2, pin_order) WHERE id = ?1 AND deleted_at IS NULL",
+            params![drawer_id, resolved_order],
+        )?;
+        Ok(affected > 0)
+    }
+
+    pub fn unpin_drawer(&self, drawer_id: &str) -> Result<bool, DbError> {
+        let affected = self.conn.execute(
+            "UPDATE drawers SET is_pinned = 0, pin_order = NULL WHERE id = ?1 AND deleted_at IS NULL",
+            [drawer_id],
+        )?;
+        Ok(affected > 0)
+    }
+
+    pub fn reorder_pinned_facts(&self, drawer_ids: &[String]) -> Result<(), DbError> {
+        self.conn.execute_batch("BEGIN IMMEDIATE;")?;
+        let result = (|| -> Result<(), DbError> {
+            for (index, drawer_id) in drawer_ids.iter().enumerate() {
+                self.conn.execute(
+                    "UPDATE drawers SET is_pinned = 1, pin_order = ?2 WHERE id = ?1 AND deleted_at IS NULL",
+                    params![drawer_id, i64::try_from(index).map_err(|_| {
+                        DbError::InvalidEnumValue {
+                            kind: "pin_order",
+                            value: index.to_string(),
+                        }
+                    })?],
+                )?;
+            }
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT;")?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(error)
+            }
+        }
+    }
+
+    pub fn get_pinned_facts(
+        &self,
+        project_id: Option<&str>,
+        budget_chars: usize,
+    ) -> Result<Vec<Drawer>, DbError> {
+        if budget_chars == 0 {
+            return Ok(Vec::new());
+        }
+
+        let has_project_id = drawers_column_exists(&self.conn, "project_id")?;
+        let updated_order = if drawers_column_exists(&self.conn, "updated_at")? {
+            "COALESCE(updated_at, added_at)"
+        } else {
+            "added_at"
+        };
+        let mut values = Vec::new();
+        let mut project_filter = String::new();
+        if has_project_id && let Some(project_id) = project_id {
+            values.push(SqlValue::Text(project_id.to_string()));
+            project_filter = " AND project_id = ?1".to_string();
+        }
+
+        let sql = format!(
+            r#"
+            SELECT {DRAWER_SELECT_COLUMNS}
+            FROM drawers
+            WHERE deleted_at IS NULL
+              AND is_pinned = 1
+              AND COALESCE(status, 'active') IN ('active', 'canonical')
+              {project_filter}
+            ORDER BY pin_order IS NULL ASC,
+                     pin_order ASC,
+                     importance DESC,
+                     {updated_order} DESC,
+                     id ASC
+            "#
+        );
+        let mut statement = self.conn.prepare(&sql)?;
+        let rows = statement
+            .query_map(params_from_iter(values), |row| {
+                drawer_from_row(row).map_err(row_decode_error)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let mut used_chars = 0usize;
+        let mut facts = Vec::new();
+        for mut drawer in rows {
+            if used_chars >= budget_chars {
+                break;
+            }
+            let remaining = budget_chars - used_chars;
+            let content_chars = drawer.content.chars().count();
+            if content_chars <= remaining {
+                used_chars += content_chars;
+                facts.push(drawer);
+            } else if remaining > 0 {
+                drawer.content = truncate_to_char_budget(&drawer.content, remaining);
+                facts.push(drawer);
+                break;
+            }
+        }
+        Ok(facts)
     }
 
     pub fn diary_rollup_days(&self) -> Result<u32, DbError> {
@@ -1408,11 +1578,11 @@ impl Database {
         ))?;
         let mut rows = statement.query_map([drawer_id], |row| {
             let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-            // DRAWER_SELECT_COLUMNS has 29 columns (indices 0-28), so
-            // the extra columns appended here start at index 29.
-            let updated_at = row.get::<_, Option<String>>(29)?;
-            let merge_count = row.get::<_, u32>(30)?;
-            let project_id = row.get::<_, Option<String>>(31)?;
+            // DRAWER_SELECT_COLUMNS has 32 columns (indices 0-31), so
+            // the extra columns appended here start at index 32.
+            let updated_at = row.get::<_, Option<String>>(32)?;
+            let merge_count = row.get::<_, u32>(33)?;
+            let project_id = row.get::<_, Option<String>>(34)?;
             Ok(DrawerDetails {
                 drawer,
                 updated_at,
@@ -1464,10 +1634,10 @@ impl Database {
             let mut statement = self.conn.prepare(&sql)?;
             let rows = statement.query_map(params_from_iter(chunk.iter()), |row| {
                 let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-                // DRAWER_SELECT_COLUMNS is 29 columns (0-28); extra columns start at 29.
-                let updated_at = row.get::<_, Option<String>>(29)?;
-                let merge_count = row.get::<_, u32>(30)?;
-                let project_id = row.get::<_, Option<String>>(31)?;
+                // DRAWER_SELECT_COLUMNS is 32 columns (0-31); extra columns start at 32.
+                let updated_at = row.get::<_, Option<String>>(32)?;
+                let merge_count = row.get::<_, u32>(33)?;
+                let project_id = row.get::<_, Option<String>>(34)?;
                 Ok((
                     drawer.id.clone(),
                     DrawerDetails {
@@ -2257,7 +2427,7 @@ impl Database {
     pub fn supersede_drawer(&self, old_id: &str, reason: &str) -> Result<bool, DbError> {
         let timestamp = super::utils::current_timestamp();
         let affected = self.conn.execute(
-            "UPDATE drawers SET deleted_at = ?1, valid_until = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            "UPDATE drawers SET status = 'superseded', deleted_at = ?1, valid_until = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             params![timestamp, old_id],
         )?;
         if affected > 0 {
@@ -2551,8 +2721,8 @@ impl Database {
                 rusqlite::params![room, exclude_drawer_id, current_project_id, sql_limit],
                 |row| {
                     let drawer = drawer_from_row(row).map_err(row_decode_error)?;
-                    // DRAWER_SELECT_COLUMNS is 29 columns (0-28); project_id appended at 29.
-                    let project_id = row.get::<_, Option<String>>(29)?;
+                    // DRAWER_SELECT_COLUMNS is 32 columns (0-31); project_id appended at 32.
+                    let project_id = row.get::<_, Option<String>>(32)?;
                     Ok(TunnelDrawer {
                         drawer,
                         target_project_id: project_id,
@@ -3546,6 +3716,10 @@ fn apply_migrations(conn: &Connection) -> Result<(), DbError> {
             ensure_v12_compaction_schema(conn, read_user_version(conn)?)?;
             continue;
         }
+        if migration.version == 13 {
+            ensure_v13_typed_pinned_schema(conn, read_user_version(conn)?)?;
+            continue;
+        }
         apply_migration_atomic(conn, migration)?;
     }
 
@@ -3557,6 +3731,9 @@ fn apply_migrations(conn: &Connection) -> Result<(), DbError> {
     }
     if read_user_version(conn)? >= 12 {
         ensure_v12_compaction_schema(conn, read_user_version(conn)?)?;
+    }
+    if read_user_version(conn)? >= 13 {
+        ensure_v13_typed_pinned_schema(conn, read_user_version(conn)?)?;
     }
 
     Ok(())
@@ -3700,6 +3877,45 @@ fn ensure_v12_compaction_schema(conn: &Connection, current_version: u32) -> Resu
     Ok(())
 }
 
+fn ensure_v13_typed_pinned_schema(conn: &Connection, current_version: u32) -> Result<(), DbError> {
+    let existing_columns = drawers_column_names(conn)?;
+    let missing_is_pinned = !existing_columns.contains("is_pinned");
+    let missing_pin_order = !existing_columns.contains("pin_order");
+    let missing_supersedes = !existing_columns.contains("supersedes");
+
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    if let Err(error) = (|| -> Result<(), DbError> {
+        if missing_is_pinned {
+            conn.execute_batch(
+                "ALTER TABLE drawers ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0 CHECK(is_pinned IN (0, 1));",
+            )?;
+        }
+        if missing_pin_order {
+            conn.execute_batch("ALTER TABLE drawers ADD COLUMN pin_order INTEGER;")?;
+        }
+        if missing_supersedes {
+            conn.execute_batch(
+                "ALTER TABLE drawers ADD COLUMN supersedes TEXT REFERENCES drawers(id);",
+            )?;
+        }
+        let rewrote_checks = rewrite_drawers_typed_ingest_checks(conn)?;
+        conn.execute_batch(V13_TYPED_PINNED_SCHEMA_SQL)?;
+        if rewrote_checks {
+            bump_sqlite_schema_version(conn)?;
+        }
+        if current_version < 13 {
+            set_user_version(conn, 13)?;
+        }
+        conn.execute_batch("COMMIT;")?;
+        Ok(())
+    })() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return Err(error);
+    }
+
+    Ok(())
+}
+
 fn rewrite_drawers_source_type_check(conn: &Connection) -> Result<bool, DbError> {
     let table_sql = conn.query_row(
         "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'drawers'",
@@ -3740,6 +3956,59 @@ fn rewrite_drawers_source_type_check(conn: &Connection) -> Result<bool, DbError>
     conn.execute_batch("PRAGMA writable_schema = OFF;")?;
     update_result?;
     bump_sqlite_schema_version(conn)?;
+    Ok(true)
+}
+
+fn rewrite_drawers_typed_ingest_checks(conn: &Connection) -> Result<bool, DbError> {
+    let table_sql = conn.query_row(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'drawers'",
+        [],
+        |row| row.get::<_, String>(0),
+    )?;
+
+    let replacements = [
+        (
+            "memory_kind TEXT NOT NULL CHECK(memory_kind IN ('evidence', 'knowledge')) DEFAULT 'evidence'",
+            "memory_kind TEXT NOT NULL DEFAULT 'evidence' CHECK(memory_kind IN ('evidence', 'knowledge', 'profile_fact'))",
+        ),
+        (
+            "memory_kind TEXT NOT NULL DEFAULT 'evidence' CHECK(memory_kind IN ('evidence', 'knowledge'))",
+            "memory_kind TEXT NOT NULL DEFAULT 'evidence' CHECK(memory_kind IN ('evidence', 'knowledge', 'profile_fact'))",
+        ),
+        (
+            "domain TEXT NOT NULL CHECK(domain IN ('project', 'agent', 'skill', 'global')) DEFAULT 'project'",
+            "domain TEXT NOT NULL DEFAULT 'project' CHECK(domain IN ('user', 'agent', 'project', 'skill', 'global'))",
+        ),
+        (
+            "domain TEXT NOT NULL DEFAULT 'project' CHECK(domain IN ('project', 'agent', 'skill', 'global'))",
+            "domain TEXT NOT NULL DEFAULT 'project' CHECK(domain IN ('user', 'agent', 'project', 'skill', 'global'))",
+        ),
+        ("field TEXT NOT NULL DEFAULT 'general'", "field TEXT"),
+        (
+            "status TEXT CHECK(status IN ('candidate', 'promoted', 'canonical', 'demoted', 'retired'))",
+            "status TEXT DEFAULT 'active' CHECK(status IN ('active', 'superseded', 'candidate', 'promoted', 'canonical', 'demoted', 'retired'))",
+        ),
+        (
+            "status TEXT DEFAULT 'active' CHECK(status IN ('candidate', 'promoted', 'canonical', 'demoted', 'retired'))",
+            "status TEXT DEFAULT 'active' CHECK(status IN ('active', 'superseded', 'candidate', 'promoted', 'canonical', 'demoted', 'retired'))",
+        ),
+    ];
+
+    let mut new_sql = table_sql.clone();
+    for (old, new) in replacements {
+        new_sql = new_sql.replace(old, new);
+    }
+    if new_sql == table_sql {
+        return Ok(false);
+    }
+
+    conn.execute_batch("PRAGMA writable_schema = ON;")?;
+    let update_result = conn.execute(
+        "UPDATE sqlite_master SET sql = ?1 WHERE type = 'table' AND name = 'drawers'",
+        [new_sql],
+    );
+    conn.execute_batch("PRAGMA writable_schema = OFF;")?;
+    update_result?;
     Ok(true)
 }
 
@@ -4279,6 +4548,7 @@ SET source_type = CASE
 
 const V11_MIGRATION_SQL: &str = "";
 const V12_MIGRATION_SQL: &str = "";
+const V13_MIGRATION_SQL: &str = "";
 const V12_COMPACTION_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_drawers_compacted_into
     ON drawers(compacted_into)
@@ -4302,6 +4572,16 @@ CREATE INDEX IF NOT EXISTS idx_consolidation_log_created_at
 
 CREATE INDEX IF NOT EXISTS idx_consolidation_log_scope
     ON consolidation_log(wing, room, project_id);
+"#;
+
+const V13_TYPED_PINNED_SCHEMA_SQL: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_drawers_pinned
+    ON drawers(is_pinned, pin_order)
+    WHERE is_pinned = 1 AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drawers_supersedes
+    ON drawers(supersedes)
+    WHERE supersedes IS NOT NULL;
 "#;
 
 fn migrations() -> &'static [Migration] {
@@ -4354,6 +4634,10 @@ fn migrations() -> &'static [Migration] {
             version: 12,
             sql: V12_MIGRATION_SQL,
         },
+        Migration {
+            version: 13,
+            sql: V13_MIGRATION_SQL,
+        },
     ];
     MIGRATIONS
 }
@@ -4400,6 +4684,7 @@ fn memory_kind_as_str(memory_kind: &MemoryKind) -> &'static str {
     match memory_kind {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
@@ -4407,6 +4692,7 @@ fn memory_kind_from_str(memory_kind: &str) -> Result<MemoryKind, DbError> {
     match memory_kind {
         "evidence" => Ok(MemoryKind::Evidence),
         "knowledge" => Ok(MemoryKind::Knowledge),
+        "profile_fact" => Ok(MemoryKind::ProfileFact),
         other => Err(DbError::InvalidEnumValue {
             kind: "memory_kind",
             value: other.to_string(),
@@ -4417,6 +4703,7 @@ fn memory_kind_from_str(memory_kind: &str) -> Result<MemoryKind, DbError> {
 fn memory_domain_as_str(domain: &MemoryDomain) -> &'static str {
     match domain {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -4426,6 +4713,7 @@ fn memory_domain_as_str(domain: &MemoryDomain) -> &'static str {
 fn memory_domain_from_str(domain: &str) -> Result<MemoryDomain, DbError> {
     match domain {
         "project" => Ok(MemoryDomain::Project),
+        "user" => Ok(MemoryDomain::User),
         "agent" => Ok(MemoryDomain::Agent),
         "skill" => Ok(MemoryDomain::Skill),
         "global" => Ok(MemoryDomain::Global),
@@ -4500,6 +4788,8 @@ fn knowledge_tier_from_str(tier: &str) -> Result<KnowledgeTier, DbError> {
 
 fn knowledge_status_as_str(status: &KnowledgeStatus) -> &'static str {
     match status {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
@@ -4510,6 +4800,8 @@ fn knowledge_status_as_str(status: &KnowledgeStatus) -> &'static str {
 
 fn knowledge_status_from_str(status: &str) -> Result<KnowledgeStatus, DbError> {
     match status {
+        "active" => Ok(KnowledgeStatus::Active),
+        "superseded" => Ok(KnowledgeStatus::Superseded),
         "candidate" => Ok(KnowledgeStatus::Candidate),
         "promoted" => Ok(KnowledgeStatus::Promoted),
         "canonical" => Ok(KnowledgeStatus::Canonical),
@@ -4768,8 +5060,11 @@ fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {
     let verification_refs = parse_string_list(row.get::<_, Option<String>>(24)?.as_deref())?;
     let scope_constraints = row.get::<_, Option<String>>(25)?;
     let trigger_hints = parse_optional_json(row.get::<_, Option<String>>(26)?.as_deref())?;
-    let effective_importance = row.get::<_, f64>(27)?;
-    let compacted_into = row.get::<_, Option<String>>(28)?;
+    let is_pinned = row.get::<_, bool>(27)?;
+    let pin_order = row.get::<_, Option<i64>>(28)?;
+    let supersedes = row.get::<_, Option<String>>(29)?;
+    let effective_importance = row.get::<_, f64>(30)?;
+    let compacted_into = row.get::<_, Option<String>>(31)?;
 
     anchor::validate_anchor_domain(&domain, &anchor_kind)
         .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
@@ -4802,6 +5097,9 @@ fn drawer_from_row(row: &Row<'_>) -> Result<Drawer, DbError> {
         verification_refs,
         scope_constraints,
         trigger_hints,
+        is_pinned,
+        pin_order,
+        supersedes,
         effective_importance,
         compacted_into,
     })

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -234,6 +234,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
+  mempal_pinned_facts  — pinned/canonical facts for always-on session context, no embedding needed
   mempal_timeline      — project-scoped overview without a query, ordered by importance+recency
   mempal_search        — semantic search with wing/room filters, citation-bearing
   mempal_context       — ordered mind-model runtime context (dao_tian -> dao_ren -> shu -> qi; evidence/cards opt-in)
@@ -532,6 +533,6 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 12);
+        assert_eq!(db.schema_version().expect("schema version"), 13);
     }
 }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -104,19 +104,21 @@ pub fn default_confidence(source_type: SourceType) -> f64 {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryKind {
     #[default]
     Evidence,
     Knowledge,
+    ProfileFact,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryDomain {
     #[default]
     Project,
+    User,
     Agent,
     Skill,
     Global,
@@ -131,7 +133,7 @@ pub enum AnchorKind {
     Worktree,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Provenance {
     Runtime,
@@ -151,6 +153,8 @@ pub enum KnowledgeTier {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum KnowledgeStatus {
+    Active,
+    Superseded,
     Candidate,
     Promoted,
     Canonical,
@@ -435,6 +439,10 @@ pub struct Drawer {
     pub verification_refs: Vec<String>,
     pub scope_constraints: Option<String>,
     pub trigger_hints: Option<TriggerHints>,
+    #[serde(default)]
+    pub is_pinned: bool,
+    pub pin_order: Option<i64>,
+    pub supersedes: Option<String>,
     /// Dynamic importance after time-decay + retrieval boost (P13).
     /// Defaults to `importance as f64` when the column doesn't exist (pre-v10 DBs).
     #[serde(default)]
@@ -488,6 +496,9 @@ impl Drawer {
             verification_refs: Vec::new(),
             scope_constraints: None,
             trigger_hints: None,
+            is_pinned: false,
+            pin_order: None,
+            supersedes: None,
             effective_importance: args.importance as f64,
             compacted_into: None,
         }
@@ -526,6 +537,9 @@ impl Default for Drawer {
             verification_refs: Vec::new(),
             scope_constraints: None,
             trigger_hints: None,
+            is_pinned: false,
+            pin_order: None,
+            supersedes: None,
             effective_importance: 0.0,
             compacted_into: None,
         }
@@ -631,6 +645,7 @@ pub struct SearchResult {
     pub anchor_kind: AnchorKind,
     pub anchor_id: String,
     pub parent_anchor_id: Option<String>,
+    pub is_pinned: bool,
     /// Static importance ranking (0-5). Raw-turn exclusion uses this field so
     /// access boosts cannot accidentally promote transcript storage into
     /// durable recall.

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -163,6 +163,7 @@ pub fn build_bootstrap_evidence_drawer_id(
 }
 
 pub fn link_superseded_drawer(drawer: &mut Drawer, old_id: &str) {
+    drawer.supersedes = Some(old_id.to_string());
     let marker = format!("supersedes:{old_id}");
     match drawer.scope_constraints.as_mut() {
         Some(existing) if !existing.trim().is_empty() => {
@@ -391,12 +392,14 @@ fn memory_kind_as_str(kind: &MemoryKind) -> &'static str {
     match kind {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
 fn memory_domain_as_str(domain: &MemoryDomain) -> &'static str {
     match domain {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -430,6 +433,8 @@ fn knowledge_tier_as_str(tier: &KnowledgeTier) -> &'static str {
 
 fn knowledge_status_as_str(status: &KnowledgeStatus) -> &'static str {
     match status {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",

--- a/src/ingest/diary.rs
+++ b/src/ingest/diary.rs
@@ -148,6 +148,9 @@ pub fn commit_prepared_diary_rollup(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: prepared.importance as f64,
         compacted_into: None,
     };

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -19,7 +19,9 @@ use crate::core::{
     config::IngestGatingConfig,
     db::Database,
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
-    types::{BootstrapEvidenceArgs, Drawer, SourceType, default_confidence},
+    types::{
+        BootstrapEvidenceArgs, Drawer, MemoryDomain, MemoryKind, SourceType, default_confidence,
+    },
     utils::{
         build_bootstrap_evidence_drawer_id, build_drawer_id, iso_timestamp, link_superseded_drawer,
         route_room_from_taxonomy,
@@ -77,6 +79,10 @@ pub struct IngestOptions<'a> {
     pub prototype_classifier: Option<&'a PrototypeClassifier>,
     pub source_file_override: Option<&'a str>,
     pub source_type: Option<SourceType>,
+    pub memory_kind: Option<MemoryKind>,
+    pub domain: Option<MemoryDomain>,
+    pub field: Option<&'a str>,
+    pub is_pinned: bool,
     pub confidence: Option<f64>,
     pub replace_existing_source: bool,
     pub no_strip_noise: bool,
@@ -223,6 +229,10 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
             prototype_classifier: None,
             source_file_override: None,
             source_type: None,
+            memory_kind: None,
+            domain: None,
+            field: None,
+            is_pinned: false,
             confidence: None,
             replace_existing_source: false,
             no_strip_noise: false,
@@ -413,6 +423,13 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             .into_iter()
             .find(|summary| Some(summary.id.as_str()) != replacement_target_id);
         if let Some(existing) = exact_duplicate {
+            if options.is_pinned {
+                db.pin_drawer(&existing.id, None)
+                    .map_err(|source| IngestError::InsertDrawer {
+                        drawer_id: existing.id.clone(),
+                        source,
+                    })?;
+            }
             stats.skipped += 1;
             stats.drawer_ids.push(existing.id);
             continue;
@@ -571,6 +588,16 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             ..drawer
         };
         let mut drawer = drawer;
+        if let Some(memory_kind) = options.memory_kind {
+            drawer.memory_kind = memory_kind;
+        }
+        if let Some(domain) = options.domain {
+            drawer.domain = domain;
+        }
+        if let Some(field) = options.field {
+            drawer.field = field.to_string();
+        }
+        drawer.is_pinned = options.is_pinned;
         if let Some(old_id) = replacement_target_id {
             link_superseded_drawer(&mut drawer, old_id);
         }
@@ -667,6 +694,10 @@ pub async fn ingest_dir<E: Embedder + ?Sized>(
             prototype_classifier: None,
             source_file_override: None,
             source_type: None,
+            memory_kind: None,
+            domain: None,
+            field: None,
+            is_pinned: false,
             confidence: None,
             replace_existing_source: false,
             no_strip_noise: false,

--- a/src/knowledge_card_backfill.rs
+++ b/src/knowledge_card_backfill.rs
@@ -232,7 +232,7 @@ fn create_card_and_event(db: &Database, drawer: &Drawer, card_id: &str) -> Resul
             .status
             .clone()
             .expect("ready candidate must have status"),
-        domain: drawer.domain.clone(),
+        domain: drawer.domain,
         field: drawer.field.clone(),
         anchor_kind: drawer.anchor_kind.clone(),
         anchor_id: drawer.anchor_id.clone(),
@@ -353,6 +353,7 @@ fn evidence_role_slug(value: &KnowledgeEvidenceRole) -> &'static str {
 fn memory_domain_slug(value: &crate::core::types::MemoryDomain) -> &'static str {
     match value {
         crate::core::types::MemoryDomain::Project => "project",
+        crate::core::types::MemoryDomain::User => "user",
         crate::core::types::MemoryDomain::Agent => "agent",
         crate::core::types::MemoryDomain::Skill => "skill",
         crate::core::types::MemoryDomain::Global => "global",
@@ -370,6 +371,8 @@ fn knowledge_tier_slug(value: &crate::core::types::KnowledgeTier) -> &'static st
 
 fn knowledge_status_slug(value: &crate::core::types::KnowledgeStatus) -> &'static str {
     match value {
+        crate::core::types::KnowledgeStatus::Active => "active",
+        crate::core::types::KnowledgeStatus::Superseded => "superseded",
         crate::core::types::KnowledgeStatus::Candidate => "candidate",
         crate::core::types::KnowledgeStatus::Promoted => "promoted",
         crate::core::types::KnowledgeStatus::Canonical => "canonical",

--- a/src/knowledge_card_lifecycle.rs
+++ b/src/knowledge_card_lifecycle.rs
@@ -583,6 +583,8 @@ fn tier_slug(value: &KnowledgeTier) -> &'static str {
 
 fn status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",

--- a/src/knowledge_card_retrieval.rs
+++ b/src/knowledge_card_retrieval.rs
@@ -182,7 +182,7 @@ fn retrieval_anchors(request: &KnowledgeCardRetrievalRequest) -> Result<Vec<Anch
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Worktree,
         anchor_id: derived.anchor_id,
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
 
     let repo_anchor_id = derived
@@ -191,12 +191,12 @@ fn retrieval_anchors(request: &KnowledgeCardRetrievalRequest) -> Result<Vec<Anch
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Repo,
         anchor_id: repo_anchor_id,
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Repo,
         anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
-        domain: request.domain.clone(),
+        domain: request.domain,
     });
     anchors.push(AnchorCandidate {
         anchor_kind: AnchorKind::Global,
@@ -251,12 +251,14 @@ fn memory_kind_slug(value: &MemoryKind) -> &'static str {
     match value {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
 fn domain_slug(value: &MemoryDomain) -> &'static str {
     match value {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",

--- a/src/knowledge_distill.rs
+++ b/src/knowledge_distill.rs
@@ -163,6 +163,9 @@ pub fn prepare_distill(db: &Database, request: DistillRequest) -> Result<Distill
         verification_refs: Vec::new(),
         scope_constraints,
         trigger_hints,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: request.importance as f64,
         compacted_into: None,
     };
@@ -243,6 +246,7 @@ fn normalize_trigger_hints(hints: TriggerHints) -> Option<TriggerHints> {
 fn parse_domain(value: &str) -> Result<MemoryDomain> {
     match value.trim() {
         "project" => Ok(MemoryDomain::Project),
+        "user" => Ok(MemoryDomain::User),
         "agent" => Ok(MemoryDomain::Agent),
         "skill" => Ok(MemoryDomain::Skill),
         "global" => Ok(MemoryDomain::Global),
@@ -330,6 +334,8 @@ fn tier_slug(value: &KnowledgeTier) -> &'static str {
 fn status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
         KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
         KnowledgeStatus::Demoted => "demoted",

--- a/src/knowledge_gate.rs
+++ b/src/knowledge_gate.rs
@@ -304,6 +304,8 @@ fn tier_slug(value: &KnowledgeTier) -> &'static str {
 
 fn status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",

--- a/src/knowledge_lifecycle.rs
+++ b/src/knowledge_lifecycle.rs
@@ -277,6 +277,8 @@ fn append_audit_entry(db: &Database, command: &str, details: &serde_json::Value)
 
 fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,10 @@ struct IngestCommandOptions<'a> {
     no_strip_noise: bool,
     diary_rollup: bool,
     source_type: Option<&'a str>,
+    memory_kind: Option<&'a str>,
+    domain: Option<&'a str>,
+    field: Option<&'a str>,
+    is_pinned: bool,
     confidence: Option<f64>,
     supersedes: Option<&'a str>,
     replace_text: Option<&'a str>,
@@ -206,6 +210,14 @@ enum Commands {
         diary_rollup: bool,
         #[arg(long = "source-type")]
         source_type: Option<String>,
+        #[arg(long = "memory-kind")]
+        memory_kind: Option<String>,
+        #[arg(long)]
+        domain: Option<String>,
+        #[arg(long)]
+        field: Option<String>,
+        #[arg(long = "is-pinned", alias = "pinned", default_value_t = false)]
+        is_pinned: bool,
         #[arg(long)]
         confidence: Option<f64>,
         #[arg(long)]
@@ -300,6 +312,20 @@ enum Commands {
     },
     Delete {
         drawer_id: String,
+    },
+    Pin {
+        drawer_id: String,
+    },
+    Unpin {
+        drawer_id: String,
+    },
+    Pinned {
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long, num_args = 1..)]
+        reorder: Vec<String>,
+        #[arg(long)]
+        json: bool,
     },
     Rollback {
         #[arg(long)]
@@ -1245,6 +1271,10 @@ fn run() -> Result<()> {
             no_strip_noise,
             diary_rollup,
             source_type,
+            memory_kind,
+            domain,
+            field,
+            is_pinned,
             confidence,
             supersedes,
             replace_text,
@@ -1266,6 +1296,10 @@ fn run() -> Result<()> {
                 no_strip_noise,
                 diary_rollup,
                 source_type: source_type.as_deref(),
+                memory_kind: memory_kind.as_deref(),
+                domain: domain.as_deref(),
+                field: field.as_deref(),
+                is_pinned,
                 confidence,
                 supersedes: supersedes.as_deref(),
                 replace_text: replace_text.as_deref(),
@@ -1346,6 +1380,13 @@ fn run() -> Result<()> {
         Commands::Project { command } => project_command(&db, command),
         Commands::Config { .. } => unreachable!(),
         Commands::Delete { drawer_id } => delete_command(&db, &drawer_id),
+        Commands::Pin { drawer_id } => pin_command(&db, &drawer_id),
+        Commands::Unpin { drawer_id } => unpin_command(&db, &drawer_id),
+        Commands::Pinned {
+            project,
+            reorder,
+            json,
+        } => pinned_command(&db, config.as_ref(), project.as_deref(), &reorder, json),
         Commands::Rollback {
             since,
             wing,
@@ -1779,6 +1820,12 @@ async fn ingest_command(
     let valid_until = validate_temporal_bound("--valid-until", options.valid_until)?;
     let source_type = parse_source_type_bound("--source-type", options.source_type)?
         .unwrap_or(SourceType::AgentInference);
+    let memory_kind = parse_memory_kind_bound("--memory-kind", options.memory_kind)?;
+    let domain = options
+        .domain
+        .map(parse_domain)
+        .transpose()
+        .context("failed to parse --domain")?;
     let confidence = resolve_confidence_bound("--confidence", source_type, options.confidence)?;
     let base_options = IngestOptions {
         room: options.room,
@@ -1793,6 +1840,10 @@ async fn ingest_command(
         prototype_classifier: None,
         source_file_override: None,
         source_type: Some(source_type),
+        memory_kind,
+        domain,
+        field: options.field,
+        is_pinned: options.is_pinned,
         confidence: Some(confidence),
         replace_existing_source: false,
         no_strip_noise: options.no_strip_noise,
@@ -1829,6 +1880,10 @@ async fn ingest_command(
             prototype_classifier: prototype_classifier.as_ref(),
             source_file_override: None,
             source_type: Some(source_type),
+            memory_kind,
+            domain,
+            field: options.field,
+            is_pinned: options.is_pinned,
             confidence: Some(confidence),
             replace_existing_source: false,
             no_strip_noise: options.no_strip_noise,
@@ -1895,6 +1950,10 @@ struct StdinIngestRecord {
     source: Option<String>,
     source_file: Option<String>,
     source_type: Option<String>,
+    memory_kind: Option<String>,
+    domain: Option<String>,
+    field: Option<String>,
+    is_pinned: Option<bool>,
     confidence: Option<f64>,
     supersedes: Option<String>,
     replace_text: Option<String>,
@@ -1953,6 +2012,17 @@ fn parse_source_type_bound(field: &str, value: Option<&str>) -> Result<Option<So
         .map(|raw| {
             raw.parse::<SourceType>()
                 .with_context(|| format!("{field} must be one of user_explicit, agent_observation, agent_inference, system_generated"))
+        })
+        .transpose()
+}
+
+fn parse_memory_kind_bound(field: &str, value: Option<&str>) -> Result<Option<MemoryKind>> {
+    value
+        .map(|raw| match raw {
+            "evidence" => Ok(MemoryKind::Evidence),
+            "knowledge" => Ok(MemoryKind::Knowledge),
+            "profile_fact" => Ok(MemoryKind::ProfileFact),
+            other => bail!("{field} must be one of evidence, knowledge, profile_fact; got {other}"),
         })
         .transpose()
 }
@@ -2023,6 +2093,23 @@ async fn ingest_stdin_command(
         options.source_type.or(record.source_type.as_deref()),
     )?
     .unwrap_or(SourceType::AgentInference);
+    let memory_kind = parse_memory_kind_bound(
+        "memory_kind",
+        options.memory_kind.or(record.memory_kind.as_deref()),
+    )?
+    .unwrap_or(MemoryKind::Evidence);
+    let domain = options
+        .domain
+        .or(record.domain.as_deref())
+        .map(parse_domain)
+        .transpose()
+        .context("failed to parse stdin ingest domain")?
+        .unwrap_or(MemoryDomain::Project);
+    let field = options
+        .field
+        .or(record.field.as_deref())
+        .unwrap_or("general");
+    let is_pinned = options.is_pinned || record.is_pinned.unwrap_or(false);
     let confidence = resolve_confidence_bound(
         "confidence",
         source_type,
@@ -2093,6 +2180,10 @@ async fn ingest_stdin_command(
     }
 
     if exact_duplicate.is_some() {
+        if is_pinned {
+            db.pin_drawer(&drawer_id, None)
+                .with_context(|| format!("failed to pin duplicate drawer {drawer_id}"))?;
+        }
         stats.skipped = 1;
         stats.drawer_ids.push(drawer_id.clone());
         if let Some(old_id) = superseded_drawer_id.as_deref() {
@@ -2205,6 +2296,10 @@ async fn ingest_stdin_command(
         ..drawer
     };
     let mut drawer = drawer;
+    drawer.memory_kind = memory_kind;
+    drawer.domain = domain;
+    drawer.field = field.to_string();
+    drawer.is_pinned = is_pinned;
     if let Some(old_id) = superseded_drawer_id.as_deref() {
         link_superseded_drawer(&mut drawer, old_id);
     }
@@ -2781,6 +2876,7 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
 fn parse_domain(value: &str) -> Result<MemoryDomain> {
     match value {
         "project" => Ok(MemoryDomain::Project),
+        "user" => Ok(MemoryDomain::User),
         "agent" => Ok(MemoryDomain::Agent),
         "skill" => Ok(MemoryDomain::Skill),
         "global" => Ok(MemoryDomain::Global),
@@ -2939,6 +3035,7 @@ struct CliSearchResult {
     memory_kind: String,
     domain: String,
     field: String,
+    is_pinned: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     statement: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2965,6 +3062,7 @@ fn build_cli_search_result(result: mempal::core::types::SearchResult) -> CliSear
         memory_kind: memory_kind_slug(&result.memory_kind).to_string(),
         domain: domain_slug(&result.domain).to_string(),
         field: result.field,
+        is_pinned: result.is_pinned,
         statement: result.statement,
         tier: result
             .tier
@@ -2986,11 +3084,13 @@ fn memory_kind_slug(v: &MemoryKind) -> &'static str {
     match v {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 fn domain_slug(v: &MemoryDomain) -> &'static str {
     match v {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -3015,6 +3115,8 @@ fn parse_knowledge_tier(v: &str) -> Result<KnowledgeTier> {
 }
 fn knowledge_status_slug(v: &KnowledgeStatus) -> &'static str {
     match v {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
@@ -3024,6 +3126,8 @@ fn knowledge_status_slug(v: &KnowledgeStatus) -> &'static str {
 }
 fn parse_knowledge_status(v: &str) -> Result<KnowledgeStatus> {
     match v {
+        "active" => Ok(KnowledgeStatus::Active),
+        "superseded" => Ok(KnowledgeStatus::Superseded),
         "candidate" => Ok(KnowledgeStatus::Candidate),
         "promoted" => Ok(KnowledgeStatus::Promoted),
         "canonical" => Ok(KnowledgeStatus::Canonical),
@@ -3154,7 +3258,7 @@ fn effective_wake_up_text(drawer: &mempal::core::types::Drawer) -> &str {
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .unwrap_or(drawer.content.as_str()),
-        MemoryKind::Evidence => drawer.content.as_str(),
+        MemoryKind::Evidence | MemoryKind::ProfileFact => drawer.content.as_str(),
     }
 }
 
@@ -4981,6 +5085,114 @@ fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
     Ok(())
 }
 
+fn pin_command(db: &Database, drawer_id: &str) -> Result<()> {
+    if !db
+        .pin_drawer(drawer_id, None)
+        .context("failed to pin drawer")?
+    {
+        bail!("drawer not found: {drawer_id}");
+    }
+    append_audit_entry(db, "pin", &serde_json::json!({ "drawer_id": drawer_id }))
+        .context("failed to append audit log")?;
+    println!("pinned {drawer_id}");
+    Ok(())
+}
+
+fn unpin_command(db: &Database, drawer_id: &str) -> Result<()> {
+    if !db
+        .unpin_drawer(drawer_id)
+        .context("failed to unpin drawer")?
+    {
+        bail!("drawer not found: {drawer_id}");
+    }
+    append_audit_entry(db, "unpin", &serde_json::json!({ "drawer_id": drawer_id }))
+        .context("failed to append audit log")?;
+    println!("unpinned {drawer_id}");
+    Ok(())
+}
+
+fn pinned_command(
+    db: &Database,
+    config: &Config,
+    project: Option<&str>,
+    reorder: &[String],
+    json: bool,
+) -> Result<()> {
+    if !reorder.is_empty() {
+        for drawer_id in reorder {
+            if db
+                .get_drawer(drawer_id)
+                .context("failed to look up pinned reorder drawer")?
+                .is_none()
+            {
+                bail!("drawer not found: {drawer_id}");
+            }
+        }
+        db.reorder_pinned_facts(reorder)
+            .context("failed to reorder pinned facts")?;
+        append_audit_entry(
+            db,
+            "pinned_reorder",
+            &serde_json::json!({ "drawer_ids": reorder }),
+        )
+        .context("failed to append audit log")?;
+    }
+
+    let cwd = env::current_dir().ok();
+    let project_id = match project {
+        Some(project) => resolve_project_id(Some(project), config, cwd.as_deref())
+            .context("failed to resolve pinned project id")?,
+        None => None,
+    };
+    let facts = db
+        .get_pinned_facts(project_id.as_deref(), 1_000_000)
+        .context("failed to load pinned facts")?;
+
+    if json {
+        let output = facts
+            .iter()
+            .map(|drawer| {
+                serde_json::json!({
+                    "drawer_id": &drawer.id,
+                    "pin_order": drawer.pin_order,
+                    "memory_kind": memory_kind_slug(&drawer.memory_kind),
+                    "domain": domain_slug(&drawer.domain),
+                    "field": &drawer.field,
+                    "status": drawer.status.as_ref().map(knowledge_status_slug),
+                    "importance": drawer.importance,
+                    "source_file": &drawer.source_file,
+                    "content": &drawer.content,
+                })
+            })
+            .collect::<Vec<_>>();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({ "facts": output }))
+                .context("failed to serialize pinned facts JSON")?
+        );
+        return Ok(());
+    }
+
+    if facts.is_empty() {
+        println!("no pinned facts");
+        return Ok(());
+    }
+    for drawer in facts {
+        let order = drawer
+            .pin_order
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{order}\t{}\t{}/{}\t{}",
+            drawer.id,
+            domain_slug(&drawer.domain),
+            drawer.field,
+            truncate_for_summary(&drawer.content, 120)
+        );
+    }
+    Ok(())
+}
+
 fn rollback_command(
     db: &Database,
     config: &Config,
@@ -5510,6 +5722,9 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     let source_type_counts = db
         .source_type_counts()
         .context("failed to count drawers per source type")?;
+    let pinned_fact_counts = db
+        .pinned_fact_counts_by_project()
+        .context("failed to count pinned facts per project")?;
     let raw_turn_count =
         count_raw_turn_drawers(db, &config.turns).context("failed to count raw turn drawers")?;
     let project_breakdown: Option<Vec<(Option<String>, i64)>> = if full {
@@ -5607,6 +5822,19 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     } else {
         for (source_type, count) in source_type_counts {
             println!("  {source_type}: {count}");
+        }
+    }
+    println!("Pinned Facts:");
+    if pinned_fact_counts.is_empty() {
+        println!("  none");
+    } else {
+        for (project_id, count) in pinned_fact_counts {
+            match project_id {
+                Some(project_id) => {
+                    println!("  {}: {count}", escape_project_id_for_display(&project_id))
+                }
+                None => println!("  NULL: {count}"),
+            }
         }
     }
     println!("Turns:");

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -9,6 +9,7 @@ pub use server::MempalMcpServer;
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
+    PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
     ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
     RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest, SearchResponse,
     SearchResultDto, StatusResponse,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -75,7 +75,8 @@ use super::tools::{
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
     MAX_READ_DRAWERS_REQUEST_IDS, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse, QueueStatsDto,
+    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
     RetrievedKnowledgeCardDto, RollbackRequest, RollbackResponse, ScopeCount, ScrubStatsDto,
     SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
     SkillSummaryDto, SourceTypeCount, StatusResponse, SystemWarning, TaxonomyEntryDto,
@@ -296,6 +297,17 @@ impl MempalMcpServer {
         self.mempal_status().await.map(|response| response.0)
     }
 
+    pub async fn pinned_facts_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<PinnedFactsResponse, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_pinned_facts(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
     pub async fn knowledge_policy_json_for_test(
         &self,
     ) -> std::result::Result<KnowledgePolicyResponse, ErrorData> {
@@ -383,6 +395,9 @@ impl MempalMcpServer {
             if exists {
                 // Dedup-resolved: drawer pre-existed; include in response list but NOT
                 // in newly_created_drawer_ids so LLM reject cannot soft-delete it.
+                if metadata.is_pinned {
+                    db.pin_drawer(chunk_did, None).map_err(db_error)?;
+                }
                 inserted_drawer_ids.push(chunk_did.clone());
                 continue;
             }
@@ -427,6 +442,7 @@ struct ValidatedIngestMetadata {
     memory_kind: MemoryKind,
     domain: MemoryDomain,
     field: String,
+    is_pinned: bool,
     anchor_kind: AnchorKind,
     anchor_id: String,
     parent_anchor_id: Option<String>,
@@ -494,10 +510,9 @@ fn validate_ingest_request(
     let derived_anchor = validate_anchor_metadata(request, &domain, source_type)?;
 
     match memory_kind {
-        MemoryKind::Evidence => {
+        MemoryKind::Evidence | MemoryKind::ProfileFact => {
             if statement.is_some()
                 || tier.is_some()
-                || status.is_some()
                 || !supporting_refs.is_empty()
                 || !counterexample_refs.is_empty()
                 || !teaching_refs.is_empty()
@@ -510,11 +525,20 @@ fn validate_ingest_request(
                     None,
                 ));
             }
+            if status.as_ref().is_some_and(|value| {
+                !matches!(value, KnowledgeStatus::Active | KnowledgeStatus::Canonical)
+            }) {
+                return Err(ErrorData::invalid_params(
+                    "evidence/profile_fact status must be active or canonical",
+                    None,
+                ));
+            }
 
             Ok(ValidatedIngestMetadata {
                 memory_kind,
                 domain,
                 field,
+                is_pinned: request.is_pinned.unwrap_or(false),
                 anchor_kind: derived_anchor.anchor_kind,
                 anchor_id: derived_anchor.anchor_id,
                 parent_anchor_id: derived_anchor.parent_anchor_id,
@@ -523,7 +547,7 @@ fn validate_ingest_request(
                 ),
                 statement: None,
                 tier: None,
-                status: None,
+                status,
                 supporting_refs: Vec::new(),
                 counterexample_refs: Vec::new(),
                 teaching_refs: Vec::new(),
@@ -576,6 +600,7 @@ fn validate_ingest_request(
                 memory_kind,
                 domain,
                 field,
+                is_pinned: request.is_pinned.unwrap_or(false),
                 anchor_kind: derived_anchor.anchor_kind,
                 anchor_id: derived_anchor.anchor_id,
                 parent_anchor_id: derived_anchor.parent_anchor_id,
@@ -640,6 +665,33 @@ struct SourceConfidence {
     confidence: f64,
 }
 
+fn format_pinned_facts_text(drawers: &[Drawer]) -> String {
+    if drawers.is_empty() {
+        return "Pinned facts: none".to_string();
+    }
+
+    let mut lines = vec!["Pinned facts:".to_string()];
+    for drawer in drawers {
+        let source = drawer.source_file.as_deref().unwrap_or(drawer.id.as_str());
+        let field = drawer.field.as_str();
+        lines.push(format!(
+            "- [{}] {}/{field} source={} importance={}: {}",
+            drawer.id,
+            match &drawer.domain {
+                MemoryDomain::Project => "project",
+                MemoryDomain::User => "user",
+                MemoryDomain::Agent => "agent",
+                MemoryDomain::Skill => "skill",
+                MemoryDomain::Global => "global",
+            },
+            source,
+            drawer.importance,
+            drawer.content
+        ));
+    }
+    lines.join("\n")
+}
+
 fn drawer_from_ingest_metadata(
     request: &IngestRequest,
     metadata: &ValidatedIngestMetadata,
@@ -659,7 +711,7 @@ fn drawer_from_ingest_metadata(
                 .as_deref()
                 .expect("validated knowledge statement"),
         )),
-        MemoryKind::Evidence => Some(source_file_or_synthetic(
+        MemoryKind::Evidence | MemoryKind::ProfileFact => Some(source_file_or_synthetic(
             drawer_id,
             request.source.as_deref(),
         )),
@@ -677,13 +729,13 @@ fn drawer_from_ingest_metadata(
         chunk_index: Some(chunk_idx as i64),
         normalize_version: CURRENT_NORMALIZE_VERSION,
         importance,
-        memory_kind: metadata.memory_kind.clone(),
-        domain: metadata.domain.clone(),
+        memory_kind: metadata.memory_kind,
+        domain: metadata.domain,
         field: metadata.field.clone(),
         anchor_kind: metadata.anchor_kind.clone(),
         anchor_id: metadata.anchor_id.clone(),
         parent_anchor_id: metadata.parent_anchor_id.clone(),
-        provenance: metadata.provenance.clone(),
+        provenance: metadata.provenance,
         statement: metadata.statement.clone(),
         tier: metadata.tier.clone(),
         status: metadata.status.clone(),
@@ -693,6 +745,9 @@ fn drawer_from_ingest_metadata(
         verification_refs: metadata.verification_refs.clone(),
         scope_constraints: metadata.scope_constraints.clone(),
         trigger_hints: metadata.trigger_hints.clone(),
+        is_pinned: metadata.is_pinned,
+        pin_order: None,
+        supersedes: None,
         effective_importance: importance as f64,
         compacted_into: None,
     }
@@ -786,6 +841,7 @@ fn parse_memory_kind(value: Option<&str>) -> std::result::Result<Option<MemoryKi
     parse_enum(value, "memory_kind", |normalized| match normalized {
         "evidence" => Some(MemoryKind::Evidence),
         "knowledge" => Some(MemoryKind::Knowledge),
+        "profile_fact" => Some(MemoryKind::ProfileFact),
         _ => None,
     })
 }
@@ -793,6 +849,7 @@ fn parse_memory_kind(value: Option<&str>) -> std::result::Result<Option<MemoryKi
 fn parse_domain(value: Option<&str>) -> std::result::Result<Option<MemoryDomain>, ErrorData> {
     parse_enum(value, "domain", |normalized| match normalized {
         "project" => Some(MemoryDomain::Project),
+        "user" => Some(MemoryDomain::User),
         "agent" => Some(MemoryDomain::Agent),
         "skill" => Some(MemoryDomain::Skill),
         "global" => Some(MemoryDomain::Global),
@@ -834,6 +891,8 @@ fn parse_tier(value: Option<&str>) -> std::result::Result<Option<KnowledgeTier>,
 #[allow(dead_code)]
 fn parse_status(value: Option<&str>) -> std::result::Result<Option<KnowledgeStatus>, ErrorData> {
     parse_enum(value, "status", |normalized| match normalized {
+        "active" => Some(KnowledgeStatus::Active),
+        "superseded" => Some(KnowledgeStatus::Superseded),
         "candidate" => Some(KnowledgeStatus::Candidate),
         "promoted" => Some(KnowledgeStatus::Promoted),
         "canonical" => Some(KnowledgeStatus::Canonical),
@@ -977,6 +1036,12 @@ impl MempalMcpServer {
                 count,
             })
             .collect();
+        let pinned_fact_counts = db
+            .pinned_fact_counts_by_project()
+            .map_err(db_error)?
+            .into_iter()
+            .map(|(project_id, count)| PinnedFactProjectCount { project_id, count })
+            .collect();
         let mut system_warnings = current_system_warnings();
         if null_project_backfill_pending > 0 {
             system_warnings.push(SystemWarning {
@@ -1004,6 +1069,7 @@ impl MempalMcpServer {
             config_loaded_at_unix_ms: cfg_meta.loaded_at_unix_ms,
             scopes,
             source_type_distribution,
+            pinned_fact_counts,
             aaak_spec: crate::aaak::generate_spec(),
             memory_protocol: crate::core::protocol::MEMORY_PROTOCOL.to_string(),
             endpoint_health: EndpointHealthDto {
@@ -1065,6 +1131,40 @@ impl MempalMcpServer {
     }
 
     #[tool(
+        name = "mempal_pinned_facts",
+        description = "Return canonical pinned facts for prompt injection without running embedding search. Use this at session start for always-on context. Results are pure SQL, scoped by project_id when provided, and capped by budget_chars."
+    )]
+    pub async fn mempal_pinned_facts(
+        &self,
+        Parameters(request): Parameters<PinnedFactsRequest>,
+    ) -> std::result::Result<Json<PinnedFactsResponse>, ErrorData> {
+        let config = ConfigHandle::current();
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await?;
+        let budget_chars = request.budget_chars.unwrap_or(4_000);
+        let db = self.open_db()?;
+        let drawers = db
+            .get_pinned_facts(project_id.as_deref(), budget_chars)
+            .map_err(db_error)?;
+        let used_chars = drawers
+            .iter()
+            .map(|drawer| drawer.content.chars().count())
+            .sum();
+        let text = format_pinned_facts_text(&drawers);
+        let facts = drawers.into_iter().map(PinnedFactDto::from).collect();
+
+        Ok(Json(PinnedFactsResponse {
+            project_id,
+            budget_chars,
+            used_chars,
+            text,
+            facts,
+            system_warnings: current_system_warnings(),
+        }))
+    }
+
+    #[tool(
         name = "mempal_search",
         description = "Search persistent project memory via vector embedding with optional wing/room filters. PREFER THIS over grepping files or guessing from general knowledge when answering ANY project-specific question — past decisions, design rationale, implementation details, bug history, how a component works, why something was built a certain way, or any other project knowledge. Every result includes drawer_id and source_file for citation, plus structured AAAK-derived signals (`entities`, `topics`, `flags`, `emotions`, `importance_stars`) for filtering and ranking."
     )]
@@ -1095,7 +1195,7 @@ impl MempalMcpServer {
         let search_options = SearchOptions {
             filters: SearchFilters {
                 memory_kind: request.memory_kind.clone(),
-                domain: request.domain.clone(),
+                domain: request.domain,
                 field: request.field.clone(),
                 tier: request.tier.clone(),
                 status: request.status.clone(),
@@ -1961,6 +2061,11 @@ impl MempalMcpServer {
                 .iter()
                 .map(|(_, id, _)| id.clone())
                 .collect::<Vec<_>>();
+            if metadata.is_pinned {
+                for id in &all_ids {
+                    db.pin_drawer(id, None).map_err(db_error)?;
+                }
+            }
             if let Some(old_id) = superseded_drawer_id.as_deref() {
                 let replacement_id = all_ids.first().map(String::as_str).unwrap_or("existing");
                 supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
@@ -2248,6 +2353,9 @@ impl MempalMcpServer {
                     if *chunk_exists {
                         // Dedup-resolved pre-lock: include in response but NOT in
                         // newly_created_drawer_ids so LLM reject cannot delete it.
+                        if metadata.is_pinned {
+                            db.pin_drawer(chunk_did, None).map_err(db_error)?;
+                        }
                         inserted_drawer_ids.push(chunk_did.clone());
                         continue;
                     }
@@ -2272,6 +2380,9 @@ impl MempalMcpServer {
                     if exists_after_lock {
                         // Dedup-resolved post-lock: include in response but NOT in
                         // newly_created_drawer_ids so LLM reject cannot delete it.
+                        if metadata.is_pinned {
+                            db.pin_drawer(chunk_did, None).map_err(db_error)?;
+                        }
                         inserted_drawer_ids.push(chunk_did.clone());
                         continue;
                     }
@@ -3529,6 +3640,7 @@ fn drawer_matches_ingest_metadata(drawer: &Drawer, metadata: &ValidatedIngestMet
         && drawer.anchor_kind == metadata.anchor_kind
         && drawer.anchor_id == metadata.anchor_id
         && drawer.parent_anchor_id == metadata.parent_anchor_id
+        && drawer.is_pinned == metadata.is_pinned
         && drawer.provenance == metadata.provenance
         && drawer.statement == metadata.statement
         && drawer.tier == metadata.tier
@@ -4035,6 +4147,9 @@ mod tests {
             verification_refs: refs.verification,
             scope_constraints: None,
             trigger_hints: None,
+            is_pinned: false,
+            pin_order: None,
+            supersedes: None,
             compacted_into: None,
         };
         db.insert_drawer(&drawer).expect("insert knowledge drawer");
@@ -4079,6 +4194,9 @@ mod tests {
             verification_refs: Vec::new(),
             scope_constraints: None,
             trigger_hints: None,
+            is_pinned: false,
+            pin_order: None,
+            supersedes: None,
             compacted_into: None,
         };
         db.insert_drawer(&drawer)
@@ -6216,6 +6334,7 @@ mod tests {
                 memory_kind: None,
                 domain: None,
                 field: None,
+                is_pinned: None,
                 provenance: None,
                 statement: None,
                 tier: None,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -675,6 +675,7 @@ pub struct SearchResultDto {
     pub memory_kind: String,
     pub domain: String,
     pub field: String,
+    pub is_pinned: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statement: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -783,6 +784,43 @@ pub struct ReadDrawersResponse {
 }
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct PinnedFactsRequest {
+    /// Optional explicit project scope. When omitted, mempal resolves the
+    /// current project from MCP roots/config just like search.
+    pub project_id: Option<String>,
+    /// Maximum number of content characters returned across pinned facts.
+    /// Defaults to 4000.
+    pub budget_chars: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PinnedFactsResponse {
+    pub project_id: Option<String>,
+    pub budget_chars: usize,
+    pub used_chars: usize,
+    pub text: String,
+    pub facts: Vec<PinnedFactDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PinnedFactDto {
+    pub drawer_id: String,
+    pub content: String,
+    pub wing: String,
+    pub room: Option<String>,
+    pub source_file: String,
+    pub memory_kind: String,
+    pub domain: String,
+    pub field: String,
+    pub status: Option<String>,
+    pub importance: i32,
+    pub pin_order: Option<i64>,
+    pub supersedes: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct IngestRequest {
     pub content: String,
     pub wing: String,
@@ -819,6 +857,7 @@ pub struct IngestRequest {
     pub memory_kind: Option<String>,
     pub domain: Option<String>,
     pub field: Option<String>,
+    pub is_pinned: Option<bool>,
     pub provenance: Option<String>,
     pub statement: Option<String>,
     pub tier: Option<String>,
@@ -943,6 +982,7 @@ pub struct StatusResponse {
     pub diary_rollup_days: u32,
     pub scopes: Vec<ScopeCount>,
     pub source_type_distribution: Vec<SourceTypeCount>,
+    pub pinned_fact_counts: Vec<PinnedFactProjectCount>,
     pub aaak_spec: String,
     pub memory_protocol: String,
     pub endpoint_health: EndpointHealthDto,
@@ -960,6 +1000,12 @@ pub struct StatusResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct SourceTypeCount {
     pub source_type: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct PinnedFactProjectCount {
+    pub project_id: Option<String>,
     pub count: i64,
 }
 
@@ -1384,6 +1430,7 @@ impl SearchResultDto {
             anchor_kind,
             anchor_id,
             parent_anchor_id,
+            is_pinned,
             importance: _,
             similarity,
             route,
@@ -1438,7 +1485,31 @@ impl SearchResultDto {
             anchor_kind: anchor_kind_slug(&anchor_kind).to_string(),
             anchor_id,
             parent_anchor_id,
+            is_pinned,
             matched_pattern_id,
+        }
+    }
+}
+
+impl From<crate::core::types::Drawer> for PinnedFactDto {
+    fn from(value: crate::core::types::Drawer) -> Self {
+        Self {
+            drawer_id: value.id.clone(),
+            content: value.content,
+            wing: value.wing,
+            room: value.room,
+            source_file: value.source_file.unwrap_or(value.id),
+            memory_kind: memory_kind_slug(&value.memory_kind).to_string(),
+            domain: domain_slug(&value.domain).to_string(),
+            field: value.field,
+            status: value
+                .status
+                .as_ref()
+                .map(knowledge_status_slug)
+                .map(str::to_string),
+            importance: value.importance,
+            pin_order: value.pin_order,
+            supersedes: value.supersedes,
         }
     }
 }
@@ -1734,12 +1805,14 @@ fn memory_kind_slug(value: &MemoryKind) -> &'static str {
     match value {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
 fn domain_slug(value: &MemoryDomain) -> &'static str {
     match value {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -1757,6 +1830,8 @@ fn knowledge_tier_slug(value: &KnowledgeTier) -> &'static str {
 
 fn knowledge_status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Candidate => "candidate",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
@@ -1846,6 +1921,7 @@ mod tests {
             anchor_kind: AnchorKind::Repo,
             anchor_id: "repo://signals".to_string(),
             parent_anchor_id: None,
+            is_pinned: false,
             importance: 3,
             similarity: 0.91,
             route: RouteDecision {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -815,6 +815,7 @@ fn result_from_drawer(
         anchor_kind: drawer.anchor_kind,
         anchor_id: drawer.anchor_id,
         parent_anchor_id: drawer.parent_anchor_id,
+        is_pinned: drawer.is_pinned,
         importance: drawer.importance,
         similarity,
         route,
@@ -1042,6 +1043,7 @@ pub fn search_by_vector(
                     anchor_kind: AnchorKind::Global,
                     anchor_id: String::new(),
                     parent_anchor_id: None,
+                    is_pinned: false,
                     importance: 0,
                     similarity: (1.0_f64 - distance) as f32,
                     route: route.clone(),
@@ -1154,6 +1156,7 @@ fn search_by_vector_scoped_exact(
                     anchor_kind: AnchorKind::Global,
                     anchor_id: String::new(),
                     parent_anchor_id: None,
+                    is_pinned: false,
                     importance: 0,
                     similarity: (1.0_f64 - distance) as f32,
                     route: route.clone(),
@@ -1276,6 +1279,7 @@ fn memory_kind_from_str(value: &str) -> rusqlite::Result<MemoryKind> {
     match value {
         "evidence" => Ok(MemoryKind::Evidence),
         "knowledge" => Ok(MemoryKind::Knowledge),
+        "profile_fact" => Ok(MemoryKind::ProfileFact),
         _ => Err(invalid_enum_value("memory_kind", value.to_string())),
     }
 }
@@ -1284,6 +1288,7 @@ fn memory_kind_slug(value: &MemoryKind) -> &'static str {
     match value {
         MemoryKind::Evidence => "evidence",
         MemoryKind::Knowledge => "knowledge",
+        MemoryKind::ProfileFact => "profile_fact",
     }
 }
 
@@ -1291,6 +1296,7 @@ fn memory_kind_slug(value: &MemoryKind) -> &'static str {
 fn memory_domain_from_str(value: &str) -> rusqlite::Result<MemoryDomain> {
     match value {
         "project" => Ok(MemoryDomain::Project),
+        "user" => Ok(MemoryDomain::User),
         "agent" => Ok(MemoryDomain::Agent),
         "skill" => Ok(MemoryDomain::Skill),
         "global" => Ok(MemoryDomain::Global),
@@ -1301,6 +1307,7 @@ fn memory_domain_from_str(value: &str) -> rusqlite::Result<MemoryDomain> {
 fn domain_slug(value: &MemoryDomain) -> &'static str {
     match value {
         MemoryDomain::Project => "project",
+        MemoryDomain::User => "user",
         MemoryDomain::Agent => "agent",
         MemoryDomain::Skill => "skill",
         MemoryDomain::Global => "global",
@@ -1331,6 +1338,8 @@ fn tier_slug(value: &KnowledgeTier) -> &'static str {
 fn knowledge_status_from_str(value: &str) -> rusqlite::Result<KnowledgeStatus> {
     match value {
         "candidate" => Ok(KnowledgeStatus::Candidate),
+        "active" => Ok(KnowledgeStatus::Active),
+        "superseded" => Ok(KnowledgeStatus::Superseded),
         "promoted" => Ok(KnowledgeStatus::Promoted),
         "canonical" => Ok(KnowledgeStatus::Canonical),
         "demoted" => Ok(KnowledgeStatus::Demoted),
@@ -1342,6 +1351,8 @@ fn knowledge_status_from_str(value: &str) -> rusqlite::Result<KnowledgeStatus> {
 fn status_slug(value: &KnowledgeStatus) -> &'static str {
     match value {
         KnowledgeStatus::Candidate => "candidate",
+        KnowledgeStatus::Active => "active",
+        KnowledgeStatus::Superseded => "superseded",
         KnowledgeStatus::Promoted => "promoted",
         KnowledgeStatus::Canonical => "canonical",
         KnowledgeStatus::Demoted => "demoted",
@@ -1430,6 +1441,7 @@ mod tests {
             anchor_kind: AnchorKind::Global,
             anchor_id: String::new(),
             parent_anchor_id: None,
+            is_pinned: false,
             importance: drawer.importance,
             similarity: 0.9,
             route: RouteDecision {

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -159,6 +159,9 @@ fn knowledge_drawer(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 3.0,
         compacted_into: None,
     }
@@ -193,6 +196,9 @@ fn evidence_drawer(id: &str, content: &str) -> Drawer {
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 2.0,
         compacted_into: None,
     }
@@ -990,10 +996,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 12);
+    assert_eq!(db.schema_version().expect("schema"), 13);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 12);
+    assert_eq!(db.schema_version().expect("schema"), 13);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/importance_decay.rs
+++ b/tests/importance_decay.rs
@@ -405,6 +405,7 @@ fn test_search_result_dto_includes_effective_importance() {
         memory_kind: "evidence".to_string(),
         domain: "project".to_string(),
         field: "default".to_string(),
+        is_pinned: false,
         statement: None,
         tier: None,
         status: None,

--- a/tests/knowledge_card_backfill.rs
+++ b/tests/knowledge_card_backfill.rs
@@ -72,6 +72,9 @@ fn knowledge_drawer(id: &str, field: &str) -> Drawer {
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         compacted_into: None,
     }
 }
@@ -106,6 +109,9 @@ fn evidence_drawer(id: &str) -> Drawer {
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         compacted_into: None,
     }
 }

--- a/tests/knowledge_card_retrieval.rs
+++ b/tests/knowledge_card_retrieval.rs
@@ -109,6 +109,9 @@ fn evidence_drawer(id: &str, content: &str) -> Drawer {
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         compacted_into: None,
     }
 }

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -248,7 +248,7 @@ fn insert_event(
 fn test_new_database_schema_version_is_12() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
     for table in [
         "knowledge_cards",
         "knowledge_evidence_links",
@@ -267,7 +267,7 @@ fn test_migration_v7_to_v10_adds_phase2_phase3_and_validity_without_data_loss() 
 
     let db = Database::open(&db_path).expect("migrate v7 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let taxonomy_count: i64 = db

--- a/tests/knowledge_lifecycle.rs
+++ b/tests/knowledge_lifecycle.rs
@@ -193,6 +193,9 @@ fn insert_knowledge_with_refs(
         verification_refs: refs.verification,
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 4.0,
         compacted_into: None,
     };
@@ -242,6 +245,9 @@ fn insert_knowledge_with_anchor(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 4.0,
         compacted_into: None,
     };

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -417,7 +417,7 @@ fn bootstrap_drawer(
         wing: "mempal".to_string(),
         room: Some("bootstrap".to_string()),
         source_file: Some(match memory_kind {
-            MemoryKind::Evidence => format!("tests://{id}"),
+            MemoryKind::Evidence | MemoryKind::ProfileFact => format!("tests://{id}"),
             MemoryKind::Knowledge => format!("knowledge://project/bootstrap/{id}"),
         }),
         source_type: SourceType::AgentInference,
@@ -426,14 +426,14 @@ fn bootstrap_drawer(
         chunk_index: Some(0),
         normalize_version: 1,
         importance: 2,
-        memory_kind: memory_kind.clone(),
+        memory_kind,
         domain: MemoryDomain::Project,
         field: anchor::DEFAULT_FIELD.to_string(),
         anchor_kind: AnchorKind::Repo,
         anchor_id: format!("repo://{id}"),
         parent_anchor_id: None,
         provenance: match memory_kind {
-            MemoryKind::Evidence => Some(Provenance::Human),
+            MemoryKind::Evidence | MemoryKind::ProfileFact => Some(Provenance::Human),
             MemoryKind::Knowledge => None,
         },
         statement: statement.map(ToOwned::to_owned),
@@ -449,6 +449,9 @@ fn bootstrap_drawer(
         verification_refs: Vec::new(),
         scope_constraints: None,
         trigger_hints: None,
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 2.0,
         compacted_into: None,
     }
@@ -559,7 +562,7 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
 
     let drawer = db
         .get_drawer("drawer_legacy_001")
@@ -654,6 +657,9 @@ fn test_insert_load_roundtrip_preserves_json_metadata_and_read_paths() {
             workflow_bias: vec!["tdd".to_string()],
             tool_needs: vec!["cargo-check".to_string()],
         }),
+        is_pinned: false,
+        pin_order: None,
+        supersedes: None,
         effective_importance: 3.0,
         compacted_into: None,
     };

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -245,7 +245,7 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -30,7 +30,7 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
 
     let event = RuntimeAdoptionEvent {
         id: "adoption_test".to_string(),

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -293,7 +293,7 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -203,7 +203,7 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 12);
+    assert_eq!(db.schema_version().expect("schema version"), 13);
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db

--- a/tests/typed_ingest_pinned.rs
+++ b/tests/typed_ingest_pinned.rs
@@ -1,0 +1,394 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::core::types::{
+    Drawer, KnowledgeStatus, MemoryDomain, MemoryKind, SourceType, default_confidence,
+};
+use mempal::core::utils::current_timestamp;
+use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
+use mempal::mcp::{IngestRequest, MempalMcpServer, PinnedFactsRequest};
+use rmcp::handler::server::wrapper::Parameters;
+use tempfile::TempDir;
+
+#[derive(Clone)]
+struct StaticEmbedderFactory {
+    dim: usize,
+}
+
+struct StaticEmbedder {
+    dim: usize,
+}
+
+#[async_trait]
+impl EmbedderFactory for StaticEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        Ok(Box::new(StaticEmbedder { dim: self.dim }))
+    }
+}
+
+#[async_trait]
+impl Embedder for StaticEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| vec![0.25; self.dim]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        "static-test"
+    }
+}
+
+#[derive(Clone)]
+struct PanicEmbedderFactory;
+
+#[async_trait]
+impl EmbedderFactory for PanicEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        panic!("pinned facts must not build an embedder")
+    }
+}
+
+struct TestEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    db_path: PathBuf,
+    config_path: PathBuf,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().join("home");
+        let mempal_home = home.join(".mempal");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let config_path = mempal_home.join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+db_path = "{}"
+
+[config_hot_reload]
+enabled = false
+
+[embed]
+backend = "model2vec"
+"#,
+                db_path.display()
+            ),
+        )
+        .expect("write config");
+        Self {
+            _tmp: tmp,
+            home,
+            db_path,
+            config_path,
+        }
+    }
+
+    fn config(&self) -> Config {
+        ConfigHandle::bootstrap(&self.config_path).expect("bootstrap config");
+        Config::load_from(&self.config_path).expect("load config")
+    }
+
+    fn db(&self) -> Database {
+        Database::open(&self.db_path).expect("open db")
+    }
+
+    fn server(&self) -> MempalMcpServer {
+        MempalMcpServer::new_with_factory_and_config(
+            self.db_path.clone(),
+            self.config(),
+            Arc::new(StaticEmbedderFactory { dim: 4 }),
+        )
+    }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn insert_drawer(
+    db: &Database,
+    id: &str,
+    content: &str,
+    is_pinned: bool,
+    pin_order: Option<i64>,
+    importance: i32,
+    status: Option<KnowledgeStatus>,
+) {
+    let source_type = SourceType::AgentObservation;
+    let drawer = Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "typed-tests".to_string(),
+        room: Some("facts".to_string()),
+        source_file: Some(format!("tests://{id}")),
+        source_type,
+        confidence: default_confidence(source_type),
+        added_at: current_timestamp(),
+        importance,
+        memory_kind: MemoryKind::ProfileFact,
+        domain: MemoryDomain::User,
+        field: "preferences".to_string(),
+        status,
+        is_pinned,
+        pin_order,
+        ..Drawer::default()
+    };
+    db.insert_drawer(&drawer).expect("insert drawer");
+}
+
+#[tokio::test]
+async fn test_typed_ingest_preserves_kind() {
+    let env = TestEnv::new();
+    let server = env.server();
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "Prefer CLI dashboards over web dashboards.".to_string(),
+            wing: "profile".to_string(),
+            room: Some("facts".to_string()),
+            source: Some("typed-test".to_string()),
+            memory_kind: Some("profile_fact".to_string()),
+            domain: Some("user".to_string()),
+            field: Some("preferences".to_string()),
+            is_pinned: Some(true),
+            ..IngestRequest::default()
+        }))
+        .await
+        .expect("typed ingest")
+        .0;
+
+    let db = env.db();
+    let drawer = db
+        .get_drawer(&response.drawer_id)
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.memory_kind, MemoryKind::ProfileFact);
+    assert_eq!(drawer.domain, MemoryDomain::User);
+    assert_eq!(drawer.field, "preferences");
+    assert!(drawer.is_pinned);
+}
+
+#[tokio::test]
+async fn test_pinned_facts_no_embedding() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "drawer_pinned_no_embed",
+        "Pinned facts load through SQL only.",
+        true,
+        Some(0),
+        5,
+        Some(KnowledgeStatus::Active),
+    );
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        env.config(),
+        Arc::new(PanicEmbedderFactory),
+    );
+
+    let response = server
+        .mempal_pinned_facts(Parameters(PinnedFactsRequest {
+            project_id: None,
+            budget_chars: Some(4_000),
+        }))
+        .await
+        .expect("pinned facts")
+        .0;
+
+    assert_eq!(response.facts.len(), 1);
+    assert_eq!(response.facts[0].drawer_id, "drawer_pinned_no_embed");
+    assert!(
+        response
+            .text
+            .contains("Pinned facts load through SQL only.")
+    );
+}
+
+#[test]
+fn test_pinned_facts_budget() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "drawer_budget",
+        "abcdefghijklmnopqrstuvwxyz",
+        true,
+        Some(0),
+        5,
+        Some(KnowledgeStatus::Active),
+    );
+
+    let facts = db.get_pinned_facts(None, 10).expect("load pinned facts");
+
+    assert_eq!(facts.len(), 1);
+    assert_eq!(facts[0].content, "abcdefghij");
+    assert_eq!(facts[0].content.chars().count(), 10);
+}
+
+#[tokio::test]
+async fn test_supersedes_chain() {
+    let env = TestEnv::new();
+    let server = env.server();
+    let old = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "Old canonical fact.".to_string(),
+            wing: "profile".to_string(),
+            room: Some("facts".to_string()),
+            source: Some("typed-test-old".to_string()),
+            ..IngestRequest::default()
+        }))
+        .await
+        .expect("old ingest")
+        .0;
+
+    let new = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "New canonical fact.".to_string(),
+            wing: "profile".to_string(),
+            room: Some("facts".to_string()),
+            source: Some("typed-test-new".to_string()),
+            supersedes: Some(old.drawer_id.clone()),
+            ..IngestRequest::default()
+        }))
+        .await
+        .expect("new ingest")
+        .0;
+
+    let db = env.db();
+    let new_drawer = db
+        .get_drawer(&new.drawer_id)
+        .expect("load new drawer")
+        .expect("new drawer exists");
+    assert_eq!(
+        new_drawer.supersedes.as_deref(),
+        Some(old.drawer_id.as_str())
+    );
+    let (status, deleted_at): (Option<String>, Option<String>) = db
+        .conn()
+        .query_row(
+            "SELECT status, deleted_at FROM drawers WHERE id = ?1",
+            [&old.drawer_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load old drawer status");
+    assert_eq!(status.as_deref(), Some("superseded"));
+    assert!(deleted_at.is_some());
+}
+
+#[tokio::test]
+async fn test_default_ingest_unchanged() {
+    let env = TestEnv::new();
+    let server = env.server();
+
+    let response = server
+        .mempal_ingest(Parameters(IngestRequest {
+            content: "Plain evidence still uses old defaults.".to_string(),
+            wing: "project".to_string(),
+            room: Some("notes".to_string()),
+            source: Some("typed-test-default".to_string()),
+            ..IngestRequest::default()
+        }))
+        .await
+        .expect("default ingest")
+        .0;
+
+    let db = env.db();
+    let drawer = db
+        .get_drawer(&response.drawer_id)
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.memory_kind, MemoryKind::Evidence);
+    assert_eq!(drawer.domain, MemoryDomain::Project);
+    assert_eq!(drawer.field, "general");
+    assert!(!drawer.is_pinned);
+    assert_eq!(drawer.pin_order, None);
+    assert_eq!(drawer.supersedes, None);
+    assert_eq!(drawer.status, None);
+}
+
+#[test]
+fn test_cli_pin_unpin_pinned_reorder() {
+    let env = TestEnv::new();
+    let db = env.db();
+    insert_drawer(
+        &db,
+        "drawer_cli_pin",
+        "CLI pin command fact.",
+        false,
+        None,
+        4,
+        Some(KnowledgeStatus::Active),
+    );
+
+    let pin = Command::new(mempal_bin())
+        .env("HOME", &env.home)
+        .args(["pin", "drawer_cli_pin"])
+        .output()
+        .expect("run pin");
+    assert!(
+        pin.status.success(),
+        "pin stderr: {}",
+        String::from_utf8_lossy(&pin.stderr)
+    );
+
+    let pinned = Command::new(mempal_bin())
+        .env("HOME", &env.home)
+        .arg("pinned")
+        .output()
+        .expect("run pinned");
+    assert!(
+        pinned.status.success(),
+        "pinned stderr: {}",
+        String::from_utf8_lossy(&pinned.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&pinned.stdout).contains("drawer_cli_pin"),
+        "pinned stdout should list drawer_cli_pin"
+    );
+
+    let reorder = Command::new(mempal_bin())
+        .env("HOME", &env.home)
+        .args(["pinned", "--reorder", "drawer_cli_pin"])
+        .output()
+        .expect("run reorder");
+    assert!(
+        reorder.status.success(),
+        "reorder stderr: {}",
+        String::from_utf8_lossy(&reorder.stderr)
+    );
+
+    let unpin = Command::new(mempal_bin())
+        .env("HOME", &env.home)
+        .args(["unpin", "drawer_cli_pin"])
+        .output()
+        .expect("run unpin");
+    assert!(
+        unpin.status.success(),
+        "unpin stderr: {}",
+        String::from_utf8_lossy(&unpin.stderr)
+    );
+
+    let is_pinned: i64 = db
+        .conn()
+        .query_row(
+            "SELECT is_pinned FROM drawers WHERE id = 'drawer_cli_pin'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read is_pinned");
+    assert_eq!(is_pinned, 0);
+}


### PR DESCRIPTION
## Summary
- Schema migration adds `memory_kind`, `domain`, `field`, `is_pinned`, `pin_order`, `supersedes`, `status` columns to drawers
- `mempal_ingest` MCP tool accepts optional typed metadata (fully backwards compatible)
- New `mempal_pinned_facts` MCP tool for always-on recall without embedding query
- CLI: `mempal pin/unpin/pinned` commands for managing canonical facts
- Supersedes chain atomically marks old drawer as superseded
- Pinned facts ordered by pin_order, importance, recency within character budget

Closes #187

## Test plan
- [x] `test_typed_ingest_preserves_kind` — ingest with memory_kind verified
- [x] `test_pinned_facts_no_embedding` — pinned recall works without embedder
- [x] `test_pinned_facts_budget` — respects character budget
- [x] `test_supersedes_chain` — superseding marks old drawer
- [x] `test_default_ingest_unchanged` — existing callers unaffected
- [x] `cargo test` — 285+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)