### PR TITLE
test(hermes): readiness suite for memory.provider=mempal gate

### DIFF
--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -68,7 +68,77 @@ When Hermes provides `project_id`, the plugin forwards it to `/api/search`,
 `cwd` is available, the plugin derives the project scope from the directory
 basename.
 
+## Intelligence modes
+
+Optional LLM-enhanced memory classification. Configure in `$HERMES_HOME/mempal.json`:
+
+```json
+{
+  "base_url": "http://127.0.0.1:3080",
+  "memory_intelligence": {
+    "mode": "local_llm",
+    "llm": {
+      "base_url": "http://127.0.0.1:18009/v1",
+      "model": "qwen3.6-27b-decensor-by-aeon",
+      "timeout_secs": 30,
+      "extra_body": {
+        "chat_template_kwargs": { "enable_thinking": false }
+      }
+    }
+  }
+}
+```
+
+| Mode | Behavior |
+|------|----------|
+| `deterministic` | No text LLM calls (default). Explicit writes, BM25+vector search only. |
+| `local_llm` | Use a local OpenAI-compatible endpoint for metadata extraction, fact extraction from turns, and session summaries. |
+| `cloud_llm` | Use a paid/cloud endpoint for the same enhancements. |
+| `auto` | Try configured LLM, fall back to deterministic on failure or missing config. |
+
+All LLM output passes deterministic validation gates before acceptance.
+Failed/slow LLM calls fall back to deterministic behavior without blocking writes.
+
 ## Circuit breaker
 
 After 5 consecutive REST failures the provider pauses for 120 seconds to avoid
 hammering a down server. Tool calls return a clear error message during cooldown.
+
+## Readiness suite
+
+Run the provider test suite to verify all features work correctly:
+
+```bash
+python3 contrib/hermes-agent-plugin/test_mempal_provider.py -v
+```
+
+The suite covers 67 tests across 12 test classes:
+
+| Area | Tests | What it verifies |
+|------|-------|-----------------|
+| Scope isolation | 9 | Profiles, wings, turn rooms, project_id, session switch, prefetch keying |
+| Write queue | 3 | Drain on shutdown, config-based availability, enqueue-not-thread |
+| Write semantics | 6 | add/replace/remove, drawer_id tracking, supersession, typed metadata |
+| Search results | 4 | Typed fields, None stripping, drawer_id in conclude/profile |
+| Pinned facts | 4 | System prompt injection, TTL cache, empty handling, session invalidation |
+| Intelligence modes | 9 | Mode switching, deterministic default, auto fallback, LLM breaker |
+| LLM client | 4 | Unconfigured returns None, breaker status, extra_body preserved |
+| Metadata validation | 6 | JSON parsing, code fence stripping, invalid kind/domain rejection |
+| Fact extraction | 5 | Grounded facts accepted, hallucination rejected, cap at 10 |
+| Provider activation | 6 | No-URL unavailable, tool schemas, breaker blocks/resets, health cache |
+| Durable memory | 5 | Single add, replace supersedes, remove deletes, verbatim conclude |
+| Reliability | 6 | 20-write drain, stale state clearing, breaker trip/reset, empty results |
+
+### Readiness checklist
+
+Before recommending `memory.provider=mempal` as authoritative backend:
+
+- [x] Scope isolation: profiles, chats, threads, projects do not leak
+- [x] Write semantics: add/replace/remove map correctly to ingest/supersede/delete
+- [x] Typed metadata: search and profile results include drawer_id and provenance
+- [x] Pinned facts: always-on context injected into system prompt
+- [x] Write queue: single worker, drains on shutdown, no data loss
+- [x] Intelligence modes: deterministic default, LLM optional, validation gates
+- [x] Circuit breaker: trips after failures, resets after cooldown
+- [x] Config: base_url, user_id, intelligence modes all configurable
+- [x] All blocker issues closed: #212, #213, #214, #215, #216, #191

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -560,5 +560,162 @@ class FactExtractionValidationTests(unittest.TestCase):
             self.assertLessEqual(len(result), 10)
 
 
+class ReadinessActivationTests(unittest.TestCase):
+    """Provider activation: config loading, availability, REST-down behavior."""
+
+    def test_no_base_url_makes_unavailable(self) -> None:
+        provider = RecordingProvider()
+        provider._hermes_home = ""
+        old = os.environ.get("MEMPAL_BASE_URL")
+        try:
+            os.environ["MEMPAL_BASE_URL"] = ""
+            self.assertFalse(provider.is_available())
+        finally:
+            if old is not None:
+                os.environ["MEMPAL_BASE_URL"] = old
+            else:
+                os.environ.pop("MEMPAL_BASE_URL", None)
+
+    def test_provider_name_is_mempal(self) -> None:
+        provider = RecordingProvider()
+        self.assertEqual(provider.name, "mempal")
+
+    def test_tool_schemas_registered(self) -> None:
+        provider = RecordingProvider()
+        schemas = provider.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        self.assertEqual(names, {"mempal_profile", "mempal_search", "mempal_conclude"})
+
+    def test_breaker_open_blocks_tool_calls(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider._consecutive_failures = 10
+        provider._breaker_open_until = time.monotonic() + 999
+
+        result = json.loads(provider.handle_tool_call("mempal_search", {"query": "test"}))
+        self.assertIn("error", result)
+        self.assertIn("unavailable", result["error"])
+
+    def test_breaker_resets_after_cooldown(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider._consecutive_failures = 10
+        provider._breaker_open_until = time.monotonic() - 1
+
+        provider.responses["/api/search"] = [{"content": "found"}]
+        result = json.loads(provider.handle_tool_call("mempal_search", {"query": "test"}))
+        self.assertIn("results", result)
+
+    def test_health_cache_prevents_probe(self) -> None:
+        provider = RecordingProvider()
+        provider._is_healthy = False
+        provider._last_health_at = time.monotonic()
+        self.assertFalse(provider.is_available())
+
+
+class ReadinessDurableMemoryTests(unittest.TestCase):
+    """Durable memory semantics: add/replace/remove correctness."""
+
+    def test_add_creates_one_ingest(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.on_memory_write("add", "profile", "single fact")
+        provider._drain_writes()
+        ingests = [b for p, b in provider.posts if p == "/api/ingest"]
+        self.assertEqual(len(ingests), 1)
+        self.assertEqual(ingests[0]["content"], "single fact")
+
+    def test_replace_supersedes_and_creates_new(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.on_memory_write("add", "profile", "v1")
+        provider._drain_writes()
+        provider.on_memory_write("replace", "profile", "v2")
+        provider._drain_writes()
+        ingests = [b for p, b in provider.posts if p == "/api/ingest"]
+        self.assertEqual(len(ingests), 2)
+        self.assertIn("supersedes", ingests[1])
+        self.assertEqual(ingests[1]["content"], "v2")
+
+    def test_remove_deletes_tracked(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.on_memory_write("add", "profile", "ephemeral")
+        provider._drain_writes()
+        provider.on_memory_write("remove", "profile", "")
+        provider._drain_writes()
+        deletes = [b for p, b in provider.posts if p == "/api/delete"]
+        self.assertEqual(len(deletes), 1)
+
+    def test_remove_without_prior_is_noop(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.on_memory_write("remove", "profile", "")
+        self.assertEqual(len(provider.posts), 0)
+
+    def test_conclude_stores_verbatim(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        result = json.loads(provider.handle_tool_call("mempal_conclude", {"conclusion": "exact text"}))
+        self.assertEqual(provider.posts[-1][1]["content"], "exact text")
+        self.assertIn("drawer_id", result)
+
+
+class ReadinessReliabilityTests(unittest.TestCase):
+    """Reliability: degradation, rapid writes, session switch draining."""
+
+    def test_rapid_writes_then_shutdown_drains_all(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        for i in range(20):
+            provider.on_memory_write("add", "profile", f"fact {i}")
+        provider.shutdown()
+        ingests = [b for p, b in provider.posts if p == "/api/ingest"]
+        self.assertEqual(len(ingests), 20)
+
+    def test_session_switch_clears_stale_state(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        with provider._prefetch_lock:
+            provider._prefetch_result = "old data"
+        with provider._pinned_facts_lock:
+            provider._pinned_facts_cache = [{"content": "stale"}]
+            provider._pinned_facts_fetched_at = time.monotonic()
+
+        provider.on_session_switch("session-b", reason="reset")
+
+        self.assertEqual(provider.prefetch("x", session_id="session-a"), "")
+        self.assertEqual(provider._pinned_facts_fetched_at, 0.0)
+
+    def test_consecutive_failures_trip_breaker(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        for _ in range(5):
+            provider._record_failure()
+        self.assertTrue(provider._is_breaker_open())
+
+    def test_success_resets_failure_count(self) -> None:
+        provider = RecordingProvider()
+        provider._consecutive_failures = 4
+        provider._record_success()
+        self.assertEqual(provider._consecutive_failures, 0)
+
+    def test_empty_search_returns_no_results_message(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.responses["/api/search"] = []
+        result = json.loads(provider.handle_tool_call("mempal_search", {"query": "nothing"}))
+        self.assertIn("result", result)
+        self.assertIn("No relevant", result["result"])
+
+    def test_empty_profile_returns_no_memories_message(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.responses["/api/timeline"] = []
+        result = json.loads(provider.handle_tool_call("mempal_profile", {}))
+        self.assertIn("result", result)
+        self.assertIn("No memories", result["result"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add 17 readiness tests across 3 new test classes: provider activation, durable memory semantics, reliability/degradation
- Update README with intelligence modes docs, CI test command (`python3 contrib/hermes-agent-plugin/test_mempal_provider.py -v`), 12-class test matrix, and readiness checklist
- 67 total tests, all passing in 0.005s

Closes #217

## Test plan
- [x] 67 tests pass across 12 test classes
- [x] README documents config requirements and readiness checklist
- [x] All blocker issues (#191, #212, #213, #214, #215, #216) are closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)