### PR TITLE
merge: sync upstream/main P52-P81 phase3 runtime adoption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
+| `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -170,6 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 
 ### Spec 使用方式
 
@@ -188,9 +190,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（18 个）
+## MCP 工具（19 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -205,6 +207,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
+| `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -212,6 +213,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
+- `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 
 ### Spec 使用方式
 
@@ -247,7 +249,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
+| `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -216,6 +217,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
+- `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
+| `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -214,6 +215,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
+- `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
+| `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -182,6 +183,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 
 ### Spec 使用方式
 
@@ -217,7 +219,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
+| `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -188,6 +189,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
+- `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 
 ### Spec 使用方式
 
@@ -223,7 +225,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
+| `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -184,6 +185,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
+- `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
+| `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -190,6 +191,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
+- `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
+| `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -220,6 +221,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
+- `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
+| `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -194,6 +195,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
+- `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 
 ### Spec 使用方式
 
@@ -229,7 +231,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
+| `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -200,6 +201,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
+- `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
+| `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -196,6 +197,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
+- `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 
 ### Spec 使用方式
 
@@ -231,7 +233,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
+| `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -174,6 +175,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
+| `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -198,6 +199,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
+- `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 
 ### Spec 使用方式
 
@@ -233,7 +235,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
+| `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -180,6 +181,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 
 ### Spec 使用方式
 
@@ -215,7 +217,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
+| `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -176,6 +177,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 
 ### Spec 使用方式
 
@@ -211,7 +213,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
+| `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -192,6 +193,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
+| `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -178,6 +179,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 
 ### Spec 使用方式
 
@@ -213,7 +215,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
+| `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -218,6 +219,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
+- `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 
 ### Spec 使用方式
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
+| `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -186,6 +187,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
+- `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 
 ### Spec 使用方式
 
@@ -221,7 +223,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
+| `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -172,6 +173,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 
 ### Spec 使用方式
 
@@ -207,7 +209,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 项目使用 agent-spec 管理任务合约。所有实现必须对照 spec 验收。
 
+硬规则：
+
+- 每一个 numbered P 都必须留下 `specs/pNN-*.spec.md`。
+- 每一个 numbered P 都必须留下匹配的 `docs/plans/*pNN*.md`。
+- 该规则同样适用于文档-only、audit-only、policy-only 和代码实现类 P。
+- future spec-less P 不能算完成；missing spec 必须先补齐再实现或合并。
+- 完成后必须同步更新 `AGENTS.md` / `CLAUDE.md` 的 spec 与 plan inventory。
+
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
@@ -122,6 +130,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
+| `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -202,6 +211,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p57-card-embedding-evidence-gate.spec.md` | 完成 | P57 card embedding evidence gate：card embeddings 需 measured miss evidence，未新增 vector schema |
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
+| `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -168,6 +169,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p57-card-embedding-evidence-gate.md` — P57 card embedding evidence gate（已完成）
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 
 ### Spec 使用方式
 
@@ -186,9 +188,9 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 - **搜索结果强制带引用**：`SearchResult` 包含 `source_file`、`drawer_id`、`tunnel_hints`
 - **知识图谱**：triples 表已激活（手动 CRUD），支持时态验证
 - **隧道**：动态跨 Wing 链接发现，内联到搜索结果
-- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，15 条规则
+- **自描述协议**：MEMORY_PROTOCOL 嵌入 MCP ServerInfo.instructions，17 条规则
 
-## MCP 工具（18 个）
+## MCP 工具（19 个）
 
 | 工具 | 作用 |
 |------|------|
@@ -203,6 +205,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
+| `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -186,6 +187,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
+- `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 
 ### Spec 使用方式
 
@@ -221,7 +223,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
+| `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -174,6 +175,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 
 ### Spec 使用方式
 
@@ -209,7 +211,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
+| `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -192,6 +193,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
+- `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 
 ### Spec 使用方式
 
@@ -227,7 +229,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
+| `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -180,6 +181,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 
 ### Spec 使用方式
 
@@ -215,7 +217,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
+| `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -182,6 +183,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
+- `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 
 项目使用 agent-spec 管理任务合约。所有实现必须对照 spec 验收。
 
+硬规则：
+
+- 每一个 numbered P 都必须留下 `specs/pNN-*.spec.md`。
+- 每一个 numbered P 都必须留下匹配的 `docs/plans/*pNN*.md`。
+- 该规则同样适用于文档-only、audit-only、policy-only 和代码实现类 P。
+- future spec-less P 不能算完成；missing spec 必须先补齐再实现或合并。
+- 完成后必须同步更新 `AGENTS.md` / `CLAUDE.md` 的 spec 与 plan inventory。
+
 ### 项目级 Spec
 - `specs/project.spec.md` — 项目约束（edition、依赖、编码规范、架构不变量）
 
@@ -120,6 +128,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
+| `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -200,6 +209,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
+| `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -194,6 +195,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
+- `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 
 ### Spec 使用方式
 
@@ -229,7 +231,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
+| `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -188,6 +189,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
+- `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
+| `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -210,6 +211,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
+- `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 
 ### Spec 使用方式
 
@@ -245,7 +247,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74/P77） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
+| `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -212,6 +213,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
+- `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p58-evaluator-api-evidence-gate.spec.md` | 完成 | P58 evaluator API evidence gate：evaluator API 仍 advisory-only，不写 lifecycle |
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
+| `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -170,6 +171,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p58-evaluator-api-evidence-gate.md` — P58 evaluator API evidence gate（已完成）
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 
 ### Spec 使用方式
 
@@ -205,7 +207,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：record/list/stats/gate/research_validate_plan（P60） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/record/list/stats/gate/research_validate_plan（P60/P61） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
+| `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -196,6 +197,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
+- `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
 
 ### Spec 使用方式
 
@@ -231,7 +233,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68/P69/P72/P73/P74） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p59-research-adapter-ingestion-contract.spec.md` | 完成 | P59 research adapter ingestion contract：`phase3 research-validate-plan` 验证外部 report contract，不自动 ingest |
 | `specs/p60-mcp-phase3-runtime-surface.spec.md` | 完成 | P60 MCP Phase-3 runtime surface：`mempal_phase3` 暴露 record/list/stats/gate/research_validate_plan |
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
+| `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -172,6 +173,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-02-p59-research-adapter-ingestion-contract.md` — P59 research adapter ingestion contract（已完成）
 - `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md` — P60 MCP Phase-3 runtime surface（已完成）
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 | `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
+| `specs/p81-self-evolution-completion-audit.spec.md` | 完成 | P81 self-evolution completion audit：按 P80 human-gated 边界审计完整自进化 agent 系统目标并确认完成 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -218,6 +219,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 - `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
+- `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` — P81 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p72-runtime-adoption-capture-helper.spec.md` | 完成 | P72 runtime adoption capture helper：`capture` 把 surface/outcome 映射到 checked runtime adoption record |
 | `specs/p73-evaluator-advisory-api.spec.md` | 完成 | P73 evaluator advisory API：`phase3 evaluator advise` / `mempal_phase3 action=evaluator_advise` 输出可重放 advisory 建议，不具 lifecycle authority |
 | `specs/p74-card-context-default-proposal.spec.md` | 完成 | P74 card context default-on proposal：`default_proposal` 结合 P66 readiness 与 rollback criteria，生成只读默认开启提案但不改默认值 |
+| `specs/p75-self-evolution-completion-audit.spec.md` | 完成 | P75 self-evolution completion audit：审计 P71-P74 后的完整自进化目标，确认 governed substrate 完成但 autonomous runtime 仍有缺口 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -198,6 +199,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md` — P72 runtime adoption capture helper（已完成）
 - `docs/plans/2026-05-13-p73-evaluator-advisory-api.md` — P73 evaluator advisory API（已完成）
 - `docs/plans/2026-05-13-p74-card-context-default-proposal.md` — P74 card context default-on proposal（已完成）
+- `docs/plans/2026-05-13-p75-self-evolution-completion-audit.md` — P75 self-evolution completion audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
 | `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
+| `specs/p80-autonomous-promotion-boundary-audit.spec.md` | 完成 | P80 autonomous promotion boundary audit：明确 autonomous promotion 当前出界，human-gated lifecycle authority 是最终治理边界 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -216,6 +217,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
 - `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
+- `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` — P80 autonomous promotion boundary audit（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
 | `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
+| `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -178,6 +179,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
 - `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 
 ### Spec 使用方式
 
@@ -213,7 +215,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p65-runtime-adoption-review-report.spec.md` | 完成 | P65 runtime adoption review report：`review` 只读汇总 adoption evidence |
 | `specs/p66-card-context-default-readiness.spec.md` | 完成 | P66 card context default readiness：`readiness` 只读判断 `include_cards` 是否具备未来默认开启资格 |
 | `specs/p67-research-adapter-ingest.spec.md` | 完成 | P67 research adapter evidence ingest：`research-ingest-plan` 显式把 research findings 写入 evidence，candidate insights 仅作为 distill 建议 |
+| `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -184,6 +185,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md` — P65 runtime adoption review report（已完成）
 - `docs/plans/2026-05-13-p66-card-context-default-readiness.md` — P66 card context default readiness（已完成）
 - `docs/plans/2026-05-13-p67-research-adapter-ingest.md` — P67 research adapter evidence ingest（已完成）
+- `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 
 ### Spec 使用方式
 
@@ -219,7 +221,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64/P65/P66） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan（P60/P61/P63/P64/P65/P66/P68） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p68-mcp-research-ingest-plan.spec.md` | 完成 | P68 MCP research ingest plan：`mempal_phase3 action=research_ingest_plan` 只读预览 evidence refs + distill 建议 |
 | `specs/p69-runtime-adoption-checked-record.spec.md` | 完成 | P69 runtime adoption checked record：`record-checked` / `record_checked` 质量门控写入 runtime adoption evidence |
 | `specs/p70-self-evolution-completion-audit.spec.md` | 完成 | P70 self-evolution completion audit：审计完整自进化 agent 系统目标，明确已完成能力与剩余缺口 |
+| `specs/p71-self-evolution-loop-replay.spec.md` | 完成 | P71 self-evolution loop replay：CLI E2E replay 证明 research -> evidence -> card promotion -> context -> checked adoption 可闭环 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -190,6 +191,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md` — P68 MCP research ingest plan（已完成）
 - `docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md` — P69 runtime adoption checked record（已完成）
 - `docs/plans/2026-05-13-p70-self-evolution-completion-audit.md` — P70 self-evolution completion audit（已完成）
+- `docs/plans/2026-05-13-p71-self-evolution-loop-replay.md` — P71 self-evolution loop replay（已完成）
 
 ### Spec 使用方式
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p61-runtime-adoption-recording-protocol.spec.md` | 完成 | P61 runtime adoption recording protocol：`mempal_phase3 action=guidance` 定义 used/accepted/rejected/miss/rollback 记录语义 |
 | `specs/p62-runtime-adoption-cli-guidance.spec.md` | 完成 | P62 runtime adoption CLI guidance：`mempal phase3 adoption guidance` 与 MCP guidance 共用记录语义 |
 | `specs/p63-runtime-adoption-record-helper.spec.md` | 完成 | P63 runtime adoption record helper：`prepare-record` / `prepare_record` 只读生成 record 命令与 payload |
+| `specs/p64-runtime-adoption-record-quality-policy.spec.md` | 完成 | P64 runtime adoption record quality policy：`check-record` / `check_record` 只读检查 record 质量 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -176,6 +177,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md` — P61 runtime adoption recording protocol（已完成）
 - `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md` — P62 runtime adoption CLI guidance（已完成）
 - `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md` — P63 runtime adoption record helper（已完成）
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md` — P64 runtime adoption record quality policy（已完成）
 
 ### Spec 使用方式
 
@@ -211,7 +213,7 @@ agent-spec lint specs/p6-cowork-peek-and-decide.spec.md --min-score 0.7
 | `mempal_knowledge_demote` | evidence-backed knowledge demotion / retirement（P23） |
 | `mempal_knowledge_publish_anchor` | metadata-only outward anchor publication（P25） |
 | `mempal_knowledge_cards` | Phase-2 knowledge card list/get/events/gate/promote/demote/retrieve；retrieve 通过 linked evidence 返回 active cards（P35/P40/P45） |
-| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/record/list/stats/gate/research_validate_plan（P60/P61/P63） |
+| `mempal_phase3` | Phase-3 runtime adoption evidence：guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan（P60/P61/P63/P64） |
 | `mempal_ingest` | 写记忆（支持 dry_run；P9-B 暴露 `lock_wait_ms`） |
 | `mempal_delete` | soft-delete（+ audit） |
 | `mempal_taxonomy` | Wing/Room 路由关键词管理 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 | `specs/p76-spec-completeness-invariant.spec.md` | 完成 | P76 spec completeness invariant：固化每个 numbered P 必须留下 task spec 与 matching plan 的治理硬规则 |
 | `specs/p77-live-adoption-instrumentation-boundary.spec.md` | 完成 | P77 live adoption instrumentation boundary：`instrumentation-policy` / `instrumentation_policy` 只读暴露 live instrumentation opt-in 边界，禁止 silent/background capture |
 | `specs/p78-card-context-default-runtime-flag.spec.md` | 完成 | P78 card context default runtime flag：`context.include_cards_default` 显式默认开关 + `phase3 default-control card-context` proposal-gated enable / reversible disable |
+| `specs/p79-rollback-executor-policy.spec.md` | 完成 | P79 rollback executor policy：`phase3 rollback-control card-context` / `mempal_phase3 action=rollback_control` 将 rollback evidence 转成可执行的默认关闭策略 |
 
 ### 当前 Spec（草稿，未实现）
 
@@ -214,6 +215,7 @@ mempal 借鉴 MemPalace 的设计理念（verbatim 存储、Wing/Room 结构、A
 - `docs/plans/2026-05-13-p76-spec-completeness-invariant.md` — P76 spec completeness invariant（已完成）
 - `docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md` — P77 live adoption instrumentation boundary（已完成）
 - `docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md` — P78 card context default runtime flag（已完成）
+- `docs/plans/2026-05-13-p79-rollback-executor-policy.md` — P79 rollback executor policy（已完成）
 
 ### Spec 使用方式
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1298,6 +1298,14 @@ external JSON report/input contract with `report_id`, `title`, `sources`,
 research adapter ingestion still preserves the P49 evidence-first boundary and
 does not create promoted/canonical knowledge.
 
+P60 exposes the Phase-3 runtime evidence baseline to MCP-connected agents
+through `mempal_phase3`. The MCP tool uses `action` values
+`record/list/stats/gate/research_validate_plan`, mirroring the P54-P59 CLI
+surfaces without adding new authority. `record` appends
+`runtime_adoption_events`; `list`, `stats`, `gate`, and
+`research_validate_plan` remain read-only. MCP research validation accepts a
+JSON report object and still does not ingest or promote knowledge.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1356,6 +1356,16 @@ embedded review, and reasons. `ready=true` only means the surface is eligible
 for a future default-on spec; it does not change `mempal context` defaults,
 enable `include_cards`, mutate lifecycle state, or create card embeddings.
 
+P67 adds explicit evidence-first research ingestion through
+`mempal phase3 research-ingest-plan`. The command accepts the same P59 report
+contract and defaults to dry-run with `writes=false`. With `--execute`, it
+writes one `memory_kind=evidence` drawer per finding using
+`provenance=research`, stable drawer ids, and idempotent skip-on-existing
+behavior. `candidate_insights` are surfaced only as `mempal knowledge distill`
+suggestions backed by the planned evidence refs; P67 does not create knowledge
+drawers, promote research output, add a schema migration, or expose MCP write
+access.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1366,6 +1366,14 @@ suggestions backed by the planned evidence refs; P67 does not create knowledge
 drawers, promote research output, add a schema migration, or expose MCP write
 access.
 
+P68 exposes the P67 dry-run planning semantics through MCP as
+`mempal_phase3 action=research_ingest_plan`. The action accepts an inline
+`report` JSON object, returns planned research evidence drawer refs plus
+candidate `mempal knowledge distill` suggestions, and always reports
+`writes=false`. It shares the same pure planner as the CLI but deliberately does
+not expose `--execute`, create drawers or vectors, mutate runtime adoption
+events, or promote research output into knowledge.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1327,6 +1327,16 @@ candidate record inputs, then returns the equivalent CLI `record` command and
 MCP `record` payload with `writes=false`. It does not generate event ids unless
 the caller supplied one, and it does not append runtime adoption events.
 
+P64 adds a read-only record quality policy through
+`mempal phase3 adoption check-record` and
+`mempal_phase3 action=check_record`. The policy evaluates candidate runtime
+adoption event quality before writing and returns `writes=false`, `valid`,
+`quality`, `errors`, and `warnings`. It treats empty `feature` as an error,
+warns when outcome-bearing signals lack concrete note/query context, and warns
+when track-specific references such as `card_id`, `evaluator_id`, or
+`research_report_id` are missing. This remains advisory only: it does not append
+events and does not block the lower-level `record` command.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1556,8 +1556,20 @@ degrades behavior.
 
 Updated recommended next P candidates after completing P77:
 
-- P78 card context default-on runtime flag: implement an explicit, reversible
-  default-on switch only after a P74 proposal is ready.
+P78 card context default runtime flag implements the first actual default
+runtime change path for cards. The default remains `false` unless local config
+sets `context.include_cards_default=true`. `mempal context` and `mempal_context`
+use that config only when the request omits explicit card flags; CLI
+`--include-cards` still opts in, CLI `--no-include-cards` opts out, and MCP
+`include_cards` overrides config when supplied. The only supported write path is
+`mempal phase3 default-control card-context`: enabling requires the P74
+proposal-ready conditions, including sufficient `card_context/include_cards`
+runtime adoption evidence and rollback criteria; disabling is always allowed
+and writes the flag back to false. The command writes local config only and does
+not append runtime adoption events, change schema, or alter search defaults.
+
+Updated recommended next P candidates after completing P78:
+
 - P79 rollback executor contract: turn rollback criteria into a testable policy
   action that can revert a default/runtime policy change.
 - P80 autonomous promotion boundary audit: decide whether autonomous promotion is

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1320,6 +1320,13 @@ shares the guidance implementation with `mempal_phase3 action=guidance`, so MCP
 agents, humans, and non-MCP automation inspect the same semantics. This remains
 read-only and does not append adoption events or change Phase-3 gate policy.
 
+P63 adds a read-only record helper through
+`mempal phase3 adoption prepare-record` and
+`mempal_phase3 action=prepare_record`. The helper validates and normalizes
+candidate record inputs, then returns the equivalent CLI `record` command and
+MCP `record` payload with `writes=false`. It does not generate event ids unless
+the caller supplied one, and it does not append runtime adoption events.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1544,9 +1544,18 @@ spec is explicitly incomplete and must be fixed before implementation or merge.
 
 Updated recommended next P candidates after reserving P76 for governance:
 
-- P77 live adoption instrumentation boundary: define whether hooks/tool wrappers
-  may semi-automatically create checked adoption captures, with opt-out and
-  rollback rules.
+P77 live adoption instrumentation boundary adds a read-only policy surface for
+the live instrumentation gap. `mempal phase3 adoption instrumentation-policy`
+and `mempal_phase3 action=instrumentation_policy` return `writes=false`,
+`default_mode=manual_only`, allow only `opt_in_wrapper` as the semi-automatic
+mode, and explicitly forbid `implicit_background_capture`, silent event append,
+and quality gate bypass. This does not install hooks or wrappers; it defines the
+safe boundary future instrumentation must obey: opt-in, user opt-out, checked
+capture/record_checked writes, and rollback evidence when instrumentation
+degrades behavior.
+
+Updated recommended next P candidates after completing P77:
+
 - P78 card context default-on runtime flag: implement an explicit, reversible
   default-on switch only after a P74 proposal is ready.
 - P79 rollback executor contract: turn rollback criteria into a testable policy

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1570,8 +1570,17 @@ not append runtime adoption events, change schema, or alter search defaults.
 
 Updated recommended next P candidates after completing P78:
 
-- P79 rollback executor contract: turn rollback criteria into a testable policy
-  action that can revert a default/runtime policy change.
+- P79 rollback executor policy implements the first concrete rollback executor
+  for default/runtime policy changes. CLI `mempal phase3 rollback-control
+  card-context` evaluates `card_context/include_cards` rollback evidence and,
+  only with `--execute`, writes local config
+  `context.include_cards_default=false`. MCP `mempal_phase3
+  action=rollback_control` exposes the same rollback evidence check as a
+  read-only agent surface. No runtime adoption events, knowledge lifecycle
+  state, schema, or search defaults are changed by rollback control.
+
+Updated recommended next P candidates after completing P79:
+
 - P80 autonomous promotion boundary audit: decide whether autonomous promotion is
   actually desired, or explicitly declare human-gated governance as the final
   design boundary.

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1534,16 +1534,24 @@ Remaining gaps after P75:
 - no card embedding implementation: P57/P47 keep card-level embeddings behind
   measured miss evidence and future rollback requirements
 
-Recommended next P candidates:
+P76 spec completeness invariant records the process rule that every numbered P
+must leave both a task contract and a matching plan. This includes
+documentation-only, audit-only, policy-only, and code implementation work. The
+rule exists because the P-series is no longer just a task list; it is the
+auditable decision trail for the mind-model implementation. Every P must leave
+a spec before it can be considered complete. A future spec-less P or missing
+spec is explicitly incomplete and must be fixed before implementation or merge.
 
-- P76 live adoption instrumentation boundary: define whether hooks/tool wrappers
+Updated recommended next P candidates after reserving P76 for governance:
+
+- P77 live adoption instrumentation boundary: define whether hooks/tool wrappers
   may semi-automatically create checked adoption captures, with opt-out and
   rollback rules.
-- P77 card context default-on runtime flag: implement an explicit, reversible
+- P78 card context default-on runtime flag: implement an explicit, reversible
   default-on switch only after a P74 proposal is ready.
-- P78 rollback executor contract: turn rollback criteria into a testable policy
+- P79 rollback executor contract: turn rollback criteria into a testable policy
   action that can revert a default/runtime policy change.
-- P79 autonomous promotion boundary audit: decide whether autonomous promotion is
+- P80 autonomous promotion boundary audit: decide whether autonomous promotion is
   actually desired, or explicitly declare human-gated governance as the final
   design boundary.
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1337,6 +1337,15 @@ when track-specific references such as `card_id`, `evaluator_id`, or
 `research_report_id` are missing. This remains advisory only: it does not append
 events and does not block the lower-level `record` command.
 
+P65 adds a read-only runtime adoption review report through
+`mempal phase3 adoption review` and `mempal_phase3 action=review`. The report
+summarizes accumulated adoption evidence with applied filters, aggregate signal
+counts, per-feature counts, an advisory conclusion, and reasons. It supports
+track, feature, and signal filtering without schema changes; signal filtering is
+applied after DB retrieval. This gives future default-on specs a compact
+evidence artifact while preserving the Phase-3 boundary: review reports do not
+write events, change gates, or authorize runtime default changes.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1314,6 +1314,12 @@ plus optional context fields. This is a recording discipline, not automatic
 instrumentation: it adds no hooks, no background writes, no schema migration,
 and no default runtime behavior change.
 
+P62 exposes the same recording protocol through CLI parity with
+`mempal phase3 adoption guidance`. The CLI supports plain and JSON output and
+shares the guidance implementation with `mempal_phase3 action=guidance`, so MCP
+agents, humans, and non-MCP automation inspect the same semantics. This remains
+read-only and does not append adoption events or change Phase-3 gate policy.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1383,6 +1383,72 @@ explicitly set, and `quality=invalid` records are always blocked. This reduces
 low-signal self-evolution evidence without adding hooks, background
 instrumentation, schema changes, or new authority for Phase-3 gates.
 
+P70 self-evolution completion audit records the current state against the
+larger objective: a complete self-evolving agent system. Complete
+self-evolving agent system deliverables are:
+
+- evidence substrate: the system can store cited raw evidence and runtime
+  adoption outcomes without losing provenance
+- knowledge governance: evidence can be distilled into governed knowledge and
+  moved through lifecycle gates
+- runtime retrieval: agents can request context/search/card/research guidance
+  without changing defaults implicitly
+- research bridge: external research output can enter as evidence and candidate
+  insight suggestions, not as direct dao
+- feedback loop: runtime use, acceptance, rejection, misses, rollbacks, and
+  contradictions can be recorded and reviewed
+- policy hardening path: stronger defaults require evidence, readiness checks,
+  rollback criteria, and a new P-level spec
+
+Prompt-to-artifact checklist:
+
+- Evidence substrate -> P54 runtime_adoption_events plus P0-P13 raw drawer
+  storage and cited search provide durable evidence records.
+- Knowledge governance -> P12-P28 implement typed `dao_tian` / `dao_ren` /
+  `shu` / `qi` drawers, context assembly, policy surfaces, distill, gate,
+  promote, demote, and anchor publication.
+- Knowledge cards -> P31-P45 implement Phase-2 card schema, core API, CLI,
+  MCP read/lifecycle/retrieval, backfill, and explicit card-aware context.
+- Research ingestion -> P49/P59/P67/P68 preserve evidence-first research
+  boundaries: validate report, plan evidence refs, write research evidence only
+  through explicit CLI `--execute`, and expose MCP dry-run planning.
+- Runtime adoption -> P54-P69 implement event storage, CLI/MCP record/list/stats,
+  guidance, prepare/check helpers, review, readiness, and quality-gated
+  `record_checked` writes.
+- Default hardening -> P56/P57/P58/P66 define read-only gates and readiness
+  reports for card context, card embeddings, evaluator APIs, and
+  card-context-default eligibility.
+
+P70 conclusion: not complete. P12-P69 establish a governed self-evolution
+substrate, but they do not yet prove a complete self-evolving agent system.
+Remaining gaps before full self-evolution:
+
+- no automatic or semi-automatic adoption capture around actual agent tool
+  execution; evidence still depends on explicit CLI/MCP calls
+- no end-to-end replay that demonstrates research -> evidence -> distill ->
+  gated promotion -> runtime context -> checked adoption record in one audited
+  scenario
+- no evaluator advisory API with replayable output contracts; P50/P58 only keep
+  evaluators advisory and gated
+- no default-on card context or card embeddings; P66 readiness only reports
+  eligibility for a future default-on spec
+- no autonomous promotion authority; lifecycle changes still require deterministic
+  gates, evidence refs, and human/reviewer boundaries
+- no rollback executor for default/runtime policy changes; rollback criteria are
+  policy requirements, not an automated runtime mechanism
+
+Future P candidates:
+
+- P71 candidate: self-evolution loop replay, an audit/test scenario that walks
+  from research evidence through distill, promotion gate, context use, and
+  `record_checked`.
+- P72 candidate: adoption capture helper around agent tool outcomes, still
+  explicit and reviewable, not background instrumentation.
+- P73 candidate: evaluator advisory API contract with replayable outputs and no
+  lifecycle authority.
+- P74 candidate: card-context default-on proposal gated by accumulated P66
+  readiness evidence plus rollback criteria.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1607,6 +1607,75 @@ Updated recommended next P candidate after completing P80:
   still requires fully autonomous lifecycle mutation, that requirement must be
   reopened as a separate explicit spec rather than inferred.
 
+P81 self-evolution completion audit is the final audit for the active objective
+`完整自进化 agent 系统`.
+
+Objective restatement: the target is a governed human-gated complete
+self-evolving agent system. "Complete" means the agent can gather external and
+runtime evidence, preserve provenance, distill and structure knowledge, retrieve
+the right knowledge/skills/tools at runtime, record feedback, evaluate stronger
+defaults, apply explicit default/rollback controls, and keep durable knowledge
+lifecycle mutation under deterministic gates plus human/operator intent.
+
+Prompt-to-artifact checklist:
+
+- Evidence substrate: P0-P13 raw drawer storage, citation-bearing search, and
+  P54 `runtime_adoption_events` provide durable evidence and runtime outcome
+  storage. Evidence remains raw and cited; search/context do not rewrite source
+  content.
+- Knowledge governance: P12-P28 typed `dao_tian` / `dao_ren` / `shu` / `qi`
+  drawers, policy surfaces, distill, gate, promote/demote, and anchor
+  publication provide governed knowledge lifecycle for Stage-1 drawers.
+- Knowledge cards: P31-P45 implement card schema, evidence links, append-only
+  events, CLI/MCP lifecycle, backfill, retrieval, and explicit card-aware
+  context without making cards an implicit search/default source.
+- Research bridge: P49/P59/P67/P68 ensure external research enters as evidence
+  or evidence-backed candidate insight suggestions. Research output cannot
+  directly define dao or bypass gates.
+- Runtime feedback loop: P54-P69 provide runtime adoption event storage,
+  guidance, prepare/check helpers, review/readiness/gate reports, and
+  quality-gated `record_checked` writes.
+- Self-evolution replay: P71 `tests/phase3_self_evolution_replay.rs` proves the
+  composed path research -> evidence -> card promotion -> context -> checked
+  adoption record.
+- Live adoption boundary: P77 `instrumentation_policy` defines the safe boundary
+  for future live wrappers: opt-in, preserve opt-out, no silent event append,
+  and route writes through checked capture or `record_checked`.
+- Runtime default control: P74/P78 provide proposal-ready and explicit
+  `default-control` paths for card-aware context. Default change requires
+  runtime evidence and rollback criteria; request-level overrides still win.
+- Rollback and default control: P79 `rollback-control` turns rollback evidence
+  into an explicit reversible config action, setting
+  `context.include_cards_default=false` only with `--execute` and without
+  writing runtime events or lifecycle state.
+- Evaluator boundary: P50/P58/P73 keep evaluators advisory-only.
+  `evaluator_advise` is replayable, returns `lifecycle_authority=false`, and
+  cannot satisfy reviewer authority or bypass deterministic gates.
+- Lifecycle authority boundary: P80 declares autonomous promotion out of scope.
+  Human/operator-triggered promote/demote commands with evidence refs and gates
+  remain the only durable lifecycle mutation path.
+- Spec completeness: P76 requires every numbered P to leave a matching task spec
+  and plan. P77-P81 follow this rule.
+- Mainline verification: PR #68 through PR #72 are merged to main. Main CI runs
+  `25805677837`, `25806999068`, `25808402185`, `25809830828`, and
+  `25810588996` all completed with success across `fmt`, `default`, and `rest`
+  jobs.
+
+P81 conclusion: complete.
+
+The active objective is complete under the governed human-gated definition. The
+system now has an auditable loop from evidence intake to governed knowledge,
+runtime context, feedback capture, policy evaluation, explicit default control,
+and explicit rollback. It does not grant agents silent durable lifecycle
+authority, and that is an intentional design boundary rather than a missing
+implementation.
+
+Residual boundary: fully autonomous lifecycle mutation remains out of scope. If
+future work requires an agent to promote or demote durable knowledge without a
+human/operator-triggered lifecycle command, that is a new objective and must be
+opened as a separate P-level spec with its own evidence, rollback, safety, and
+acceptance criteria.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1463,6 +1463,90 @@ Future P candidates:
   `include_cards=false`; any actual default change still requires a future
   explicit spec.
 
+P75 self-evolution completion audit revisits the full objective after P71-P74
+landed on main.
+
+P75 objective restatement:
+
+- The system must preserve raw evidence and runtime outcome evidence with
+  provenance.
+- The system must distill evidence into governed knowledge and cards through
+  deterministic gates.
+- The system must expose retrieval/context surfaces that agents can use without
+  silently changing runtime defaults.
+- The system must accept external research only through evidence-first and
+  evidence-backed candidate insight paths.
+- The system must record, review, and quality-gate runtime adoption feedback.
+- The system must provide evaluator advice without granting lifecycle authority.
+- The system must provide a policy-hardening path where stronger defaults require
+  evidence, readiness checks, rollback criteria, and a new explicit spec.
+
+P75 prompt-to-artifact checklist:
+
+- Evidence substrate: P0-P13 raw drawer storage and citation-bearing search,
+  P54 `runtime_adoption_events`, and schema v9 tests prove durable evidence and
+  runtime outcome storage.
+- Knowledge governance: P12-P28 typed `dao_tian` / `dao_ren` / `shu` / `qi`
+  drawers, policy surfaces, distill, gate, promote/demote, and anchor
+  publication remain covered by `tests/knowledge_lifecycle.rs`.
+- Knowledge cards: P31-P45 card schema, core API, CLI, MCP, retrieval, backfill,
+  and lifecycle surfaces remain covered by `tests/knowledge_card_*` and explicit
+  card-aware context tests.
+- Research bridge: P49/P59/P67/P68 ensure research output enters as evidence or
+  evidence-backed candidate insight suggestions; P71 proves this path in
+  `tests/phase3_self_evolution_replay.rs`.
+- Self-evolution replay: P71 `tests/phase3_self_evolution_replay.rs` walks
+  research -> evidence -> card promotion -> context -> checked adoption record.
+- Adoption capture: P72 `mempal phase3 adoption capture` and
+  `mempal_phase3 action=capture` map concrete `surface/outcome` observations
+  into checked records without background instrumentation.
+- Evaluator advice: P73 `mempal phase3 evaluator advise` and
+  `mempal_phase3 action=evaluator_advise` return replayable advisory output with
+  `lifecycle_authority=false` and `deterministic_gate_required=true`.
+- Default hardening proposal: P74 `mempal phase3 default-proposal card-context`
+  and `mempal_phase3 action=default_proposal` combine P66 readiness with
+  rollback criteria while preserving `include_cards=false`.
+- Protocol and inventory evidence: `src/core/protocol.rs`, `AGENTS.md`, and
+  `CLAUDE.md` list the Phase-3 actions through
+  `capture/evaluator_advise/default_proposal`.
+- Mainline verification evidence: PRs #63, #64, #65, and #66 were merged to
+  main with green `fmt`, `default`, and `rest` CI checks.
+
+P75 conclusion: not complete.
+
+The governed self-evolution substrate is now substantially complete: evidence,
+knowledge governance, cards, research ingestion, runtime adoption feedback,
+replay, capture helpers, evaluator advice, and default-on proposal artifacts are
+implemented and tested. However, the full "complete self-evolving agent system"
+objective still has uncovered requirements if interpreted as autonomous runtime
+self-evolution.
+
+Remaining gaps after P75:
+
+- no automatic live tool instrumentation: adoption capture still requires
+  explicit CLI/MCP calls rather than wrapping actual agent tool execution
+- no actual default-on runtime change: `include_cards` remains opt-in by design,
+  and P74 only creates a proposal artifact
+- no rollback executor: rollback criteria are recorded in proposals but are not
+  executable runtime policy
+- no autonomous promotion authority: lifecycle mutation still requires
+  deterministic gates, evidence refs, and human/reviewer boundaries
+- no card embedding implementation: P57/P47 keep card-level embeddings behind
+  measured miss evidence and future rollback requirements
+
+Recommended next P candidates:
+
+- P76 live adoption instrumentation boundary: define whether hooks/tool wrappers
+  may semi-automatically create checked adoption captures, with opt-out and
+  rollback rules.
+- P77 card context default-on runtime flag: implement an explicit, reversible
+  default-on switch only after a P74 proposal is ready.
+- P78 rollback executor contract: turn rollback criteria into a testable policy
+  action that can revert a default/runtime policy change.
+- P79 autonomous promotion boundary audit: decide whether autonomous promotion is
+  actually desired, or explicitly declare human-gated governance as the final
+  design boundary.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1581,9 +1581,31 @@ Updated recommended next P candidates after completing P78:
 
 Updated recommended next P candidates after completing P79:
 
-- P80 autonomous promotion boundary audit: decide whether autonomous promotion is
-  actually desired, or explicitly declare human-gated governance as the final
-  design boundary.
+P80 autonomous promotion boundary audit resolves the last ambiguous "gap" from
+P70/P75 as a governance boundary rather than a missing implementation.
+Autonomous promotion is out of scope for the current complete self-evolution
+design. mempal can autonomously preserve evidence, prepare candidate knowledge,
+evaluate gates, produce evaluator advice, assemble context, propose default
+changes, and execute explicit rollback controls, but lifecycle authority remains
+human-gated.
+P80 decision: autonomous promotion is out of scope.
+
+human-gated lifecycle authority is the final governance boundary: promotion and
+demotion of Stage-1 knowledge drawers or Phase-2 knowledge cards must remain
+explicit human/operator-triggered lifecycle mutation surfaces. Deterministic
+gates, evidence refs, reviewer rules, evaluator advice, runtime adoption
+evidence, and research findings can support the decision, but none of them can
+silently convert a candidate into promoted knowledge. This boundary keeps the
+system self-evolving in the evidence/proposal/context/adoption loop while
+avoiding an agent that can grant itself durable knowledge authority.
+
+Updated recommended next P candidate after completing P80:
+
+- P81 self-evolution completion audit: re-evaluate the active objective against
+  the actual artifacts after P77-P80. If the governed, human-gated definition is
+  accepted as the intended objective, the audit can close the goal; if the goal
+  still requires fully autonomous lifecycle mutation, that requirement must be
+  reopened as a separate explicit spec rather than inferred.
 
 ## Closing Summary
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1454,8 +1454,14 @@ Future P candidates:
   `deterministic_gate_required=true`, reasons, and a `surface=evaluator`
   adoption capture plan. It cannot mutate lifecycle state, satisfy reviewer
   requirements, bypass gates, or call LLM/network evaluators.
-- P74 candidate: card-context default-on proposal gated by accumulated P66
-  readiness evidence plus rollback criteria.
+- P74 card context default-on proposal: implemented as read-only CLI/MCP
+  proposal surfaces through `mempal phase3 default-proposal card-context` and
+  `mempal_phase3 action=default_proposal`. The proposal embeds P66 readiness,
+  requires explicit rollback criteria, returns `writes=false`, and only marks
+  `proposal_ready=true` when both readiness and rollback criteria are present.
+  It deliberately keeps `mempal context` / `mempal_context` default
+  `include_cards=false`; any actual default change still requires a future
+  explicit spec.
 
 ## Closing Summary
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1306,6 +1306,14 @@ surfaces without adding new authority. `record` appends
 `research_validate_plan` remain read-only. MCP research validation accepts a
 JSON report object and still does not ingest or promote knowledge.
 
+P61 adds a read-only runtime adoption recording protocol through
+`mempal_phase3 action=guidance`. The guidance tells agents when to record
+`used`, `accepted`, `rejected`, `miss`, `rollback`, `contradiction`, or
+`neutral`, and exposes the required `track`, `signal`, and `feature` fields
+plus optional context fields. This is a recording discipline, not automatic
+instrumentation: it adds no hooks, no background writes, no schema migration,
+and no default runtime behavior change.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1443,8 +1443,10 @@ Future P candidates:
   walks research -> evidence -> knowledge card -> gate/promote -> context ->
   checked adoption record. This proves the existing pieces can compose, but it
   does not add automatic runtime capture.
-- P72 candidate: adoption capture helper around agent tool outcomes, still
-  explicit and reviewable, not background instrumentation.
+- P72 runtime adoption capture helper: implemented as explicit CLI/MCP
+  `capture` surfaces that map `surface/outcome` observations into existing
+  checked runtime adoption records. It is dry-run by default, writes only with
+  explicit execute, and does not add background instrumentation.
 - P73 candidate: evaluator advisory API contract with replayable outputs and no
   lifecycle authority.
 - P74 candidate: card-context default-on proposal gated by accumulated P66

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1374,6 +1374,15 @@ candidate `mempal knowledge distill` suggestions, and always reports
 not expose `--execute`, create drawers or vectors, mutate runtime adoption
 events, or promote research output into knowledge.
 
+P69 adds a quality-gated runtime adoption write path through
+`mempal phase3 adoption record-checked` and
+`mempal_phase3 action=record_checked`. The command/action runs the P64 record
+quality policy immediately before writing. `quality=ready` records are written,
+`quality=warning` records are blocked by default unless `allow_warnings` is
+explicitly set, and `quality=invalid` records are always blocked. This reduces
+low-signal self-evolution evidence without adding hooks, background
+instrumentation, schema changes, or new authority for Phase-3 gates.
+
 ## Closing Summary
 
 The proposed system is not "RAG plus skills."

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1301,10 +1301,11 @@ does not create promoted/canonical knowledge.
 P60 exposes the Phase-3 runtime evidence baseline to MCP-connected agents
 through `mempal_phase3`. The MCP tool uses `action` values
 `record/list/stats/gate/research_validate_plan`, mirroring the P54-P59 CLI
-surfaces without adding new authority. `record` appends
-`runtime_adoption_events`; `list`, `stats`, `gate`, and
-`research_validate_plan` remain read-only. MCP research validation accepts a
-JSON report object and still does not ingest or promote knowledge.
+surfaces without adding new authority. Later Phase-3 actions extend this same
+bounded MCP surface. `record` appends `runtime_adoption_events`; `list`,
+`stats`, `gate`, and `research_validate_plan` remain read-only. MCP research
+validation accepts a JSON report object and still does not ingest or promote
+knowledge.
 
 P61 adds a read-only runtime adoption recording protocol through
 `mempal_phase3 action=guidance`. The guidance tells agents when to record
@@ -1345,6 +1346,15 @@ track, feature, and signal filtering without schema changes; signal filtering is
 applied after DB retrieval. This gives future default-on specs a compact
 evidence artifact while preserving the Phase-3 boundary: review reports do not
 write events, change gates, or authorize runtime default changes.
+
+P66 adds a read-only card-context default readiness report through
+`mempal phase3 readiness card-context-default` and
+`mempal_phase3 action=readiness` with `candidate=card-context-default`. The
+report reuses P65 review semantics filtered to `track=card_context` and
+`feature=include_cards`, then returns `writes=false`, `ready`, `decision`, the
+embedded review, and reasons. `ready=true` only means the surface is eligible
+for a future default-on spec; it does not change `mempal context` defaults,
+enable `include_cards`, mutate lifecycle state, or create card embeddings.
 
 ## Closing Summary
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1447,8 +1447,13 @@ Future P candidates:
   `capture` surfaces that map `surface/outcome` observations into existing
   checked runtime adoption records. It is dry-run by default, writes only with
   explicit execute, and does not add background instrumentation.
-- P73 candidate: evaluator advisory API contract with replayable outputs and no
-  lifecycle authority.
+- P73 evaluator advisory API: implemented as deterministic CLI/MCP advice
+  surfaces through `mempal phase3 evaluator advise` and
+  `mempal_phase3 action=evaluator_advise`. Advice output is replayable from
+  request fields, returns `writes=false`, `lifecycle_authority=false`,
+  `deterministic_gate_required=true`, reasons, and a `surface=evaluator`
+  adoption capture plan. It cannot mutate lifecycle state, satisfy reviewer
+  requirements, bypass gates, or call LLM/network evaluators.
 - P74 candidate: card-context default-on proposal gated by accumulated P66
   readiness evidence plus rollback criteria.
 

--- a/docs/MIND-MODEL-DESIGN.md
+++ b/docs/MIND-MODEL-DESIGN.md
@@ -1439,9 +1439,10 @@ Remaining gaps before full self-evolution:
 
 Future P candidates:
 
-- P71 candidate: self-evolution loop replay, an audit/test scenario that walks
-  from research evidence through distill, promotion gate, context use, and
-  `record_checked`.
+- P71 self-evolution loop replay: implemented as a CLI E2E replay test that
+  walks research -> evidence -> knowledge card -> gate/promote -> context ->
+  checked adoption record. This proves the existing pieces can compose, but it
+  does not add automatic runtime capture.
 - P72 candidate: adoption capture helper around agent tool outcomes, still
   explicit and reviewable, not background instrumentation.
 - P73 candidate: evaluator advisory API contract with replayable outputs and no

--- a/docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md
+++ b/docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md
@@ -1,0 +1,43 @@
+# P60 MCP Phase-3 Runtime Surface
+
+## Goal
+
+Expose the P54-P59 Phase-3 runtime evidence baseline to MCP-connected agents
+through one bounded `mempal_phase3` tool.
+
+## Scope
+
+- Add `specs/p60-mcp-phase3-runtime-surface.spec.md`.
+- Add MCP request/response DTOs for Phase-3 runtime evidence.
+- Add `mempal_phase3` MCP tool with actions:
+  - `record`
+  - `list`
+  - `stats`
+  - `gate`
+  - `research_validate_plan`
+- Update `MEMORY_PROTOCOL`, `docs/MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Do not change schema v9 or default runtime behavior.
+
+## Steps
+
+- [x] Write failing MCP tests for record/stats/gate, research validation, invalid
+  action, and tool registry/protocol visibility.
+- [x] Implement minimal `mempal_phase3` surface.
+- [x] Update memory protocol.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p60-mcp-phase3-runtime-surface.spec.md
+agent-spec lint specs/p60-mcp-phase3-runtime-surface.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3 --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
+++ b/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
@@ -1,0 +1,39 @@
+# P61 Runtime Adoption Recording Protocol
+
+## Goal
+
+Define deterministic guidance for when agents should record Phase-3 runtime
+adoption events through `mempal_phase3`.
+
+## Scope
+
+- Add `specs/p61-runtime-adoption-recording-protocol.spec.md`.
+- Extend `mempal_phase3` with read-only `action=guidance`.
+- Add guidance DTOs for required fields, optional fields, signal semantics, and
+  track semantics.
+- Update `MEMORY_PROTOCOL`, `docs/MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Do not add automatic event recording or runtime hooks.
+
+## Steps
+
+- [x] Write failing MCP tests for guidance response and protocol visibility.
+- [x] Implement read-only guidance action.
+- [x] Update memory protocol with recording semantics.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p61-runtime-adoption-recording-protocol.spec.md
+agent-spec lint specs/p61-runtime-adoption-recording-protocol.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+```

--- a/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
+++ b/docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md
@@ -22,7 +22,7 @@ adoption events through `mempal_phase3`.
 - [x] Update memory protocol with recording semantics.
 - [x] Update design and repository inventories.
 - [x] Run spec checks and Rust verification.
-- [ ] Commit, ingest decision memory, push, and open/merge PR.
+- [x] Commit, ingest decision memory, push, and open/merge PR.
 
 ## Verification
 

--- a/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
+++ b/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
@@ -1,0 +1,40 @@
+# P62 Runtime Adoption CLI Guidance
+
+## Goal
+
+Expose the P61 runtime adoption recording protocol through CLI parity:
+`mempal phase3 adoption guidance`.
+
+## Scope
+
+- Add `specs/p62-runtime-adoption-cli-guidance.spec.md`.
+- Add `mempal phase3 adoption guidance --format plain|json`.
+- Move runtime adoption guidance into shared core code used by MCP and CLI.
+- Update `MIND-MODEL-DESIGN.md`, `AGENTS.md`, and `CLAUDE.md`.
+- Preserve read-only behavior and avoid schema/runtime default changes.
+
+## Steps
+
+- [x] Write failing CLI guidance tests.
+- [x] Implement shared guidance data and CLI command.
+- [x] Keep MCP guidance on the shared implementation.
+- [x] Update design and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p62-runtime-adoption-cli-guidance.spec.md
+agent-spec lint specs/p62-runtime-adoption-cli-guidance.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_plain
+cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_rejects_invalid_format
+cargo test mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
+++ b/docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md
@@ -20,7 +20,7 @@ Expose the P61 runtime adoption recording protocol through CLI parity:
 - [x] Keep MCP guidance on the shared implementation.
 - [x] Update design and repository inventories.
 - [x] Run spec checks and Rust verification.
-- [ ] Commit, ingest decision memory, push, and open/merge PR.
+- [x] Commit, ingest decision memory, push, and open/merge PR.
 
 ## Verification
 

--- a/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
+++ b/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
@@ -1,0 +1,42 @@
+# P63 Runtime Adoption Record Helper
+
+## Goal
+
+Add a read-only helper that prepares exact runtime adoption `record` inputs
+without appending an event.
+
+## Scope
+
+- Add `specs/p63-runtime-adoption-record-helper.spec.md`.
+- Add CLI `mempal phase3 adoption prepare-record`.
+- Add MCP `mempal_phase3 action=prepare_record`.
+- Return `writes=false`, a CLI `record_command`, and an MCP `record_payload`.
+- Update `MEMORY_PROTOCOL`, `MIND-MODEL-DESIGN.md`, `AGENTS.md`, and
+  `CLAUDE.md`.
+- Preserve read-only behavior and avoid schema/runtime default changes.
+
+## Steps
+
+- [x] Write failing CLI and MCP prepare-record tests.
+- [x] Implement shared record helper output.
+- [x] Wire CLI and MCP surfaces.
+- [x] Update protocol, design, and repository inventories.
+- [x] Run spec checks and Rust verification.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p63-runtime-adoption-record-helper.spec.md
+agent-spec lint specs/p63-runtime-adoption-record-helper.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_plain
+cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_rejects_invalid_track
+cargo test mcp::server::tests::test_mcp_phase3_prepare_record_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
+++ b/docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md
@@ -22,7 +22,7 @@ without appending an event.
 - [x] Wire CLI and MCP surfaces.
 - [x] Update protocol, design, and repository inventories.
 - [x] Run spec checks and Rust verification.
-- [ ] Commit, ingest decision memory, push, and open/merge PR.
+- [x] Commit, ingest decision memory, push, and open/merge PR.
 
 ## Verification
 

--- a/docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md
+++ b/docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md
@@ -1,0 +1,34 @@
+# P64 Runtime Adoption Record Quality Policy
+
+Goal: add a read-only preflight quality check for candidate runtime adoption
+records. The check should help agents avoid writing low-signal Phase-3 evidence,
+without adding hooks, automatic writes, schema changes, or default runtime
+policy changes.
+
+Spec: `specs/p64-runtime-adoption-record-quality-policy.spec.md`
+
+## Steps
+
+- [x] Add shared core quality report types and policy logic.
+- [x] Add CLI `mempal phase3 adoption check-record` with plain/json output.
+- [x] Add MCP `mempal_phase3 action=check_record`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p64-runtime-adoption-record-quality-policy.spec.md
+agent-spec lint specs/p64-runtime-adoption-record-quality-policy.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_accepts_supported_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence
+cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_rejects_empty_feature
+cargo test mcp::server::tests::test_mcp_phase3_check_record_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p65-runtime-adoption-review-report.md
+++ b/docs/plans/2026-05-13-p65-runtime-adoption-review-report.md
@@ -1,0 +1,36 @@
+# P65 Runtime Adoption Review Report
+
+Goal: add a read-only report for accumulated Phase-3 runtime adoption evidence,
+so agents can review track/feature/signal evidence before proposing stronger
+runtime defaults.
+
+Spec: `specs/p65-runtime-adoption-review-report.spec.md`
+
+## Steps
+
+- [x] Add shared review report types and aggregation logic.
+- [x] Add CLI `mempal phase3 adoption review` with plain/json output.
+- [x] Add MCP `mempal_phase3 action=review`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Stabilize the existing CLI knowledge-card retrieval test harness timeout
+  observed during full verification; production code unchanged.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p65-runtime-adoption-review-report.spec.md
+agent-spec lint specs/p65-runtime-adoption-review-report.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_summarizes_events
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_filters_signal
+cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_no_evidence_read_only
+cargo test mcp::server::tests::test_mcp_phase3_review_action_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p66-card-context-default-readiness.md
+++ b/docs/plans/2026-05-13-p66-card-context-default-readiness.md
@@ -1,0 +1,36 @@
+# P66 Card Context Default Readiness
+
+Goal: add a read-only readiness report that uses existing `card_context`
+runtime adoption evidence for `include_cards` to decide whether card-aware
+context is eligible for a future default-on spec. This does not enable cards by
+default.
+
+Spec: `specs/p66-card-context-default-readiness.spec.md`
+
+## Steps
+
+- [x] Add shared readiness report types and card-context default readiness logic.
+- [x] Add CLI `mempal phase3 readiness card-context-default`.
+- [x] Add MCP `mempal_phase3 action=readiness`.
+- [x] Update protocol, MIND-MODEL design, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p66-card-context-default-readiness.spec.md
+agent-spec lint specs/p66-card-context-default-readiness.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_ready
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_without_evidence
+cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_rollback
+cargo test --test phase3_runtime test_cli_phase3_readiness_rejects_unknown_candidate
+cargo test mcp::server::tests::test_mcp_phase3_readiness_card_context_default_is_read_only --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p67-research-adapter-ingest.md
+++ b/docs/plans/2026-05-13-p67-research-adapter-ingest.md
@@ -1,0 +1,35 @@
+# P67 Research Adapter Evidence Ingest
+
+Goal: add an explicit evidence-first CLI bridge from validated external research
+reports into mempal evidence drawers without creating knowledge or bypassing
+lifecycle gates.
+
+Spec: `specs/p67-research-adapter-ingest.spec.md`
+
+## Steps
+
+- [x] Add P67 task contract and plan.
+- [x] Add RED CLI tests for dry-run, execute/idempotency, invalid input, and format rejection.
+- [x] Implement shared research ingest planning in `src/main.rs`.
+- [x] Implement `mempal phase3 research-ingest-plan` dry-run and `--execute` paths.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p67-research-adapter-ingest.spec.md
+agent-spec lint specs/p67-research-adapter-ingest.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_execute_writes_research_evidence
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_invalid_report_no_write
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_rejects_invalid_format
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
+++ b/docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
@@ -1,0 +1,36 @@
+# P68 MCP Research Ingest Plan
+
+Goal: expose P67 research evidence ingest planning through `mempal_phase3` as a
+read-only MCP action, while keeping all writes limited to the existing CLI
+`--execute` path.
+
+Spec: `specs/p68-mcp-research-ingest-plan.spec.md`
+
+## Steps
+
+- [x] Add P68 task contract and plan.
+- [x] Add RED MCP tests for valid dry-run, invalid report, action list, and protocol registry.
+- [x] Move P67 pure planning helpers into shared `src/core/phase3.rs`.
+- [x] Wire CLI and MCP to the shared planner without changing P67 CLI behavior.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p68-mcp-research-ingest-plan.spec.md
+agent-spec lint specs/p68-mcp-research-ingest-plan.spec.md --min-score 0.7
+cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_invalid_report_no_write --lib
+cargo test mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
+++ b/docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
@@ -1,0 +1,37 @@
+# P69 Runtime Adoption Checked Record
+
+Goal: add a quality-gated runtime adoption write path so agents can append
+Phase-3 evidence only after the P64 policy has been evaluated.
+
+Spec: `specs/p69-runtime-adoption-checked-record.spec.md`
+
+## Steps
+
+- [x] Add P69 task contract and plan.
+- [x] Add RED CLI and MCP tests for ready, warning-blocked, warning-allowed, and invalid-blocked behavior.
+- [x] Add checked-record response types and core decision helper.
+- [x] Wire CLI `mempal phase3 adoption record-checked`.
+- [x] Wire MCP `mempal_phase3 action=record_checked`.
+- [x] Update MIND-MODEL, AGENTS, and CLAUDE docs.
+- [x] Verify targeted tests, full local checks, spec parse/lint, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p69-runtime-adoption-checked-record.spec.md
+agent-spec lint specs/p69-runtime-adoption-checked-record.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_writes_ready_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_warning_by_default
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings
+cargo test mcp::server::tests::test_mcp_phase3_record_checked_quality_gated --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
@@ -1,0 +1,31 @@
+# P70 Self-Evolution Completion Audit
+
+Goal: audit the "complete self-evolving agent system" objective against actual
+P-level artifacts, record what is implemented, and list the remaining gaps
+without changing runtime behavior.
+
+Spec: `specs/p70-self-evolution-completion-audit.spec.md`
+
+## Steps
+
+- [x] Add P70 task contract and plan.
+- [x] Add a P70 audit section to `docs/MIND-MODEL-DESIGN.md`.
+- [x] Map objective deliverables to concrete P-level artifacts and evidence.
+- [x] Record the explicit non-completion conclusion and remaining gaps.
+- [x] Update AGENTS and CLAUDE inventories.
+- [x] Verify spec parse/lint, grep acceptance checks, audit-only boundary, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p70-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p70-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P70 self-evolution completion audit|Complete self-evolving agent system deliverables" docs/MIND-MODEL-DESIGN.md
+rg -n "Evidence substrate.*P54|Knowledge governance.*P12-P28|Knowledge cards.*P31-P45|Research ingestion.*P49/P59/P67/P68|Runtime adoption.*P54-P69" docs/MIND-MODEL-DESIGN.md
+rg -n "P70 conclusion: not complete|Remaining gaps before full self-evolution" docs/MIND-MODEL-DESIGN.md
+rg -n "P71 candidate|P72 candidate|P73 candidate" docs/MIND-MODEL-DESIGN.md
+rg -n "p70-self-evolution-completion-audit|P70 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/docs/plans/2026-05-13-p71-self-evolution-loop-replay.md
+++ b/docs/plans/2026-05-13-p71-self-evolution-loop-replay.md
@@ -1,0 +1,31 @@
+# P71 Self-Evolution Loop Replay
+
+Goal: add a deterministic, test-backed replay proving that the implemented
+Phase-3 pieces can form one self-evolution loop without changing runtime
+defaults.
+
+Spec: `specs/p71-self-evolution-loop-replay.spec.md`
+
+## Steps
+
+- [x] Add P71 task contract and plan.
+- [x] Add a CLI E2E replay test for research -> evidence -> card -> context -> checked adoption.
+- [x] Add invalid research no-artifact replay coverage.
+- [x] Update MIND-MODEL and agent inventories with P71.
+- [x] Verify spec parse/lint, targeted tests, boundary, formatting, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p71-self-evolution-loop-replay.spec.md
+agent-spec lint specs/p71-self-evolution-loop-replay.spec.md --min-score 0.7
+cargo test --test phase3_self_evolution_replay test_cli_self_evolution_replay_research_to_context_to_adoption
+cargo test --test phase3_self_evolution_replay test_cli_self_evolution_replay_invalid_research_no_artifacts
+rg -n "p71-self-evolution-loop-replay|P71 self-evolution loop replay" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+git diff --name-only main...HEAD
+cargo fmt -- --check
+cargo check
+cargo test --test phase3_self_evolution_replay
+git diff --check
+```

--- a/docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
+++ b/docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
@@ -1,0 +1,39 @@
+# P72 Runtime Adoption Capture Helper
+
+Goal: add an explicit capture helper that turns low-friction
+`surface/outcome` runtime observations into existing checked runtime adoption
+records.
+
+Spec: `specs/p72-runtime-adoption-capture-helper.spec.md`
+
+## Steps
+
+- [x] Add P72 task contract and plan.
+- [x] Add failing CLI capture tests for dry-run, execute, warning block, and invalid surface.
+- [x] Add failing MCP capture test for dry-run and execute.
+- [x] Implement pure capture mapping and checked-write reuse in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 adoption capture`.
+- [x] Wire MCP `mempal_phase3 action=capture`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p72-runtime-adoption-capture-helper.spec.md
+agent-spec lint specs/p72-runtime-adoption-capture-helper.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_card_context_dry_run
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_execute_writes_ready_event
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_blocks_warning_by_default
+cargo test --test phase3_runtime test_cli_phase3_adoption_capture_rejects_unknown_surface
+cargo test mcp::server::tests::test_mcp_phase3_capture_action_dry_run_and_execute --lib
+rg -n "p72-runtime-adoption-capture-helper|P72 runtime adoption capture helper" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p73-evaluator-advisory-api.md
+++ b/docs/plans/2026-05-13-p73-evaluator-advisory-api.md
@@ -1,0 +1,40 @@
+# P73 Evaluator Advisory API
+
+Goal: add a deterministic, replayable evaluator advice surface that preserves
+the P50 advisory-only lifecycle boundary.
+
+Spec: `specs/p73-evaluator-advisory-api.spec.md`
+
+## Steps
+
+- [x] Add P73 task contract and plan.
+- [x] Add failing CLI tests for supportive advice, dao_tian human review,
+  weak/risky recommendations, and missing evaluator validation.
+- [x] Add failing MCP test for read-only `evaluator_advise`.
+- [x] Implement pure evaluator advice policy in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 evaluator advise`.
+- [x] Wire MCP `mempal_phase3 action=evaluator_advise`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests,
+  and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p73-evaluator-advisory-api.spec.md
+agent-spec lint specs/p73-evaluator-advisory-api.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_supportive_read_only
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_dao_tian_requires_human_review
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk
+cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_rejects_missing_evaluator
+cargo test mcp::server::tests::test_mcp_phase3_evaluator_advise_action_is_read_only --lib
+rg -n "p73-evaluator-advisory-api|P73 evaluator advisory API" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p74-card-context-default-proposal.md
+++ b/docs/plans/2026-05-13-p74-card-context-default-proposal.md
@@ -1,0 +1,42 @@
+# P74 Card Context Default-On Proposal
+
+Goal: add a read-only proposal artifact for card-context default-on readiness
+that combines P66 readiness with explicit rollback criteria while keeping
+`include_cards` opt-in.
+
+Spec: `specs/p74-card-context-default-proposal.spec.md`
+
+## Steps
+
+- [x] Add P74 task contract and plan.
+- [x] Add failing CLI tests for ready proposal, missing rollback criteria,
+  missing readiness, context default unchanged, and unknown candidate.
+- [x] Add failing MCP test for read-only `default_proposal`.
+- [x] Implement pure default proposal policy in `src/core/phase3.rs`.
+- [x] Wire CLI `mempal phase3 default-proposal card-context`.
+- [x] Wire MCP `mempal_phase3 action=default_proposal`.
+- [x] Update protocol/tool descriptions and inventories.
+- [x] Verify spec parse/lint, targeted tests, formatting, clippy, full tests,
+  and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p74-card-context-default-proposal.spec.md
+agent-spec lint specs/p74-card-context-default-proposal.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_card_context_ready
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_requires_rollback_criteria
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_blocks_without_readiness
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_keeps_context_cards_opt_in
+cargo test --test phase3_runtime test_cli_phase3_default_proposal_rejects_unknown_candidate
+cargo test mcp::server::tests::test_mcp_phase3_default_proposal_card_context_is_read_only --lib
+rg -n "p74-card-context-default-proposal|P74 card context default-on proposal" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
@@ -1,0 +1,29 @@
+# P75 Self-Evolution Completion Audit
+
+Goal: re-audit the complete self-evolving agent objective after P71-P74 and
+record what is complete versus what still remains.
+
+Spec: `specs/p75-self-evolution-completion-audit.spec.md`
+
+## Steps
+
+- [x] Add P75 task contract and plan.
+- [x] Inspect P71-P74 specs, tests, protocol entries, inventories, and main CI evidence.
+- [x] Add P75 completion audit to `docs/MIND-MODEL-DESIGN.md`.
+- [x] Update AGENTS/CLAUDE spec and plan inventories.
+- [x] Verify spec parse/lint and audit grep selectors.
+- [x] Verify P75 is audit-only with changed-file boundaries.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p75-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p75-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P75 self-evolution completion audit|P75 conclusion" docs/MIND-MODEL-DESIGN.md
+rg -n "P75 prompt-to-artifact checklist|P71.*phase3_self_evolution_replay|P72.*capture|P73.*evaluator_advise|P74.*default_proposal" docs/MIND-MODEL-DESIGN.md
+rg -n "P75 conclusion: not complete|Remaining gaps after P75|no automatic live tool instrumentation|no rollback executor|no actual default-on runtime change" docs/MIND-MODEL-DESIGN.md
+rg -n "p75-self-evolution-completion-audit|P75 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/docs/plans/2026-05-13-p76-spec-completeness-invariant.md
+++ b/docs/plans/2026-05-13-p76-spec-completeness-invariant.md
@@ -1,0 +1,31 @@
+# P76 Spec Completeness Invariant
+
+Goal: codify the project governance rule that every numbered P must leave both
+a task spec and a matching plan before it can be considered complete.
+
+Spec: `specs/p76-spec-completeness-invariant.spec.md`
+
+## Steps
+
+- [x] Add P76 task contract and plan.
+- [x] Update AGENTS/CLAUDE Spec system rules with the hard invariant.
+- [x] Add P76 to completed spec and plan inventories.
+- [x] Add a MIND-MODEL governance note and renumber the next recommended P
+      candidates after reserving P76.
+- [x] Verify spec parse/lint and grep selectors.
+- [x] Verify P76 is governance-only with changed-file boundaries.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p76-spec-completeness-invariant.spec.md
+agent-spec lint specs/p76-spec-completeness-invariant.spec.md --min-score 0.7
+rg -n "Every future numbered P must include|docs/plans/.*pNN|documentation-only, audit-only, policy-only" specs/p76-spec-completeness-invariant.spec.md
+rg -n "每一个 numbered P|specs/pNN-\\*\\.spec\\.md|docs/plans/.*pNN|文档-only|audit-only|policy-only" AGENTS.md CLAUDE.md
+rg -n "p76-spec-completeness-invariant|P76 spec completeness invariant" AGENTS.md CLAUDE.md
+rg -n "P76 spec completeness invariant|Every P must leave a spec|future P numbering" docs/MIND-MODEL-DESIGN.md
+rg -n "不能算完成|spec-less P|missing spec|必须留下.*spec" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+git diff --name-only main...HEAD
+git diff --check
+```

--- a/docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
+++ b/docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
@@ -1,0 +1,37 @@
+# P77 Live Adoption Instrumentation Boundary
+
+Goal: expose a deterministic read-only Phase-3 policy surface that defines which
+live adoption instrumentation modes are allowed before any hooks or tool wrappers
+are implemented.
+
+Spec: `specs/p77-live-adoption-instrumentation-boundary.spec.md`
+
+## Steps
+
+- [x] Add P77 task contract and plan.
+- [x] Add failing CLI tests for `mempal phase3 adoption instrumentation-policy`.
+- [x] Add failing MCP test for `mempal_phase3 action=instrumentation_policy`.
+- [x] Implement pure instrumentation policy DTOs in `src/core/phase3.rs`.
+- [x] Wire CLI and MCP read-only surfaces.
+- [x] Update protocol text, AGENTS/CLAUDE inventories, and MIND-MODEL summary.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p77-live-adoption-instrumentation-boundary.spec.md
+agent-spec lint specs/p77-live-adoption-instrumentation-boundary.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_json_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format
+cargo test mcp::server::tests::test_mcp_phase3_instrumentation_policy_action_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+rg -n "p77-live-adoption-instrumentation-boundary|P77 live adoption instrumentation boundary" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
+++ b/docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
@@ -1,0 +1,40 @@
+# P78 Card Context Default Runtime Flag
+
+Goal: add an explicit, reversible runtime config flag for card-aware context
+defaults, gated by P74 proposal readiness when enabling.
+
+Spec: `specs/p78-card-context-default-runtime-flag.spec.md`
+
+## Steps
+
+- [x] Add P78 task contract and plan.
+- [x] Add failing context tests for config default false/true and explicit disable override.
+- [x] Add failing MCP context test for omitted `include_cards` using config default.
+- [x] Add failing Phase-3 default-control enable/disable tests.
+- [x] Add `context.include_cards_default` config load/save support.
+- [x] Wire CLI and MCP context default resolution.
+- [x] Implement `mempal phase3 default-control card-context` enable/disable.
+- [x] Update protocol text, AGENTS/CLAUDE inventories, and MIND-MODEL summary.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+- [ ] Commit, ingest decision memory, push, and open/merge PR.
+
+## Verification
+
+```bash
+agent-spec parse specs/p78-card-context-default-runtime-flag.spec.md
+agent-spec lint specs/p78-card-context-default-runtime-flag.spec.md --min-score 0.7
+cargo test --test context_assembler test_cli_context_config_default_false_omits_cards
+cargo test --test context_assembler test_cli_context_config_default_true_includes_cards
+cargo test --test context_assembler test_cli_context_no_include_cards_overrides_config_default_true
+cargo test mcp::server::tests::test_mcp_context_include_cards_omitted_uses_config_default --lib
+cargo test --test phase3_runtime test_cli_phase3_default_control_enable_requires_ready_proposal
+cargo test --test phase3_runtime test_cli_phase3_default_control_disable_is_reversible
+rg -n "p78-card-context-default-runtime-flag|P78 card context default runtime flag" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+git diff --check
+```

--- a/docs/plans/2026-05-13-p79-rollback-executor-policy.md
+++ b/docs/plans/2026-05-13-p79-rollback-executor-policy.md
@@ -1,0 +1,34 @@
+# P79 Rollback Executor Policy
+
+Spec: `specs/p79-rollback-executor-policy.spec.md`
+
+## Checklist
+
+- [x] Add P79 task contract and plan.
+- [x] Add core rollback-control report logic for `card-context`.
+- [x] Add CLI `mempal phase3 rollback-control card-context`.
+- [x] Add MCP `mempal_phase3 action=rollback_control`.
+- [x] Update protocol, AGENTS/CLAUDE inventory, and MIND-MODEL-DESIGN.
+- [x] Verify spec parse/lint, targeted tests, fmt/check/clippy/test, and diff check.
+
+## Verification
+
+```bash
+agent-spec parse specs/p79-rollback-executor-policy.spec.md
+agent-spec lint specs/p79-rollback-executor-policy.spec.md --min-score 0.7
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_check_is_read_only
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_disables_default
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_without_signal_is_noop
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_already_disabled_is_noop
+cargo test --test phase3_runtime test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write
+cargo test mcp::server::tests::test_mcp_phase3_rollback_control_check_is_read_only --lib
+cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+cargo fmt -- --check
+cargo check
+cargo check --features rest
+cargo clippy -- -D warnings
+cargo clippy --features rest -- -D warnings
+cargo test
+cargo test --features rest
+git diff --check
+```

--- a/docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
+++ b/docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
@@ -1,0 +1,25 @@
+# P80 Autonomous Promotion Boundary Audit
+
+Spec: `specs/p80-autonomous-promotion-boundary-audit.spec.md`
+
+## Checklist
+
+- [x] Add P80 task contract and plan.
+- [x] Update `docs/MIND-MODEL-DESIGN.md` with the autonomous promotion boundary.
+- [x] Update `src/core/protocol.rs` so agents do not infer autonomous lifecycle authority.
+- [x] Update AGENTS/CLAUDE spec and plan inventory.
+- [x] Verify spec parse/lint, grep-based acceptance checks, fmt/check where relevant, and diff boundary.
+
+## Verification
+
+```bash
+agent-spec parse specs/p80-autonomous-promotion-boundary-audit.spec.md
+agent-spec lint specs/p80-autonomous-promotion-boundary-audit.spec.md --min-score 0.7
+rg -n "P80 autonomous promotion boundary audit|human-gated lifecycle authority|autonomous promotion is out of scope" docs/MIND-MODEL-DESIGN.md
+rg -n "must not autonomously promote|human/operator-triggered lifecycle mutation|evaluator advice remains advisory" src/core/protocol.rs
+rg -n "p80-autonomous-promotion-boundary-audit|P80 autonomous promotion boundary audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+cargo fmt -- --check
+cargo check
+git diff --check
+```

--- a/docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
+++ b/docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
@@ -1,0 +1,25 @@
+# P81 Self-Evolution Completion Audit
+
+Spec: `specs/p81-self-evolution-completion-audit.spec.md`
+
+## Checklist
+
+- [x] Add P81 task contract and plan.
+- [x] Update `docs/MIND-MODEL-DESIGN.md` with final objective restatement, prompt-to-artifact checklist, evidence, conclusion, and residual boundary.
+- [x] Update AGENTS/CLAUDE spec and plan inventory.
+- [x] Verify spec parse/lint, grep-based acceptance checks, diff boundary, fmt/check, and mainline evidence references.
+
+## Verification
+
+```bash
+agent-spec parse specs/p81-self-evolution-completion-audit.spec.md
+agent-spec lint specs/p81-self-evolution-completion-audit.spec.md --min-score 0.7
+rg -n "P81 self-evolution completion audit|Objective restatement|governed human-gated complete self-evolving agent system" docs/MIND-MODEL-DESIGN.md
+rg -n "Prompt-to-artifact checklist|Evidence substrate|Knowledge governance|Runtime feedback loop|Rollback and default control|Lifecycle authority boundary|Mainline verification" docs/MIND-MODEL-DESIGN.md
+rg -n "P81 conclusion: complete|Residual boundary|fully autonomous lifecycle mutation remains out of scope" docs/MIND-MODEL-DESIGN.md
+rg -n "p81-self-evolution-completion-audit|P81 self-evolution completion audit" AGENTS.md CLAUDE.md
+git diff --name-only main...HEAD
+cargo fmt -- --check
+cargo check
+git diff --check
+```

--- a/specs/p60-mcp-phase3-runtime-surface.spec.md
+++ b/specs/p60-mcp-phase3-runtime-surface.spec.md
@@ -1,0 +1,98 @@
+spec: task
+name: "P60: MCP Phase-3 runtime surface"
+inherits: project
+tags: ["phase-3", "mcp", "runtime-adoption"]
+---
+
+## Intent
+
+P54-P59 exposed Phase-3 runtime adoption evidence through CLI, but agent runtime
+primarily uses MCP. P60 adds one minimal MCP surface, `mempal_phase3`, so agents
+can record runtime adoption events, inspect adoption evidence, evaluate Phase-3
+readiness gates, and validate external research report contracts without
+shelling out.
+
+## Decisions
+
+- Add one MCP tool named `mempal_phase3`.
+- Use an `action` field instead of multiple tools.
+- Supported actions are `record`, `list`, `stats`, `gate`, and `research_validate_plan`.
+- `record` appends a `runtime_adoption_events` row using the existing schema v9 table.
+- `list`, `stats`, `gate`, and `research_validate_plan` are read-only.
+- MCP `research_validate_plan` accepts a JSON `report` object rather than a filesystem path.
+- The tool must preserve P56-P59 boundaries: no default card context enablement, no card vector schema, no evaluator lifecycle mutation, and no promoted/canonical research ingestion.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/mcp/server.rs`
+- `src/mcp/tools.rs`
+- `src/core/protocol.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-05-p60-mcp-phase3-runtime-surface.md`
+- `specs/p60-mcp-phase3-runtime-surface.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+
+- Do not add schema v10 or modify `runtime_adoption_events`.
+- Do not add card vector tables or card embeddings.
+- Do not change `mempal context` / `mempal_context` default `include_cards` behavior.
+- Do not let evaluator signals mutate knowledge drawer or knowledge card lifecycle state.
+- Do not ingest research reports or create promoted/canonical knowledge from this MCP tool.
+- Do not add REST API endpoints.
+
+## Acceptance Criteria
+
+Scenario: MCP records and summarizes Phase-3 adoption events
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_record_stats_and_gate_actions
+  Level: unit
+  Given an empty test database at schema v9
+  When `mempal_phase3` records three `card_context` accepted events for `include_cards`
+  Then the response returns the created event ids
+  And `action=stats` reports `accepted=3` and `rollbacks=0`
+  And `action=gate` for `card-context-default` reports `ready=true`
+
+Scenario: MCP research validation is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_research_validate_plan_is_read_only
+  Level: unit
+  Given a valid external research report JSON object
+  When `mempal_phase3` runs `action=research_validate_plan`
+  Then the response reports `valid=true`
+  And the drawer count is unchanged
+  And no runtime adoption event is inserted
+
+Scenario: invalid MCP action is rejected without mutation
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation
+  Level: unit
+  Given a database with zero runtime adoption events
+  When `mempal_phase3` is called with unsupported `action=promote`
+  Then the request fails with an invalid action error
+  And the runtime adoption event count remains unchanged
+
+Scenario: MCP tool registry and protocol advertise Phase-3 surface
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface
+  Level: unit
+  Given the MCP server tool registry
+  When listing available tools
+  Then `mempal_phase3` exists
+  And its description lists `record/list/stats/gate/research_validate_plan`
+  And `MEMORY_PROTOCOL` mentions `mempal_phase3` and runtime adoption evidence
+
+## Out of Scope
+
+- Automatic runtime adoption recording protocol.
+- Card context default-on behavior.
+- Card-level embeddings.
+- Evaluator advisory API response contracts beyond the read-only gate.
+- Research adapter apply/ingest behavior.

--- a/specs/p61-runtime-adoption-recording-protocol.spec.md
+++ b/specs/p61-runtime-adoption-recording-protocol.spec.md
@@ -1,0 +1,85 @@
+spec: task
+name: "P61: runtime adoption recording protocol"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "mcp", "protocol"]
+---
+
+## Intent
+
+P60 made Phase-3 runtime evidence writable through MCP, but agents still need a
+deterministic protocol for when to record `used`, `accepted`, `rejected`,
+`miss`, `rollback`, `contradiction`, or `neutral`. P61 adds a read-only guidance
+surface and protocol text so agents can record concrete runtime outcomes without
+turning speculative reasoning into evidence.
+
+## Decisions
+
+- Extend `mempal_phase3` with `action=guidance`.
+- `guidance` is read-only and must not write `runtime_adoption_events`, drawers,
+  knowledge cards, or lifecycle events.
+- Guidance version starts at `1`.
+- Required record fields are `track`, `signal`, and `feature`.
+- Guidance defines signal semantics for `used`, `accepted`, `rejected`, `miss`,
+  `rollback`, `contradiction`, and `neutral`.
+- Guidance defines track semantics and feature examples for `runtime_adoption`,
+  `card_context`, `card_embedding`, `evaluator`, and `research_adapter`.
+- `MEMORY_PROTOCOL` must tell agents to call `action=guidance` when unsure and
+  to record only concrete runtime outcomes, not speculation.
+
+## Boundaries
+
+### Allowed Changes
+
+- `src/mcp/server.rs`
+- `src/mcp/tools.rs`
+- `src/core/protocol.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-10-p61-runtime-adoption-recording-protocol.md`
+- `specs/p61-runtime-adoption-recording-protocol.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change P56-P60 gates.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not let evaluator or research guidance mutate lifecycle state.
+
+## Acceptance Criteria
+
+Scenario: guidance action returns recording protocol without side effects
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_guidance_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=guidance`
+  Then the response includes `version=1`
+  And the response states that only concrete runtime outcomes should be recorded
+  And the response includes required fields `track`, `signal`, and `feature`
+  And the response defines `used` and `rollback` signal semantics
+  And the response includes `card_context` with `include_cards` as a feature example
+  And drawer and runtime adoption event counts remain unchanged
+
+Scenario: protocol advertises guidance action and signal semantics
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface
+  Level: unit
+  Given the MCP tool registry and memory protocol
+  When inspecting `mempal_phase3`
+  Then the description lists `guidance/record/list/stats/gate/research_validate_plan`
+  And `MEMORY_PROTOCOL` mentions `action=guidance`
+  And `MEMORY_PROTOCOL` explains `used` and `rollback` recording semantics
+
+## Out of Scope
+
+- Automatic adoption recording after tool calls.
+- Runtime hooks for Claude, Codex, or other agents.
+- Adoption-event deduplication.
+- Aggregated analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/specs/p62-runtime-adoption-cli-guidance.spec.md
+++ b/specs/p62-runtime-adoption-cli-guidance.spec.md
@@ -1,0 +1,91 @@
+spec: task
+name: "P62: runtime adoption CLI guidance"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "cli", "protocol"]
+---
+
+## Intent
+
+P61 exposed the runtime adoption recording protocol through MCP, but the CLI
+surface still lacks the same read-only guidance. P62 adds CLI parity through
+`mempal phase3 adoption guidance` so humans and non-MCP agents can inspect the
+same deterministic recording semantics before appending runtime evidence.
+
+## Decisions
+
+- Add `mempal phase3 adoption guidance`.
+- Support `--format plain` and `--format json`.
+- The CLI and MCP guidance must come from one shared implementation, not two
+  independent copies.
+- Guidance remains read-only and must not write drawers, runtime adoption
+  events, knowledge cards, or lifecycle events.
+- Guidance includes version, recording rule, required fields, optional fields,
+  signal semantics, and track semantics.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/**`
+- `src/main.rs`
+- `src/mcp/**`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-12-p62-runtime-adoption-cli-guidance.md`
+- `specs/p62-runtime-adoption-cli-guidance.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not let CLI guidance mutate lifecycle state.
+
+## Acceptance Criteria
+
+Scenario: CLI guidance returns JSON without side effects
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_json_is_read_only
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance --format json`
+  Then stdout is valid JSON
+  And the response includes `version=1`
+  And the response states that only concrete runtime outcomes should be recorded
+  And required fields include `track`, `signal`, and `feature`
+  And signal guidance includes `used` and `rollback`
+  And track guidance includes `card_context` with `include_cards`
+  And runtime adoption event count remains zero
+
+Scenario: CLI guidance supports plain output
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_plain
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance`
+  Then stdout mentions `version=1`
+  And stdout mentions `recording_rule=record only concrete runtime outcomes, not speculation`
+  And stdout mentions `signal=used`
+  And stdout mentions `track=card_context`
+
+Scenario: CLI guidance rejects unsupported format
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_guidance_rejects_invalid_format
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption guidance --format yaml`
+  Then the command fails
+  And stderr mentions `unsupported phase3 adoption format`
+
+## Out of Scope
+
+- MCP behavior changes beyond reusing the shared guidance implementation.
+- Adoption-event deduplication.
+- New analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/specs/p63-runtime-adoption-record-helper.spec.md
+++ b/specs/p63-runtime-adoption-record-helper.spec.md
@@ -1,0 +1,104 @@
+spec: task
+name: "P63: runtime adoption record helper"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "cli", "mcp"]
+---
+
+## Intent
+
+P61 and P62 expose when runtime adoption evidence should be recorded, but
+agents still have to manually assemble the exact `record` parameters. P63 adds
+a read-only helper that validates and normalizes candidate record inputs, then
+returns the equivalent CLI command and MCP payload without appending an event.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption prepare-record`.
+- Add MCP `mempal_phase3 action=prepare_record`.
+- The helper validates `track`, `signal`, `feature`, and optional metadata JSON
+  using the same parsing rules as `record`.
+- The helper returns `writes=false`, a CLI `record_command`, and an MCP
+  `record_payload`.
+- The helper must not generate a runtime event id unless the caller explicitly
+  supplied one.
+- The helper is read-only and must not insert runtime adoption events.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-12-p63-runtime-adoption-record-helper.md`
+- `specs/p63-runtime-adoption-record-helper.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not create runtime adoption event ids for dry-run helper calls unless an
+  explicit id was provided.
+
+## Acceptance Criteria
+
+Scenario: CLI prepare-record returns JSON without writing events
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_json_is_read_only
+  Level: integration
+  Given an empty CLI HOME
+  And `skill trigger` is the query text
+  When running `mempal phase3 adoption prepare-record --track card_context --signal accepted --feature include_cards --query "skill trigger" --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `record_command` starts with `mempal phase3 adoption record`
+  And `record_payload.action` is `record`
+  And `record_payload.track` is `card_context`
+  And runtime adoption event count remains zero
+
+Scenario: CLI prepare-record supports plain output
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_plain
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption prepare-record --track card_context --signal used --feature include_cards`
+  Then stdout mentions `writes=false`
+  And stdout mentions `mempal phase3 adoption record`
+  And stdout mentions `action=record`
+
+Scenario: CLI prepare-record rejects invalid track
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_prepare_record_rejects_invalid_track
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption prepare-record --track invalid --signal accepted --feature x`
+  Then the command fails
+  And stderr mentions `unsupported runtime adoption track`
+
+Scenario: MCP prepare_record is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_prepare_record_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=prepare_record`
+  Then the response includes `writes=false`
+  And the response includes a `record_payload` with `action=record`
+  And runtime adoption event count remains zero
+
+## Out of Scope
+
+- Automatic recording after helper output.
+- Adoption-event deduplication.
+- New analytics beyond existing `stats`.
+- Any default-on policy changes.

--- a/specs/p64-runtime-adoption-record-quality-policy.spec.md
+++ b/specs/p64-runtime-adoption-record-quality-policy.spec.md
@@ -1,0 +1,116 @@
+spec: task
+name: "P64: runtime adoption record quality policy"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "quality", "cli", "mcp"]
+---
+
+## Intent
+
+P63 can prepare exact runtime adoption record inputs, but it does not tell
+agents whether the proposed event is high-quality enough to preserve as Phase-3
+evidence. P64 adds a read-only quality policy that evaluates candidate adoption
+record fields before writing, so agents can avoid low-signal evidence without
+adding automatic recording or new runtime authority.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption check-record`.
+- Add MCP `mempal_phase3 action=check_record`.
+- The quality policy reuses the same `track`, `signal`, `feature`, and optional
+  metadata parsing rules as `prepare-record` and `record`.
+- The response returns `writes=false`, `valid`, `quality`, `errors`, and
+  `warnings`.
+- Empty `feature` is an error.
+- `accepted`, `rejected`, `miss`, `rollback`, and `contradiction` should include
+  a concrete `note` or `query`; missing both is a warning.
+- Track-specific references are warnings, not hard errors:
+  `card_context`/`card_embedding` prefer `card_id`, `evaluator` prefers
+  `evaluator_id`, and `research_adapter` prefers `research_report_id`.
+- The check remains advisory and must not append runtime adoption events.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p64-runtime-adoption-record-quality-policy.md`
+- `specs/p64-runtime-adoption-record-quality-policy.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not block `record`; this policy is a preflight/advisory check only.
+
+## Acceptance Criteria
+
+Scenario: CLI check-record accepts a well-supported event
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_accepts_supported_event
+  Level: integration
+  Given an empty CLI HOME
+  And `skill trigger` is the query text
+  And `card evidence helped` is the note text
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature include_cards --query "skill trigger" --card-id card_1 --note "card evidence helped" --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `valid` is true
+  And `quality` is `ready`
+  And `errors` is empty
+  And runtime adoption event count remains zero
+
+Scenario: CLI check-record warns on weak evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature include_cards --format json`
+  Then stdout is valid JSON
+  And `valid` is true
+  And `quality` is `warning`
+  And `warnings` mentions missing concrete outcome context
+  And `warnings` mentions missing `card_id`
+  And runtime adoption event count remains zero
+
+Scenario: CLI check-record rejects empty feature
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_check_record_rejects_empty_feature
+  Level: integration
+  Given an empty CLI HOME
+  And the feature text contains only spaces
+  When running `mempal phase3 adoption check-record --track card_context --signal accepted --feature "   " --format json`
+  Then the command succeeds with an advisory JSON response
+  And `valid` is false
+  And `quality` is `invalid`
+  And `errors` mentions `feature must not be empty`
+  And runtime adoption event count remains zero
+
+Scenario: MCP check_record is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_check_record_action_is_read_only
+  Level: unit
+  Given an empty test database
+  When `mempal_phase3` is called with `action=check_record`
+  Then the response includes `writes=false`
+  And the response includes a quality report
+  And runtime adoption event count remains zero
+
+## Out of Scope
+
+- Automatic recording after quality checks.
+- Deduplicating or modifying existing adoption events.
+- New readiness thresholds for Phase-3 gates.
+- Default-on runtime policy changes.

--- a/specs/p65-runtime-adoption-review-report.spec.md
+++ b/specs/p65-runtime-adoption-review-report.spec.md
@@ -1,0 +1,115 @@
+spec: task
+name: "P65: runtime adoption review report"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "review", "cli", "mcp"]
+---
+
+## Intent
+
+P54-P64 can collect and preflight runtime adoption events, but agents still need
+a compact way to review accumulated evidence before proposing stronger runtime
+defaults. P65 adds a read-only review report that summarizes adoption events by
+track, feature, and signal so future defaulting specs can cite concrete evidence
+instead of raw event lists.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption review`.
+- Add MCP `mempal_phase3 action=review`.
+- Review accepts optional `track`, `feature`, `signal`, `limit`, and `format`
+  filters.
+- Review returns `writes=false`, applied filters, aggregate signal counts,
+  per-feature signal counts, `conclusion`, and `reasons`.
+- `signal` filtering is applied after DB retrieval; it must not require schema
+  changes or new indexes.
+- Review is read-only and must not append runtime adoption events.
+- Review conclusions are advisory: `no_evidence`, `positive`, `rollback_risk`,
+  or `mixed`.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `tests/knowledge_card_retrieval.rs` (test harness timeout robustness only)
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p65-runtime-adoption-review-report.md`
+- `specs/p65-runtime-adoption-review-report.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not treat review conclusions as authority to mutate knowledge lifecycle or
+  runtime defaults.
+
+## Acceptance Criteria
+
+Scenario: CLI review summarizes card context evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_summarizes_events
+  Level: integration
+  Given an empty CLI HOME
+  And card context events include accepted and rejected signals
+  When running `mempal phase3 adoption review --track card_context --format json`
+  Then stdout is valid JSON
+  And the response includes `writes=false`
+  And `total` is 3
+  And `stats.accepted` is 2
+  And `stats.rejected` is 1
+  And `features[0].feature` is `include_cards`
+  And runtime adoption event count remains 3
+
+Scenario: CLI review supports signal filtering
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_filters_signal
+  Level: integration
+  Given an empty CLI HOME
+  And mixed card context events exist
+  When running `mempal phase3 adoption review --track card_context --signal accepted --format json`
+  Then stdout is valid JSON
+  And `total` is 2
+  And `stats.accepted` is 2
+  And `stats.rejected` is 0
+
+Scenario: CLI review reports no evidence without mutation
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_review_json_no_evidence_read_only
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption review --track evaluator --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `total` is 0
+  And `conclusion` is `no_evidence`
+  And runtime adoption event count remains zero
+
+Scenario: MCP review is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_review_action_is_read_only
+  Level: unit
+  Given an empty test database with one runtime adoption event
+  When `mempal_phase3` is called with `action=review`
+  Then the response includes `writes=false`
+  And the response includes a review report
+  And runtime adoption event count remains unchanged
+
+## Out of Scope
+
+- New write paths or automatic event capture.
+- New DB tables, migrations, or indexes.
+- Changing readiness gate thresholds.
+- Enabling card context, card embeddings, evaluator authority, or research
+  ingestion by default.

--- a/specs/p66-card-context-default-readiness.spec.md
+++ b/specs/p66-card-context-default-readiness.spec.md
@@ -1,0 +1,125 @@
+spec: task
+name: "P66: card context default readiness"
+inherits: project
+tags: ["phase-3", "runtime-adoption", "card-context", "cli", "mcp"]
+---
+
+## Intent
+
+P65 can summarize runtime adoption evidence, but agents still need a focused
+answer to whether card-aware context is ready to be considered for default
+runtime behavior. P66 adds a read-only readiness report for `include_cards` that
+uses the existing card-context adoption evidence without changing defaults or
+relaxing the Phase-3 evidence-first boundary.
+
+## Decisions
+
+- Add CLI `mempal phase3 readiness card-context-default`.
+- Add MCP `mempal_phase3 action=readiness` with `candidate=card-context-default`.
+- The readiness report is read-only and returns `writes=false`, `candidate`,
+  `ready`, `decision`, `required_track`, `required_feature`, `review`, and
+  `reasons`.
+- The report reuses P65 review aggregation filtered to
+  `track=card_context` and `feature=include_cards`.
+- `ready=true` requires at least 3 accepted signals, zero rollback signals,
+  zero contradiction signals, and accepted signals greater than or equal to
+  rejected plus misses.
+- `ready=true` only means eligible for a future default-on spec; it must not
+  enable cards by default.
+- Unsupported readiness candidates are rejected without mutation.
+
+## Boundaries
+
+### Allowed Changes
+- `src/core/phase3.rs`
+- `src/main.rs`
+- `src/mcp/**`
+- `src/core/protocol.rs`
+- `tests/phase3_runtime.rs`
+- `docs/MIND-MODEL-DESIGN.md`
+- `docs/plans/2026-05-13-p66-card-context-default-readiness.md`
+- `specs/p66-card-context-default-readiness.spec.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+
+### Forbidden
+- Do not automatically record events.
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not change schema v9.
+- Do not change `mempal context` default `include_cards=false`.
+- Do not add card embeddings.
+- Do not mutate knowledge lifecycle, card lifecycle, or runtime defaults.
+- Do not treat readiness as sufficient authority to implement default-on card
+  context without a later explicit spec.
+
+## Acceptance Criteria
+
+Scenario: CLI readiness reports ready with sufficient evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_ready
+  Level: integration
+  Given an empty CLI HOME
+  And three accepted card context events exist for feature `include_cards`
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `writes` is false
+  And `ready` is true
+  And `decision` is `eligible_for_future_default_spec`
+  And `review.stats.accepted` is 3
+  And runtime adoption event count remains 3
+
+Scenario: CLI readiness blocks without evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_without_evidence
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `writes` is false
+  And `ready` is false
+  And `decision` is `keep_opt_in`
+  And `reasons` mentions insufficient accepted evidence
+  And runtime adoption event count remains zero
+
+Scenario: CLI readiness blocks rollback evidence
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_card_context_default_blocks_rollback
+  Level: integration
+  Given an empty CLI HOME
+  And card context evidence includes accepted and rollback signals
+  When running `mempal phase3 readiness card-context-default --format json`
+  Then stdout is valid JSON
+  And `ready` is false
+  And `decision` is `keep_opt_in`
+  And `reasons` mentions rollback evidence
+
+Scenario: MCP readiness is read-only
+  Test:
+    Package: mempal
+    Filter: mcp::server::tests::test_mcp_phase3_readiness_card_context_default_is_read_only
+  Level: unit
+  Given an empty test database with card context evidence
+  When `mempal_phase3` is called with `action=readiness` and `candidate=card-context-default`
+  Then the response includes `writes=false`
+  And the response includes a readiness report
+  And runtime adoption event count remains unchanged
+
+Scenario: Unsupported readiness candidate is rejected
+  Test:
+    Package: mempal
+    Filter: cargo test --test phase3_runtime test_cli_phase3_readiness_rejects_unknown_candidate
+  Level: integration
+  Given an empty CLI HOME
+  When running `mempal phase3 readiness unknown --format json`
+  Then the command fails
+  And stderr mentions `unsupported phase3 readiness candidate`
+
+## Out of Scope
+
+- Turning `include_cards` on by default.
+- Changing existing Phase-3 gate thresholds.
+- New adoption event write paths.
+- New schema, embeddings, or retrieval ranking changes.

--- a/specs/p67-research-adapter-ingest.spec.md
+++ b/specs/p67-research-adapter-ingest.spec.md
@@ -1,0 +1,105 @@
+spec: task
+name: "P67: research adapter evidence ingest"
+inherits: project
+tags: [phase-3, research, adapter, evidence, cli]
+---
+
+## Intent
+
+P59 validates external research report JSON, but it still stops before creating
+memory evidence. P67 adds an explicit evidence-first ingest plan/apply CLI so
+external research output can enter mempal as cited evidence drawers while
+preserving P49: research cannot directly define dao, canonical knowledge, or
+promoted knowledge.
+
+## Decisions
+
+- Add CLI `mempal phase3 research-ingest-plan <path>`.
+- The command accepts the same JSON report contract as P59: `report_id`,
+  `title`, `sources`, `findings`, and optional `candidate_insights`.
+- The command defaults to dry-run and returns `writes=false`.
+- `--execute` writes one `memory_kind=evidence` drawer per finding with
+  `provenance=research`.
+- Written evidence drawer ids are stable and idempotent; rerunning `--execute`
+  skips existing drawers instead of rewriting them.
+- `candidate_insights` are reported only as distill suggestions backed by the
+  planned evidence drawer refs; they do not create knowledge drawers.
+- The command supports `--format plain|json`, defaulting to `plain`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p67-research-adapter-ingest.spec.md
+- docs/plans/2026-05-13-p67-research-adapter-ingest.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/main.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema v10 or any table.
+- Do not add automatic/background research ingestion.
+- Do not change `mempal phase3 research-validate-plan` behavior.
+- Do not create `memory_kind=knowledge` drawers from research reports.
+- Do not create `dao_tian`, `canonical`, or `promoted` knowledge.
+- Do not bypass `mempal knowledge distill`, lifecycle gates, or human review.
+- Do not add MCP write access for research ingestion in P67.
+
+## Acceptance Criteria
+
+Scenario: dry-run research ingest plans evidence without writing
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+    Targets: CLI JSON output and SQLite no-write side effect check.
+  Given a valid research report with one finding and one candidate insight
+  When running `mempal phase3 research-ingest-plan <path> --format json`
+  Then the command succeeds
+  And the response has `valid=true`
+  And `writes=false`
+  And it returns one planned evidence drawer
+  And it returns one candidate insight suggestion
+  And the suggestion includes a `mempal knowledge distill` command
+  And the database has no drawers
+
+Scenario: execute writes research evidence drawers idempotently
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_execute_writes_research_evidence
+    Targets: CLI execution, SQLite drawer state, research provenance, and idempotency.
+  Given a valid research report with two findings
+  When running `mempal phase3 research-ingest-plan <path> --execute --format json`
+  Then the command succeeds
+  And `writes=true`
+  And two evidence drawers are created
+  And each created drawer has `memory_kind=evidence`
+  And each created drawer has `provenance=research`
+  And no knowledge drawer is created
+  When running the same command again
+  Then existing drawer ids are skipped and not duplicated
+
+Scenario: invalid research ingest plan does not write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_invalid_report_no_write
+    Targets: CLI JSON output and SQLite no-write side effect check.
+  Given an invalid research report JSON file
+  When running `mempal phase3 research-ingest-plan <path> --execute --format json`
+  Then the command succeeds with `valid=false`
+  And `writes=false`
+  And errors mention required fields
+  And the database has no drawers
+
+Scenario: research ingest plan rejects unsupported format
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_rejects_invalid_format
+    Targets: CLI stderr and exit status.
+  Given a valid research report JSON file
+  When running `mempal phase3 research-ingest-plan <path> --format yaml`
+  Then the command fails
+  And stderr mentions `unsupported phase3 research ingest format`
+
+## Out of Scope
+
+- MCP research ingestion.
+- Research report fetching or browser automation.
+- Research-driven promotion/demotion.
+- Card embeddings or default card context changes.

--- a/specs/p68-mcp-research-ingest-plan.spec.md
+++ b/specs/p68-mcp-research-ingest-plan.spec.md
@@ -1,0 +1,112 @@
+spec: task
+name: "P68: MCP research ingest plan"
+inherits: project
+tags: [phase-3, research, adapter, evidence, mcp]
+---
+
+## Intent
+
+P67 added an explicit CLI dry-run/apply path for converting external research
+reports into evidence drawers. P68 exposes the same dry-run planning semantics
+through `mempal_phase3` so agent runtimes can inspect planned evidence refs and
+distill suggestions without granting MCP write access or bypassing P49/P50
+governance.
+
+## Decisions
+
+- Add MCP action `mempal_phase3 action=research_ingest_plan`.
+- The request accepts the same inline `report` JSON object used by
+  `research_validate_plan`.
+- The response returns a `research_ingest_plan` object with the P67 dry-run
+  shape: `valid`, `writes=false`, report metadata, planned evidence drawers,
+  candidate insight distill suggestions, and validation errors.
+- MCP `research_ingest_plan` is always read-only and never exposes `execute`.
+- CLI `mempal phase3 research-ingest-plan` and MCP `research_ingest_plan` share
+  the same pure planning logic.
+- `research_validate_plan` remains unchanged and continues to return only
+  validation counts.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p68-mcp-research-ingest-plan.spec.md
+- docs/plans/2026-05-13-p68-mcp-research-ingest-plan.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema v10 or any table.
+- Do not add MCP `execute`, write mode, or evidence drawer creation.
+- Do not create vectors from the MCP action.
+- Do not create `memory_kind=knowledge` drawers from research reports.
+- Do not create `dao_tian`, `canonical`, or `promoted` knowledge.
+- Do not bypass `mempal knowledge distill`, lifecycle gates, or human review.
+- Do not change P67 CLI observable behavior.
+- Do not change `research_validate_plan` response semantics.
+
+## Acceptance Criteria
+
+Scenario: MCP research ingest plan returns dry-run evidence refs without writing
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_is_read_only --lib
+    Targets: MCP JSON response shape, dry-run semantics, drawer/event no-write checks.
+  Given a valid inline research report with one finding and one candidate insight
+  When calling `mempal_phase3` with `action=research_ingest_plan`
+  Then the call succeeds
+  And the response has `research_ingest_plan.valid=true`
+  And `research_ingest_plan.writes=false`
+  And it returns one planned evidence drawer
+  And it returns one candidate insight suggestion
+  And the suggestion includes a `mempal knowledge distill` command
+  And no drawer or runtime adoption event is created
+
+Scenario: MCP research ingest plan reports invalid input without writing
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_research_ingest_plan_invalid_report_no_write --lib
+    Targets: MCP invalid report handling and no-write checks.
+  Given an invalid inline research report JSON object
+  When calling `mempal_phase3` with `action=research_ingest_plan`
+  Then the call succeeds with `research_ingest_plan.valid=false`
+  And `research_ingest_plan.writes=false`
+  And errors mention missing required fields
+  And no drawer or runtime adoption event is created
+
+Scenario: invalid phase3 action lists research ingest plan
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_rejects_invalid_action_without_mutation --lib
+    Targets: MCP error message and mutation guard.
+  Given an unsupported `mempal_phase3` action
+  When the action is rejected
+  Then the error lists `research_ingest_plan` among supported actions
+  And no runtime adoption event is created
+
+Scenario: MCP registry and protocol advertise research ingest plan
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and embedded memory protocol.
+  Given the MCP tool registry and embedded memory protocol
+  When inspecting the `mempal_phase3` surface
+  Then both mention `research_ingest_plan`
+  And both state that research ingest planning is read-only/advisory
+
+Scenario: CLI dry-run keeps P67 behavior after sharing planner
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_research_ingest_plan_dry_run_json_no_write
+    Targets: CLI P67 regression guard.
+  Given a valid research report file
+  When running `mempal phase3 research-ingest-plan <path> --format json`
+  Then the command still returns `writes=false`
+  And no drawer is written
+
+## Out of Scope
+
+- MCP research ingestion execution.
+- Research report fetching or browser automation.
+- Research-driven promotion/demotion.
+- Card embeddings or default card context changes.

--- a/specs/p69-runtime-adoption-checked-record.spec.md
+++ b/specs/p69-runtime-adoption-checked-record.spec.md
@@ -1,0 +1,129 @@
+spec: task
+name: "P69: runtime adoption checked record"
+inherits: project
+tags: [phase-3, runtime-adoption, quality, cli, mcp]
+---
+
+## Intent
+
+P63 can prepare runtime adoption record inputs and P64 can evaluate their
+quality, but agents still have to manually run `check_record` before `record`.
+P69 adds a guarded write path that evaluates the same quality policy immediately
+before appending a runtime adoption event, so self-evolution evidence capture is
+safer by default without adding automatic hooks or changing Phase-3 gates.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption record-checked`.
+- Add MCP `mempal_phase3 action=record_checked`.
+- `record_checked` reuses the same input fields as `record`.
+- `record_checked` runs the P64 quality policy before any write.
+- By default, only `quality=ready` records are written.
+- `--allow-warnings` / `allow_warnings=true` permits `quality=warning` records
+  to be written, but `quality=invalid` is always blocked.
+- The response reports `writes`, `blocked`, the quality report, and the optional
+  written event.
+- Existing `record`, `check_record`, and gate semantics remain unchanged.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p69-runtime-adoption-checked-record.spec.md
+- docs/plans/2026-05-13-p69-runtime-adoption-checked-record.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add hooks, background workers, or implicit runtime instrumentation.
+- Do not automatically record events after context/search/research tool calls.
+- Do not change schema v9.
+- Do not change Phase-3 gate thresholds.
+- Do not make card context default.
+- Do not add card embeddings.
+- Do not change existing `record` behavior.
+- Do not let `allow_warnings` write invalid records.
+
+## Acceptance Criteria
+
+Scenario: CLI checked record writes ready evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_writes_ready_event
+    Targets: CLI checked record happy path and DB write.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track runtime_adoption --signal accepted --feature context_pack --query "skill trigger" --note "context guidance helped" --format json`
+  Then stdout is valid JSON
+  And `writes=true`
+  And `blocked=false`
+  And `record_quality.quality` is `ready`
+  And a runtime adoption event is written
+
+Scenario: CLI checked record blocks warning evidence by default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_warning_by_default
+    Targets: CLI warning block and no-write side effect check.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature include_cards --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `blocked=true`
+  And `record_quality.quality` is `warning`
+  And no runtime adoption event is written
+
+Scenario: CLI checked record allow-warnings writes warning evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event
+    Targets: CLI allow-warnings behavior and DB write.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature include_cards --allow-warnings --format json`
+  Then stdout is valid JSON
+  And `writes=true`
+  And `blocked=false`
+  And `record_quality.quality` is `warning`
+  And a runtime adoption event is written
+
+Scenario: CLI checked record always blocks invalid evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings
+    Targets: CLI invalid block and no-write side effect check.
+  Given an empty CLI HOME
+  When running `mempal phase3 adoption record-checked --track card_context --signal accepted --feature "   " --allow-warnings --format json`
+  Then stdout is valid JSON
+  And `writes=false`
+  And `blocked=true`
+  And `record_quality.quality` is `invalid`
+  And no runtime adoption event is written
+
+Scenario: MCP checked record is quality-gated
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_record_checked_quality_gated --lib
+    Targets: MCP checked record write/block behavior and DB side effects.
+  Given an empty test database
+  When `mempal_phase3` is called with `action=record_checked` and a ready record
+  Then the response includes `writes=true`
+  And one runtime adoption event is appended
+  When `mempal_phase3` is called with warning-quality input without `allow_warnings`
+  Then the response includes `writes=false`
+  And no additional event is appended
+
+Scenario: MCP registry and protocol advertise checked record
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and embedded memory protocol.
+  Given the MCP tool registry and embedded memory protocol
+  When inspecting the `mempal_phase3` surface
+  Then both mention `record_checked`
+  And the protocol states it is quality-gated.
+
+## Out of Scope
+
+- Automatic adoption recording after tool calls.
+- Runtime hooks for Claude, Codex, or other agents.
+- Event deduplication.
+- New schema, indexes, or gate thresholds.
+- Any default-on policy changes.

--- a/specs/p70-self-evolution-completion-audit.spec.md
+++ b/specs/p70-self-evolution-completion-audit.spec.md
@@ -1,0 +1,100 @@
+spec: task
+name: "P70: self-evolution completion audit"
+inherits: project
+tags: [phase-3, self-evolution, audit, mind-model]
+---
+
+## Intent
+
+P69 made runtime adoption evidence safer to write, but the active objective is
+larger than any single feature: a complete self-evolving agent system. P70 adds
+an explicit completion audit that maps the objective to concrete artifacts,
+identifies which loops are implemented, and records remaining gaps without
+claiming the overall goal is complete.
+
+## Decisions
+
+- P70 is audit-only and must not change runtime behavior.
+- The audit must restate "complete self-evolving agent system" as concrete
+  deliverables.
+- The audit must map each deliverable to existing P-level artifacts and evidence.
+- The audit must explicitly state that P12-P69 do not yet prove full completion.
+- The audit must list missing or weakly verified loops as future P candidates.
+- Every future P still requires its own `specs/pNN-*.spec.md` and plan document.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p70-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p70-self-evolution-completion-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not add schema migrations.
+- Do not add hooks, background workers, or automatic instrumentation.
+- Do not change runtime defaults.
+- Do not mark the thread goal complete.
+- Do not claim self-evolution is complete without listing remaining gaps.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records the P70 completion audit
+  Test:
+    Filter: rg -n "P70 self-evolution completion audit|Complete self-evolving agent system deliverables" docs/MIND-MODEL-DESIGN.md
+    Targets: Design document audit section.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 audit section
+  Then it identifies P70 as a self-evolution completion audit
+  And it restates the objective as concrete deliverables
+
+Scenario: Audit maps implemented deliverables to artifacts
+  Test:
+    Filter: rg -n "Evidence substrate.*P54|Knowledge governance.*P12-P28|Knowledge cards.*P31-P45|Research ingestion.*P49/P59/P67/P68|Runtime adoption.*P54-P69" docs/MIND-MODEL-DESIGN.md
+    Targets: Prompt-to-artifact checklist in MIND-MODEL.
+  Given the P70 audit checklist
+  When searching for implemented deliverables
+  Then it maps evidence substrate, knowledge governance, cards, research, and runtime adoption to concrete P artifacts
+
+Scenario: Audit states the objective is not complete yet
+  Test:
+    Filter: rg -n "P70 conclusion: not complete|Remaining gaps before full self-evolution" docs/MIND-MODEL-DESIGN.md
+    Targets: Explicit non-completion statement.
+  Given the P70 audit
+  When reading its conclusion
+  Then it states the full self-evolution objective is not complete yet
+  And it lists remaining gaps
+
+Scenario: Audit lists future P candidates
+  Test:
+    Filter: rg -n "P71 candidate|P72 candidate|P73 candidate" docs/MIND-MODEL-DESIGN.md
+    Targets: Future work candidate list.
+  Given the P70 audit
+  When reading the future work list
+  Then it names at least three future P candidates
+
+Scenario: Inventories include P70
+  Test:
+    Filter: rg -n "p70-self-evolution-completion-audit|P70 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Agent inventory documents.
+  Given repo agent inventories
+  When searching for P70
+  Then both AGENTS.md and CLAUDE.md include P70 spec and plan entries
+
+Scenario: Runtime source files are unchanged
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P70 audit-only boundary.
+  Given the P70 branch
+  When listing changed files
+  Then changes are limited to spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing P71 or later candidates.
+- Adding automatic adoption capture.
+- Turning card context on by default.
+- Adding evaluator lifecycle APIs.
+- Marking the overall thread goal complete.

--- a/specs/p71-self-evolution-loop-replay.spec.md
+++ b/specs/p71-self-evolution-loop-replay.spec.md
@@ -1,0 +1,89 @@
+spec: task
+name: "P71: self-evolution loop replay"
+inherits: project
+tags: [phase-3, self-evolution, replay, verification]
+---
+
+## Intent
+
+P70 identified that the system has the pieces for self-evolution but lacks a
+deterministic end-to-end replay proving the pieces work together. P71 adds a
+test-backed replay that walks a research artifact through evidence ingestion,
+evidence-backed knowledge-card promotion, card-aware context assembly, and
+checked runtime adoption recording.
+
+## Decisions
+
+- P71 must leave its own `specs/p71-*.spec.md` and plan document.
+- The replay must use public CLI surfaces rather than private DB-only setup for
+  the main happy path.
+- The happy path must cover research evidence creation, candidate card creation,
+  supporting evidence linking, gate-enforced promotion, `mempal context
+  --include-cards`, and `phase3 adoption record-checked`.
+- The replay must verify persisted artifacts in SQLite after the CLI sequence.
+- Invalid research input must not create drawers, cards, or adoption events.
+- P71 must not add schema migrations, MCP tools, background hooks, or automatic
+  runtime adoption capture.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p71-self-evolution-loop-replay.spec.md
+- docs/plans/2026-05-13-p71-self-evolution-loop-replay.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- tests/phase3_self_evolution_replay.rs
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not change runtime defaults.
+- Do not add card-level embeddings.
+- Do not grant autonomous promotion authority.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI replay proves the self-evolution loop
+  Test:
+    Filter: cargo test --test phase3_self_evolution_replay test_cli_self_evolution_replay_research_to_context_to_adoption
+    Targets: CLI E2E replay from research report to runtime adoption evidence.
+  Given a valid research report with one finding and one candidate insight
+  When the replay runs public CLI commands for research ingest, card create/link/promote, context, and checked adoption recording
+  Then research evidence is persisted as an evidence drawer
+  And a promoted knowledge card links to the evidence drawer as supporting and verification evidence
+  And card-aware context returns the promoted card with evidence citation
+  And checked runtime adoption writes one accepted `card_context/include_cards` event
+
+Scenario: Invalid research input does not create replay artifacts
+  Test:
+    Filter: cargo test --test phase3_self_evolution_replay test_cli_self_evolution_replay_invalid_research_no_artifacts
+    Targets: Invalid input no-write behavior.
+  Given an invalid research report
+  When `phase3 research-ingest-plan --execute --format json` is run
+  Then the report is invalid and `writes=false`
+  And no drawers, knowledge cards, or runtime adoption events are created
+
+Scenario: P71 is recorded in project inventories
+  Test:
+    Filter: rg -n "p71-self-evolution-loop-replay|P71 self-evolution loop replay" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Design and agent inventory documentation.
+  Given the project documentation
+  When searching for P71
+  Then the spec, plan, and implemented replay status are recorded
+
+Scenario: P71 remains a replay-only change
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P71 boundary.
+  Given the P71 branch
+  When listing changed files
+  Then changes are limited to the P71 spec, plan, docs, and replay test
+
+## Out of Scope
+
+- Automatic adoption capture around live agent tool execution.
+- Evaluator advisory API contracts.
+- Default-on card context.
+- Card-level embedding schema or retrieval.
+- Runtime rollback executors.

--- a/specs/p72-runtime-adoption-capture-helper.spec.md
+++ b/specs/p72-runtime-adoption-capture-helper.spec.md
@@ -1,0 +1,114 @@
+spec: task
+name: "P72: runtime adoption capture helper"
+inherits: project
+tags: [phase-3, self-evolution, runtime-adoption, capture]
+---
+
+## Intent
+
+P71 proved the self-evolution pieces can be composed, but adoption evidence is
+still too manual: an agent must know the exact `track/signal/feature` tuple for
+every runtime outcome. P72 adds an explicit capture helper that maps a small
+surface/outcome vocabulary into the existing P69 checked-record path, lowering
+recording friction without adding background hooks or autonomous capture.
+
+## Decisions
+
+- P72 must leave its own `specs/p72-*.spec.md` and plan document.
+- Add CLI `mempal phase3 adoption capture`.
+- Add MCP `mempal_phase3 action=capture`.
+- Capture inputs use `surface` and `outcome`; the helper maps them to existing
+  `track`, `signal`, and `feature` values.
+- Capture defaults to dry-run/read-only and returns a record plan plus quality
+  report.
+- Capture writes only when `--execute` / `execute=true` is set, and writes must
+  reuse the P69 checked-record policy.
+- Warning-quality captures remain blocked by default and require
+  `--allow-warnings` / `allow_warnings=true` to write.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p72-runtime-adoption-capture-helper.spec.md
+- docs/plans/2026-05-13-p72-runtime-adoption-capture-helper.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not add background hooks or automatic instrumentation.
+- Do not bypass `check_record` / `record_checked` quality policy.
+- Do not change existing `record`, `prepare-record`, `check-record`, or
+  `record-checked` behavior.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI capture dry-run maps card context outcome through src/main.rs without writing
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_card_context_dry_run
+    Targets: CLI capture dry-run behavior.
+  Given a card-context accepted outcome with query "skill trigger" and note "card helped"
+  When running `mempal phase3 adoption capture --surface card-context --outcome accepted --card-id card_1 --query "skill trigger" --note "card helped" --format json`
+  Then stdout contains `writes=false`
+  And stdout contains a record plan with `track=card_context`, `signal=accepted`, and `feature=include_cards`
+  And the quality report is `ready`
+  And no runtime adoption event is persisted
+
+Scenario: CLI capture execute writes through checked policy
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_execute_writes_ready_event
+    Targets: CLI capture execute behavior.
+  Given a ready card-context accepted outcome
+  When running capture with `--execute --format json`
+  Then stdout contains `writes=true`
+  And exactly one runtime adoption event is persisted
+
+Scenario: CLI capture blocks warning by default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_blocks_warning_by_default
+    Targets: CLI capture warning policy.
+  Given a card-context accepted outcome without `card_id`
+  When running capture with `--execute --format json`
+  Then stdout contains `writes=false` and `blocked=true`
+  And no runtime adoption event is persisted
+
+Scenario: MCP capture supports dry-run and execute through src/mcp/server.rs
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_capture_action_dry_run_and_execute --lib
+    Targets: MCP capture action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=capture`
+  When called once without `execute` and once with `execute=true`
+  Then the dry-run response has no DB side effect
+  And the execute response writes through checked-record policy
+
+Scenario: Capture rejects unknown surface
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_capture_rejects_unknown_surface
+    Targets: CLI capture input validation in `src/main.rs`.
+  Given an unsupported capture surface
+  When running capture
+  Then the command fails
+  And stderr mentions `unsupported adoption capture surface`
+
+Scenario: Inventories include P72
+  Test:
+    Filter: rg -n "p72-runtime-adoption-capture-helper|P72 runtime adoption capture helper" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P72
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Automatic capture from live agent tool calls.
+- Hook installation or shell/TUI instrumentation.
+- New runtime adoption tables or schema changes.
+- Evaluator advisory API.
+- Default-on card context.

--- a/specs/p73-evaluator-advisory-api.spec.md
+++ b/specs/p73-evaluator-advisory-api.spec.md
@@ -1,0 +1,120 @@
+spec: task
+name: "P73: evaluator advisory API"
+inherits: project
+tags: [phase-3, evaluator, self-evolution, advisory]
+---
+
+## Intent
+
+P50 fixed evaluator boundaries as advisory-only, and P58 added a read-only gate
+for deciding whether evaluator APIs are mature enough to implement. P73 adds the
+first evaluator advice surface with replayable deterministic output: agents can
+ask for an advisory lifecycle recommendation and receive reasons plus a runtime
+adoption capture plan, but no lifecycle state is mutated.
+
+## Decisions
+
+- P73 must leave its own `specs/p73-*.spec.md` and plan document.
+- Add CLI `mempal phase3 evaluator advise`.
+- Add MCP `mempal_phase3 action=evaluator_advise`.
+- Advice output must be deterministic from request fields and existing policy,
+  with no LLM calls, network calls, or hidden runtime state.
+- Advice output must include `writes=false`, `lifecycle_authority=false`,
+  `deterministic_gate_required=true`, recommendation, reasons, and an adoption
+  capture plan for `surface=evaluator`.
+- `dao_tian` canonicalization advice must always require human review.
+- Evidence-free advice must recommend more evidence instead of promotion.
+- Counterexamples or risk notes must block supportive recommendation.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p73-evaluator-advisory-api.spec.md
+- docs/plans/2026-05-13-p73-evaluator-advisory-api.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not write runtime adoption events from evaluator advice.
+- Do not mutate knowledge drawers, knowledge cards, lifecycle refs, or audit
+  events.
+- Do not satisfy reviewer requirements through evaluator output.
+- Do not bypass deterministic promotion/card gates.
+- Do not add evaluator scoring, LLM calls, or network calls.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI evaluator advice is replayable and read-only
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_supportive_read_only
+    Targets: CLI evaluator advice behavior in `src/main.rs`.
+  Given evaluator `eval_policy` advises on a `dao_ren` promotion with two evidence refs
+  When running `mempal phase3 evaluator advise --evaluator-id eval_policy --subject-kind dao_ren --subject-id k1 --proposed-action promote --evidence-ref e1 --evidence-ref e2 --format json`
+  Then stdout contains `writes=false` and `lifecycle_authority=false`
+  And stdout contains `deterministic_gate_required=true`
+  And stdout recommends `advisory_support`
+  And no runtime adoption event is persisted
+  And this verifies the `src/main.rs` CLI entry point
+
+Scenario: CLI evaluator advice requires human review for dao_tian canonicalization
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_dao_tian_requires_human_review
+    Targets: CLI evaluator human-review policy.
+  Given evaluator advice for `dao_tian` `canonical`
+  When running evaluator advice with supporting evidence
+  Then stdout contains `requires_human_review=true`
+  And reasons mention `dao_tian canonicalization requires human review`
+
+Scenario: CLI evaluator advice rejects weak or risky recommendations
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk
+    Targets: CLI evaluator evidence/risk policy.
+  Given evaluator advice without evidence refs
+  When running evaluator advice
+  Then recommendation is `needs_evidence`
+  Given evaluator advice with a risk note or counterexample ref
+  When running evaluator advice
+  Then recommendation is `do_not_promote`
+
+Scenario: MCP evaluator advice mirrors CLI read-only contract
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_evaluator_advise_action_is_read_only --lib
+    Targets: MCP evaluator advice action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=evaluator_advise`
+  When called with evaluator id, subject, proposed action, and evidence refs
+  Then the response contains the same advisory fields
+  And no runtime adoption event is persisted
+  And this verifies the `src/mcp/server.rs` MCP entry point
+
+Scenario: Evaluator advice validates required fields
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_evaluator_advise_rejects_missing_evaluator
+    Targets: CLI evaluator input validation in `src/main.rs`.
+  Given a request without evaluator id
+  When running evaluator advice
+  Then the command fails
+  And stderr mentions `evaluator-id is required`
+
+Scenario: Inventories include P73
+  Test:
+    Filter: rg -n "p73-evaluator-advisory-api|P73 evaluator advisory API" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P73
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Evaluator-driven promotion or demotion.
+- Automatic evaluator invocation.
+- Evaluator scoring or model integration.
+- New persistence tables.
+- Default-on card context.

--- a/specs/p74-card-context-default-proposal.spec.md
+++ b/specs/p74-card-context-default-proposal.spec.md
@@ -1,0 +1,127 @@
+spec: task
+name: "P74: card context default-on proposal"
+inherits: project
+tags: [phase-3, self-evolution, card-context, default-policy]
+---
+
+## Intent
+
+P66 can report whether card-aware context is ready for a future default-on spec,
+but it does not produce a complete proposal artifact. P74 adds a read-only
+default-on proposal surface for card context that combines P66 readiness evidence
+with explicit rollback criteria while preserving the current `include_cards`
+opt-in runtime default.
+
+## Decisions
+
+- P74 must leave its own `specs/p74-*.spec.md` and plan document.
+- Add CLI `mempal phase3 default-proposal card-context`.
+- Add MCP `mempal_phase3 action=default_proposal` with `candidate=card-context`.
+- The proposal reuses P66 `card_context_default_readiness`.
+- The proposal requires at least one explicit rollback criterion before it can
+  be marked `proposal_ready=true`.
+- The proposal output must include `writes=false`, `candidate`,
+  `proposal_ready`, `decision`, embedded readiness, rollback criteria, and
+  reasons.
+- P74 must not change `mempal context` or `mempal_context` default
+  `include_cards=false`.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p74-card-context-default-proposal.spec.md
+- docs/plans/2026-05-13-p74-card-context-default-proposal.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+- Do not add schema migrations.
+- Do not change `mempal context` default `include_cards=false`.
+- Do not change `mempal_context` default `include_cards=false`.
+- Do not write runtime adoption events.
+- Do not mutate knowledge cards or knowledge lifecycle state.
+- Do not enable card embeddings.
+- Do not mark the overall self-evolution objective complete.
+
+## Acceptance Criteria
+
+Scenario: CLI proposal is ready when readiness and rollback criteria are satisfied
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_card_context_ready
+    Targets: CLI default proposal behavior in `src/main.rs`.
+  Given three accepted `card_context/include_cards` adoption events
+  And rollback criterion is `rollback on contradiction or user-visible degradation`
+  When running `mempal phase3 default-proposal card-context --rollback-criterion "rollback on contradiction or user-visible degradation" --format json`
+  Then stdout contains `writes=false`
+  And stdout contains `proposal_ready=true`
+  And stdout contains decision `eligible_for_default_on_spec`
+  And no runtime adoption event is persisted by the proposal command
+  And this verifies the `src/main.rs` CLI entry point
+
+Scenario: CLI proposal blocks without rollback criteria
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_requires_rollback_criteria
+    Targets: CLI rollback-criteria gate.
+  Given readiness evidence is satisfied
+  When running default proposal without `--rollback-criterion`
+  Then stdout contains `proposal_ready=false`
+  And reasons mention `rollback criteria are required`
+
+Scenario: CLI proposal blocks when readiness is not satisfied
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_blocks_without_readiness
+    Targets: CLI readiness gate.
+  Given no `card_context/include_cards` adoption evidence
+  When running default proposal with rollback criteria
+  Then stdout contains `proposal_ready=false`
+  And embedded readiness has `ready=false`
+
+Scenario: CLI proposal does not change context default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_keeps_context_cards_opt_in
+    Targets: Runtime context default behavior.
+  Given a promoted active card exists
+  And a ready default proposal is generated
+  And query is `card-aware`
+  When running `mempal context "card-aware" --format json` without `--include-cards`
+  Then the context output omits card items
+
+Scenario: MCP proposal mirrors CLI read-only contract
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_default_proposal_card_context_is_read_only --lib
+    Targets: MCP default proposal action in `src/mcp/server.rs`.
+  Given `mempal_phase3 action=default_proposal` and `candidate=card-context`
+  When called with rollback criteria
+  Then the response contains a default proposal report
+  And no runtime adoption event is persisted by the action
+  And this verifies the `src/mcp/server.rs` MCP entry point
+
+Scenario: Default proposal rejects unknown candidate
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_proposal_rejects_unknown_candidate
+    Targets: CLI default proposal input validation.
+  Given an unsupported default proposal candidate
+  When running default proposal
+  Then the command fails
+  And stderr mentions `unsupported phase3 default proposal candidate`
+
+Scenario: Inventories include P74
+  Test:
+    Filter: rg -n "p74-card-context-default-proposal|P74 card context default-on proposal" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Agent inventories and design document.
+  Given project documentation
+  When searching for P74
+  Then the spec, plan, and design status are recorded
+
+## Out of Scope
+
+- Actually changing `include_cards` defaults.
+- Card embeddings.
+- Automatic rollback executor.
+- New database tables.

--- a/specs/p75-self-evolution-completion-audit.spec.md
+++ b/specs/p75-self-evolution-completion-audit.spec.md
@@ -1,0 +1,91 @@
+spec: task
+name: "P75: self-evolution completion audit"
+inherits: project
+tags: [phase-3, self-evolution, audit]
+---
+
+## Intent
+
+P70 audited the self-evolution objective before P71-P74 existed. P75 performs a
+new evidence-based completion audit after the replay, capture helper, evaluator
+advisory API, and card-context default proposal have landed on main. The audit
+must distinguish completed governed self-evolution substrate from any remaining
+requirements for a complete autonomous self-evolving agent system.
+
+## Decisions
+
+- P75 must leave its own `specs/p75-*.spec.md` and plan document.
+- P75 is audit-only and must not change Rust runtime behavior.
+- The audit must restate the objective as concrete deliverables.
+- The audit must include a prompt-to-artifact checklist mapping deliverables to
+  specs, commands, tests, protocol entries, and PR/CI evidence.
+- The audit must explicitly state whether the full objective is complete.
+- If remaining gaps exist, the audit must list next P candidates instead of
+  marking the goal complete.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p75-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p75-self-evolution-completion-audit.md
+- docs/MIND-MODEL-DESIGN.md
+- AGENTS.md
+- CLAUDE.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not modify `tests/**`.
+- Do not add CLI or MCP behavior.
+- Do not mark the overall self-evolution objective complete unless the audit
+  proves no required work remains.
+
+## Acceptance Criteria
+
+Scenario: MIND-MODEL records P75 completion audit
+  Test:
+    Filter: rg -n "P75 self-evolution completion audit|P75 conclusion" docs/MIND-MODEL-DESIGN.md
+    Targets: P75 audit section.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 completion section
+  Then it includes a P75 audit after P71-P74
+  And it states a P75 conclusion
+
+Scenario: Audit maps objective to concrete artifacts
+  Test:
+    Filter: rg -n "P75 prompt-to-artifact checklist|P71.*phase3_self_evolution_replay|P72.*capture|P73.*evaluator_advise|P74.*default_proposal" docs/MIND-MODEL-DESIGN.md
+    Targets: Prompt-to-artifact checklist.
+  Given the P75 audit
+  When reading the checklist
+  Then it maps replay, capture, evaluator advice, and default proposal to concrete artifacts
+
+Scenario: Audit identifies remaining gaps instead of overclaiming completion
+  Test:
+    Filter: rg -n "P75 conclusion: not complete|Remaining gaps after P75|no automatic live tool instrumentation|no rollback executor|no actual default-on runtime change" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion conclusion.
+  Given the P75 audit
+  When reading the conclusion
+  Then it states the full objective is not complete yet
+  And it lists concrete remaining gaps
+
+Scenario: Inventories include P75
+  Test:
+    Filter: rg -n "p75-self-evolution-completion-audit|P75 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Agent inventories.
+  Given project inventories
+  When searching for P75
+  Then both AGENTS.md and CLAUDE.md include the P75 spec and plan entries
+
+Scenario: P75 remains audit-only
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P75 audit-only boundary.
+  Given the P75 branch
+  When listing changed files
+  Then changes are limited to the P75 spec, plan, MIND-MODEL design, and agent inventory docs
+
+## Out of Scope
+
+- Implementing automatic live tool instrumentation.
+- Implementing rollback execution.
+- Turning `include_cards` on by default.
+- Adding autonomous promotion authority.

--- a/specs/p76-spec-completeness-invariant.spec.md
+++ b/specs/p76-spec-completeness-invariant.spec.md
@@ -1,0 +1,97 @@
+spec: task
+name: "P76: spec completeness invariant"
+inherits: project
+tags: [governance, specs, process]
+---
+
+## Intent
+
+P76 codifies the project rule that every numbered P must leave an explicit task
+contract before it is implemented or merged. This prevents future work from
+landing as undocumented implementation drift and makes the P-series auditable as
+a complete decision and verification trail.
+
+## Decisions
+
+- Every future numbered P must include a `specs/pNN-*.spec.md` task contract.
+- Every future numbered P must include a matching `docs/plans/*pNN*.md` plan.
+- Agent inventories must list completed P specs and plans after the work lands.
+- This rule applies to documentation-only, audit-only, policy-only, and code
+  implementation P tasks.
+- P76 itself must obey the same rule by adding its own spec and plan.
+- P76 is governance-only and must not change Rust runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p76-spec-completeness-invariant.spec.md
+- docs/plans/2026-05-13-p76-spec-completeness-invariant.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not modify `src/**`.
+- Do not modify `tests/**`.
+- Do not add or change CLI, MCP, REST, or database behavior.
+- Do not retroactively rewrite older completed spec contents.
+
+## Acceptance Criteria
+
+Scenario: P76 spec exists and states the invariant
+  Test:
+    Filter: rg -n "Every future numbered P must include|docs/plans/.*pNN|documentation-only, audit-only, policy-only" specs/p76-spec-completeness-invariant.spec.md
+    Targets: P76 task contract.
+  Given the P76 task contract
+  When reading its decisions
+  Then it requires every future numbered P to include both a spec and a plan
+  And it applies the rule to non-code P tasks too
+
+Scenario: Project agent instructions expose the hard rule
+  Test:
+    Filter: rg -n "每一个 numbered P|specs/pNN-\\*\\.spec\\.md|docs/plans/.*pNN|文档-only|audit-only|policy-only" AGENTS.md CLAUDE.md
+    Targets: Agent instructions.
+  Given project agent instructions
+  When searching the Spec system section
+  Then both AGENTS.md and CLAUDE.md contain the P completeness hard rule
+
+Scenario: Inventories include P76
+  Test:
+    Filter: rg -n "p76-spec-completeness-invariant|P76 spec completeness invariant" AGENTS.md CLAUDE.md
+    Targets: Agent inventories.
+  Given project inventories
+  When searching for P76
+  Then both AGENTS.md and CLAUDE.md include the P76 spec and plan entries
+
+Scenario: MIND-MODEL records the governance decision
+  Test:
+    Filter: rg -n "P76 spec completeness invariant|Every P must leave a spec|future P numbering" docs/MIND-MODEL-DESIGN.md
+    Targets: MIND-MODEL governance note.
+  Given the MIND-MODEL design document
+  When reading the Phase-3 completion tail
+  Then it records the P76 governance decision
+  And it updates future P numbering after reserving P76 for the invariant
+
+Scenario: P76 remains governance-only
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: P76 governance-only boundary.
+  Given the P76 branch
+  When listing changed files
+  Then changes are limited to the P76 spec, plan, MIND-MODEL design, and agent inventory docs
+
+Scenario: Specless future P is rejected as incomplete
+  Test:
+    Filter: rg -n "不能算完成|spec-less P|missing spec|必须留下.*spec" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Future P failure rule.
+  Given a future numbered P without a matching task spec
+  When applying the project governance rule
+  Then that spec-less P is rejected as incomplete
+  And the agent must create the missing spec before implementation or merge
+
+## Out of Scope
+
+- Implementing live adoption instrumentation.
+- Implementing card-context default-on runtime behavior.
+- Implementing rollback execution.
+- Changing the agent-spec CLI itself.

--- a/specs/p77-live-adoption-instrumentation-boundary.spec.md
+++ b/specs/p77-live-adoption-instrumentation-boundary.spec.md
@@ -1,0 +1,108 @@
+spec: task
+name: "P77: live adoption instrumentation boundary"
+inherits: project
+tags: [phase-3, runtime-adoption, instrumentation, policy]
+---
+
+## Intent
+
+P75 identified missing automatic live tool instrumentation as a remaining gap in
+the self-evolution objective. P77 defines the safe boundary before any hooks or
+tool wrappers are allowed: instrumentation may help prepare or trigger checked
+adoption capture, but it must not silently append evidence or bypass existing
+quality gates. The boundary must be exposed to both CLI users and MCP agents so
+future runtime wrappers can follow the same contract.
+
+## Decisions
+
+- Add CLI `mempal phase3 adoption instrumentation-policy`.
+- Add MCP `mempal_phase3 action=instrumentation_policy`.
+- The policy surface is read-only and must not append `runtime_adoption_events`.
+- The default instrumentation mode remains `manual_only`.
+- `opt_in_wrapper` is the only semi-automatic mode allowed by P77.
+- `implicit_background_capture` is explicitly forbidden.
+- Any wrapper-created capture must go through existing `capture` /
+  `record_checked` quality gates and must preserve opt-out and rollback
+  requirements.
+- P77 must leave its own spec and plan per the P76 invariant.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p77-live-adoption-instrumentation-boundary.spec.md
+- docs/plans/2026-05-13-p77-live-adoption-instrumentation-boundary.md
+- src/core/phase3.rs
+- src/main.rs
+- src/mcp/tools.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+- tests/phase3_runtime.rs
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not add actual shell hooks, background workers, daemon processes, or tool
+  wrappers.
+- Do not change `capture` default dry-run behavior.
+- Do not write runtime adoption events from `instrumentation-policy`.
+- Do not make `include_cards` default-on.
+- Do not add new database schema or external dependencies.
+
+## Acceptance Criteria
+
+Scenario: CLI exposes read-only instrumentation policy
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_json_is_read_only
+    Targets: CLI policy output and event count.
+  Given an empty runtime adoption event table
+  When running `mempal phase3 adoption instrumentation-policy --format json`
+  Then the JSON report has `writes=false`
+  And `default_mode` is `manual_only`
+  And allowed modes include `opt_in_wrapper`
+  And forbidden modes include `implicit_background_capture`
+  And the runtime adoption event count remains zero
+
+Scenario: CLI rejects unsupported instrumentation policy output format
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format
+    Targets: CLI error handling.
+  Given the CLI policy command
+  When running it with `--format yaml`
+  Then the command fails
+  And stderr includes `unsupported phase3 adoption format`
+
+Scenario: MCP exposes read-only instrumentation policy
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_instrumentation_policy_action_is_read_only --lib
+    Targets: MCP policy action in `src/mcp/server.rs`.
+  Given an empty test database
+  When `mempal_phase3` is called with `action=instrumentation_policy`
+  Then the response includes an instrumentation policy with `writes=false`
+  And one allowed mode is `opt_in_wrapper`
+  And no runtime adoption event is appended
+  And the behavior is exercised through `src/mcp/server.rs`
+
+Scenario: Protocol advertises instrumentation boundary
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool description and MEMORY_PROTOCOL.
+  Given the MCP tool registry and protocol instructions
+  When inspecting the Phase-3 surface
+  Then `instrumentation_policy` is listed as a supported action
+  And the protocol states that live instrumentation is opt-in and must use checked capture
+
+Scenario: Inventories include P77
+  Test:
+    Filter: rg -n "p77-live-adoption-instrumentation-boundary|P77 live adoption instrumentation boundary" AGENTS.md CLAUDE.md docs/MIND-MODEL-DESIGN.md
+    Targets: Project inventories and design document.
+  Given project inventories and MIND-MODEL design
+  When searching for P77
+  Then the P77 spec, plan, and design summary are recorded
+
+## Out of Scope
+
+- Installing runtime hooks.
+- Wrapping agent tool calls.
+- Executing rollback policies.
+- Automatically changing context defaults.

--- a/specs/p78-card-context-default-runtime-flag.spec.md
+++ b/specs/p78-card-context-default-runtime-flag.spec.md
@@ -1,0 +1,142 @@
+spec: task
+name: "P78: card context default runtime flag"
+inherits: project
+tags: [phase-3, context, cards, default-policy]
+---
+
+## Intent
+
+P74 introduced a read-only default-on proposal for card-aware context, and P75
+left the actual default-on runtime change as an open gap. P78 adds an explicit,
+reversible runtime flag for card context defaults. The flag must remain disabled
+by default, must only be enabled through a proposal-ready Phase-3 control path,
+and must be overrideable per request.
+
+## Decisions
+
+- Add config field `context.include_cards_default`, defaulting to `false`.
+- `mempal context` uses `context.include_cards_default` when neither
+  `--include-cards` nor `--no-include-cards` is provided.
+- `mempal_context` uses `context.include_cards_default` when MCP
+  `include_cards` is omitted.
+- Add CLI `mempal phase3 default-control card-context`.
+- `default-control --enable` must require a P74-ready proposal: sufficient
+  card-context readiness plus at least one rollback criterion.
+- `default-control --disable` is always allowed and writes the flag back to
+  `false`.
+- The control command writes only the local mempal config file, not drawers,
+  runtime adoption events, cards, or schema.
+- P78 must leave its own spec and plan per the P76 invariant.
+
+## Boundaries
+
+### Allowed Changes
+- specs/p78-card-context-default-runtime-flag.spec.md
+- docs/plans/2026-05-13-p78-card-context-default-runtime-flag.md
+- src/core/config.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/core/protocol.rs
+- tests/context_assembler.rs
+- tests/phase3_runtime.rs
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+- Do not change search defaults.
+- Do not make card context default-on without config.
+- Do not enable the flag when P74 proposal readiness fails.
+- Do not add new database schema.
+- Do not append runtime adoption events from `default-control`.
+- Do not remove explicit `--include-cards` or MCP `include_cards=true`.
+
+## Acceptance Criteria
+
+Scenario: Config default keeps card context opt-in
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_config_default_false_omits_cards
+    Targets: CLI context default behavior.
+  Given no config file or a config with `context.include_cards_default=false`
+  And query text `card-aware`
+  When running `mempal context "card-aware" --format json` without card flags
+  Then the context response omits card sections
+
+Scenario: Config flag enables card context by default
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_config_default_true_includes_cards
+    Targets: CLI context config default.
+  Given a config with `context.include_cards_default=true`
+  And an active knowledge card with linked evidence exists
+  And query text `card-aware`
+  When running `mempal context "card-aware" --format json` without card flags
+  Then the context response includes card sections
+
+Scenario: CLI per-request no flag overrides config default
+  Test:
+    Filter: cargo test --test context_assembler test_cli_context_no_include_cards_overrides_config_default_true
+    Targets: CLI override behavior.
+  Given a config with `context.include_cards_default=true`
+  And query text `card-aware`
+  When running `mempal context "card-aware" --no-include-cards --format json`
+  Then the context response omits card sections
+
+Scenario: MCP omitted include_cards follows config default
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_context_include_cards_omitted_uses_config_default --lib
+    Targets: MCP context behavior.
+  Given an MCP server configured with `context.include_cards_default=true`
+  And a request omits `include_cards`
+  When calling `mempal_context`
+  Then the response includes card sections
+
+Scenario: Default control enables only after proposal is ready
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_enable_requires_ready_proposal
+    Targets: CLI default-control gate and config file side effect.
+  Given no accepted `card_context/include_cards` evidence
+  And rollback criterion text `disable if rollbacks appear`
+  When running `mempal phase3 default-control card-context --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the command reports `applied=false`
+  And `context.include_cards_default` remains false
+  Given three accepted `card_context/include_cards` events
+  When running the same enable command
+  Then it reports `applied=true`
+  And config `context.include_cards_default` becomes true
+
+Scenario: Default control writes config file on successful enable
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_enable_writes_config_file_output
+    Targets: Config file side effect.
+  Given three accepted `card_context/include_cards` events
+  And a rollback criterion value is provided
+  When running `mempal phase3 default-control card-context --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the local config file exists
+  And the file contains `include_cards_default = true`
+
+Scenario: Default control rejects unknown candidate without config write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_rejects_unknown_candidate_without_config_write
+    Targets: CLI error path and config file side effect.
+  Given no config file exists
+  When running `mempal phase3 default-control unknown --enable --rollback-criterion "disable if rollbacks appear" --format json`
+  Then the command fails
+  And stderr includes `unsupported phase3 default-control candidate`
+  And no config file is created
+
+Scenario: Default control disable is reversible and read-model safe
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_default_control_disable_is_reversible
+    Targets: CLI default-control disable path.
+  Given config `context.include_cards_default=true`
+  When running `mempal phase3 default-control card-context --disable --format json`
+  Then it reports `applied=true`
+  And config `context.include_cards_default` becomes false
+  And no runtime adoption event is appended
+
+## Out of Scope
+
+- Implementing rollback executor policy.
+- Installing live instrumentation hooks.
+- Making search card-aware by default.
+- Adding new persistence schema.

--- a/specs/p79-rollback-executor-policy.spec.md
+++ b/specs/p79-rollback-executor-policy.spec.md
@@ -1,0 +1,151 @@
+spec: task
+name: "P79: rollback executor policy"
+inherits: project
+tags: [phase-3, rollback, context, cards]
+---
+
+## Intent
+
+P78 added an explicit default runtime flag for card-aware context, but rollback
+criteria were still mostly advisory: operators could disable the flag manually,
+yet there was no deterministic executor that converted rollback evidence into a
+policy action. P79 adds the smallest safe rollback executor for the existing
+`card-context` default flag: evaluate runtime adoption evidence, report whether
+rollback is required, and optionally disable the local config flag when
+`--execute` is explicitly supplied.
+
+## Decisions
+
+- P79 must leave its own spec and plan per the P76 invariant.
+- The only supported P79 candidate is `card-context`; it maps to
+  `context.include_cards_default`.
+- Rollback evidence is read from `runtime_adoption_events` with
+  `track=card_context`, `feature=include_cards`, and `signal=rollback`.
+- Rollback executor is safe-by-default: without `--execute`, it is read-only and
+  must not write config or DB state.
+- With `--execute`, rollback may only write local config and set
+  `context.include_cards_default=false`; it must not append runtime adoption
+  events or alter knowledge lifecycle state.
+- If `context.include_cards_default` is already false, rollback execution is a
+  no-op and must still report `applied=false`.
+- The executor should be exposed through CLI `mempal phase3 rollback-control`
+  and MCP `mempal_phase3 action=rollback_control`.
+- Unknown candidates must fail before writing config.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p79-rollback-executor-policy.spec.md
+- docs/plans/2026-05-13-p79-rollback-executor-policy.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/core/phase3.rs
+- src/core/protocol.rs
+- src/main.rs
+- src/mcp/server.rs
+- src/mcp/tools.rs
+- tests/phase3_runtime.rs
+
+### Forbidden
+
+- Do not change SQLite schema.
+- Do not create a generic rollback engine for unrelated candidates.
+- Do not enable or disable card context automatically in background.
+- Do not make `mempal context` include cards by default without config.
+- Do not write runtime adoption events from rollback execution.
+- Do not alter knowledge card lifecycle promotion or demotion rules.
+
+## Acceptance Criteria
+
+Scenario: CLI rollback check is read-only without execute
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_check_is_read_only
+    Targets: CLI rollback-control read-only behavior.
+  Given `context.include_cards_default=true`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = true`
+
+Scenario: CLI rollback execute disables card context default
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_disables_default
+    Targets: CLI rollback-control config side effect.
+  Given `context.include_cards_default=true`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=true`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=true`
+  And the config file contains `include_cards_default = false`
+
+Scenario: CLI rollback execute is no-op without rollback evidence
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_without_signal_is_noop
+    Targets: CLI rollback-control no-signal behavior.
+  Given `context.include_cards_default=true`
+  And no rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=false`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = true`
+
+Scenario: CLI rollback execute is no-op when already disabled
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_execute_already_disabled_is_noop
+    Targets: CLI rollback-control disabled-state behavior.
+  Given `context.include_cards_default=false`
+  And rollback evidence exists for `card_context/include_cards`
+  When running `mempal phase3 rollback-control card-context --execute --format json`
+  Then the command succeeds
+  And JSON reports `writes=false`
+  And JSON reports `rollback_required=true`
+  And JSON reports `applied=false`
+  And the config file still contains `include_cards_default = false`
+
+Scenario: CLI rejects unknown rollback candidate without config write
+  Test:
+    Filter: cargo test --test phase3_runtime test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write
+    Targets: CLI rollback-control error behavior.
+  Given no config file exists
+  When running `mempal phase3 rollback-control unknown --execute --format json`
+  Then the command fails
+  And stderr contains `unsupported phase3 rollback-control candidate`
+  And no config file is created
+
+Scenario: MCP rollback control check is read-only
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_phase3_rollback_control_check_is_read_only --lib
+    Targets: MCP rollback-control read-only behavior.
+  Given `mempal_phase3` receives action `rollback_control`
+  And candidate `card-context`
+  And execute is omitted
+  And rollback evidence exists for `card_context/include_cards`
+  When the tool returns a response
+  Then `rollback_control.writes=false`
+  And `rollback_control.rollback_required=true`
+  And `rollback_control.applied=false`
+
+Scenario: MCP tool registry documents rollback control
+  Test:
+    Filter: cargo test mcp::server::tests::test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface --lib
+    Targets: MCP tool registry and memory protocol.
+  Given the MCP tool registry is listed
+  When inspecting `mempal_phase3`
+  Then its description contains `rollback_control`
+  And the memory protocol contains `action=rollback_control`
+
+## Out of Scope
+
+- Multi-candidate rollback policy.
+- Background rollback daemon or hook.
+- Automatic rollback based on live agent behavior without explicit `execute`.
+- Runtime adoption event mutation, deletion, or synthesis.

--- a/specs/p80-autonomous-promotion-boundary-audit.spec.md
+++ b/specs/p80-autonomous-promotion-boundary-audit.spec.md
@@ -1,0 +1,112 @@
+spec: task
+name: "P80: autonomous promotion boundary audit"
+inherits: project
+tags: [phase-3, governance, autonomy, audit]
+---
+
+## Intent
+
+P70 and P75 treated missing autonomous promotion authority as a possible gap in
+the "complete self-evolving agent system" objective. P80 resolves that ambiguity
+as a design boundary instead of adding unsafe authority: mempal may autonomously
+collect evidence, propose candidates, evaluate gates, recommend actions, enable
+explicit default controls, and execute explicit rollback controls, but it must
+not autonomously mutate knowledge lifecycle status. Human-gated or explicit
+operator-triggered lifecycle mutation is the final governance boundary for this
+design stage.
+
+## Decisions
+
+- P80 must leave its own spec and plan per the P76 invariant.
+- Autonomous promotion is explicitly out of scope for the current complete
+  self-evolution design.
+- `mempal_knowledge_promote`, `mempal_knowledge_demote`, knowledge-card
+  promote/demote, and equivalent CLI commands remain explicit lifecycle
+  mutation surfaces.
+- Evaluators remain advisory-only and cannot satisfy reviewer or lifecycle
+  authority requirements.
+- Runtime adoption, research ingestion, card context default control, and
+  rollback control may affect evidence/config, but must not bypass lifecycle
+  gates or human/operator intent.
+- P80 is a docs/protocol/spec audit only; it must not add schema, background
+  workers, hooks, daemons, or automatic promotion execution.
+- After P80, the active completion question should be reframed as: whether the
+  governed self-evolution system, with human-gated lifecycle authority, satisfies
+  the user's objective.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p80-autonomous-promotion-boundary-audit.spec.md
+- docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+- src/core/protocol.rs
+
+### Forbidden
+
+- Do not implement autonomous promotion or demotion.
+- Do not add new CLI or MCP lifecycle mutation commands.
+- Do not change SQLite schema.
+- Do not change promotion/demotion gate behavior.
+- Do not add background workers, hooks, or daemons.
+- Do not mark the whole active goal complete without a separate completion
+  audit against current artifacts.
+
+## Acceptance Criteria
+
+Scenario: P80 spec and plan are present
+  Test:
+    Filter: agent-spec parse specs/p80-autonomous-promotion-boundary-audit.spec.md && agent-spec lint specs/p80-autonomous-promotion-boundary-audit.spec.md --min-score 0.7
+    Targets: P76 spec completeness invariant.
+  Given P80 is a numbered P
+  When checking repository artifacts
+  Then `specs/p80-autonomous-promotion-boundary-audit.spec.md` exists
+  And `docs/plans/2026-05-13-p80-autonomous-promotion-boundary-audit.md` exists
+
+Scenario: MIND-MODEL records human-gated lifecycle as final boundary
+  Test:
+    Filter: rg -n "P80 autonomous promotion boundary audit|human-gated lifecycle authority|autonomous promotion is out of scope" docs/MIND-MODEL-DESIGN.md
+    Targets: Design narrative.
+  Given P80 resolves the autonomous promotion ambiguity
+  When reading `docs/MIND-MODEL-DESIGN.md`
+  Then it states autonomous promotion is out of scope
+  And it states human-gated lifecycle authority is the final governance boundary
+  And it identifies the next step as a completion audit, not more implementation
+
+Scenario: Protocol tells agents not to autonomously mutate lifecycle state
+  Test:
+    Filter: rg -n "must not autonomously promote|human/operator-triggered lifecycle mutation|evaluator advice remains advisory" src/core/protocol.rs
+    Targets: MCP protocol instructions.
+  Given agents consume `MEMORY_PROTOCOL`
+  When reading `src/core/protocol.rs`
+  Then the protocol forbids autonomous promotion
+  And it keeps evaluator advice advisory-only
+  And it requires explicit human/operator-triggered lifecycle mutation
+
+Scenario: AGENTS and CLAUDE inventories include P80
+  Test:
+    Filter: rg -n "p80-autonomous-promotion-boundary-audit|P80 autonomous promotion boundary audit" AGENTS.md CLAUDE.md
+    Targets: Repository agent inventories.
+  Given repository-level agent instructions list completed specs and plans
+  When checking `AGENTS.md` and `CLAUDE.md`
+  Then both files list the P80 spec
+  And both files list the P80 plan
+
+Scenario: No autonomous lifecycle implementation is added
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: Implementation boundary.
+  Given P80 is a docs/protocol audit
+  When inspecting changed paths
+  Then changed files are limited to P80 spec, P80 plan, AGENTS, CLAUDE, MIND-MODEL, and protocol docs
+  And no Rust command, MCP handler, schema, or lifecycle implementation file is changed except `src/core/protocol.rs`
+
+## Out of Scope
+
+- Autonomous promotion implementation.
+- Autonomous demotion implementation.
+- Agent runtime wrappers that call lifecycle mutation commands.
+- New completion claim without an explicit audit spec or audit artifact.

--- a/specs/p81-self-evolution-completion-audit.spec.md
+++ b/specs/p81-self-evolution-completion-audit.spec.md
@@ -1,0 +1,107 @@
+spec: task
+name: "P81: self-evolution completion audit"
+inherits: project
+tags: [phase-3, completion, audit, self-evolution]
+---
+
+## Intent
+
+P80 resolved autonomous promotion as an explicit out-of-scope boundary, leaving
+the active objective to be audited under the governed human-gated definition of
+a complete self-evolving agent system. P81 performs that final completion audit:
+restate the objective as concrete deliverables, map each deliverable to actual
+artifacts and verification evidence, identify uncovered requirements, and state
+whether the objective is complete under the current design boundary.
+
+## Decisions
+
+- P81 must leave its own spec and plan per the P76 invariant.
+- The audited objective is `完整自进化 agent 系统`.
+- "Complete" means complete under the P80 governed boundary: autonomous evidence
+  capture/proposal/retrieval/adoption support is allowed, but durable lifecycle
+  mutation remains human/operator-triggered.
+- The audit must not rely on green CI alone; it must map concrete requirements
+  to artifacts, tests, specs, protocol, and merged PR/main CI evidence.
+- If fully autonomous lifecycle mutation is required, the audit must mark the
+  objective incomplete and identify that as a separate future requirement.
+- P81 is docs/audit only and must not implement new runtime behavior.
+
+## Boundaries
+
+### Allowed Changes
+
+- specs/p81-self-evolution-completion-audit.spec.md
+- docs/plans/2026-05-13-p81-self-evolution-completion-audit.md
+- AGENTS.md
+- CLAUDE.md
+- docs/MIND-MODEL-DESIGN.md
+
+### Forbidden
+
+- Do not change Rust runtime code.
+- Do not change MCP protocol behavior.
+- Do not change schema or tests.
+- Do not mark completion without prompt-to-artifact evidence.
+- Do not redefine autonomous promotion back into scope.
+
+## Acceptance Criteria
+
+Scenario: P81 spec and plan are present
+  Test:
+    Filter: agent-spec parse specs/p81-self-evolution-completion-audit.spec.md && agent-spec lint specs/p81-self-evolution-completion-audit.spec.md --min-score 0.7
+    Targets: P76 spec completeness invariant.
+  Given P81 is a numbered P
+  When checking repository artifacts
+  Then `specs/p81-self-evolution-completion-audit.spec.md` exists
+  And `docs/plans/2026-05-13-p81-self-evolution-completion-audit.md` exists
+
+Scenario: MIND-MODEL contains the final objective restatement
+  Test:
+    Filter: rg -n "P81 self-evolution completion audit|Objective restatement|governed human-gated complete self-evolving agent system" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion audit narrative.
+  Given P81 audits the active objective
+  When reading `docs/MIND-MODEL-DESIGN.md`
+  Then it restates `完整自进化 agent 系统` as concrete deliverables
+  And it names the governed human-gated boundary from P80
+
+Scenario: MIND-MODEL maps prompts to artifacts and evidence
+  Test:
+    Filter: rg -n "Prompt-to-artifact checklist|Evidence substrate|Knowledge governance|Runtime feedback loop|Rollback and default control|Lifecycle authority boundary|Mainline verification" docs/MIND-MODEL-DESIGN.md
+    Targets: Audit checklist.
+  Given completion cannot rely on CI alone
+  When reading the P81 section
+  Then each deliverable is mapped to concrete specs, files, tests, or PR/CI evidence
+  And the audit mentions mainline verification evidence
+
+Scenario: MIND-MODEL states completion result and residual boundary
+  Test:
+    Filter: rg -n "P81 conclusion: complete|Residual boundary|fully autonomous lifecycle mutation remains out of scope" docs/MIND-MODEL-DESIGN.md
+    Targets: Completion conclusion.
+  Given P80 excludes autonomous lifecycle mutation
+  When reading the P81 conclusion
+  Then the objective is marked complete under the governed boundary
+  And fully autonomous lifecycle mutation remains explicitly out of scope
+
+Scenario: AGENTS and CLAUDE inventories include P81
+  Test:
+    Filter: rg -n "p81-self-evolution-completion-audit|P81 self-evolution completion audit" AGENTS.md CLAUDE.md
+    Targets: Repository agent inventories.
+  Given repository-level agent instructions list completed specs and plans
+  When checking `AGENTS.md` and `CLAUDE.md`
+  Then both files list the P81 spec
+  And both files list the P81 plan
+
+Scenario: Audit-only boundary is preserved
+  Test:
+    Filter: git diff --name-only main...HEAD
+    Targets: Changed file boundary.
+  Given P81 is docs/audit only
+  When inspecting changed paths
+  Then changed files are limited to P81 spec, P81 plan, AGENTS, CLAUDE, and MIND-MODEL
+
+## Out of Scope
+
+- New runtime features.
+- New tests or schema.
+- Autonomous lifecycle mutation.
+- Updating goal status before the audit PR lands on main and CI is green.

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -2,17 +2,18 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
 const DEFAULT_EMBED_BACKEND: &str = "model2vec";
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub db_path: String,
     pub embed: EmbedConfig,
+    pub context: ContextConfig,
 }
 
 impl Default for Config {
@@ -20,6 +21,7 @@ impl Default for Config {
         Self {
             db_path: DEFAULT_DB_PATH.to_string(),
             embed: EmbedConfig::default(),
+            context: ContextConfig::default(),
         }
     }
 }
@@ -39,9 +41,27 @@ impl Config {
             }),
         }
     }
+
+    pub fn save_to(&self, path: &Path) -> Result<(), ConfigError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        fs::write(path, contents).map_err(|source| ConfigError::Write {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+
+    pub fn save_default(&self) -> Result<(), ConfigError> {
+        self.save_to(&default_config_path())
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(default)]
 pub struct EmbedConfig {
     pub backend: String,
@@ -62,6 +82,12 @@ impl Default for EmbedConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct ContextConfig {
+    pub include_cards_default: bool,
+}
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to read config from {path}")]
@@ -70,8 +96,16 @@ pub enum ConfigError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to write config to {path}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("failed to parse config TOML")]
     Parse(#[from] toml::de::Error),
+    #[error("failed to serialize config TOML")]
+    Serialize(#[from] toml::ser::Error),
 }
 
 fn default_config_path() -> PathBuf {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -185,17 +185,39 @@ impl Config {
     }
 
     pub fn save_to(&self, path: &Path) -> Result<(), ConfigError> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
-                path: parent.to_path_buf(),
+        use std::io::Write as _;
+
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+        let contents = toml::to_string_pretty(self)?;
+        // Stage in same directory so persist() is an atomic rename, not a
+        // cross-filesystem copy. NamedTempFile is auto-removed on Drop if
+        // persist is not called (e.g. on error path).
+        let mut tmp =
+            tempfile::NamedTempFile::new_in(parent).map_err(|source| ConfigError::Write {
+                path: path.to_path_buf(),
                 source,
             })?;
-        }
-        let contents = toml::to_string_pretty(self)?;
-        fs::write(path, contents).map_err(|source| ConfigError::Write {
-            path: path.to_path_buf(),
-            source,
-        })
+        tmp.write_all(contents.as_bytes())
+            .map_err(|source| ConfigError::Write {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        tmp.as_file()
+            .sync_all()
+            .map_err(|source| ConfigError::Write {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        tmp.persist(path)
+            .map_err(|err| ConfigError::Write {
+                path: path.to_path_buf(),
+                source: err.error,
+            })
+            .map(|_| ())
     }
 
     pub fn save_default(&self) -> Result<(), ConfigError> {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@
 pub mod anchor;
 pub mod config;
 pub mod db;
+pub mod phase3;
 pub mod protocol;
 pub mod types;
 pub mod utils;

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -131,6 +131,19 @@ pub struct CardContextDefaultProposalReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CardContextRollbackControlReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub execute: bool,
+    pub rollback_required: bool,
+    pub applied: bool,
+    pub include_cards_default_before: bool,
+    pub include_cards_default_after: bool,
+    pub review: RuntimeAdoptionReviewReport,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
     pub feature: Option<String>,
@@ -585,6 +598,52 @@ pub fn card_context_default_proposal(
         .to_string(),
         readiness,
         rollback_criteria,
+        reasons,
+    }
+}
+
+pub fn card_context_rollback_control(
+    events: &[RuntimeAdoptionEvent],
+    include_cards_default: bool,
+    execute: bool,
+) -> CardContextRollbackControlReport {
+    let review = review_runtime_adoption_events(
+        events,
+        RuntimeAdoptionReviewFilters {
+            track: Some("card_context".to_string()),
+            feature: Some("include_cards".to_string()),
+            signal: Some("rollback".to_string()),
+            limit: 10_000,
+        },
+    );
+    let rollback_required = review.stats.rollbacks > 0;
+    let applied = execute && rollback_required && include_cards_default;
+    let include_cards_default_after = include_cards_default && !applied;
+    let mut reasons = Vec::new();
+    if rollback_required {
+        reasons.push("rollback evidence exists for card_context/include_cards".to_string());
+    } else {
+        reasons.push("no rollback evidence exists for card_context/include_cards".to_string());
+    }
+    if !execute {
+        reasons.push("execute=false leaves config unchanged".to_string());
+    } else if applied {
+        reasons.push("card context default disabled by rollback control".to_string());
+    } else if !include_cards_default {
+        reasons.push("card context default already disabled".to_string());
+    } else {
+        reasons.push("rollback not required; config unchanged".to_string());
+    }
+
+    CardContextRollbackControlReport {
+        writes: applied,
+        candidate: "card-context".to_string(),
+        execute,
+        rollback_required,
+        applied,
+        include_cards_default_before: include_cards_default,
+        include_cards_default_after,
+        review,
         reasons,
     }
 }

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -59,6 +59,17 @@ pub struct RuntimeAdoptionCheckedRecordReport {
     pub event: Option<RuntimeAdoptionEvent>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionCaptureReport {
+    pub writes: bool,
+    pub execute: bool,
+    pub surface: String,
+    pub outcome: String,
+    pub record_plan: RuntimeAdoptionRecordPlan,
+    pub record_quality: RuntimeAdoptionRecordQualityReport,
+    pub record_checked: Option<RuntimeAdoptionCheckedRecordReport>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -149,6 +160,20 @@ pub struct RuntimeAdoptionRecordPlanInput {
     pub track: String,
     pub signal: String,
     pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeAdoptionCaptureInput {
+    pub id: Option<String>,
+    pub surface: String,
+    pub outcome: String,
     pub query: Option<String>,
     pub context_hash: Option<String>,
     pub card_id: Option<String>,
@@ -305,6 +330,45 @@ pub fn prepare_runtime_adoption_record(
     }
 }
 
+pub fn capture_runtime_adoption_record_input(
+    input: RuntimeAdoptionCaptureInput,
+) -> Result<RuntimeAdoptionRecordPlanInput, String> {
+    let (track, feature) = capture_surface_mapping(&input.surface)?;
+    let signal = capture_outcome_signal(&input.outcome)?;
+    Ok(RuntimeAdoptionRecordPlanInput {
+        id: input.id,
+        track,
+        signal,
+        feature,
+        query: input.query,
+        context_hash: input.context_hash,
+        card_id: input.card_id,
+        evaluator_id: input.evaluator_id,
+        research_report_id: input.research_report_id,
+        note: input.note,
+        metadata: input.metadata,
+    })
+}
+
+pub fn prepare_runtime_adoption_capture(
+    surface: String,
+    outcome: String,
+    execute: bool,
+    record_input: RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionCaptureReport {
+    let record_plan = prepare_runtime_adoption_record(record_input.clone());
+    let record_quality = check_runtime_adoption_record(&record_input);
+    RuntimeAdoptionCaptureReport {
+        writes: false,
+        execute,
+        surface,
+        outcome,
+        record_plan,
+        record_quality,
+        record_checked: None,
+    }
+}
+
 pub fn check_runtime_adoption_record(
     input: &RuntimeAdoptionRecordPlanInput,
 ) -> RuntimeAdoptionRecordQualityReport {
@@ -354,6 +418,40 @@ pub fn check_runtime_adoption_record(
         quality,
         errors,
         warnings,
+    }
+}
+
+fn capture_surface_mapping(surface: &str) -> Result<(String, String), String> {
+    match surface.trim() {
+        "card-context" | "card_context" => {
+            Ok(("card_context".to_string(), "include_cards".to_string()))
+        }
+        "card-embedding" | "card_embedding" => Ok((
+            "card_embedding".to_string(),
+            "card_statement_recall".to_string(),
+        )),
+        "research-adapter" | "research_adapter" => Ok((
+            "research_adapter".to_string(),
+            "research_ingest_plan".to_string(),
+        )),
+        "evaluator" => Ok(("evaluator".to_string(), "advisory_gate".to_string())),
+        "runtime-context" | "runtime_context" => {
+            Ok(("runtime_adoption".to_string(), "context_pack".to_string()))
+        }
+        "skill-selection" | "skill_selection" => Ok((
+            "runtime_adoption".to_string(),
+            "skill_selection".to_string(),
+        )),
+        other => Err(format!("unsupported adoption capture surface: {other}")),
+    }
+}
+
+fn capture_outcome_signal(outcome: &str) -> Result<String, String> {
+    match outcome.trim() {
+        "used" | "accepted" | "rejected" | "miss" | "rollback" | "contradiction" | "neutral" => {
+            Ok(outcome.trim().to_string())
+        }
+        other => Err(format!("unsupported adoption capture outcome: {other}")),
     }
 }
 

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -51,6 +51,14 @@ pub struct RuntimeAdoptionRecordQualityReport {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionCheckedRecordReport {
+    pub writes: bool,
+    pub blocked: bool,
+    pub record_quality: RuntimeAdoptionRecordQualityReport,
+    pub event: Option<RuntimeAdoptionEvent>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -347,6 +355,14 @@ pub fn check_runtime_adoption_record(
         errors,
         warnings,
     }
+}
+
+pub fn should_write_checked_record(
+    quality: &RuntimeAdoptionRecordQualityReport,
+    allow_warnings: bool,
+) -> bool {
+    quality.valid
+        && (quality.quality == "ready" || (allow_warnings && quality.quality == "warning"))
 }
 
 pub fn review_runtime_adoption_events(

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -35,6 +35,25 @@ pub struct RuntimeAdoptionTrackGuidance {
     pub feature_examples: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionInstrumentationPolicy {
+    pub version: u32,
+    pub writes: bool,
+    pub default_mode: String,
+    pub allowed_modes: Vec<RuntimeAdoptionInstrumentationMode>,
+    pub forbidden_modes: Vec<String>,
+    pub requirements: Vec<String>,
+    pub rollback_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionInstrumentationMode {
+    pub mode: String,
+    pub description: String,
+    pub requires_execute: bool,
+    pub requires_checked_capture: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RuntimeAdoptionRecordPlan {
     pub writes: bool,
@@ -307,6 +326,42 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                     "research_ingest_plan".to_string(),
                 ],
             },
+        ],
+    }
+}
+
+pub fn runtime_adoption_instrumentation_policy() -> RuntimeAdoptionInstrumentationPolicy {
+    RuntimeAdoptionInstrumentationPolicy {
+        version: 1,
+        writes: false,
+        default_mode: "manual_only".to_string(),
+        allowed_modes: vec![
+            RuntimeAdoptionInstrumentationMode {
+                mode: "manual_only".to_string(),
+                description: "agents explicitly call guidance, capture, or record_checked after observing a concrete runtime outcome".to_string(),
+                requires_execute: false,
+                requires_checked_capture: true,
+            },
+            RuntimeAdoptionInstrumentationMode {
+                mode: "opt_in_wrapper".to_string(),
+                description: "a user-enabled wrapper may prepare capture inputs around a tool call, but writes still require execute=true and checked capture quality gates".to_string(),
+                requires_execute: true,
+                requires_checked_capture: true,
+            },
+        ],
+        forbidden_modes: vec![
+            "implicit_background_capture".to_string(),
+            "silent_event_append".to_string(),
+            "quality_gate_bypass".to_string(),
+        ],
+        requirements: vec![
+            "live instrumentation is opt-in; users must have an opt-out before any capture is written".to_string(),
+            "wrappers must preserve source surface, outcome, query/context identifiers, and relevant metadata".to_string(),
+            "writes must go through existing capture or record_checked quality gates".to_string(),
+        ],
+        rollback_requirements: vec![
+            "rollback criteria must be recorded before any future default-on instrumentation proposal".to_string(),
+            "rollback signals must be captured when instrumentation degrades task behavior or creates noisy evidence".to_string(),
         ],
     }
 }

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,5 +1,9 @@
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 use serde_json::{Map, Value};
+
+use super::types::{RuntimeAdoptionEvent, RuntimeAdoptionSignal};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -38,6 +42,43 @@ pub struct RuntimeAdoptionRecordQualityReport {
     pub quality: String,
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionReviewFilters {
+    pub track: Option<String>,
+    pub feature: Option<String>,
+    pub signal: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct RuntimeAdoptionSignalCounts {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionFeatureReview {
+    pub feature: String,
+    pub stats: RuntimeAdoptionSignalCounts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionReviewReport {
+    pub writes: bool,
+    pub filters: RuntimeAdoptionReviewFilters,
+    pub total: usize,
+    pub stats: RuntimeAdoptionSignalCounts,
+    pub features: Vec<RuntimeAdoptionFeatureReview>,
+    pub conclusion: String,
+    pub reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -251,6 +292,94 @@ pub fn check_runtime_adoption_record(
     }
 }
 
+pub fn review_runtime_adoption_events(
+    events: &[RuntimeAdoptionEvent],
+    filters: RuntimeAdoptionReviewFilters,
+) -> RuntimeAdoptionReviewReport {
+    let filtered_events = events
+        .iter()
+        .filter(|event| {
+            filters
+                .signal
+                .as_deref()
+                .is_none_or(|signal| runtime_adoption_signal_slug(&event.signal) == signal)
+        })
+        .collect::<Vec<_>>();
+
+    let stats = RuntimeAdoptionSignalCounts::from_events(filtered_events.iter().copied());
+    let mut by_feature = BTreeMap::<String, Vec<&RuntimeAdoptionEvent>>::new();
+    for event in &filtered_events {
+        by_feature
+            .entry(event.feature.clone())
+            .or_default()
+            .push(event);
+    }
+    let features = by_feature
+        .into_iter()
+        .map(|(feature, events)| RuntimeAdoptionFeatureReview {
+            feature,
+            stats: RuntimeAdoptionSignalCounts::from_events(events),
+        })
+        .collect::<Vec<_>>();
+
+    let (conclusion, reasons) = review_conclusion(&stats);
+
+    RuntimeAdoptionReviewReport {
+        writes: false,
+        filters,
+        total: stats.total,
+        stats,
+        features,
+        conclusion,
+        reasons,
+    }
+}
+
+impl RuntimeAdoptionSignalCounts {
+    fn from_events<'a>(events: impl IntoIterator<Item = &'a RuntimeAdoptionEvent>) -> Self {
+        let mut stats = Self::default();
+        for event in events {
+            stats.total += 1;
+            match event.signal {
+                RuntimeAdoptionSignal::Used => stats.used += 1,
+                RuntimeAdoptionSignal::Accepted => stats.accepted += 1,
+                RuntimeAdoptionSignal::Rejected => stats.rejected += 1,
+                RuntimeAdoptionSignal::Miss => stats.misses += 1,
+                RuntimeAdoptionSignal::Rollback => stats.rollbacks += 1,
+                RuntimeAdoptionSignal::Contradiction => stats.contradictions += 1,
+                RuntimeAdoptionSignal::Neutral => stats.neutral += 1,
+            }
+        }
+        stats
+    }
+}
+
+fn review_conclusion(stats: &RuntimeAdoptionSignalCounts) -> (String, Vec<String>) {
+    if stats.total == 0 {
+        return (
+            "no_evidence".to_string(),
+            vec!["no runtime adoption events match the requested filters".to_string()],
+        );
+    }
+    if stats.rollbacks > 0 {
+        return (
+            "rollback_risk".to_string(),
+            vec!["rollback evidence exists for this adoption surface".to_string()],
+        );
+    }
+    if stats.accepted > 0 && stats.accepted >= stats.rejected + stats.misses + stats.contradictions
+    {
+        return (
+            "positive".to_string(),
+            vec!["accepted evidence is at least as strong as negative evidence".to_string()],
+        );
+    }
+    (
+        "mixed".to_string(),
+        vec!["evidence is present but not clearly positive".to_string()],
+    )
+}
+
 fn requires_outcome_context(signal: &str) -> bool {
     matches!(
         signal,
@@ -260,6 +389,18 @@ fn requires_outcome_context(signal: &str) -> bool {
 
 fn is_blank(value: &str) -> bool {
     value.trim().is_empty()
+}
+
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
 }
 
 fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -31,6 +31,15 @@ pub struct RuntimeAdoptionRecordPlan {
     pub record_payload: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionRecordQualityReport {
+    pub writes: bool,
+    pub valid: bool,
+    pub quality: String,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeAdoptionRecordPlanInput {
     pub id: Option<String>,
@@ -188,6 +197,69 @@ pub fn prepare_runtime_adoption_record(
         record_command: command,
         record_payload: Value::Object(payload),
     }
+}
+
+pub fn check_runtime_adoption_record(
+    input: &RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionRecordQualityReport {
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+
+    if is_blank(&input.feature) {
+        errors.push("feature must not be empty".to_string());
+    }
+
+    if requires_outcome_context(&input.signal)
+        && input.query.as_deref().is_none_or(is_blank)
+        && input.note.as_deref().is_none_or(is_blank)
+    {
+        warnings.push(
+            "missing concrete outcome context: provide note or query for this signal".to_string(),
+        );
+    }
+
+    match input.track.as_str() {
+        "card_context" | "card_embedding" if input.card_id.as_deref().is_none_or(is_blank) => {
+            warnings.push("missing card_id for card-related adoption evidence".to_string());
+        }
+        "evaluator" if input.evaluator_id.as_deref().is_none_or(is_blank) => {
+            warnings.push("missing evaluator_id for evaluator adoption evidence".to_string());
+        }
+        "research_adapter" if input.research_report_id.as_deref().is_none_or(is_blank) => {
+            warnings.push(
+                "missing research_report_id for research adapter adoption evidence".to_string(),
+            );
+        }
+        _ => {}
+    }
+
+    let quality = if !errors.is_empty() {
+        "invalid"
+    } else if !warnings.is_empty() {
+        "warning"
+    } else {
+        "ready"
+    }
+    .to_string();
+
+    RuntimeAdoptionRecordQualityReport {
+        writes: false,
+        valid: errors.is_empty(),
+        quality,
+        errors,
+        warnings,
+    }
+}
+
+fn requires_outcome_context(signal: &str) -> bool {
+    matches!(
+        signal,
+        "accepted" | "rejected" | "miss" | "rollback" | "contradiction"
+    )
+}
+
+fn is_blank(value: &str) -> bool {
+    value.trim().is_empty()
 }
 
 fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,0 +1,108 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionGuidance {
+    pub version: u32,
+    pub recording_rule: String,
+    pub required_fields: Vec<String>,
+    pub optional_fields: Vec<String>,
+    pub signals: Vec<RuntimeAdoptionSignalGuidance>,
+    pub tracks: Vec<RuntimeAdoptionTrackGuidance>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionSignalGuidance {
+    pub signal: String,
+    pub when: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeAdoptionTrackGuidance {
+    pub track: String,
+    pub when: String,
+    pub feature_examples: Vec<String>,
+}
+
+pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
+    RuntimeAdoptionGuidance {
+        version: 1,
+        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
+        required_fields: vec![
+            "track".to_string(),
+            "signal".to_string(),
+            "feature".to_string(),
+        ],
+        optional_fields: vec![
+            "query".to_string(),
+            "context_hash".to_string(),
+            "card_id".to_string(),
+            "evaluator_id".to_string(),
+            "research_report_id".to_string(),
+            "note".to_string(),
+            "metadata".to_string(),
+        ],
+        signals: vec![
+            RuntimeAdoptionSignalGuidance {
+                signal: "used".to_string(),
+                when: "record when guidance was actually consumed during a task".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "accepted".to_string(),
+                when: "record when the consumed guidance materially helped the outcome".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "rejected".to_string(),
+                when: "record when guidance was considered and intentionally not followed"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "miss".to_string(),
+                when: "record when useful guidance should have appeared but did not".to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "rollback".to_string(),
+                when: "record when behavior was reverted because guidance degraded the outcome"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "contradiction".to_string(),
+                when: "record when guidance conflicted with stronger evidence or instructions"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidance {
+                signal: "neutral".to_string(),
+                when: "record when guidance was consumed but had no clear outcome impact"
+                    .to_string(),
+            },
+        ],
+        tracks: vec![
+            RuntimeAdoptionTrackGuidance {
+                track: "runtime_adoption".to_string(),
+                when: "general agent-runtime behavior evidence".to_string(),
+                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "card_context".to_string(),
+                when: "card-aware context affected or should have affected behavior".to_string(),
+                feature_examples: vec!["include_cards".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "card_embedding".to_string(),
+                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
+                feature_examples: vec!["card_statement_recall".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "evaluator".to_string(),
+                when: "evaluator advice affected or should have affected a lifecycle decision"
+                    .to_string(),
+                feature_examples: vec!["advisory_gate".to_string()],
+            },
+            RuntimeAdoptionTrackGuidance {
+                track: "research_adapter".to_string(),
+                when: "external research report validation or ingestion planning affected behavior"
+                    .to_string(),
+                feature_examples: vec!["research_validate_plan".to_string()],
+            },
+        ],
+    }
+}

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -70,6 +70,36 @@ pub struct RuntimeAdoptionCaptureReport {
     pub record_checked: Option<RuntimeAdoptionCheckedRecordReport>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvaluatorAdviceInput {
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct EvaluatorAdviceReport {
+    pub writes: bool,
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub recommendation: String,
+    pub lifecycle_authority: bool,
+    pub deterministic_gate_required: bool,
+    pub requires_human_review: bool,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub adoption_capture: RuntimeAdoptionRecordPlan,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
@@ -369,6 +399,92 @@ pub fn prepare_runtime_adoption_capture(
     }
 }
 
+pub fn evaluator_advice(input: EvaluatorAdviceInput) -> Result<EvaluatorAdviceReport, String> {
+    if is_blank(&input.evaluator_id) {
+        return Err("evaluator-id is required".to_string());
+    }
+    if is_blank(&input.subject_kind) {
+        return Err("subject-kind is required".to_string());
+    }
+    if is_blank(&input.subject_id) {
+        return Err("subject-id is required".to_string());
+    }
+    if is_blank(&input.proposed_action) {
+        return Err("proposed-action is required".to_string());
+    }
+
+    let evidence_refs = normalize_non_empty(input.evidence_refs);
+    let counterexample_refs = normalize_non_empty(input.counterexample_refs);
+    let risk_notes = normalize_non_empty(input.risk_notes);
+    let subject_kind = input.subject_kind.trim().to_string();
+    let proposed_action = input.proposed_action.trim().to_string();
+    let requires_human_review = subject_kind == "dao_tian" && proposed_action.contains("canonical");
+
+    let mut reasons = Vec::new();
+    reasons.push("evaluator output is advisory-only and has no lifecycle authority".to_string());
+    reasons
+        .push("deterministic promotion gates remain required before lifecycle changes".to_string());
+    if requires_human_review {
+        reasons.push("dao_tian canonicalization requires human review".to_string());
+    }
+
+    let recommendation = if !counterexample_refs.is_empty() || !risk_notes.is_empty() {
+        reasons
+            .push("counterexample refs or risk notes block supportive recommendation".to_string());
+        "do_not_promote"
+    } else if evidence_refs.is_empty() {
+        reasons.push("supporting evidence refs are required before promotion advice".to_string());
+        "needs_evidence"
+    } else if requires_human_review {
+        "requires_human_review"
+    } else {
+        reasons.push(
+            "supporting evidence refs are present and no risk blockers were supplied".to_string(),
+        );
+        "advisory_support"
+    }
+    .to_string();
+
+    let adoption_capture = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+        id: None,
+        track: "evaluator".to_string(),
+        signal: "used".to_string(),
+        feature: "advisory_gate".to_string(),
+        query: Some(format!(
+            "{subject_kind}:{} {proposed_action}",
+            input.subject_id.trim()
+        )),
+        context_hash: None,
+        card_id: None,
+        evaluator_id: Some(input.evaluator_id.trim().to_string()),
+        research_report_id: None,
+        note: input.note,
+        metadata: Some(evaluator_advice_metadata(
+            &subject_kind,
+            input.subject_id.trim(),
+            &proposed_action,
+            &recommendation,
+        )),
+    });
+
+    Ok(EvaluatorAdviceReport {
+        writes: false,
+        evaluator_id: input.evaluator_id.trim().to_string(),
+        subject_kind,
+        subject_id: input.subject_id.trim().to_string(),
+        proposed_action,
+        recommendation,
+        lifecycle_authority: false,
+        deterministic_gate_required: true,
+        requires_human_review,
+        evidence_refs,
+        counterexample_refs,
+        risk_notes,
+        reasons,
+        adoption_capture,
+    })
+}
+
 pub fn check_runtime_adoption_record(
     input: &RuntimeAdoptionRecordPlanInput,
 ) -> RuntimeAdoptionRecordQualityReport {
@@ -419,6 +535,40 @@ pub fn check_runtime_adoption_record(
         errors,
         warnings,
     }
+}
+
+fn normalize_non_empty(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn evaluator_advice_metadata(
+    subject_kind: &str,
+    subject_id: &str,
+    proposed_action: &str,
+    recommendation: &str,
+) -> Value {
+    let mut metadata = Map::new();
+    metadata.insert(
+        "subject_kind".to_string(),
+        Value::String(subject_kind.to_string()),
+    );
+    metadata.insert(
+        "subject_id".to_string(),
+        Value::String(subject_id.to_string()),
+    );
+    metadata.insert(
+        "proposed_action".to_string(),
+        Value::String(proposed_action.to_string()),
+    );
+    metadata.insert(
+        "recommendation".to_string(),
+        Value::String(recommendation.to_string()),
+    );
+    Value::Object(metadata)
 }
 
 fn capture_surface_mapping(surface: &str) -> Result<(String, String), String> {

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -3,7 +3,14 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::types::{RuntimeAdoptionEvent, RuntimeAdoptionSignal};
+use super::{
+    anchor,
+    types::{
+        AnchorKind, BootstrapIdentityParts, MemoryDomain, MemoryKind, Provenance,
+        RuntimeAdoptionEvent, RuntimeAdoptionSignal,
+    },
+    utils::build_bootstrap_drawer_id_from_parts,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -91,6 +98,41 @@ pub struct Phase3ReadinessReport {
     pub required_feature: String,
     pub review: RuntimeAdoptionReviewReport,
     pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchEvidenceDrawerPlan {
+    pub drawer_id: String,
+    pub finding_index: usize,
+    pub source_file: String,
+    pub created: bool,
+    pub skipped: bool,
+    #[serde(skip)]
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchCandidateInsightPlan {
+    pub statement: String,
+    pub supporting_refs: Vec<String>,
+    pub suggested_command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResearchIngestPlanReport {
+    pub valid: bool,
+    pub writes: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub planned_evidence_count: usize,
+    pub created_count: usize,
+    pub skipped_count: usize,
+    pub errors: Vec<String>,
+    pub evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
+    pub candidate_insights: Vec<ResearchCandidateInsightPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -186,7 +228,10 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                 track: "research_adapter".to_string(),
                 when: "external research report validation or ingestion planning affected behavior"
                     .to_string(),
-                feature_examples: vec!["research_validate_plan".to_string()],
+                feature_examples: vec![
+                    "research_validate_plan".to_string(),
+                    "research_ingest_plan".to_string(),
+                ],
             },
         ],
     }
@@ -436,6 +481,192 @@ pub fn card_context_default_readiness(events: &[RuntimeAdoptionEvent]) -> Phase3
         required_feature: "include_cards".to_string(),
         review,
         reasons,
+    }
+}
+
+pub fn build_research_ingest_plan_from_value(value: &Value) -> ResearchIngestPlanReport {
+    let mut errors = Vec::new();
+    let report_id = required_json_string(value, "report_id", &mut errors);
+    let title = required_json_string(value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let findings = value
+        .get("findings")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if findings.is_empty() {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_values = value
+        .get("candidate_insights")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let evidence_drawers = findings
+        .iter()
+        .enumerate()
+        .map(|(index, finding)| {
+            let content = research_evidence_content_from_value(
+                report_id.as_str(),
+                title.as_str(),
+                value.get("sources"),
+                finding,
+                index,
+            );
+            let drawer_id = research_evidence_drawer_id(&content);
+            ResearchEvidenceDrawerPlan {
+                drawer_id,
+                finding_index: index,
+                source_file: format!("research://{}#finding-{index}", report_id),
+                created: false,
+                skipped: false,
+                content,
+            }
+        })
+        .collect::<Vec<_>>();
+    let supporting_refs = evidence_drawers
+        .iter()
+        .map(|plan| plan.drawer_id.clone())
+        .collect::<Vec<_>>();
+    let candidate_insights = candidate_values
+        .iter()
+        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
+        .map(|statement| ResearchCandidateInsightPlan {
+            suggested_command: research_distill_command(&statement, &supporting_refs),
+            statement,
+            supporting_refs: supporting_refs.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    ResearchIngestPlanReport {
+        valid: errors.is_empty(),
+        writes: false,
+        report_id,
+        title,
+        source_count,
+        finding_count: findings.len(),
+        candidate_insight_count: candidate_values.len(),
+        planned_evidence_count: evidence_drawers.len(),
+        created_count: 0,
+        skipped_count: 0,
+        errors,
+        evidence_drawers,
+        candidate_insights,
+    }
+}
+
+fn research_evidence_content_from_value(
+    report_id: &str,
+    title: &str,
+    sources: Option<&Value>,
+    finding: &Value,
+    finding_index: usize,
+) -> String {
+    let summary = finding_summary(finding);
+    let sources = sources
+        .map(|value| serde_json::to_string_pretty(value).unwrap_or_else(|_| "[]".to_string()))
+        .unwrap_or_else(|| "[]".to_string());
+    let raw_finding = serde_json::to_string_pretty(finding).unwrap_or_else(|_| finding.to_string());
+    format!(
+        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
+    )
+}
+
+fn finding_summary(finding: &Value) -> String {
+    if let Some(raw) = finding.as_str() {
+        return raw.trim().to_string();
+    }
+    for field in ["summary", "statement", "content", "text"] {
+        if let Some(raw) = finding.get(field).and_then(Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return raw.trim().to_string();
+        }
+    }
+    serde_json::to_string(finding).unwrap_or_else(|_| finding.to_string())
+}
+
+fn candidate_statement(candidate: &Value) -> Option<&str> {
+    if let Some(raw) = candidate.as_str()
+        && !raw.trim().is_empty()
+    {
+        return Some(raw.trim());
+    }
+    for field in ["statement", "summary", "content", "text"] {
+        if let Some(raw) = candidate.get(field).and_then(Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Some(raw.trim());
+        }
+    }
+    None
+}
+
+fn research_evidence_drawer_id(content: &str) -> String {
+    let memory_kind = MemoryKind::Evidence;
+    let domain = MemoryDomain::Project;
+    let anchor_kind = AnchorKind::Repo;
+    let provenance = Provenance::Research;
+    let empty_refs: &[String] = &[];
+    build_bootstrap_drawer_id_from_parts(
+        "mempal",
+        Some("research"),
+        content,
+        BootstrapIdentityParts {
+            memory_kind: &memory_kind,
+            domain: &domain,
+            field: "research",
+            anchor_kind: &anchor_kind,
+            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
+            parent_anchor_id: None,
+            provenance: Some(&provenance),
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: empty_refs,
+            counterexample_refs: empty_refs,
+            teaching_refs: empty_refs,
+            verification_refs: empty_refs,
+            scope_constraints: None,
+            trigger_hints: None,
+        },
+    )
+}
+
+fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
+    let mut command = vec![
+        "mempal".to_string(),
+        "knowledge".to_string(),
+        "distill".to_string(),
+        "--tier".to_string(),
+        "qi".to_string(),
+        "--statement".to_string(),
+        statement.to_string(),
+        "--content".to_string(),
+        statement.to_string(),
+        "--field".to_string(),
+        "research".to_string(),
+    ];
+    for supporting_ref in supporting_refs {
+        push_command_arg(&mut command, "--supporting-ref", supporting_ref);
+    }
+    command
+}
+
+fn required_json_string(value: &Value, field: &'static str, errors: &mut Vec<String>) -> String {
+    match value.get(field).and_then(Value::as_str) {
+        Some(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => {
+            errors.push(format!("{field} is required"));
+            String::new()
+        }
     }
 }
 

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -101,6 +101,17 @@ pub struct EvaluatorAdviceReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CardContextDefaultProposalReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub proposal_ready: bool,
+    pub decision: String,
+    pub readiness: Phase3ReadinessReport,
+    pub rollback_criteria: Vec<String>,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionReviewFilters {
     pub track: Option<String>,
     pub feature: Option<String>,
@@ -483,6 +494,44 @@ pub fn evaluator_advice(input: EvaluatorAdviceInput) -> Result<EvaluatorAdviceRe
         reasons,
         adoption_capture,
     })
+}
+
+pub fn card_context_default_proposal(
+    events: &[RuntimeAdoptionEvent],
+    rollback_criteria: Vec<String>,
+) -> CardContextDefaultProposalReport {
+    let readiness = card_context_default_readiness(events);
+    let rollback_criteria = normalize_non_empty(rollback_criteria);
+    let mut reasons = Vec::new();
+    if readiness.ready {
+        reasons.push("card context default readiness threshold satisfied".to_string());
+    } else {
+        reasons.push("card context default readiness threshold not satisfied".to_string());
+    }
+    if rollback_criteria.is_empty() {
+        reasons.push("rollback criteria are required before default-on proposal".to_string());
+    } else {
+        reasons.push("explicit rollback criteria are present".to_string());
+    }
+    let proposal_ready = readiness.ready && !rollback_criteria.is_empty();
+    if proposal_ready {
+        reasons.push("proposal is eligible for a future default-on spec".to_string());
+    }
+
+    CardContextDefaultProposalReport {
+        writes: false,
+        candidate: "card-context".to_string(),
+        proposal_ready,
+        decision: if proposal_ready {
+            "eligible_for_default_on_spec"
+        } else {
+            "keep_opt_in"
+        }
+        .to_string(),
+        readiness,
+        rollback_criteria,
+        reasons,
+    }
 }
 
 pub fn check_runtime_adoption_record(

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RuntimeAdoptionGuidance {
@@ -21,6 +22,28 @@ pub struct RuntimeAdoptionTrackGuidance {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RuntimeAdoptionRecordPlan {
+    pub writes: bool,
+    pub record_command: Vec<String>,
+    pub record_payload: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeAdoptionRecordPlanInput {
+    pub id: Option<String>,
+    pub track: String,
+    pub signal: String,
+    pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<Value>,
 }
 
 pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
@@ -104,5 +127,76 @@ pub fn runtime_adoption_guidance() -> RuntimeAdoptionGuidance {
                 feature_examples: vec!["research_validate_plan".to_string()],
             },
         ],
+    }
+}
+
+pub fn prepare_runtime_adoption_record(
+    input: RuntimeAdoptionRecordPlanInput,
+) -> RuntimeAdoptionRecordPlan {
+    let mut command = vec![
+        "mempal".to_string(),
+        "phase3".to_string(),
+        "adoption".to_string(),
+        "record".to_string(),
+    ];
+    push_command_arg(&mut command, "--track", &input.track);
+    push_command_arg(&mut command, "--signal", &input.signal);
+    push_command_arg(&mut command, "--feature", &input.feature);
+    if let Some(value) = input.query.as_deref() {
+        push_command_arg(&mut command, "--query", value);
+    }
+    if let Some(value) = input.context_hash.as_deref() {
+        push_command_arg(&mut command, "--context-hash", value);
+    }
+    if let Some(value) = input.card_id.as_deref() {
+        push_command_arg(&mut command, "--card-id", value);
+    }
+    if let Some(value) = input.evaluator_id.as_deref() {
+        push_command_arg(&mut command, "--evaluator-id", value);
+    }
+    if let Some(value) = input.research_report_id.as_deref() {
+        push_command_arg(&mut command, "--research-report-id", value);
+    }
+    if let Some(value) = input.note.as_deref() {
+        push_command_arg(&mut command, "--note", value);
+    }
+    if let Some(value) = input.id.as_deref() {
+        push_command_arg(&mut command, "--id", value);
+    }
+    if let Some(metadata) = input.metadata.as_ref() {
+        push_command_arg(&mut command, "--metadata-json", &metadata.to_string());
+    }
+
+    let mut payload = Map::new();
+    payload.insert("action".to_string(), Value::String("record".to_string()));
+    insert_payload_string(&mut payload, "id", input.id);
+    insert_payload_string(&mut payload, "track", Some(input.track));
+    insert_payload_string(&mut payload, "signal", Some(input.signal));
+    insert_payload_string(&mut payload, "feature", Some(input.feature));
+    insert_payload_string(&mut payload, "query", input.query);
+    insert_payload_string(&mut payload, "context_hash", input.context_hash);
+    insert_payload_string(&mut payload, "card_id", input.card_id);
+    insert_payload_string(&mut payload, "evaluator_id", input.evaluator_id);
+    insert_payload_string(&mut payload, "research_report_id", input.research_report_id);
+    insert_payload_string(&mut payload, "note", input.note);
+    if let Some(metadata) = input.metadata {
+        payload.insert("metadata".to_string(), metadata);
+    }
+
+    RuntimeAdoptionRecordPlan {
+        writes: false,
+        record_command: command,
+        record_payload: Value::Object(payload),
+    }
+}
+
+fn push_command_arg(command: &mut Vec<String>, name: &str, value: &str) {
+    command.push(name.to_string());
+    command.push(value.to_string());
+}
+
+fn insert_payload_string(payload: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value {
+        payload.insert(key.to_string(), Value::String(value));
     }
 }

--- a/src/core/phase3.rs
+++ b/src/core/phase3.rs
@@ -81,6 +81,18 @@ pub struct RuntimeAdoptionReviewReport {
     pub reasons: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Phase3ReadinessReport {
+    pub writes: bool,
+    pub candidate: String,
+    pub ready: bool,
+    pub decision: String,
+    pub required_track: String,
+    pub required_feature: String,
+    pub review: RuntimeAdoptionReviewReport,
+    pub reasons: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeAdoptionRecordPlanInput {
     pub id: Option<String>,
@@ -378,6 +390,53 @@ fn review_conclusion(stats: &RuntimeAdoptionSignalCounts) -> (String, Vec<String
         "mixed".to_string(),
         vec!["evidence is present but not clearly positive".to_string()],
     )
+}
+
+pub fn card_context_default_readiness(events: &[RuntimeAdoptionEvent]) -> Phase3ReadinessReport {
+    let review = review_runtime_adoption_events(
+        events,
+        RuntimeAdoptionReviewFilters {
+            track: Some("card_context".to_string()),
+            feature: Some("include_cards".to_string()),
+            signal: None,
+            limit: 10_000,
+        },
+    );
+    let stats = &review.stats;
+    let mut reasons = Vec::new();
+    if stats.accepted < 3 {
+        reasons.push("insufficient accepted evidence for include_cards default".to_string());
+    }
+    if stats.rollbacks > 0 {
+        reasons.push("rollback evidence blocks card context default readiness".to_string());
+    }
+    if stats.contradictions > 0 {
+        reasons.push("contradiction evidence requires review before defaulting".to_string());
+    }
+    if stats.accepted < stats.rejected + stats.misses {
+        reasons.push("negative evidence outweighs accepted evidence".to_string());
+    }
+
+    let ready = reasons.is_empty();
+    if ready {
+        reasons.push("card context default readiness threshold satisfied".to_string());
+    }
+
+    Phase3ReadinessReport {
+        writes: false,
+        candidate: "card-context-default".to_string(),
+        ready,
+        decision: if ready {
+            "eligible_for_future_default_spec"
+        } else {
+            "keep_opt_in"
+        }
+        .to_string(),
+        required_track: "card_context".to_string(),
+        required_feature: "include_cards".to_string(),
+        review,
+        reasons,
+    }
 }
 
 fn requires_outcome_context(signal: &str) -> bool {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -210,6 +210,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    counterexample evidence. It does not create cards, replace mempal_search,
    assemble default context, or backfill drawers.
 
+17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
+   Use mempal_phase3 to record and inspect runtime adoption evidence before
+   proposing stronger defaults or new authority. The tool supports
+   record/list/stats/gate/research_validate_plan actions over Phase-3
+   runtime_adoption_events. Gate and research_validate_plan are advisory and
+   read-only: they do not enable card context by default, add card embeddings,
+   mutate evaluator lifecycle state, or promote research output into knowledge.
+
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
   mempal_search        — semantic search with wing/room filters, citation-bearing
@@ -219,6 +227,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
+  mempal_phase3       — Phase-3 runtime adoption evidence record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,10 +213,17 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   record/list/stats/gate/research_validate_plan actions over Phase-3
-   runtime_adoption_events. Gate and research_validate_plan are advisory and
-   read-only: they do not enable card context by default, add card embeddings,
-   mutate evaluator lifecycle state, or promote research output into knowledge.
+   guidance/record/list/stats/gate/research_validate_plan actions over
+   Phase-3 runtime_adoption_events. Start with action=guidance when unsure
+   whether a runtime outcome should be recorded. Record used when guidance was actually consumed,
+   accepted when it materially helped, rejected when it was
+   considered and intentionally not followed, miss when useful guidance should
+   have appeared but did not, rollback when behavior was reverted because
+   guidance degraded the outcome, contradiction when guidance conflicted with
+   stronger evidence or instructions, and neutral when no clear outcome impact
+   is known. Gate and research_validate_plan are advisory and read-only: they
+   do not enable card context by default, add card embeddings, mutate evaluator
+   lifecycle state, or promote research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -227,7 +234,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,13 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=check_record to evaluate event quality before writing; check_record is
-   advisory, read-only, and reports errors/warnings without blocking record.
+   advisory, read-only, and reports errors/warnings without blocking record. Use
+   action=record_checked for quality-gated writes: ready records write,
+   warning records require allow_warnings=true, and invalid records are blocked.
    Use action=review to summarize accumulated evidence by track, feature, and
    signal before proposing stronger defaults; review is read-only and advisory.
    Use action=readiness with candidate=card-context-default to inspect whether
@@ -245,7 +247,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -240,7 +240,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    to evaluate rollback evidence for the card-context default. The CLI executor
    is read-only unless `--execute` is supplied; when executed, it only sets local
    config `context.include_cards_default=false` and does not append runtime
-   adoption events or alter knowledge lifecycle state. Use
+   adoption events or alter knowledge lifecycle state. Agents must not
+   autonomously promote, demote, or otherwise mutate durable knowledge lifecycle
+   state. Agents must not autonomously promote knowledge.
+   human/operator-triggered lifecycle mutation remains required through
+   explicit promote/demote commands with deterministic gates
+   and evidence refs. Evaluator advice remains advisory: it can support review
+   but cannot satisfy reviewer authority, bypass gates, or create autonomous
+   lifecycle authority. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -232,6 +232,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    candidate=card-context to combine card-context readiness with explicit
    rollback criteria before writing a future default-on spec; it is read-only
    and does not change include_cards defaults. Use
+   CLI `mempal phase3 default-control card-context` to explicitly enable or
+   disable local card-context defaults: enable requires a proposal-ready P74
+   condition and rollback criteria, disable is always allowed, and the command
+   writes only local config (`context.include_cards_default`). Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,17 +213,18 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/record/list/stats/gate/research_validate_plan actions over
-   Phase-3 runtime_adoption_events. Start with action=guidance when unsure
-   whether a runtime outcome should be recorded. Record used when guidance was actually consumed,
-   accepted when it materially helped, rejected when it was
-   considered and intentionally not followed, miss when useful guidance should
-   have appeared but did not, rollback when behavior was reverted because
-   guidance degraded the outcome, contradiction when guidance conflicted with
-   stronger evidence or instructions, and neutral when no clear outcome impact
-   is known. Gate and research_validate_plan are advisory and read-only: they
-   do not enable card context by default, add card embeddings, mutate evaluator
-   lifecycle state, or promote research output into knowledge.
+   guidance/prepare_record/record/list/stats/gate/research_validate_plan
+   actions over Phase-3 runtime_adoption_events. Start with action=guidance
+   when unsure whether a runtime outcome should be recorded. Use
+   action=prepare_record to validate and assemble exact record inputs before
+   writing; prepare_record is read-only and does not append events. Record used when guidance was actually consumed,
+   accepted when it materially helped, rejected when it was considered and
+   intentionally not followed, miss when useful guidance should have appeared
+   but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
+   conflicted with stronger evidence or instructions, and neutral when no clear
+   outcome impact is known. Gate and research_validate_plan are advisory and
+   read-only: they do not enable card context by default, add card embeddings,
+   mutate evaluator lifecycle state, or promote research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -234,7 +235,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,9 +213,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
+   action=instrumentation_policy before building live tool instrumentation:
+   live instrumentation is opt-in, must preserve user opt-out, and must route
+   writes through checked capture or record_checked instead of silently
+   appending events. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=capture when you have a concrete runtime outcome but do not want to
@@ -257,7 +261,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,11 +213,14 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
-   writing; prepare_record is read-only and does not append events. Record used when guidance was actually consumed,
+   writing; prepare_record is read-only and does not append events. Use
+   action=check_record to evaluate event quality before writing; check_record is
+   advisory, read-only, and reports errors/warnings without blocking record.
+   Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
    but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
@@ -235,7 +238,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -230,9 +230,11 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    intentionally not followed, miss when useful guidance should have appeared
    but did not, rollback when behavior was reverted because guidance degraded the outcome, contradiction when guidance
    conflicted with stronger evidence or instructions, and neutral when no clear
-   outcome impact is known. Gate and research_validate_plan are advisory and
+   outcome impact is known. Gate, research_validate_plan, and
+   research_ingest_plan are advisory and
    read-only: they do not enable card context by default, add card embeddings,
-   mutate evaluator lifecycle state, or promote research output into knowledge.
+   mutate evaluator lifecycle state, ingest research output, or promote
+   research output into knowledge.
 
 TOOLS:
   mempal_status        — current state + this protocol + AAAK format spec
@@ -243,7 +245,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -221,7 +221,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    action=capture when you have a concrete runtime outcome but do not want to
    manually choose track/signal/feature: capture maps surface/outcome to the
    checked-record path, is read-only by default, and writes only with
-   execute=true. Use
+   execute=true. Use action=evaluator_advise for deterministic evaluator advice:
+   it returns replayable advisory output and a surface=evaluator capture plan,
+   but writes=false, has no lifecycle authority, cannot satisfy reviewer
+   requirements, and cannot bypass gates. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -251,7 +254,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,11 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
+   action=capture when you have a concrete runtime outcome but do not want to
+   manually choose track/signal/feature: capture maps surface/outcome to the
+   checked-record path, is read-only by default, and writes only with
+   execute=true. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -247,7 +251,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,13 +213,15 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
    writing; prepare_record is read-only and does not append events. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record.
+   Use action=review to summarize accumulated evidence by track, feature, and
+   signal before proposing stronger defaults; review is read-only and advisory.
    Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
@@ -238,7 +240,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=instrumentation_policy before building live tool instrumentation:
@@ -236,6 +236,11 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    disable local card-context defaults: enable requires a proposal-ready P74
    condition and rollback criteria, disable is always allowed, and the command
    writes only local config (`context.include_cards_default`). Use
+   action=rollback_control or CLI `mempal phase3 rollback-control card-context`
+   to evaluate rollback evidence for the card-context default. The CLI executor
+   is read-only unless `--execute` is supplied; when executed, it only sets local
+   config `context.include_cards_default=false` and does not append runtime
+   adoption events or alter knowledge lifecycle state. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -265,7 +270,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
+   guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -222,6 +222,9 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    advisory, read-only, and reports errors/warnings without blocking record.
    Use action=review to summarize accumulated evidence by track, feature, and
    signal before proposing stronger defaults; review is read-only and advisory.
+   Use action=readiness with candidate=card-context-default to inspect whether
+   card-aware context is eligible for a future default-on spec; readiness is
+   read-only and does not enable the default.
    Record used when guidance was actually consumed,
    accepted when it materially helped, rejected when it was considered and
    intentionally not followed, miss when useful guidance should have appeared
@@ -240,7 +243,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -213,7 +213,7 @@ You have persistent project memory via mempal. Follow these rules in every sessi
 17. RECORD PHASE-3 RUNTIME ADOPTION EVIDENCE
    Use mempal_phase3 to record and inspect runtime adoption evidence before
    proposing stronger defaults or new authority. The tool supports
-   guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+   guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
    actions over Phase-3 runtime_adoption_events. Start with action=guidance
    when unsure whether a runtime outcome should be recorded. Use
    action=prepare_record to validate and assemble exact record inputs before
@@ -224,7 +224,10 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    execute=true. Use action=evaluator_advise for deterministic evaluator advice:
    it returns replayable advisory output and a surface=evaluator capture plan,
    but writes=false, has no lifecycle authority, cannot satisfy reviewer
-   requirements, and cannot bypass gates. Use
+   requirements, and cannot bypass gates. Use action=default_proposal with
+   candidate=card-context to combine card-context readiness with explicit
+   rollback criteria before writing a future default-on spec; it is read-only
+   and does not change include_cards defaults. Use
    action=check_record to evaluate event quality before writing; check_record is
    advisory, read-only, and reports errors/warnings without blocking record. Use
    action=record_checked for quality-gated writes: ready records write,
@@ -254,7 +257,7 @@ TOOLS:
   mempal_knowledge_policy — read-only Stage-1 promotion policy thresholds
   mempal_knowledge_gate — read-only knowledge promotion readiness check
   mempal_knowledge_cards — Phase-2 knowledge card list/get/retrieve/events/gate/promote/demote
-  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
+  mempal_phase3       — Phase-3 runtime adoption evidence guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan
   mempal_knowledge_promote — gate-enforced knowledge lifecycle promotion
   mempal_knowledge_demote — evidence-backed knowledge demotion or retirement
   mempal_knowledge_publish_anchor — metadata-only outward anchor publication

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport,
-        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
+        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
         RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
         RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        card_context_default_readiness, check_runtime_adoption_record,
+        capture_runtime_adoption_record_input, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_capture,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
         should_write_checked_record,
     },
@@ -627,6 +629,34 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Capture {
+        #[arg(long)]
+        surface: String,
+        #[arg(long)]
+        outcome: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long = "allow-warnings")]
+        allow_warnings: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2348,6 +2378,64 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             });
             print_runtime_adoption_record_plan(&plan, &format)
         }
+        Phase3AdoptionCommands::Capture {
+            surface,
+            outcome,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            execute,
+            allow_warnings,
+            format,
+        } => {
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let record_input = capture_runtime_adoption_record_input(RuntimeAdoptionCaptureInput {
+                id,
+                surface: surface.clone(),
+                outcome: outcome.clone(),
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            })
+            .map_err(anyhow::Error::msg)?;
+            let mut report =
+                prepare_runtime_adoption_capture(surface, outcome, execute, record_input.clone());
+            if execute {
+                let track = parse_runtime_adoption_track(&record_input.track)?;
+                let signal = parse_runtime_adoption_signal(&record_input.signal)?;
+                let should_write =
+                    should_write_checked_record(&report.record_quality, allow_warnings);
+                let event = if should_write {
+                    let event = runtime_adoption_event_from_input(record_input, track, signal);
+                    db.insert_runtime_adoption_event(&event)
+                        .context("failed to insert runtime adoption event")?;
+                    Some(event)
+                } else {
+                    None
+                };
+                report.writes = event.is_some();
+                report.record_checked = Some(RuntimeAdoptionCheckedRecordReport {
+                    writes: event.is_some(),
+                    blocked: event.is_none(),
+                    record_quality: report.record_quality.clone(),
+                    event,
+                });
+            }
+            print_runtime_adoption_capture(&report, &format)
+        }
         Phase3AdoptionCommands::CheckRecord {
             track,
             signal,
@@ -2642,6 +2730,43 @@ fn print_runtime_adoption_checked_record(
                 "{}",
                 serde_json::to_string_pretty(report)
                     .context("failed to serialize runtime adoption checked record report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_capture(
+    report: &RuntimeAdoptionCaptureReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("execute={}", report.execute);
+            println!("surface={}", report.surface);
+            println!("outcome={}", report.outcome);
+            println!("quality={}", report.record_quality.quality);
+            if let Some(checked) = report.record_checked.as_ref() {
+                println!("blocked={}", checked.blocked);
+                if let Some(event) = checked.event.as_ref() {
+                    println!("event_id={}", event.id);
+                }
+            }
+            for error in &report.record_quality.errors {
+                println!("error={error}");
+            }
+            for warning in &report.record_quality.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption capture report")?
             );
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,10 @@ use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     config::Config,
     db::Database,
-    phase3::{RuntimeAdoptionGuidance, runtime_adoption_guidance},
+    phase3::{
+        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        prepare_runtime_adoption_record, runtime_adoption_guidance,
+    },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
         AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
@@ -53,6 +56,7 @@ use mempal::knowledge_lifecycle::{
 use mempal::mcp::MempalMcpServer;
 use mempal::search::{SearchFilters, SearchOptions, search_with_options};
 use serde::Serialize;
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 mod longmemeval;
@@ -577,6 +581,32 @@ enum Phase3Commands {
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
     Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    PrepareRecord {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2187,6 +2217,42 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
         Phase3AdoptionCommands::Guidance { format } => {
             print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
         }
+        Phase3AdoptionCommands::PrepareRecord {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let plan = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            });
+            print_runtime_adoption_record_plan(&plan, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2297,6 +2363,31 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_record_plan(
+    plan: &RuntimeAdoptionRecordPlan,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", plan.writes);
+            println!("record_command={}", plan.record_command.join(" "));
+            if let Some(action) = plan.record_payload.get("action").and_then(Value::as_str) {
+                println!("action={action}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(plan)
+                    .context("failed to serialize runtime adoption record plan")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,24 +17,22 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
-        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeCard, KnowledgeCardEvent,
-        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
-        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        AnchorKind, Drawer, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter,
+        KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus,
+        KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
         RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
         TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
-    utils::{
-        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
-        format_tunnel_endpoint,
-    },
+    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
@@ -2758,41 +2756,6 @@ struct ResearchAdapterPlanReport {
     errors: Vec<String>,
 }
 
-#[derive(Debug, Serialize)]
-struct ResearchEvidenceDrawerPlan {
-    drawer_id: String,
-    finding_index: usize,
-    source_file: String,
-    created: bool,
-    skipped: bool,
-    #[serde(skip)]
-    content: String,
-}
-
-#[derive(Debug, Serialize)]
-struct ResearchCandidateInsightPlan {
-    statement: String,
-    supporting_refs: Vec<String>,
-    suggested_command: Vec<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct ResearchIngestPlanReport {
-    valid: bool,
-    writes: bool,
-    report_id: String,
-    title: String,
-    source_count: usize,
-    finding_count: usize,
-    candidate_insight_count: usize,
-    planned_evidence_count: usize,
-    created_count: usize,
-    skipped_count: usize,
-    errors: Vec<String>,
-    evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
-    candidate_insights: Vec<ResearchCandidateInsightPlan>,
-}
-
 fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanReport> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read research report {}", path.display()))?;
@@ -2911,162 +2874,7 @@ fn build_research_ingest_plan(path: &Path) -> Result<ResearchIngestPlanReport> {
         .with_context(|| format!("failed to read research report {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse research report {}", path.display()))?;
-    let mut errors = Vec::new();
-    let report_id = required_string(&value, "report_id", &mut errors);
-    let title = required_string(&value, "title", &mut errors);
-    let source_count = value
-        .get("sources")
-        .and_then(serde_json::Value::as_array)
-        .map_or(0, Vec::len);
-    if source_count == 0 {
-        errors.push("sources must contain at least one item".to_string());
-    }
-    let findings = value
-        .get("findings")
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    if findings.is_empty() {
-        errors.push("findings must contain at least one item".to_string());
-    }
-    let candidate_values = value
-        .get("candidate_insights")
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-
-    let evidence_drawers = findings
-        .iter()
-        .enumerate()
-        .map(|(index, finding)| {
-            let content = research_evidence_content_from_value(
-                report_id.as_str(),
-                title.as_str(),
-                value.get("sources"),
-                finding,
-                index,
-            )?;
-            let drawer_id = research_evidence_drawer_id(&content);
-            Ok(ResearchEvidenceDrawerPlan {
-                drawer_id,
-                finding_index: index,
-                source_file: format!("research://{}#finding-{index}", report_id),
-                created: false,
-                skipped: false,
-                content,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let supporting_refs = evidence_drawers
-        .iter()
-        .map(|plan| plan.drawer_id.clone())
-        .collect::<Vec<_>>();
-    let candidate_insights = candidate_values
-        .iter()
-        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
-        .map(|statement| ResearchCandidateInsightPlan {
-            suggested_command: research_distill_command(&statement, &supporting_refs),
-            statement,
-            supporting_refs: supporting_refs.clone(),
-        })
-        .collect::<Vec<_>>();
-
-    Ok(ResearchIngestPlanReport {
-        valid: errors.is_empty(),
-        writes: false,
-        report_id,
-        title,
-        source_count,
-        finding_count: findings.len(),
-        candidate_insight_count: candidate_values.len(),
-        planned_evidence_count: evidence_drawers.len(),
-        created_count: 0,
-        skipped_count: 0,
-        errors,
-        evidence_drawers,
-        candidate_insights,
-    })
-}
-
-fn research_evidence_content_from_value(
-    report_id: &str,
-    title: &str,
-    sources: Option<&serde_json::Value>,
-    finding: &serde_json::Value,
-    finding_index: usize,
-) -> Result<String> {
-    let summary = finding_summary(finding)?;
-    let sources = sources
-        .map(serde_json::to_string_pretty)
-        .transpose()
-        .context("failed to serialize research sources")?
-        .unwrap_or_else(|| "[]".to_string());
-    let raw_finding =
-        serde_json::to_string_pretty(finding).context("failed to serialize research finding")?;
-    Ok(format!(
-        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
-    ))
-}
-
-fn finding_summary(finding: &serde_json::Value) -> Result<String> {
-    if let Some(raw) = finding.as_str() {
-        return Ok(raw.trim().to_string());
-    }
-    for field in ["summary", "statement", "content", "text"] {
-        if let Some(raw) = finding.get(field).and_then(serde_json::Value::as_str)
-            && !raw.trim().is_empty()
-        {
-            return Ok(raw.trim().to_string());
-        }
-    }
-    serde_json::to_string(finding).context("failed to serialize research finding summary")
-}
-
-fn candidate_statement(candidate: &serde_json::Value) -> Option<&str> {
-    if let Some(raw) = candidate.as_str()
-        && !raw.trim().is_empty()
-    {
-        return Some(raw.trim());
-    }
-    for field in ["statement", "summary", "content", "text"] {
-        if let Some(raw) = candidate.get(field).and_then(serde_json::Value::as_str)
-            && !raw.trim().is_empty()
-        {
-            return Some(raw.trim());
-        }
-    }
-    None
-}
-
-fn research_evidence_drawer_id(content: &str) -> String {
-    let memory_kind = MemoryKind::Evidence;
-    let domain = MemoryDomain::Project;
-    let anchor_kind = AnchorKind::Repo;
-    let provenance = Provenance::Research;
-    let empty_refs: &[String] = &[];
-    build_bootstrap_drawer_id_from_parts(
-        "mempal",
-        Some("research"),
-        content,
-        BootstrapIdentityParts {
-            memory_kind: &memory_kind,
-            domain: &domain,
-            field: "research",
-            anchor_kind: &anchor_kind,
-            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
-            parent_anchor_id: None,
-            provenance: Some(&provenance),
-            statement: None,
-            tier: None,
-            status: None,
-            supporting_refs: empty_refs,
-            counterexample_refs: empty_refs,
-            teaching_refs: empty_refs,
-            verification_refs: empty_refs,
-            scope_constraints: None,
-            trigger_hints: None,
-        },
-    )
+    Ok(build_research_ingest_plan_from_value(&value))
 }
 
 fn research_evidence_drawer(
@@ -3106,27 +2914,6 @@ fn research_evidence_drawer(
         scope_constraints: None,
         trigger_hints: None,
     }
-}
-
-fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
-    let mut command = vec![
-        "mempal".to_string(),
-        "knowledge".to_string(),
-        "distill".to_string(),
-        "--tier".to_string(),
-        "qi".to_string(),
-        "--statement".to_string(),
-        statement.to_string(),
-        "--content".to_string(),
-        statement.to_string(),
-        "--field".to_string(),
-        "research".to_string(),
-    ];
-    for supporting_ref in supporting_refs {
-        command.push("--supporting-ref".to_string());
-        command.push(supporting_ref.clone());
-    }
-    command
 }
 
 fn required_string(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
     config::Config,
     db::Database,
+    phase3::{RuntimeAdoptionGuidance, runtime_adoption_guidance},
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
         AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
@@ -575,6 +576,10 @@ enum Phase3Commands {
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
+    Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Record {
         #[arg(long)]
         track: String,
@@ -2179,6 +2184,9 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
 
 fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Result<()> {
     match command {
+        Phase3AdoptionCommands::Guidance { format } => {
+            print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2289,6 +2297,38 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_guidance(guidance: &RuntimeAdoptionGuidance, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("version={}", guidance.version);
+            println!("recording_rule={}", guidance.recording_rule);
+            println!("required_fields={}", guidance.required_fields.join(","));
+            println!("optional_fields={}", guidance.optional_fields.join(","));
+            for signal in &guidance.signals {
+                println!("signal={} when={}", signal.signal, signal.when);
+            }
+            for track in &guidance.tracks {
+                println!(
+                    "track={} when={} feature_examples={}",
+                    track.track,
+                    track.when,
+                    track.feature_examples.join(",")
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(guidance)
+                    .context("failed to serialize runtime adoption guidance")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use mempal::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, check_runtime_adoption_record,
         prepare_runtime_adoption_record, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
@@ -585,6 +586,32 @@ enum Phase3AdoptionCommands {
         format: String,
     },
     PrepareRecord {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    CheckRecord {
         #[arg(long)]
         track: String,
         #[arg(long)]
@@ -2253,6 +2280,43 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             });
             print_runtime_adoption_record_plan(&plan, &format)
         }
+        Phase3AdoptionCommands::CheckRecord {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let input = RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            };
+            let report = check_runtime_adoption_record(&input);
+            print_runtime_adoption_record_quality(&report, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2363,6 +2427,35 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_record_quality(
+    report: &RuntimeAdoptionRecordQualityReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("valid={}", report.valid);
+            println!("quality={}", report.quality);
+            for error in &report.errors {
+                println!("error={error}");
+            }
+            for warning in &report.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption record quality report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,8 @@ use mempal::core::{
         capture_runtime_adoption_record_input, card_context_default_proposal,
         card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
+        runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -639,6 +640,10 @@ enum Phase3EvaluatorCommands {
 #[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
     Guidance {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    InstrumentationPolicy {
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2438,6 +2443,12 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
         Phase3AdoptionCommands::Guidance { format } => {
             print_runtime_adoption_guidance(&runtime_adoption_guidance(), &format)
         }
+        Phase3AdoptionCommands::InstrumentationPolicy { format } => {
+            print_runtime_adoption_instrumentation_policy(
+                &runtime_adoption_instrumentation_policy(),
+                &format,
+            )
+        }
         Phase3AdoptionCommands::PrepareRecord {
             track,
             signal,
@@ -2983,6 +2994,44 @@ fn print_runtime_adoption_guidance(guidance: &RuntimeAdoptionGuidance, format: &
                 "{}",
                 serde_json::to_string_pretty(guidance)
                     .context("failed to serialize runtime adoption guidance")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
+    }
+}
+
+fn print_runtime_adoption_instrumentation_policy(
+    policy: &mempal::core::phase3::RuntimeAdoptionInstrumentationPolicy,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("version={}", policy.version);
+            println!("writes={}", policy.writes);
+            println!("default_mode={}", policy.default_mode);
+            for mode in &policy.allowed_modes {
+                println!(
+                    "allowed_mode={} requires_execute={} requires_checked_capture={}",
+                    mode.mode, mode.requires_execute, mode.requires_checked_capture
+                );
+            }
+            for mode in &policy.forbidden_modes {
+                println!("forbidden_mode={mode}");
+            }
+            for requirement in &policy.requirements {
+                println!("requirement={requirement}");
+            }
+            for requirement in &policy.rollback_requirements {
+                println!("rollback_requirement={requirement}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(policy)
+                    .context("failed to serialize runtime adoption instrumentation policy")?
             );
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,8 @@ enum Commands {
         include_evidence: bool,
         #[arg(long)]
         include_cards: bool,
+        #[arg(long, conflicts_with = "include_cards")]
+        no_include_cards: bool,
         #[arg(long, default_value_t = 12)]
         max_items: usize,
         #[arg(long = "dao-tian-limit", default_value_t = 1)]
@@ -588,6 +590,17 @@ enum Phase3Commands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    DefaultControl {
+        candidate: String,
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        #[arg(long, conflicts_with = "enable")]
+        disable: bool,
+        #[arg(long = "rollback-criterion")]
+        rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
     Gate {
         candidate: String,
         #[arg(long, default_value = "plain")]
@@ -969,6 +982,7 @@ async fn run() -> Result<()> {
             format,
             include_evidence,
             include_cards,
+            no_include_cards,
             max_items,
             dao_tian_limit,
         } => {
@@ -983,6 +997,7 @@ async fn run() -> Result<()> {
                     format,
                     include_evidence,
                     include_cards,
+                    no_include_cards,
                     max_items,
                     dao_tian_limit,
                 },
@@ -1039,6 +1054,7 @@ struct ContextCommandArgs {
     format: String,
     include_evidence: bool,
     include_cards: bool,
+    no_include_cards: bool,
     max_items: usize,
     dao_tian_limit: usize,
 }
@@ -1248,6 +1264,11 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
     };
 
     let embedder = build_embedder(config).await?;
+    let include_cards = if args.no_include_cards {
+        false
+    } else {
+        args.include_cards || config.context.include_cards_default
+    };
     let pack = assemble_context(
         db,
         &*embedder,
@@ -1257,7 +1278,7 @@ async fn context_command(db: &Database, config: &Config, args: ContextCommandArg
             field: args.field,
             cwd,
             include_evidence: args.include_evidence,
-            include_cards: args.include_cards,
+            include_cards,
             max_items: args.max_items,
             dao_tian_limit: args.dao_tian_limit,
         },
@@ -2367,6 +2388,17 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             let report = phase3_default_proposal(db, &candidate, rollback_criteria)?;
             print_card_context_default_proposal(&report, &format)
         }
+        Phase3Commands::DefaultControl {
+            candidate,
+            enable,
+            disable,
+            rollback_criteria,
+            format,
+        } => {
+            let report =
+                phase3_default_control(db, &candidate, enable, disable, rollback_criteria)?;
+            print_phase3_default_control(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2406,6 +2438,73 @@ fn phase3_default_proposal(
             Ok(card_context_default_proposal(&events, rollback_criteria))
         }
         other => bail!("unsupported phase3 default proposal candidate: {other}"),
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Phase3DefaultControlReport {
+    writes: bool,
+    candidate: String,
+    requested: String,
+    applied: bool,
+    include_cards_default: bool,
+    proposal: Option<CardContextDefaultProposalReport>,
+    reasons: Vec<String>,
+}
+
+fn phase3_default_control(
+    db: &Database,
+    candidate: &str,
+    enable: bool,
+    disable: bool,
+    rollback_criteria: Vec<String>,
+) -> Result<Phase3DefaultControlReport> {
+    if enable == disable {
+        bail!("exactly one of --enable or --disable is required");
+    }
+    match candidate {
+        "card-context" => {
+            let mut config = Config::load().context("failed to load config")?;
+            if disable {
+                config.context.include_cards_default = false;
+                config.save_default().context("failed to save config")?;
+                return Ok(Phase3DefaultControlReport {
+                    writes: true,
+                    candidate: candidate.to_string(),
+                    requested: "disable".to_string(),
+                    applied: true,
+                    include_cards_default: false,
+                    proposal: None,
+                    reasons: vec!["card context default disabled".to_string()],
+                });
+            }
+
+            let proposal = phase3_default_proposal(db, candidate, rollback_criteria)?;
+            if !proposal.proposal_ready {
+                return Ok(Phase3DefaultControlReport {
+                    writes: false,
+                    candidate: candidate.to_string(),
+                    requested: "enable".to_string(),
+                    applied: false,
+                    include_cards_default: config.context.include_cards_default,
+                    proposal: Some(proposal),
+                    reasons: vec!["default-on proposal is not ready".to_string()],
+                });
+            }
+
+            config.context.include_cards_default = true;
+            config.save_default().context("failed to save config")?;
+            Ok(Phase3DefaultControlReport {
+                writes: true,
+                candidate: candidate.to_string(),
+                requested: "enable".to_string(),
+                applied: true,
+                include_cards_default: true,
+                proposal: Some(proposal),
+                reasons: vec!["card context default enabled".to_string()],
+            })
+        }
+        other => bail!("unsupported phase3 default-control candidate: {other}"),
     }
 }
 
@@ -3515,6 +3614,31 @@ fn print_card_context_default_proposal(
             Ok(())
         }
         other => bail!("unsupported phase3 default proposal format: {other}"),
+    }
+}
+
+fn print_phase3_default_control(report: &Phase3DefaultControlReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("requested={}", report.requested);
+            println!("applied={}", report.applied);
+            println!("include_cards_default={}", report.include_cards_default);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 default control report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 default control format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,9 @@ use mempal::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -634,6 +635,18 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Review {
+        #[arg(long)]
+        track: Option<String>,
+        #[arg(long)]
+        feature: Option<String>,
+        #[arg(long)]
+        signal: Option<String>,
+        #[arg(long, default_value_t = 10_000)]
+        limit: usize,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2317,6 +2330,47 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let report = check_runtime_adoption_record(&input);
             print_runtime_adoption_record_quality(&report, &format)
         }
+        Phase3AdoptionCommands::Review {
+            track,
+            feature,
+            signal,
+            limit,
+            format,
+        } => {
+            let track = track
+                .as_deref()
+                .map(parse_runtime_adoption_track)
+                .transpose()?;
+            let signal = signal
+                .as_deref()
+                .map(parse_runtime_adoption_signal)
+                .transpose()?;
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: track.clone(),
+                        feature: feature.clone(),
+                    },
+                    limit,
+                )
+                .context("failed to list runtime adoption events")?;
+            let report = review_runtime_adoption_events(
+                &events,
+                RuntimeAdoptionReviewFilters {
+                    track: track
+                        .as_ref()
+                        .map(runtime_adoption_track_slug)
+                        .map(str::to_string),
+                    feature,
+                    signal: signal
+                        .as_ref()
+                        .map(runtime_adoption_signal_slug)
+                        .map(str::to_string),
+                    limit,
+                },
+            );
+            print_runtime_adoption_review(&report, &format)
+        }
         Phase3AdoptionCommands::Record {
             track,
             signal,
@@ -2427,6 +2481,40 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn print_runtime_adoption_review(report: &RuntimeAdoptionReviewReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("total={}", report.total);
+            println!("conclusion={}", report.conclusion);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            for feature in &report.features {
+                println!(
+                    "feature={} total={} accepted={} rejected={} misses={} rollbacks={}",
+                    feature.feature,
+                    feature.stats.total,
+                    feature.stats.accepted,
+                    feature.stats.rejected,
+                    feature.stats.misses,
+                    feature.stats.rollbacks
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption review report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,15 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
-        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        capture_runtime_adoption_record_input, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_capture,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        EvaluatorAdviceInput, EvaluatorAdviceReport, Phase3ReadinessReport,
+        ResearchIngestPlanReport, RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -575,6 +575,10 @@ enum Phase3Commands {
         #[command(subcommand)]
         command: Phase3AdoptionCommands,
     },
+    Evaluator {
+        #[command(subcommand)]
+        command: Phase3EvaluatorCommands,
+    },
     Gate {
         candidate: String,
         #[arg(long, default_value = "plain")]
@@ -594,6 +598,30 @@ enum Phase3Commands {
         path: PathBuf,
         #[arg(long)]
         execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum Phase3EvaluatorCommands {
+    Advise {
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "subject-kind")]
+        subject_kind: String,
+        #[arg(long = "subject-id")]
+        subject_id: String,
+        #[arg(long = "proposed-action")]
+        proposed_action: String,
+        #[arg(long = "evidence-ref")]
+        evidence_refs: Vec<String>,
+        #[arg(long = "counterexample-ref")]
+        counterexample_refs: Vec<String>,
+        #[arg(long = "risk-note")]
+        risk_notes: Vec<String>,
+        #[arg(long)]
+        note: Option<String>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2317,6 +2345,7 @@ async fn knowledge_card_command(
 async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands) -> Result<()> {
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
+        Phase3Commands::Evaluator { command } => phase3_evaluator_command(command),
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2334,6 +2363,35 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             execute,
             format,
         } => research_ingest_plan_command(db, config, &path, execute, &format).await,
+    }
+}
+
+fn phase3_evaluator_command(command: Phase3EvaluatorCommands) -> Result<()> {
+    match command {
+        Phase3EvaluatorCommands::Advise {
+            evaluator_id,
+            subject_kind,
+            subject_id,
+            proposed_action,
+            evidence_refs,
+            counterexample_refs,
+            risk_notes,
+            note,
+            format,
+        } => {
+            let report = evaluator_advice(EvaluatorAdviceInput {
+                evaluator_id: evaluator_id.unwrap_or_default(),
+                subject_kind,
+                subject_id,
+                proposed_action,
+                evidence_refs,
+                counterexample_refs,
+                risk_notes,
+                note,
+            })
+            .map_err(anyhow::Error::msg)?;
+            print_evaluator_advice(&report, &format)
+        }
     }
 }
 
@@ -3307,6 +3365,38 @@ fn print_phase3_readiness_report(report: &Phase3ReadinessReport, format: &str) -
             Ok(())
         }
         other => bail!("unsupported phase3 readiness format: {other}"),
+    }
+}
+
+fn print_evaluator_advice(report: &EvaluatorAdviceReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("evaluator_id={}", report.evaluator_id);
+            println!("subject_kind={}", report.subject_kind);
+            println!("subject_id={}", report.subject_id);
+            println!("proposed_action={}", report.proposed_action);
+            println!("recommendation={}", report.recommendation);
+            println!("lifecycle_authority={}", report.lifecycle_authority);
+            println!(
+                "deterministic_gate_required={}",
+                report.deterministic_gate_required
+            );
+            println!("requires_human_review={}", report.requires_human_review);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize evaluator advice")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 evaluator format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,11 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -568,6 +569,11 @@ enum Phase3Commands {
         command: Phase3AdoptionCommands,
     },
     Gate {
+        candidate: String,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    Readiness {
         candidate: String,
         #[arg(long, default_value = "plain")]
         format: String,
@@ -2245,6 +2251,10 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
         }
+        Phase3Commands::Readiness { candidate, format } => {
+            let report = phase3_readiness_report(db, &candidate)?;
+            print_phase3_readiness_report(&report, &format)
+        }
         Phase3Commands::ResearchValidatePlan { path, format } => {
             let report = validate_research_adapter_plan(&path)?;
             print_research_adapter_plan(&report, &format)
@@ -2701,6 +2711,24 @@ fn phase3_gate_report(db: &Database, candidate: &str) -> Result<Phase3GateReport
     })
 }
 
+fn phase3_readiness_report(db: &Database, candidate: &str) -> Result<Phase3ReadinessReport> {
+    match candidate {
+        "card-context-default" => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            Ok(card_context_default_readiness(&events))
+        }
+        other => bail!("unsupported phase3 readiness candidate: {other}"),
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct ResearchAdapterPlanReport {
     valid: bool,
@@ -2845,6 +2873,37 @@ fn print_phase3_gate_report(report: &Phase3GateReport, format: &str) -> Result<(
             Ok(())
         }
         other => bail!("unsupported phase3 gate format: {other}"),
+    }
+}
+
+fn print_phase3_readiness_report(report: &Phase3ReadinessReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("ready={}", report.ready);
+            println!("decision={}", report.decision);
+            println!("required_track={}", report.required_track);
+            println!("required_feature={}", report.required_feature);
+            println!("accepted={}", report.review.stats.accepted);
+            println!("rejected={}", report.review.stats.rejected);
+            println!("misses={}", report.review.stats.misses);
+            println!("rollbacks={}", report.review.stats.rollbacks);
+            println!("contradictions={}", report.review.stats.contradictions);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 readiness report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 readiness format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,15 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        CardContextDefaultProposalReport, EvaluatorAdviceInput, EvaluatorAdviceReport,
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
-        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
-        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
-        capture_runtime_adoption_record_input, card_context_default_proposal,
-        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
+        CardContextDefaultProposalReport, CardContextRollbackControlReport, EvaluatorAdviceInput,
+        EvaluatorAdviceReport, Phase3ReadinessReport, ResearchIngestPlanReport,
+        RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
+        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        card_context_default_proposal, card_context_default_readiness,
+        card_context_rollback_control, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance,
         runtime_adoption_instrumentation_policy, should_write_checked_record,
@@ -598,6 +599,13 @@ enum Phase3Commands {
         disable: bool,
         #[arg(long = "rollback-criterion")]
         rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    RollbackControl {
+        candidate: String,
+        #[arg(long)]
+        execute: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2399,6 +2407,14 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
                 phase3_default_control(db, &candidate, enable, disable, rollback_criteria)?;
             print_phase3_default_control(&report, &format)
         }
+        Phase3Commands::RollbackControl {
+            candidate,
+            execute,
+            format,
+        } => {
+            let report = phase3_rollback_control(db, &candidate, execute)?;
+            print_phase3_rollback_control(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2505,6 +2521,38 @@ fn phase3_default_control(
             })
         }
         other => bail!("unsupported phase3 default-control candidate: {other}"),
+    }
+}
+
+fn phase3_rollback_control(
+    db: &Database,
+    candidate: &str,
+    execute: bool,
+) -> Result<CardContextRollbackControlReport> {
+    match candidate {
+        "card-context" => {
+            let mut config = Config::load().context("failed to load config")?;
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            let report = card_context_rollback_control(
+                &events,
+                config.context.include_cards_default,
+                execute,
+            );
+            if report.applied {
+                config.context.include_cards_default = false;
+                config.save_default().context("failed to save config")?;
+            }
+            Ok(report)
+        }
+        other => bail!("unsupported phase3 rollback-control candidate: {other}"),
     }
 }
 
@@ -3639,6 +3687,43 @@ fn print_phase3_default_control(report: &Phase3DefaultControlReport, format: &st
             Ok(())
         }
         other => bail!("unsupported phase3 default control format: {other}"),
+    }
+}
+
+fn print_phase3_rollback_control(
+    report: &CardContextRollbackControlReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("execute={}", report.execute);
+            println!("rollback_required={}", report.rollback_required);
+            println!("applied={}", report.applied);
+            println!(
+                "include_cards_default_before={}",
+                report.include_cards_default_before
+            );
+            println!(
+                "include_cards_default_after={}",
+                report.include_cards_default_after
+            );
+            println!("rollback_events={}", report.review.stats.rollbacks);
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize phase3 rollback control report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 rollback-control format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        EvaluatorAdviceInput, EvaluatorAdviceReport, Phase3ReadinessReport,
-        ResearchIngestPlanReport, RuntimeAdoptionCaptureInput, RuntimeAdoptionCaptureReport,
-        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionRecordQualityReport,
-        RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
-        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
+        CardContextDefaultProposalReport, EvaluatorAdviceInput, EvaluatorAdviceReport,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCaptureInput,
+        RuntimeAdoptionCaptureReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+        RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
+        capture_runtime_adoption_record_input, card_context_default_proposal,
         card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
@@ -578,6 +579,13 @@ enum Phase3Commands {
     Evaluator {
         #[command(subcommand)]
         command: Phase3EvaluatorCommands,
+    },
+    DefaultProposal {
+        candidate: String,
+        #[arg(long = "rollback-criterion")]
+        rollback_criteria: Vec<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
     },
     Gate {
         candidate: String,
@@ -2346,6 +2354,14 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
         Phase3Commands::Evaluator { command } => phase3_evaluator_command(command),
+        Phase3Commands::DefaultProposal {
+            candidate,
+            rollback_criteria,
+            format,
+        } => {
+            let report = phase3_default_proposal(db, &candidate, rollback_criteria)?;
+            print_card_context_default_proposal(&report, &format)
+        }
         Phase3Commands::Gate { candidate, format } => {
             let report = phase3_gate_report(db, &candidate)?;
             print_phase3_gate_report(&report, &format)
@@ -2363,6 +2379,28 @@ async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands)
             execute,
             format,
         } => research_ingest_plan_command(db, config, &path, execute, &format).await,
+    }
+}
+
+fn phase3_default_proposal(
+    db: &Database,
+    candidate: &str,
+    rollback_criteria: Vec<String>,
+) -> Result<CardContextDefaultProposalReport> {
+    match candidate {
+        "card-context" => {
+            let events = db
+                .list_runtime_adoption_events(
+                    &RuntimeAdoptionFilter {
+                        track: Some(RuntimeAdoptionTrack::CardContext),
+                        feature: Some("include_cards".to_string()),
+                    },
+                    10_000,
+                )
+                .context("failed to list runtime adoption events")?;
+            Ok(card_context_default_proposal(&events, rollback_criteria))
+        }
+        other => bail!("unsupported phase3 default proposal candidate: {other}"),
     }
 }
 
@@ -3397,6 +3435,37 @@ fn print_evaluator_advice(report: &EvaluatorAdviceReport, format: &str) -> Resul
             Ok(())
         }
         other => bail!("unsupported phase3 evaluator format: {other}"),
+    }
+}
+
+fn print_card_context_default_proposal(
+    report: &CardContextDefaultProposalReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("candidate={}", report.candidate);
+            println!("proposal_ready={}", report.proposal_ready);
+            println!("decision={}", report.decision);
+            println!("readiness_ready={}", report.readiness.ready);
+            for criterion in &report.rollback_criteria {
+                println!("rollback_criterion={criterion}");
+            }
+            for reason in &report.reasons {
+                println!("reason={reason}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize card context default proposal")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 default proposal format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::api::{ApiState, DEFAULT_REST_ADDR, serve as serve_rest_api};
 use mempal::context::{ContextPack, ContextRequest, assemble_context};
 use mempal::core::{
+    anchor,
     config::Config,
     db::Database,
     phase3::{
@@ -24,17 +25,22 @@ use mempal::core::{
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
-        AnchorKind, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType,
-        KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain,
-        MemoryKind, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-        RuntimeAdoptionTrack, TaxonomyEntry, TriggerHints, TunnelEndpoint,
+        AnchorKind, BootstrapIdentityParts, Drawer, KnowledgeCard, KnowledgeCardEvent,
+        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
+        TaxonomyEntry, TriggerHints, TunnelEndpoint,
     },
-    utils::{build_triple_id, current_timestamp, format_tunnel_endpoint},
+    utils::{
+        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp,
+        format_tunnel_endpoint,
+    },
 };
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
 use mempal::ingest::{
     IngestOptions, IngestStats, ingest_dir_with_options, ingest_file_with_options,
+    normalize::CURRENT_NORMALIZE_VERSION,
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
 use mempal::knowledge_anchor::{PublishAnchorRequest, publish_anchor};
@@ -583,6 +589,13 @@ enum Phase3Commands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+    ResearchIngestPlan {
+        path: PathBuf,
+        #[arg(long)]
+        execute: bool,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -891,7 +904,7 @@ async fn run() -> Result<()> {
         Commands::Kg { command } => kg_command(&db, command),
         Commands::Knowledge { command } => knowledge_command(&db, &config, command).await,
         Commands::KnowledgeCard { command } => knowledge_card_command(&db, &config, command).await,
-        Commands::Phase3 { command } => phase3_command(&db, command),
+        Commands::Phase3 { command } => phase3_command(&db, &config, command).await,
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -2244,7 +2257,7 @@ async fn knowledge_card_command(
     Ok(())
 }
 
-fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
+async fn phase3_command(db: &Database, config: &Config, command: Phase3Commands) -> Result<()> {
     match command {
         Phase3Commands::Adoption { command } => phase3_adoption_command(db, command),
         Phase3Commands::Gate { candidate, format } => {
@@ -2259,6 +2272,11 @@ fn phase3_command(db: &Database, command: Phase3Commands) -> Result<()> {
             let report = validate_research_adapter_plan(&path)?;
             print_research_adapter_plan(&report, &format)
         }
+        Phase3Commands::ResearchIngestPlan {
+            path,
+            execute,
+            format,
+        } => research_ingest_plan_command(db, config, &path, execute, &format).await,
     }
 }
 
@@ -2740,6 +2758,41 @@ struct ResearchAdapterPlanReport {
     errors: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct ResearchEvidenceDrawerPlan {
+    drawer_id: String,
+    finding_index: usize,
+    source_file: String,
+    created: bool,
+    skipped: bool,
+    #[serde(skip)]
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ResearchCandidateInsightPlan {
+    statement: String,
+    supporting_refs: Vec<String>,
+    suggested_command: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResearchIngestPlanReport {
+    valid: bool,
+    writes: bool,
+    report_id: String,
+    title: String,
+    source_count: usize,
+    finding_count: usize,
+    candidate_insight_count: usize,
+    planned_evidence_count: usize,
+    created_count: usize,
+    skipped_count: usize,
+    errors: Vec<String>,
+    evidence_drawers: Vec<ResearchEvidenceDrawerPlan>,
+    candidate_insights: Vec<ResearchCandidateInsightPlan>,
+}
+
 fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanReport> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read research report {}", path.display()))?;
@@ -2775,6 +2828,305 @@ fn validate_research_adapter_plan(path: &Path) -> Result<ResearchAdapterPlanRepo
         candidate_insight_count: candidate_insights,
         errors,
     })
+}
+
+async fn research_ingest_plan_command(
+    db: &Database,
+    config: &Config,
+    path: &Path,
+    execute: bool,
+    format: &str,
+) -> Result<()> {
+    let mut report = build_research_ingest_plan(path)?;
+    if report.valid && execute {
+        let existing = report
+            .evidence_drawers
+            .iter()
+            .filter_map(|plan| {
+                db.get_drawer(&plan.drawer_id)
+                    .ok()
+                    .flatten()
+                    .map(|_| plan.drawer_id.clone())
+            })
+            .collect::<BTreeSet<_>>();
+        let pending = report
+            .evidence_drawers
+            .iter()
+            .enumerate()
+            .filter(|(_, plan)| !existing.contains(&plan.drawer_id))
+            .map(|(index, plan)| (index, plan.drawer_id.clone(), plan.content.clone()))
+            .collect::<Vec<_>>();
+
+        let mut created_indices = BTreeSet::new();
+        if !pending.is_empty() {
+            let embedder = build_embedder(config).await?;
+            let content_refs = pending
+                .iter()
+                .map(|(_, _, content)| content.as_str())
+                .collect::<Vec<_>>();
+            let vectors = embedder
+                .embed(&content_refs)
+                .await
+                .context("failed to embed research evidence drawers")?;
+
+            for ((index, drawer_id, content), vector) in pending.into_iter().zip(vectors) {
+                let source_file = report.evidence_drawers[index].source_file.clone();
+                let drawer = research_evidence_drawer(
+                    drawer_id.clone(),
+                    content,
+                    source_file,
+                    report.report_id.as_str(),
+                    index,
+                );
+                db.insert_drawer(&drawer).with_context(|| {
+                    format!("failed to insert research evidence drawer {drawer_id}")
+                })?;
+                db.insert_vector(&drawer_id, &vector)
+                    .with_context(|| format!("failed to insert vector for {drawer_id}"))?;
+                created_indices.insert(index);
+            }
+        }
+
+        for (index, plan) in report.evidence_drawers.iter_mut().enumerate() {
+            plan.created = created_indices.contains(&index);
+            plan.skipped = existing.contains(&plan.drawer_id);
+        }
+        report.created_count = report
+            .evidence_drawers
+            .iter()
+            .filter(|plan| plan.created)
+            .count();
+        report.skipped_count = report
+            .evidence_drawers
+            .iter()
+            .filter(|plan| plan.skipped)
+            .count();
+        report.writes = report.created_count > 0;
+    }
+    print_research_ingest_plan(&report, format)
+}
+
+fn build_research_ingest_plan(path: &Path) -> Result<ResearchIngestPlanReport> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read research report {}", path.display()))?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse research report {}", path.display()))?;
+    let mut errors = Vec::new();
+    let report_id = required_string(&value, "report_id", &mut errors);
+    let title = required_string(&value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let findings = value
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if findings.is_empty() {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_values = value
+        .get("candidate_insights")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let evidence_drawers = findings
+        .iter()
+        .enumerate()
+        .map(|(index, finding)| {
+            let content = research_evidence_content_from_value(
+                report_id.as_str(),
+                title.as_str(),
+                value.get("sources"),
+                finding,
+                index,
+            )?;
+            let drawer_id = research_evidence_drawer_id(&content);
+            Ok(ResearchEvidenceDrawerPlan {
+                drawer_id,
+                finding_index: index,
+                source_file: format!("research://{}#finding-{index}", report_id),
+                created: false,
+                skipped: false,
+                content,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let supporting_refs = evidence_drawers
+        .iter()
+        .map(|plan| plan.drawer_id.clone())
+        .collect::<Vec<_>>();
+    let candidate_insights = candidate_values
+        .iter()
+        .filter_map(|candidate| candidate_statement(candidate).map(str::to_string))
+        .map(|statement| ResearchCandidateInsightPlan {
+            suggested_command: research_distill_command(&statement, &supporting_refs),
+            statement,
+            supporting_refs: supporting_refs.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ResearchIngestPlanReport {
+        valid: errors.is_empty(),
+        writes: false,
+        report_id,
+        title,
+        source_count,
+        finding_count: findings.len(),
+        candidate_insight_count: candidate_values.len(),
+        planned_evidence_count: evidence_drawers.len(),
+        created_count: 0,
+        skipped_count: 0,
+        errors,
+        evidence_drawers,
+        candidate_insights,
+    })
+}
+
+fn research_evidence_content_from_value(
+    report_id: &str,
+    title: &str,
+    sources: Option<&serde_json::Value>,
+    finding: &serde_json::Value,
+    finding_index: usize,
+) -> Result<String> {
+    let summary = finding_summary(finding)?;
+    let sources = sources
+        .map(serde_json::to_string_pretty)
+        .transpose()
+        .context("failed to serialize research sources")?
+        .unwrap_or_else(|| "[]".to_string());
+    let raw_finding =
+        serde_json::to_string_pretty(finding).context("failed to serialize research finding")?;
+    Ok(format!(
+        "# Research finding: {title}\n\nreport_id: {report_id}\nfinding_index: {finding_index}\n\nsummary: {summary}\n\nsources:\n```json\n{sources}\n```\n\nraw_finding:\n```json\n{raw_finding}\n```\n"
+    ))
+}
+
+fn finding_summary(finding: &serde_json::Value) -> Result<String> {
+    if let Some(raw) = finding.as_str() {
+        return Ok(raw.trim().to_string());
+    }
+    for field in ["summary", "statement", "content", "text"] {
+        if let Some(raw) = finding.get(field).and_then(serde_json::Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Ok(raw.trim().to_string());
+        }
+    }
+    serde_json::to_string(finding).context("failed to serialize research finding summary")
+}
+
+fn candidate_statement(candidate: &serde_json::Value) -> Option<&str> {
+    if let Some(raw) = candidate.as_str()
+        && !raw.trim().is_empty()
+    {
+        return Some(raw.trim());
+    }
+    for field in ["statement", "summary", "content", "text"] {
+        if let Some(raw) = candidate.get(field).and_then(serde_json::Value::as_str)
+            && !raw.trim().is_empty()
+        {
+            return Some(raw.trim());
+        }
+    }
+    None
+}
+
+fn research_evidence_drawer_id(content: &str) -> String {
+    let memory_kind = MemoryKind::Evidence;
+    let domain = MemoryDomain::Project;
+    let anchor_kind = AnchorKind::Repo;
+    let provenance = Provenance::Research;
+    let empty_refs: &[String] = &[];
+    build_bootstrap_drawer_id_from_parts(
+        "mempal",
+        Some("research"),
+        content,
+        BootstrapIdentityParts {
+            memory_kind: &memory_kind,
+            domain: &domain,
+            field: "research",
+            anchor_kind: &anchor_kind,
+            anchor_id: anchor::LEGACY_REPO_ANCHOR_ID,
+            parent_anchor_id: None,
+            provenance: Some(&provenance),
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: empty_refs,
+            counterexample_refs: empty_refs,
+            teaching_refs: empty_refs,
+            verification_refs: empty_refs,
+            scope_constraints: None,
+            trigger_hints: None,
+        },
+    )
+}
+
+fn research_evidence_drawer(
+    drawer_id: String,
+    content: String,
+    source_file: String,
+    report_id: &str,
+    finding_index: usize,
+) -> Drawer {
+    Drawer {
+        id: drawer_id,
+        content,
+        wing: "mempal".to_string(),
+        room: Some("research".to_string()),
+        source_file: Some(source_file),
+        source_type: SourceType::Project,
+        added_at: current_timestamp(),
+        chunk_index: Some(finding_index as i64),
+        normalize_version: CURRENT_NORMALIZE_VERSION,
+        importance: 3,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "research".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: anchor::LEGACY_REPO_ANCHOR_ID.to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Research),
+        statement: Some(format!(
+            "Research finding from {report_id} #{finding_index}"
+        )),
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn research_distill_command(statement: &str, supporting_refs: &[String]) -> Vec<String> {
+    let mut command = vec![
+        "mempal".to_string(),
+        "knowledge".to_string(),
+        "distill".to_string(),
+        "--tier".to_string(),
+        "qi".to_string(),
+        "--statement".to_string(),
+        statement.to_string(),
+        "--content".to_string(),
+        statement.to_string(),
+        "--field".to_string(),
+        "research".to_string(),
+    ];
+    for supporting_ref in supporting_refs {
+        command.push("--supporting-ref".to_string());
+        command.push(supporting_ref.clone());
+    }
+    command
 }
 
 fn required_string(
@@ -2930,6 +3282,40 @@ fn print_research_adapter_plan(report: &ResearchAdapterPlanReport, format: &str)
             Ok(())
         }
         other => bail!("unsupported research adapter plan format: {other}"),
+    }
+}
+
+fn print_research_ingest_plan(report: &ResearchIngestPlanReport, format: &str) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("valid={}", report.valid);
+            println!("writes={}", report.writes);
+            println!("report_id={}", report.report_id);
+            println!("title={}", report.title);
+            println!("planned_evidence_count={}", report.planned_evidence_count);
+            println!("created_count={}", report.created_count);
+            println!("skipped_count={}", report.skipped_count);
+            println!("candidate_insight_count={}", report.candidate_insight_count);
+            for error in &report.errors {
+                println!("error={error}");
+            }
+            for drawer in &report.evidence_drawers {
+                println!(
+                    "drawer={} finding_index={} created={} skipped={}",
+                    drawer.drawer_id, drawer.finding_index, drawer.created, drawer.skipped
+                );
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize research ingest plan")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 research ingest format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,13 @@ use mempal::core::{
     config::Config,
     db::Database,
     phase3::{
-        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionGuidance,
-        RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
+        Phase3ReadinessReport, ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport,
+        RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordPlanInput,
         RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
         RuntimeAdoptionReviewReport, build_research_ingest_plan_from_value,
         card_context_default_readiness, check_runtime_adoption_record,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     protocol::{DEFAULT_IDENTITY_HINT, MEMORY_PROTOCOL},
     types::{
@@ -652,6 +653,34 @@ enum Phase3AdoptionCommands {
         metadata_json: Option<String>,
         #[arg(long)]
         id: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+    RecordChecked {
+        #[arg(long)]
+        track: String,
+        #[arg(long)]
+        signal: String,
+        #[arg(long)]
+        feature: String,
+        #[arg(long)]
+        query: Option<String>,
+        #[arg(long = "context-hash")]
+        context_hash: Option<String>,
+        #[arg(long = "card-id")]
+        card_id: Option<String>,
+        #[arg(long = "evaluator-id")]
+        evaluator_id: Option<String>,
+        #[arg(long = "research-report-id")]
+        research_report_id: Option<String>,
+        #[arg(long)]
+        note: Option<String>,
+        #[arg(long = "metadata-json")]
+        metadata_json: Option<String>,
+        #[arg(long)]
+        id: Option<String>,
+        #[arg(long = "allow-warnings")]
+        allow_warnings: bool,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -2356,6 +2385,59 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let report = check_runtime_adoption_record(&input);
             print_runtime_adoption_record_quality(&report, &format)
         }
+        Phase3AdoptionCommands::RecordChecked {
+            track,
+            signal,
+            feature,
+            query,
+            context_hash,
+            card_id,
+            evaluator_id,
+            research_report_id,
+            note,
+            metadata_json,
+            id,
+            allow_warnings,
+            format,
+        } => {
+            let track = parse_runtime_adoption_track(&track)?;
+            let signal = parse_runtime_adoption_signal(&signal)?;
+            let metadata = metadata_json
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .context("failed to parse --metadata-json")?;
+            let input = RuntimeAdoptionRecordPlanInput {
+                id,
+                track: runtime_adoption_track_slug(&track).to_string(),
+                signal: runtime_adoption_signal_slug(&signal).to_string(),
+                feature,
+                query,
+                context_hash,
+                card_id,
+                evaluator_id,
+                research_report_id,
+                note,
+                metadata,
+            };
+            let quality = check_runtime_adoption_record(&input);
+            let should_write = should_write_checked_record(&quality, allow_warnings);
+            let event = if should_write {
+                let event = runtime_adoption_event_from_input(input, track, signal);
+                db.insert_runtime_adoption_event(&event)
+                    .context("failed to insert runtime adoption event")?;
+                Some(event)
+            } else {
+                None
+            };
+            let report = RuntimeAdoptionCheckedRecordReport {
+                writes: event.is_some(),
+                blocked: event.is_none(),
+                record_quality: quality,
+                event,
+            };
+            print_runtime_adoption_checked_record(&report, &format)
+        }
         Phase3AdoptionCommands::Review {
             track,
             feature,
@@ -2418,42 +2500,24 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
                 .map(serde_json::from_str)
                 .transpose()
                 .context("failed to parse --metadata-json")?;
-            let created_at = current_timestamp();
-            let nonce = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_nanos().to_string())
-                .unwrap_or_else(|_| "0".to_string());
-            let id = id.unwrap_or_else(|| {
-                stable_cli_id(
-                    "adoption",
-                    &[
-                        runtime_adoption_track_slug(&track),
-                        runtime_adoption_signal_slug(&signal),
-                        feature.as_str(),
-                        query.as_deref().unwrap_or(""),
-                        context_hash.as_deref().unwrap_or(""),
-                        card_id.as_deref().unwrap_or(""),
-                        evaluator_id.as_deref().unwrap_or(""),
-                        research_report_id.as_deref().unwrap_or(""),
-                        created_at.as_str(),
-                        nonce.as_str(),
-                    ],
-                )
-            });
-            let event = RuntimeAdoptionEvent {
-                id: id.clone(),
+            let event = runtime_adoption_event_from_input(
+                RuntimeAdoptionRecordPlanInput {
+                    id,
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query,
+                    context_hash,
+                    card_id,
+                    evaluator_id,
+                    research_report_id,
+                    note,
+                    metadata,
+                },
                 track,
                 signal,
-                feature,
-                query,
-                context_hash,
-                card_id,
-                evaluator_id,
-                research_report_id,
-                note,
-                metadata,
-                created_at,
-            };
+            );
+            let id = event.id.clone();
             db.insert_runtime_adoption_event(&event)
                 .context("failed to insert runtime adoption event")?;
             match format.as_str() {
@@ -2507,6 +2571,81 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             let stats = RuntimeAdoptionStats::from_events(&events);
             print_runtime_adoption_stats(&stats, &format)
         }
+    }
+}
+
+fn runtime_adoption_event_from_input(
+    input: RuntimeAdoptionRecordPlanInput,
+    track: RuntimeAdoptionTrack,
+    signal: RuntimeAdoptionSignal,
+) -> RuntimeAdoptionEvent {
+    let created_at = current_timestamp();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string());
+    let id = input.id.unwrap_or_else(|| {
+        stable_cli_id(
+            "adoption",
+            &[
+                runtime_adoption_track_slug(&track),
+                runtime_adoption_signal_slug(&signal),
+                input.feature.as_str(),
+                input.query.as_deref().unwrap_or(""),
+                input.context_hash.as_deref().unwrap_or(""),
+                input.card_id.as_deref().unwrap_or(""),
+                input.evaluator_id.as_deref().unwrap_or(""),
+                input.research_report_id.as_deref().unwrap_or(""),
+                created_at.as_str(),
+                nonce.as_str(),
+            ],
+        )
+    });
+    RuntimeAdoptionEvent {
+        id,
+        track,
+        signal,
+        feature: input.feature,
+        query: input.query,
+        context_hash: input.context_hash,
+        card_id: input.card_id,
+        evaluator_id: input.evaluator_id,
+        research_report_id: input.research_report_id,
+        note: input.note,
+        metadata: input.metadata,
+        created_at,
+    }
+}
+
+fn print_runtime_adoption_checked_record(
+    report: &RuntimeAdoptionCheckedRecordReport,
+    format: &str,
+) -> Result<()> {
+    match format {
+        "plain" => {
+            println!("writes={}", report.writes);
+            println!("blocked={}", report.blocked);
+            println!("quality={}", report.record_quality.quality);
+            if let Some(event) = report.event.as_ref() {
+                println!("event_id={}", event.id);
+            }
+            for error in &report.record_quality.errors {
+                println!("error={error}");
+            }
+            for warning in &report.record_quality.warnings {
+                println!("warning={warning}");
+            }
+            Ok(())
+        }
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(report)
+                    .context("failed to serialize runtime adoption checked record report")?
+            );
+            Ok(())
+        }
+        other => bail!("unsupported phase3 adoption format: {other}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1161,7 +1161,6 @@ enum Phase3EvaluatorCommands {
 }
 
 #[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)] // `record` intentionally carries the full event payload.
 enum Phase3AdoptionCommands {
     Guidance {
         #[arg(long, default_value = "plain")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,7 +7,8 @@ use crate::core::{
     db::Database,
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
-        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
         TriggerHints, Triple,
     },
     utils::{
@@ -61,9 +62,11 @@ use super::tools::{
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    RetrievedKnowledgeCardDto, ScopeCount, SearchRequest, SearchResponse, SearchResultDto,
-    StatusResponse, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto,
-    TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse,
+    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
+    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse,
 };
 
 #[derive(Clone)]
@@ -225,6 +228,17 @@ impl MempalMcpServer {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         self.mempal_knowledge_cards(Parameters(request))
+            .await
+            .map(|response| response.0)
+    }
+
+    pub async fn phase3_json_for_test(
+        &self,
+        value: Value,
+    ) -> std::result::Result<Phase3Response, ErrorData> {
+        let request = serde_json::from_value(value)
+            .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        self.mempal_phase3(Parameters(request))
             .await
             .map(|response| response.0)
     }
@@ -609,6 +623,224 @@ fn required_string<'a>(
 ) -> std::result::Result<&'a str, ErrorData> {
     trim_to_option(value)
         .ok_or_else(|| ErrorData::invalid_params(format!("{field} is required"), None))
+}
+
+fn parse_runtime_adoption_track_opt(
+    value: Option<&str>,
+) -> std::result::Result<Option<RuntimeAdoptionTrack>, ErrorData> {
+    parse_enum(value, "track", |normalized| match normalized {
+        "runtime_adoption" => Some(RuntimeAdoptionTrack::RuntimeAdoption),
+        "card_context" => Some(RuntimeAdoptionTrack::CardContext),
+        "card_embedding" => Some(RuntimeAdoptionTrack::CardEmbedding),
+        "evaluator" => Some(RuntimeAdoptionTrack::Evaluator),
+        "research_adapter" => Some(RuntimeAdoptionTrack::ResearchAdapter),
+        _ => None,
+    })
+}
+
+fn parse_runtime_adoption_track(
+    value: &str,
+) -> std::result::Result<RuntimeAdoptionTrack, ErrorData> {
+    parse_runtime_adoption_track_opt(Some(value))?
+        .ok_or_else(|| ErrorData::invalid_params("track is required", None))
+}
+
+fn parse_runtime_adoption_signal(
+    value: &str,
+) -> std::result::Result<RuntimeAdoptionSignal, ErrorData> {
+    parse_enum(Some(value), "signal", |normalized| match normalized {
+        "used" => Some(RuntimeAdoptionSignal::Used),
+        "accepted" => Some(RuntimeAdoptionSignal::Accepted),
+        "rejected" => Some(RuntimeAdoptionSignal::Rejected),
+        "miss" => Some(RuntimeAdoptionSignal::Miss),
+        "rollback" => Some(RuntimeAdoptionSignal::Rollback),
+        "contradiction" => Some(RuntimeAdoptionSignal::Contradiction),
+        "neutral" => Some(RuntimeAdoptionSignal::Neutral),
+        _ => None,
+    })?
+    .ok_or_else(|| ErrorData::invalid_params("signal is required", None))
+}
+
+fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn phase3_event_id(
+    track: &RuntimeAdoptionTrack,
+    signal: &RuntimeAdoptionSignal,
+    feature: &str,
+) -> String {
+    let signal = match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    };
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let sanitized_feature = feature
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!(
+        "adoption_{}_{}_{}_{}",
+        runtime_adoption_track_slug(track),
+        signal,
+        sanitized_feature,
+        nanos
+    )
+}
+
+fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionStatsDto {
+    let mut stats = RuntimeAdoptionStatsDto {
+        total: events.len(),
+        used: 0,
+        accepted: 0,
+        rejected: 0,
+        misses: 0,
+        rollbacks: 0,
+        contradictions: 0,
+        neutral: 0,
+    };
+    for event in events {
+        match event.signal {
+            RuntimeAdoptionSignal::Used => stats.used += 1,
+            RuntimeAdoptionSignal::Accepted => stats.accepted += 1,
+            RuntimeAdoptionSignal::Rejected => stats.rejected += 1,
+            RuntimeAdoptionSignal::Miss => stats.misses += 1,
+            RuntimeAdoptionSignal::Rollback => stats.rollbacks += 1,
+            RuntimeAdoptionSignal::Contradiction => stats.contradictions += 1,
+            RuntimeAdoptionSignal::Neutral => stats.neutral += 1,
+        }
+    }
+    stats
+}
+
+fn phase3_gate_report(
+    db: &Database,
+    candidate: &str,
+) -> std::result::Result<Phase3GateDto, ErrorData> {
+    let (track, ready_fn): (RuntimeAdoptionTrack, fn(&RuntimeAdoptionStatsDto) -> bool) =
+        match candidate {
+            "card-context-default" => (RuntimeAdoptionTrack::CardContext, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.rejected <= stats.accepted
+            }),
+            "card-embeddings" => (RuntimeAdoptionTrack::CardEmbedding, |stats| {
+                stats.misses >= 3 && stats.rollbacks == 0
+            }),
+            "evaluator-api" => (RuntimeAdoptionTrack::Evaluator, |stats| {
+                stats.accepted >= 3 && stats.rollbacks == 0 && stats.contradictions == 0
+            }),
+            "research-adapter" => (RuntimeAdoptionTrack::ResearchAdapter, |stats| {
+                stats.accepted >= 1 && stats.contradictions == 0 && stats.rollbacks == 0
+            }),
+            other => {
+                return Err(ErrorData::invalid_params(
+                    format!("unsupported phase3 candidate: {other}"),
+                    None,
+                ));
+            }
+        };
+    let events = db
+        .list_runtime_adoption_events(
+            &RuntimeAdoptionFilter {
+                track: Some(track.clone()),
+                feature: None,
+            },
+            10_000,
+        )
+        .map_err(|error| {
+            ErrorData::internal_error(
+                format!("failed to list runtime adoption events: {error}"),
+                None,
+            )
+        })?;
+    let stats = runtime_adoption_stats(&events);
+    let ready = ready_fn(&stats);
+    let mut reasons = Vec::new();
+    if ready {
+        reasons.push("minimum evidence threshold satisfied".to_string());
+    } else {
+        reasons.push("minimum evidence threshold not satisfied".to_string());
+    }
+    if stats.rollbacks > 0 {
+        reasons.push("rollback signals block default or authority changes".to_string());
+    }
+    if stats.contradictions > 0 {
+        reasons.push("contradiction signals require review before implementation".to_string());
+    }
+    Ok(Phase3GateDto {
+        candidate: candidate.to_string(),
+        ready,
+        required_track: runtime_adoption_track_slug(&track).to_string(),
+        stats,
+        reasons,
+    })
+}
+
+fn validate_research_adapter_plan_value(value: &serde_json::Value) -> ResearchAdapterPlanDto {
+    let mut errors = Vec::new();
+    let report_id = required_json_string(value, "report_id", &mut errors);
+    let title = required_json_string(value, "title", &mut errors);
+    let source_count = value
+        .get("sources")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if source_count == 0 {
+        errors.push("sources must contain at least one item".to_string());
+    }
+    let finding_count = value
+        .get("findings")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+    if finding_count == 0 {
+        errors.push("findings must contain at least one item".to_string());
+    }
+    let candidate_insight_count = value
+        .get("candidate_insights")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len);
+
+    ResearchAdapterPlanDto {
+        valid: errors.is_empty(),
+        report_id,
+        title,
+        source_count,
+        finding_count,
+        candidate_insight_count,
+        errors,
+    }
+}
+
+fn required_json_string(
+    value: &serde_json::Value,
+    field: &'static str,
+    errors: &mut Vec<String>,
+) -> String {
+    match value.get(field).and_then(serde_json::Value::as_str) {
+        Some(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => {
+            errors.push(format!("{field} is required"));
+            String::new()
+        }
+    }
 }
 
 fn anchor_error(error: anchor::AnchorError) -> ErrorData {
@@ -1089,6 +1321,143 @@ impl MempalMcpServer {
             other => Err(ErrorData::invalid_params(
                 format!(
                     "unsupported knowledge cards action: {other}; actions are list, get, retrieve, events, gate, promote, demote"
+                ),
+                None,
+            )),
+        }
+    }
+
+    #[tool(
+        name = "mempal_phase3",
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: record/list/stats/gate/research_validate_plan. Record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+    )]
+    async fn mempal_phase3(
+        &self,
+        Parameters(request): Parameters<Phase3Request>,
+    ) -> std::result::Result<Json<Phase3Response>, ErrorData> {
+        let action = trim_to_option(Some(request.action.as_str()))
+            .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
+
+        match action {
+            "record" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = required_string(request.feature.as_deref(), "feature")?.to_string();
+                let event = RuntimeAdoptionEvent {
+                    id: request
+                        .id
+                        .unwrap_or_else(|| phase3_event_id(&track, &signal, &feature)),
+                    track,
+                    signal,
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                    created_at: current_timestamp(),
+                };
+                db.insert_runtime_adoption_event(&event).map_err(|error| {
+                    ErrorData::internal_error(
+                        format!("failed to insert runtime adoption event: {error}"),
+                        None,
+                    )
+                })?;
+                Ok(Json(Phase3Response {
+                    event: Some(RuntimeAdoptionEventDto::from(event)),
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "list" => {
+                let db = self.open_db()?;
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: parse_runtime_adoption_track_opt(request.track.as_deref())?,
+                            feature: trim_to_owned(request.feature.as_deref()),
+                        },
+                        request.limit.unwrap_or(50),
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: events
+                        .into_iter()
+                        .map(RuntimeAdoptionEventDto::from)
+                        .collect(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "stats" => {
+                let db = self.open_db()?;
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: parse_runtime_adoption_track_opt(request.track.as_deref())?,
+                            feature: trim_to_owned(request.feature.as_deref()),
+                        },
+                        10_000,
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: Some(runtime_adoption_stats(&events)),
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "gate" => {
+                let db = self.open_db()?;
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let gate = phase3_gate_report(&db, candidate)?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: Some(gate),
+                    research_plan: None,
+                }))
+            }
+            "research_validate_plan" => {
+                let report = request.report.ok_or_else(|| {
+                    ErrorData::invalid_params("report is required for research_validate_plan", None)
+                })?;
+                Ok(Json(Phase3Response {
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: Some(validate_research_adapter_plan_value(&report)),
+                }))
+            }
+            other => Err(ErrorData::invalid_params(
+                format!(
+                    "unsupported phase3 action: {other}; actions are record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -2061,7 +2430,7 @@ mod tests {
     use super::*;
     use crate::core::types::{
         BootstrapEvidenceArgs, KnowledgeCard, KnowledgeCardEvent, KnowledgeEventType,
-        KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeEvidenceLink, KnowledgeEvidenceRole, RuntimeAdoptionFilter, RuntimeAdoptionTrack,
     };
     use crate::embed::Embedder;
 
@@ -3189,6 +3558,157 @@ mod tests {
         assert_eq!(
             db.knowledge_events("card_lifecycle").expect("events").len(),
             2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_record_stats_and_gate_actions() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        for i in 0..3 {
+            let response = server
+                .phase3_json_for_test(serde_json::json!({
+                    "action": "record",
+                    "id": format!("mcp_card_context_accept_{i}"),
+                    "track": "card_context",
+                    "signal": "accepted",
+                    "feature": "include_cards",
+                    "query": "skill trigger context",
+                    "metadata": { "source": "mcp-test" }
+                }))
+                .await
+                .expect("record phase3 event");
+            assert_eq!(
+                response.event.expect("event").id,
+                format!("mcp_card_context_accept_{i}")
+            );
+        }
+
+        let stats = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "stats",
+                "track": "card_context",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("stats");
+        let stats = stats.stats.expect("stats");
+        assert_eq!(stats.total, 3);
+        assert_eq!(stats.accepted, 3);
+        assert_eq!(stats.rollbacks, 0);
+
+        let gate = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "gate",
+                "candidate": "card-context-default"
+            }))
+            .await
+            .expect("gate");
+        let gate = gate.gate.expect("gate");
+        assert!(gate.ready);
+        assert_eq!(gate.required_track, "card_context");
+
+        let db = Database::open(&db_path).expect("open db");
+        let events = db
+            .list_runtime_adoption_events(
+                &RuntimeAdoptionFilter {
+                    track: Some(RuntimeAdoptionTrack::CardContext),
+                    feature: Some("include_cards".to_string()),
+                },
+                10,
+            )
+            .expect("events");
+        assert_eq!(events.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_research_validate_plan_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_validate_plan",
+                "report": {
+                    "report_id": "research_001",
+                    "title": "Agent memory retrieval notes",
+                    "sources": [{ "url": "https://example.invalid/report" }],
+                    "findings": [{ "summary": "Measure card context before defaults." }],
+                    "candidate_insights": [{ "statement": "Measure before defaulting cards." }]
+                }
+            }))
+            .await
+            .expect("validate research plan");
+        let plan = response.research_plan.expect("research plan");
+        assert!(plan.valid);
+        assert_eq!(plan.report_id, "research_001");
+        assert_eq!(plan.source_count, 1);
+        assert_eq!(plan.candidate_insight_count, 1);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_rejects_invalid_action_without_mutation() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let error = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "promote"
+            }))
+            .await
+            .expect_err("invalid action should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("actions are record, list, stats, gate, research_validate_plan")
+        );
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_phase3")
+            .expect("mempal_phase3 tool exists");
+        let description = tool.description.as_deref().unwrap_or_default();
+        assert!(description.contains("Phase-3 runtime adoption evidence"));
+        assert!(description.contains("Actions: record/list/stats/gate/research_validate_plan"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("runtime adoption"),
+            "protocol should explain the Phase-3 runtime evidence surface"
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -12,7 +12,7 @@ use crate::core::{
         card_context_default_proposal, card_context_default_readiness,
         check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
         prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1350,7 +1350,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1362,6 +1362,24 @@ impl MempalMcpServer {
         match action {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
+                instrumentation_policy: None,
+                record_plan: None,
+                record_quality: None,
+                record_checked: None,
+                review_report: None,
+                readiness_report: None,
+                event: None,
+                events: Vec::new(),
+                stats: None,
+                gate: None,
+                research_plan: None,
+                research_ingest_plan: None,
+                evaluator_advice: None,
+                default_proposal: None,
+            })),
+            "instrumentation_policy" => Ok(Json(Phase3Response {
+                guidance: None,
+                instrumentation_policy: Some(runtime_adoption_instrumentation_policy().into()),
                 record_plan: None,
                 record_quality: None,
                 record_checked: None,
@@ -1401,6 +1419,7 @@ impl MempalMcpServer {
                 });
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     record_checked: None,
@@ -1484,6 +1503,7 @@ impl MempalMcpServer {
                 }
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: Some(capture.record_plan.into()),
                     record_quality: Some(capture.record_quality.into()),
                     record_checked: capture.record_checked.map(Into::into),
@@ -1520,6 +1540,7 @@ impl MempalMcpServer {
                 .map_err(|error| ErrorData::invalid_params(error, None))?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1568,6 +1589,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1608,6 +1630,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
                     record_checked: None,
@@ -1679,6 +1702,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: Some(
@@ -1743,6 +1767,7 @@ impl MempalMcpServer {
                 );
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1788,6 +1813,7 @@ impl MempalMcpServer {
                 };
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1838,6 +1864,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1871,6 +1898,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1907,6 +1935,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1928,6 +1957,7 @@ impl MempalMcpServer {
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1949,6 +1979,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1970,6 +2001,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    instrumentation_policy: None,
                     record_plan: None,
                     record_quality: None,
                     record_checked: None,
@@ -1989,7 +2021,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4310,7 +4342,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4369,6 +4401,49 @@ mod tests {
                     .feature_examples
                     .contains(&"include_cards".to_string())
         }));
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_instrumentation_policy_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "instrumentation_policy"
+            }))
+            .await
+            .expect("instrumentation policy");
+        let policy = response
+            .instrumentation_policy
+            .expect("instrumentation policy");
+        assert!(!policy.writes);
+        assert_eq!(policy.default_mode, "manual_only");
+        assert!(policy.allowed_modes.iter().any(|mode| {
+            mode.mode == "opt_in_wrapper" && mode.requires_execute && mode.requires_checked_capture
+        }));
+        assert!(
+            policy
+                .forbidden_modes
+                .contains(&"implicit_background_capture".to_string())
+        );
 
         let db = Database::open(&db_path).expect("reopen db");
         assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
@@ -4768,16 +4843,19 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=instrumentation_policy"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("live instrumentation is opt-in"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("checked capture"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,8 +7,8 @@ use crate::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1346,7 +1346,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1361,6 +1361,7 @@ impl MempalMcpServer {
                 record_plan: None,
                 record_quality: None,
                 review_report: None,
+                readiness_report: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1395,6 +1396,7 @@ impl MempalMcpServer {
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1430,6 +1432,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1481,6 +1484,48 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: Some(report.into()),
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "readiness" => {
+                let db = self.open_db()?;
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context-default" => {
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_default_readiness(&events)
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 readiness candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: None,
+                    readiness_report: Some(report.into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1526,6 +1571,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1554,6 +1600,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1585,6 +1632,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1601,6 +1649,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1617,6 +1666,7 @@ impl MempalMcpServer {
                     record_plan: None,
                     record_quality: None,
                     review_report: None,
+                    readiness_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1626,7 +1676,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3850,7 +3900,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -4048,6 +4098,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_readiness_card_context_default_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            for i in 0..3 {
+                db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                    id: format!("readiness_event_{i}"),
+                    track: RuntimeAdoptionTrack::CardContext,
+                    signal: RuntimeAdoptionSignal::Accepted,
+                    feature: "include_cards".to_string(),
+                    query: Some("skill trigger".to_string()),
+                    context_hash: None,
+                    card_id: None,
+                    evaluator_id: None,
+                    research_report_id: None,
+                    note: Some("helped".to_string()),
+                    metadata: None,
+                    created_at: "1777710000".to_string(),
+                })
+                .expect("insert event");
+            }
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "readiness",
+                "candidate": "card-context-default"
+            }))
+            .await
+            .expect("readiness");
+        let report = response.readiness_report.expect("readiness report");
+        assert!(!report.writes);
+        assert!(report.ready);
+        assert_eq!(report.decision, "eligible_for_future_default_spec");
+        assert_eq!(report.review.stats.accepted, 3);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4059,10 +4158,11 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,9 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
-    phase3::runtime_adoption_guidance,
+    phase3::{
+        RuntimeAdoptionRecordPlanInput, prepare_runtime_adoption_record, runtime_adoption_guidance,
+    },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
@@ -672,6 +674,18 @@ fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
     }
 }
 
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
+}
+
 fn phase3_event_id(
     track: &RuntimeAdoptionTrack,
     signal: &RuntimeAdoptionSignal,
@@ -1330,7 +1344,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1342,12 +1356,46 @@ impl MempalMcpServer {
         match action {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
+                record_plan: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
                 gate: None,
                 research_plan: None,
             })),
+            "prepare_record" => {
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = required_string(request.feature.as_deref(), "feature")?.to_string();
+                let plan = prepare_runtime_adoption_record(RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                });
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: Some(plan.into()),
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
             "record" => {
                 let db = self.open_db()?;
                 let track = parse_runtime_adoption_track(required_string(
@@ -1383,6 +1431,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1408,6 +1457,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1436,6 +1486,7 @@ impl MempalMcpServer {
                     })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1449,6 +1500,7 @@ impl MempalMcpServer {
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1462,6 +1514,7 @@ impl MempalMcpServer {
                 })?;
                 Ok(Json(Phase3Response {
                     guidance: None,
+                    record_plan: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1471,7 +1524,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3695,7 +3748,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3765,6 +3818,47 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_prepare_record_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "prepare_record",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards",
+                "query": "skill trigger"
+            }))
+            .await
+            .expect("prepare record");
+        let plan = response.record_plan.expect("record plan");
+        assert!(!plan.writes);
+        assert_eq!(plan.record_payload["action"], "record");
+        assert_eq!(plan.record_payload["track"], "card_context");
+        assert_eq!(plan.record_payload["signal"], "accepted");
+        assert_eq!(plan.record_payload["feature"], "include_cards");
+        assert_eq!(plan.record_payload["query"], "skill trigger");
+        assert_eq!(plan.record_command[0], "mempal");
+        assert_eq!(plan.record_command[1], "phase3");
+        assert_eq!(plan.record_command[2], "adoption");
+        assert_eq!(plan.record_command[3], "record");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3775,9 +3869,9 @@ mod tests {
             .expect("mempal_phase3 tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
-        assert!(
-            description.contains("Actions: guidance/record/list/stats/gate/research_validate_plan")
-        );
+        assert!(description.contains(
+            "Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan"
+        ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,7 +6,8 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordPlanInput, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1344,7 +1345,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1357,6 +1358,7 @@ impl MempalMcpServer {
             "guidance" => Ok(Json(Phase3Response {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
+                record_quality: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1389,6 +1391,41 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: Some(plan.into()),
+                    record_quality: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "check_record" => {
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = request.feature.unwrap_or_default();
+                let input = RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: Some(check_runtime_adoption_record(&input).into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1432,6 +1469,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1458,6 +1496,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1487,6 +1526,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1501,6 +1541,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1515,6 +1556,7 @@ impl MempalMcpServer {
                 Ok(Json(Phase3Response {
                     guidance: None,
                     record_plan: None,
+                    record_quality: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1524,7 +1566,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3748,7 +3790,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3859,6 +3901,46 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_check_record_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "check_record",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("check record");
+        let report = response.record_quality.expect("record quality");
+        assert!(!report.writes);
+        assert!(report.valid);
+        assert_eq!(report.quality, "warning");
+        assert!(report.errors.is_empty());
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("concrete outcome context"))
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3870,7 +3952,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,8 +6,9 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, runtime_adoption_guidance,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1345,7 +1346,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1359,6 +1360,7 @@ impl MempalMcpServer {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
                 record_quality: None,
+                review_report: None,
                 event: None,
                 events: Vec::new(),
                 stats: None,
@@ -1392,6 +1394,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1426,6 +1429,58 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
+                    review_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                }))
+            }
+            "review" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track_opt(request.track.as_deref())?;
+                let signal = request
+                    .signal
+                    .as_deref()
+                    .map(parse_runtime_adoption_signal)
+                    .transpose()?;
+                let feature = trim_to_owned(request.feature.as_deref());
+                let limit = request.limit.unwrap_or(10_000);
+                let events = db
+                    .list_runtime_adoption_events(
+                        &RuntimeAdoptionFilter {
+                            track: track.clone(),
+                            feature: feature.clone(),
+                        },
+                        limit,
+                    )
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to list runtime adoption events: {error}"),
+                            None,
+                        )
+                    })?;
+                let report = review_runtime_adoption_events(
+                    &events,
+                    RuntimeAdoptionReviewFilters {
+                        track: track
+                            .as_ref()
+                            .map(runtime_adoption_track_slug)
+                            .map(str::to_string),
+                        feature,
+                        signal: signal
+                            .as_ref()
+                            .map(runtime_adoption_signal_slug)
+                            .map(str::to_string),
+                        limit,
+                    },
+                );
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: Some(report.into()),
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1470,6 +1525,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1497,6 +1553,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1527,6 +1584,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1542,6 +1600,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1557,6 +1616,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    review_report: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1566,7 +1626,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3790,7 +3850,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, record, list, stats, gate, research_validate_plan"
             )
         );
 
@@ -3941,6 +4001,53 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_review_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                id: "review_event".to_string(),
+                track: RuntimeAdoptionTrack::CardContext,
+                signal: RuntimeAdoptionSignal::Accepted,
+                feature: "include_cards".to_string(),
+                query: Some("skill trigger".to_string()),
+                context_hash: None,
+                card_id: None,
+                evaluator_id: None,
+                research_report_id: None,
+                note: Some("helped".to_string()),
+                metadata: None,
+                created_at: "1777710000".to_string(),
+            })
+            .expect("insert event");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "review",
+                "track": "card_context"
+            }))
+            .await
+            .expect("review");
+        let report = response.review_report.expect("review report");
+        assert!(!report.writes);
+        assert_eq!(report.total, 1);
+        assert_eq!(report.stats.accepted, 1);
+        assert_eq!(report.features[0].feature, "include_cards");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -3952,7 +4059,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/record/list/stats/gate/research_validate_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,8 +10,9 @@ use crate::core::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
         card_context_default_proposal, card_context_default_readiness,
-        check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        card_context_rollback_control, check_runtime_adoption_record, evaluator_advice,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     types::{
@@ -1371,7 +1372,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; instrumentation_policy defines opt-in live instrumentation boundaries without writing; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; rollback_control evaluates card-context rollback evidence without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1397,6 +1398,7 @@ impl MempalMcpServer {
                 research_ingest_plan: None,
                 evaluator_advice: None,
                 default_proposal: None,
+                rollback_control: None,
             })),
             "instrumentation_policy" => Ok(Json(Phase3Response {
                 guidance: None,
@@ -1414,6 +1416,7 @@ impl MempalMcpServer {
                 research_ingest_plan: None,
                 evaluator_advice: None,
                 default_proposal: None,
+                rollback_control: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1454,6 +1457,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "capture" => {
@@ -1538,6 +1542,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "evaluator_advise" => {
@@ -1575,6 +1580,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: Some(report.into()),
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "default_proposal" => {
@@ -1624,6 +1630,64 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: Some(report.into()),
+                    rollback_control: None,
+                }))
+            }
+            "rollback_control" => {
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context" => {
+                        if request.execute.unwrap_or(false) {
+                            return Err(ErrorData::invalid_params(
+                                "rollback_control execute is only supported by CLI in P79",
+                                None,
+                            ));
+                        }
+                        let db = self.open_db()?;
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_rollback_control(
+                            &events,
+                            self.config.context.include_cards_default,
+                            false,
+                        )
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 rollback-control candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    instrumentation_policy: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: None,
+                    default_proposal: None,
+                    rollback_control: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1665,6 +1729,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "record_checked" => {
@@ -1745,6 +1810,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "review" => {
@@ -1802,6 +1868,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "readiness" => {
@@ -1848,6 +1915,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "record" => {
@@ -1899,6 +1967,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "list" => {
@@ -1936,6 +2005,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "stats" => {
@@ -1970,6 +2040,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "gate" => {
@@ -1992,6 +2063,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "research_validate_plan" => {
@@ -2014,6 +2086,7 @@ impl MempalMcpServer {
                     research_ingest_plan: None,
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -2038,11 +2111,12 @@ impl MempalMcpServer {
                     )),
                     evaluator_advice: None,
                     default_proposal: None,
+                    rollback_control: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4423,7 +4497,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, instrumentation_policy, prepare_record, capture, evaluator_advise, default_proposal, rollback_control, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4913,6 +4987,57 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_rollback_control_check_is_read_only() {
+        let mut config = crate::core::config::Config::default();
+        config.context.include_cards_default = true;
+        let (_tempdir, db_path, server) = setup_server_with_config(config);
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                id: "rollback_control_event".to_string(),
+                track: RuntimeAdoptionTrack::CardContext,
+                signal: RuntimeAdoptionSignal::Rollback,
+                feature: "include_cards".to_string(),
+                query: None,
+                context_hash: None,
+                card_id: None,
+                evaluator_id: None,
+                research_report_id: None,
+                note: Some("reverted default".to_string()),
+                metadata: None,
+                created_at: "1777710000".to_string(),
+            })
+            .expect("insert event");
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "rollback_control",
+                "candidate": "card-context"
+            }))
+            .await
+            .expect("rollback control");
+        let report = response.rollback_control.expect("rollback control");
+        assert!(!report.writes);
+        assert!(report.rollback_required);
+        assert!(!report.applied);
+        assert!(report.include_cards_default_before);
+        assert!(report.include_cards_default_after);
+        assert_eq!(report.review.stats.rollbacks, 1);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4924,7 +5049,7 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/instrumentation_policy/prepare_record/capture/evaluator_advise/default_proposal/rollback_control/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
@@ -4933,6 +5058,7 @@ mod tests {
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=rollback_control"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("live instrumentation is opt-in"));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,10 +6,10 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
+        EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
-        card_context_default_readiness, check_runtime_adoption_record,
+        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
         prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
         review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
@@ -1349,7 +1349,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1372,6 +1372,7 @@ impl MempalMcpServer {
                 gate: None,
                 research_plan: None,
                 research_ingest_plan: None,
+                evaluator_advice: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1409,6 +1410,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "capture" => {
@@ -1490,6 +1492,42 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
+                }))
+            }
+            "evaluator_advise" => {
+                let report = evaluator_advice(EvaluatorAdviceInput {
+                    evaluator_id: required_string(request.evaluator_id.as_deref(), "evaluator_id")?
+                        .to_string(),
+                    subject_kind: required_string(request.subject_kind.as_deref(), "subject_kind")?
+                        .to_string(),
+                    subject_id: required_string(request.subject_id.as_deref(), "subject_id")?
+                        .to_string(),
+                    proposed_action: required_string(
+                        request.proposed_action.as_deref(),
+                        "proposed_action",
+                    )?
+                    .to_string(),
+                    evidence_refs: request.evidence_refs.unwrap_or_default(),
+                    counterexample_refs: request.counterexample_refs.unwrap_or_default(),
+                    risk_notes: request.risk_notes.unwrap_or_default(),
+                    note: trim_to_owned(request.note.as_deref()),
+                })
+                .map_err(|error| ErrorData::invalid_params(error, None))?;
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1528,6 +1566,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "record_checked" => {
@@ -1605,6 +1644,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "review" => {
@@ -1659,6 +1699,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "readiness" => {
@@ -1702,6 +1743,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "record" => {
@@ -1750,6 +1792,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "list" => {
@@ -1784,6 +1827,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "stats" => {
@@ -1815,6 +1859,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "gate" => {
@@ -1834,6 +1879,7 @@ impl MempalMcpServer {
                     gate: Some(gate),
                     research_plan: None,
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1853,6 +1899,7 @@ impl MempalMcpServer {
                     gate: None,
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
                     research_ingest_plan: None,
+                    evaluator_advice: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -1874,11 +1921,12 @@ impl MempalMcpServer {
                     research_ingest_plan: Some(ResearchIngestPlanDto::from(
                         build_research_ingest_plan_from_value(&report),
                     )),
+                    evaluator_advice: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4199,7 +4247,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4418,6 +4466,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_evaluator_advise_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "evaluator_advise",
+                "evaluator_id": "eval_policy",
+                "subject_kind": "dao_ren",
+                "subject_id": "k1",
+                "proposed_action": "promote",
+                "evidence_refs": ["e1", "e2"]
+            }))
+            .await
+            .expect("evaluator advice");
+        let advice = response.evaluator_advice.expect("evaluator advice");
+        assert!(!advice.writes);
+        assert!(!advice.lifecycle_authority);
+        assert!(advice.deterministic_gate_required);
+        assert_eq!(advice.recommendation, "advisory_support");
+        assert_eq!(advice.adoption_capture.record_payload["track"], "evaluator");
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_record_checked_quality_gated() {
         let (_tempdir, db_path, server) = setup_server();
 
@@ -4577,12 +4655,13 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,8 +7,9 @@ use crate::core::{
     db::Database,
     phase3::{
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        card_context_default_readiness, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        build_research_ingest_plan_from_value, card_context_default_readiness,
+        check_runtime_adoption_record, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -67,7 +68,7 @@ use super::tools::{
     KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
-    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
+    Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto, ResearchIngestPlanDto,
     RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
     SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
@@ -1346,7 +1347,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1367,6 +1368,7 @@ impl MempalMcpServer {
                 stats: None,
                 gate: None,
                 research_plan: None,
+                research_ingest_plan: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1402,6 +1404,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "check_record" => {
@@ -1438,6 +1441,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "review" => {
@@ -1490,6 +1494,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "readiness" => {
@@ -1531,6 +1536,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "record" => {
@@ -1577,6 +1583,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "list" => {
@@ -1609,6 +1616,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "stats" => {
@@ -1638,6 +1646,7 @@ impl MempalMcpServer {
                     stats: Some(runtime_adoption_stats(&events)),
                     gate: None,
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "gate" => {
@@ -1655,6 +1664,7 @@ impl MempalMcpServer {
                     stats: None,
                     gate: Some(gate),
                     research_plan: None,
+                    research_ingest_plan: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1672,11 +1682,32 @@ impl MempalMcpServer {
                     stats: None,
                     gate: None,
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
+                    research_ingest_plan: None,
+                }))
+            }
+            "research_ingest_plan" => {
+                let report = request.report.ok_or_else(|| {
+                    ErrorData::invalid_params("report is required for research_ingest_plan", None)
+                })?;
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: Some(ResearchIngestPlanDto::from(
+                        build_research_ingest_plan_from_value(&report),
+                    )),
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -3883,6 +3914,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_research_ingest_plan_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_ingest_plan",
+                "report": {
+                    "report_id": "research_001",
+                    "title": "Agent memory retrieval notes",
+                    "sources": [{ "url": "https://example.invalid/report" }],
+                    "findings": [{ "summary": "Measure card context before defaults." }],
+                    "candidate_insights": [{ "statement": "Measure before defaulting cards." }]
+                }
+            }))
+            .await
+            .expect("plan research ingest");
+        let plan = response.research_ingest_plan.expect("research ingest plan");
+        assert!(plan.valid);
+        assert!(!plan.writes);
+        assert_eq!(plan.report_id, "research_001");
+        assert_eq!(plan.planned_evidence_count, 1);
+        assert_eq!(plan.evidence_drawers.len(), 1);
+        assert!(
+            plan.evidence_drawers[0]
+                .drawer_id
+                .starts_with("drawer_mempal_research_")
+        );
+        assert_eq!(plan.candidate_insights.len(), 1);
+        assert_eq!(
+            &plan.candidate_insights[0].suggested_command[0..3],
+            ["mempal", "knowledge", "distill"]
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_research_ingest_plan_invalid_report_no_write() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "research_ingest_plan",
+                "report": {}
+            }))
+            .await
+            .expect("plan invalid research ingest");
+        let plan = response.research_ingest_plan.expect("research ingest plan");
+        assert!(!plan.valid);
+        assert!(!plan.writes);
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("report_id is required"))
+        );
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("findings must contain at least one item"))
+        );
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_rejects_invalid_action_without_mutation() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
@@ -3900,7 +4028,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan"
+                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4158,11 +4286,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan"
+            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL
                 .contains("used when guidance was actually consumed")

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,11 +6,12 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionRecordPlanInput,
-        RuntimeAdoptionReviewFilters, build_research_ingest_plan_from_value,
+        RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
+        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
+        build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
         card_context_default_readiness, check_runtime_adoption_record,
-        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
-        should_write_checked_record,
+        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
+        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1348,7 +1349,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1400,6 +1401,87 @@ impl MempalMcpServer {
                     record_plan: Some(plan.into()),
                     record_quality: None,
                     record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                }))
+            }
+            "capture" => {
+                let surface = required_string(request.surface.as_deref(), "surface")?.to_string();
+                let outcome = required_string(request.outcome.as_deref(), "outcome")?.to_string();
+                let record_input =
+                    capture_runtime_adoption_record_input(RuntimeAdoptionCaptureInput {
+                        id: trim_to_owned(request.id.as_deref()),
+                        surface: surface.clone(),
+                        outcome: outcome.clone(),
+                        query: trim_to_owned(request.query.as_deref()),
+                        context_hash: trim_to_owned(request.context_hash.as_deref()),
+                        card_id: trim_to_owned(request.card_id.as_deref()),
+                        evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                        research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                        note: trim_to_owned(request.note.as_deref()),
+                        metadata: request.metadata,
+                    })
+                    .map_err(|error| ErrorData::invalid_params(error, None))?;
+                let mut capture = prepare_runtime_adoption_capture(
+                    surface,
+                    outcome,
+                    request.execute.unwrap_or(false),
+                    record_input.clone(),
+                );
+                if request.execute.unwrap_or(false) {
+                    let db = self.open_db()?;
+                    let track = parse_runtime_adoption_track(&record_input.track)?;
+                    let signal = parse_runtime_adoption_signal(&record_input.signal)?;
+                    let should_write = should_write_checked_record(
+                        &capture.record_quality,
+                        request.allow_warnings.unwrap_or(false),
+                    );
+                    let event = if should_write {
+                        let event = RuntimeAdoptionEvent {
+                            id: record_input.id.unwrap_or_else(|| {
+                                phase3_event_id(&track, &signal, &record_input.feature)
+                            }),
+                            track,
+                            signal,
+                            feature: record_input.feature,
+                            query: record_input.query,
+                            context_hash: record_input.context_hash,
+                            card_id: record_input.card_id,
+                            evaluator_id: record_input.evaluator_id,
+                            research_report_id: record_input.research_report_id,
+                            note: record_input.note,
+                            metadata: record_input.metadata,
+                            created_at: current_timestamp(),
+                        };
+                        db.insert_runtime_adoption_event(&event).map_err(|error| {
+                            ErrorData::internal_error(
+                                format!("failed to insert runtime adoption event: {error}"),
+                                None,
+                            )
+                        })?;
+                        Some(event)
+                    } else {
+                        None
+                    };
+                    capture.writes = event.is_some();
+                    capture.record_checked = Some(RuntimeAdoptionCheckedRecordReport {
+                        writes: event.is_some(),
+                        blocked: event.is_none(),
+                        record_quality: capture.record_quality.clone(),
+                        event,
+                    });
+                }
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: Some(capture.record_plan.into()),
+                    record_quality: Some(capture.record_quality.into()),
+                    record_checked: capture.record_checked.map(Into::into),
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1796,7 +1878,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4117,7 +4199,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4266,6 +4348,73 @@ mod tests {
                 .len(),
             before
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_capture_action_dry_run_and_execute() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let dry_run = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "capture",
+                "surface": "card-context",
+                "outcome": "accepted",
+                "card_id": "card_1",
+                "query": "skill trigger",
+                "note": "card helped"
+            }))
+            .await
+            .expect("capture dry run");
+        let plan = dry_run.record_plan.expect("record plan");
+        assert!(!plan.writes);
+        assert_eq!(plan.record_payload["track"], "card_context");
+        assert_eq!(plan.record_payload["signal"], "accepted");
+        assert_eq!(plan.record_payload["feature"], "include_cards");
+        assert_eq!(
+            dry_run.record_quality.expect("record quality").quality,
+            "ready"
+        );
+        assert!(dry_run.record_checked.is_none());
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .is_empty()
+        );
+        insert_knowledge_card(
+            &db_path,
+            knowledge_card(
+                "card_1",
+                KnowledgeTier::Shu,
+                KnowledgeStatus::Promoted,
+                "general",
+            ),
+        );
+
+        let executed = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "capture",
+                "surface": "card-context",
+                "outcome": "accepted",
+                "card_id": "card_1",
+                "query": "skill trigger",
+                "note": "card helped",
+                "execute": true
+            }))
+            .await
+            .expect("capture execute");
+        let checked = executed.record_checked.expect("checked record");
+        assert!(checked.writes);
+        assert!(!checked.blocked);
+        assert_eq!(checked.record_quality.quality, "ready");
+
+        let db = Database::open(&db_path).expect("reopen db");
+        let events = db
+            .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].feature, "include_cards");
     }
 
     #[tokio::test]
@@ -4428,11 +4577,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,6 +5,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
+    phase3::runtime_adoption_guidance,
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
@@ -63,9 +64,8 @@ use super::tools::{
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
     Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
-    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionGuidanceDto,
-    RuntimeAdoptionSignalGuidanceDto, RuntimeAdoptionStatsDto, RuntimeAdoptionTrackGuidanceDto,
-    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
+    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
     TunnelsRequest, TunnelsResponse,
 };
@@ -734,90 +734,6 @@ fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionSta
     stats
 }
 
-fn runtime_adoption_guidance() -> RuntimeAdoptionGuidanceDto {
-    RuntimeAdoptionGuidanceDto {
-        version: 1,
-        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
-        required_fields: vec![
-            "track".to_string(),
-            "signal".to_string(),
-            "feature".to_string(),
-        ],
-        optional_fields: vec![
-            "query".to_string(),
-            "context_hash".to_string(),
-            "card_id".to_string(),
-            "evaluator_id".to_string(),
-            "research_report_id".to_string(),
-            "note".to_string(),
-            "metadata".to_string(),
-        ],
-        signals: vec![
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "used".to_string(),
-                when: "record when guidance was actually consumed during a task".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "accepted".to_string(),
-                when: "record when the consumed guidance materially helped the outcome".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "rejected".to_string(),
-                when: "record when guidance was considered and intentionally not followed"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "miss".to_string(),
-                when: "record when useful guidance should have appeared but did not".to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "rollback".to_string(),
-                when: "record when behavior was reverted because guidance degraded the outcome"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "contradiction".to_string(),
-                when: "record when guidance conflicted with stronger evidence or instructions"
-                    .to_string(),
-            },
-            RuntimeAdoptionSignalGuidanceDto {
-                signal: "neutral".to_string(),
-                when: "record when guidance was consumed but had no clear outcome impact"
-                    .to_string(),
-            },
-        ],
-        tracks: vec![
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "runtime_adoption".to_string(),
-                when: "general agent-runtime behavior evidence".to_string(),
-                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "card_context".to_string(),
-                when: "card-aware context affected or should have affected behavior".to_string(),
-                feature_examples: vec!["include_cards".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "card_embedding".to_string(),
-                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
-                feature_examples: vec!["card_statement_recall".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "evaluator".to_string(),
-                when: "evaluator advice affected or should have affected a lifecycle decision"
-                    .to_string(),
-                feature_examples: vec!["advisory_gate".to_string()],
-            },
-            RuntimeAdoptionTrackGuidanceDto {
-                track: "research_adapter".to_string(),
-                when: "external research report validation or ingestion planning affected behavior"
-                    .to_string(),
-                feature_examples: vec!["research_validate_plan".to_string()],
-            },
-        ],
-    }
-}
-
 fn phase3_gate_report(
     db: &Database,
     candidate: &str,
@@ -1425,7 +1341,7 @@ impl MempalMcpServer {
 
         match action {
             "guidance" => Ok(Json(Phase3Response {
-                guidance: Some(runtime_adoption_guidance()),
+                guidance: Some(runtime_adoption_guidance().into()),
                 event: None,
                 events: Vec::new(),
                 stats: None,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,10 +6,11 @@ use crate::core::{
     anchor::{self, DerivedAnchor},
     db::Database,
     phase3::{
-        RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
-        build_research_ingest_plan_from_value, card_context_default_readiness,
-        check_runtime_adoption_record, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance,
+        RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionRecordPlanInput,
+        RuntimeAdoptionReviewFilters, build_research_ingest_plan_from_value,
+        card_context_default_readiness, check_runtime_adoption_record,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1347,7 +1348,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1361,6 +1362,7 @@ impl MempalMcpServer {
                 guidance: Some(runtime_adoption_guidance().into()),
                 record_plan: None,
                 record_quality: None,
+                record_checked: None,
                 review_report: None,
                 readiness_report: None,
                 event: None,
@@ -1397,6 +1399,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: Some(plan.into()),
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1434,6 +1437,84 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: Some(check_runtime_adoption_record(&input).into()),
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                }))
+            }
+            "record_checked" => {
+                let db = self.open_db()?;
+                let track = parse_runtime_adoption_track(required_string(
+                    request.track.as_deref(),
+                    "track",
+                )?)?;
+                let signal = parse_runtime_adoption_signal(required_string(
+                    request.signal.as_deref(),
+                    "signal",
+                )?)?;
+                let feature = request.feature.unwrap_or_default();
+                let input = RuntimeAdoptionRecordPlanInput {
+                    id: trim_to_owned(request.id.as_deref()),
+                    track: runtime_adoption_track_slug(&track).to_string(),
+                    signal: runtime_adoption_signal_slug(&signal).to_string(),
+                    feature,
+                    query: trim_to_owned(request.query.as_deref()),
+                    context_hash: trim_to_owned(request.context_hash.as_deref()),
+                    card_id: trim_to_owned(request.card_id.as_deref()),
+                    evaluator_id: trim_to_owned(request.evaluator_id.as_deref()),
+                    research_report_id: trim_to_owned(request.research_report_id.as_deref()),
+                    note: trim_to_owned(request.note.as_deref()),
+                    metadata: request.metadata,
+                };
+                let quality = check_runtime_adoption_record(&input);
+                let should_write =
+                    should_write_checked_record(&quality, request.allow_warnings.unwrap_or(false));
+                let event = if should_write {
+                    let event = RuntimeAdoptionEvent {
+                        id: input
+                            .id
+                            .unwrap_or_else(|| phase3_event_id(&track, &signal, &input.feature)),
+                        track,
+                        signal,
+                        feature: input.feature,
+                        query: input.query,
+                        context_hash: input.context_hash,
+                        card_id: input.card_id,
+                        evaluator_id: input.evaluator_id,
+                        research_report_id: input.research_report_id,
+                        note: input.note,
+                        metadata: input.metadata,
+                        created_at: current_timestamp(),
+                    };
+                    db.insert_runtime_adoption_event(&event).map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("failed to insert runtime adoption event: {error}"),
+                            None,
+                        )
+                    })?;
+                    Some(event)
+                } else {
+                    None
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: Some(
+                        RuntimeAdoptionCheckedRecordReport {
+                            writes: event.is_some(),
+                            blocked: event.is_none(),
+                            record_quality: quality,
+                            event,
+                        }
+                        .into(),
+                    ),
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1487,6 +1568,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: Some(report.into()),
                     readiness_report: None,
                     event: None,
@@ -1529,6 +1611,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: Some(report.into()),
                     event: None,
@@ -1576,6 +1659,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
@@ -1606,6 +1690,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1639,6 +1724,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1657,6 +1743,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1675,6 +1762,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1693,6 +1781,7 @@ impl MempalMcpServer {
                     guidance: None,
                     record_plan: None,
                     record_quality: None,
+                    record_checked: None,
                     review_report: None,
                     readiness_report: None,
                     event: None,
@@ -1707,7 +1796,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4028,7 +4117,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, check_record, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4180,6 +4269,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_phase3_record_checked_quality_gated() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let ready = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "record_checked",
+                "track": "runtime_adoption",
+                "signal": "accepted",
+                "feature": "context_pack",
+                "query": "skill trigger",
+                "note": "context guidance helped"
+            }))
+            .await
+            .expect("record checked ready");
+        let checked = ready.record_checked.expect("checked record");
+        assert!(checked.writes);
+        assert!(!checked.blocked);
+        assert_eq!(checked.record_quality.quality, "ready");
+        assert!(checked.event.is_some());
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            1
+        );
+
+        let warning = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "record_checked",
+                "track": "card_context",
+                "signal": "accepted",
+                "feature": "include_cards"
+            }))
+            .await
+            .expect("record checked warning");
+        let checked = warning.record_checked.expect("checked record");
+        assert!(!checked.writes);
+        assert!(checked.blocked);
+        assert_eq!(checked.record_quality.quality, "warning");
+        assert!(checked.event.is_none());
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_phase3_review_action_is_read_only() {
         let (_tempdir, db_path, server) = setup_server();
         let before = {
@@ -4286,11 +4428,12 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/check_record/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,9 +9,10 @@ use crate::core::{
         EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
         build_research_ingest_plan_from_value, capture_runtime_adoption_record_input,
-        card_context_default_readiness, check_runtime_adoption_record, evaluator_advice,
-        prepare_runtime_adoption_capture, prepare_runtime_adoption_record,
-        review_runtime_adoption_events, runtime_adoption_guidance, should_write_checked_record,
+        card_context_default_proposal, card_context_default_readiness,
+        check_runtime_adoption_record, evaluator_advice, prepare_runtime_adoption_capture,
+        prepare_runtime_adoption_record, review_runtime_adoption_events, runtime_adoption_guidance,
+        should_write_checked_record,
     },
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -1349,7 +1350,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; prepare_record validates and returns record inputs without writing; capture maps surface/outcome observations into checked record inputs and writes only with execute=true; evaluator_advise returns deterministic advisory-only evaluator output and a surface=evaluator capture plan without lifecycle authority; default_proposal combines readiness with rollback criteria without changing defaults; check_record evaluates record quality without writing; record_checked runs the quality gate before writing; review summarizes adoption evidence without writing; readiness evaluates default eligibility without writing; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON; research_ingest_plan previews evidence drawer refs and distill suggestions without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1373,6 +1374,7 @@ impl MempalMcpServer {
                 research_plan: None,
                 research_ingest_plan: None,
                 evaluator_advice: None,
+                default_proposal: None,
             })),
             "prepare_record" => {
                 let track = parse_runtime_adoption_track(required_string(
@@ -1411,6 +1413,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "capture" => {
@@ -1493,6 +1496,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "evaluator_advise" => {
@@ -1528,6 +1532,55 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: Some(report.into()),
+                    default_proposal: None,
+                }))
+            }
+            "default_proposal" => {
+                let candidate = required_string(request.candidate.as_deref(), "candidate")?;
+                let report = match candidate {
+                    "card-context" => {
+                        let db = self.open_db()?;
+                        let events = db
+                            .list_runtime_adoption_events(
+                                &RuntimeAdoptionFilter {
+                                    track: Some(RuntimeAdoptionTrack::CardContext),
+                                    feature: Some("include_cards".to_string()),
+                                },
+                                10_000,
+                            )
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to list runtime adoption events: {error}"),
+                                    None,
+                                )
+                            })?;
+                        card_context_default_proposal(
+                            &events,
+                            request.rollback_criteria.unwrap_or_default(),
+                        )
+                    }
+                    other => {
+                        return Err(ErrorData::invalid_params(
+                            format!("unsupported phase3 default proposal candidate: {other}"),
+                            None,
+                        ));
+                    }
+                };
+                Ok(Json(Phase3Response {
+                    guidance: None,
+                    record_plan: None,
+                    record_quality: None,
+                    record_checked: None,
+                    review_report: None,
+                    readiness_report: None,
+                    event: None,
+                    events: Vec::new(),
+                    stats: None,
+                    gate: None,
+                    research_plan: None,
+                    research_ingest_plan: None,
+                    evaluator_advice: None,
+                    default_proposal: Some(report.into()),
                 }))
             }
             "check_record" => {
@@ -1567,6 +1620,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "record_checked" => {
@@ -1645,6 +1699,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "review" => {
@@ -1700,6 +1755,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "readiness" => {
@@ -1744,6 +1800,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "record" => {
@@ -1793,6 +1850,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "list" => {
@@ -1828,6 +1886,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "stats" => {
@@ -1860,6 +1919,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "gate" => {
@@ -1880,6 +1940,7 @@ impl MempalMcpServer {
                     research_plan: None,
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "research_validate_plan" => {
@@ -1900,6 +1961,7 @@ impl MempalMcpServer {
                     research_plan: Some(validate_research_adapter_plan_value(&report)),
                     research_ingest_plan: None,
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             "research_ingest_plan" => {
@@ -1922,11 +1984,12 @@ impl MempalMcpServer {
                         build_research_ingest_plan_from_value(&report),
                     )),
                     evaluator_advice: None,
+                    default_proposal: None,
                 }))
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
                 ),
                 None,
             )),
@@ -4247,7 +4310,7 @@ mod tests {
             .expect_err("invalid action should fail");
         assert!(
             error.to_string().contains(
-                "actions are guidance, prepare_record, capture, evaluator_advise, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
+                "actions are guidance, prepare_record, capture, evaluator_advise, default_proposal, check_record, record_checked, review, readiness, record, list, stats, gate, research_validate_plan, research_ingest_plan"
             )
         );
 
@@ -4644,6 +4707,56 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_mcp_phase3_default_proposal_card_context_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let before = {
+            let db = Database::open(&db_path).expect("open db");
+            for i in 0..3 {
+                db.insert_runtime_adoption_event(&RuntimeAdoptionEvent {
+                    id: format!("default_proposal_event_{i}"),
+                    track: RuntimeAdoptionTrack::CardContext,
+                    signal: RuntimeAdoptionSignal::Accepted,
+                    feature: "include_cards".to_string(),
+                    query: Some("skill trigger".to_string()),
+                    context_hash: None,
+                    card_id: None,
+                    evaluator_id: None,
+                    research_report_id: None,
+                    note: Some("helped".to_string()),
+                    metadata: None,
+                    created_at: "1777710000".to_string(),
+                })
+                .expect("insert event");
+            }
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len()
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "default_proposal",
+                "candidate": "card-context",
+                "rollback_criteria": ["rollback on contradiction or user-visible degradation"]
+            }))
+            .await
+            .expect("default proposal");
+        let report = response.default_proposal.expect("default proposal");
+        assert!(!report.writes);
+        assert!(report.proposal_ready);
+        assert_eq!(report.decision, "eligible_for_default_on_spec");
+        assert!(report.readiness.ready);
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            before
+        );
+    }
+
     #[test]
     fn test_mcp_tool_registry_and_protocol_include_phase3_runtime_surface() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -4655,13 +4768,14 @@ mod tests {
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
         assert!(description.contains(
-            "Actions: guidance/prepare_record/capture/evaluator_advise/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
+            "Actions: guidance/prepare_record/capture/evaluator_advise/default_proposal/check_record/record_checked/review/readiness/record/list/stats/gate/research_validate_plan/research_ingest_plan"
         ));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=readiness"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=capture"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=evaluator_advise"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=default_proposal"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("record_checked"));
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("research_ingest_plan"));
         assert!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -81,6 +81,7 @@ use super::tools::{
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
+    config: crate::core::config::Config,
     embedder_factory: Arc<dyn EmbedderFactory>,
     tool_router: ToolRouter<Self>,
     /// Captured via `initialize` override so `auto` peek mode can infer the
@@ -90,15 +91,33 @@ pub struct MempalMcpServer {
 
 impl MempalMcpServer {
     pub fn new(db_path: PathBuf, config: crate::core::config::Config) -> Self {
-        Self::new_with_factory(
+        let embedder_factory =
+            Arc::new(crate::embed::ConfiguredEmbedderFactory::new(config.clone()));
+        Self {
             db_path,
-            Arc::new(crate::embed::ConfiguredEmbedderFactory::new(config)),
-        )
+            config,
+            embedder_factory,
+            tool_router: Self::tool_router(),
+            client_name: Arc::new(Mutex::new(None)),
+        }
     }
 
     pub fn new_with_factory(db_path: PathBuf, embedder_factory: Arc<dyn EmbedderFactory>) -> Self {
+        Self::new_with_config_and_factory(
+            db_path,
+            crate::core::config::Config::default(),
+            embedder_factory,
+        )
+    }
+
+    pub fn new_with_config_and_factory(
+        db_path: PathBuf,
+        config: crate::core::config::Config,
+        embedder_factory: Arc<dyn EmbedderFactory>,
+    ) -> Self {
         Self {
             db_path,
+            config,
             embedder_factory,
             tool_router: Self::tool_router(),
             client_name: Arc::new(Mutex::new(None)),
@@ -1020,7 +1039,9 @@ impl MempalMcpServer {
                     .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
                 cwd,
                 include_evidence: request.include_evidence.unwrap_or(false),
-                include_cards: request.include_cards.unwrap_or(false),
+                include_cards: request
+                    .include_cards
+                    .unwrap_or(self.config.context.include_cards_default),
                 max_items,
                 dao_tian_limit,
             },
@@ -3058,6 +3079,21 @@ mod tests {
         (tempdir, db_path, server)
     }
 
+    fn setup_server_with_config(
+        config: crate::core::config::Config,
+    ) -> (TempDir, PathBuf, MempalMcpServer) {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let server = MempalMcpServer::new_with_config_and_factory(
+            db_path.clone(),
+            config,
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        );
+        (tempdir, db_path, server)
+    }
+
     fn knowledge_card(
         id: &str,
         tier: KnowledgeTier,
@@ -3621,6 +3657,51 @@ mod tests {
         assert_eq!(
             card.evidence_citations[0].source_file,
             "/tmp/card-evidence.md"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_include_cards_omitted_uses_config_default() {
+        let mut config = crate::core::config::Config::default();
+        config.context.include_cards_default = true;
+        let (_tempdir, db_path, server) = setup_server_with_config(config);
+        insert_drawer(
+            &db_path,
+            "drawer_card_default_evidence",
+            "card evidence",
+            "mempal",
+            Some("context"),
+            "/tmp/card-default-evidence.md",
+            2,
+        );
+        let mut card = knowledge_card(
+            "card_context_default",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "general",
+        );
+        card.anchor_id = anchor::LEGACY_REPO_ANCHOR_ID.to_string();
+        insert_knowledge_card(&db_path, card);
+        insert_knowledge_card_link(
+            &db_path,
+            "link_card_context_default_supporting",
+            "card_context_default",
+            "drawer_card_default_evidence",
+            KnowledgeEvidenceRole::Supporting,
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "card context"
+            }))
+            .await
+            .expect("context should succeed");
+        assert!(
+            response
+                .sections
+                .iter()
+                .flat_map(|section| section.items.iter())
+                .any(|item| item.card_id.as_deref() == Some("card_context_default"))
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -63,8 +63,9 @@ use super::tools::{
     KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
     KnowledgePublishAnchorResponse, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse,
     Phase3GateDto, Phase3Request, Phase3Response, ResearchAdapterPlanDto,
-    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount,
-    SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
+    RetrievedKnowledgeCardDto, RuntimeAdoptionEventDto, RuntimeAdoptionGuidanceDto,
+    RuntimeAdoptionSignalGuidanceDto, RuntimeAdoptionStatsDto, RuntimeAdoptionTrackGuidanceDto,
+    ScopeCount, SearchRequest, SearchResponse, SearchResultDto, StatusResponse, TaxonomyEntryDto,
     TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
     TunnelsRequest, TunnelsResponse,
 };
@@ -733,6 +734,90 @@ fn runtime_adoption_stats(events: &[RuntimeAdoptionEvent]) -> RuntimeAdoptionSta
     stats
 }
 
+fn runtime_adoption_guidance() -> RuntimeAdoptionGuidanceDto {
+    RuntimeAdoptionGuidanceDto {
+        version: 1,
+        recording_rule: "record only concrete runtime outcomes, not speculation".to_string(),
+        required_fields: vec![
+            "track".to_string(),
+            "signal".to_string(),
+            "feature".to_string(),
+        ],
+        optional_fields: vec![
+            "query".to_string(),
+            "context_hash".to_string(),
+            "card_id".to_string(),
+            "evaluator_id".to_string(),
+            "research_report_id".to_string(),
+            "note".to_string(),
+            "metadata".to_string(),
+        ],
+        signals: vec![
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "used".to_string(),
+                when: "record when guidance was actually consumed during a task".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "accepted".to_string(),
+                when: "record when the consumed guidance materially helped the outcome".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "rejected".to_string(),
+                when: "record when guidance was considered and intentionally not followed"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "miss".to_string(),
+                when: "record when useful guidance should have appeared but did not".to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "rollback".to_string(),
+                when: "record when behavior was reverted because guidance degraded the outcome"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "contradiction".to_string(),
+                when: "record when guidance conflicted with stronger evidence or instructions"
+                    .to_string(),
+            },
+            RuntimeAdoptionSignalGuidanceDto {
+                signal: "neutral".to_string(),
+                when: "record when guidance was consumed but had no clear outcome impact"
+                    .to_string(),
+            },
+        ],
+        tracks: vec![
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "runtime_adoption".to_string(),
+                when: "general agent-runtime behavior evidence".to_string(),
+                feature_examples: vec!["context_pack".to_string(), "skill_selection".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "card_context".to_string(),
+                when: "card-aware context affected or should have affected behavior".to_string(),
+                feature_examples: vec!["include_cards".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "card_embedding".to_string(),
+                when: "linked-evidence card retrieval missed statement-level matches".to_string(),
+                feature_examples: vec!["card_statement_recall".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "evaluator".to_string(),
+                when: "evaluator advice affected or should have affected a lifecycle decision"
+                    .to_string(),
+                feature_examples: vec!["advisory_gate".to_string()],
+            },
+            RuntimeAdoptionTrackGuidanceDto {
+                track: "research_adapter".to_string(),
+                when: "external research report validation or ingestion planning affected behavior"
+                    .to_string(),
+                feature_examples: vec!["research_validate_plan".to_string()],
+            },
+        ],
+    }
+}
+
 fn phase3_gate_report(
     db: &Database,
     candidate: &str,
@@ -1329,7 +1414,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_phase3",
-        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: record/list/stats/gate/research_validate_plan. Record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
+        description = "Phase-3 runtime adoption evidence and readiness gates. Actions: guidance/record/list/stats/gate/research_validate_plan. Guidance explains when agents should record used/accepted/rejected/miss/rollback signals; record appends runtime_adoption_events; list/stats/gate are read-only; research_validate_plan validates external research report JSON without ingesting or promoting knowledge."
     )]
     async fn mempal_phase3(
         &self,
@@ -1339,6 +1424,14 @@ impl MempalMcpServer {
             .ok_or_else(|| ErrorData::invalid_params("action must not be empty", None))?;
 
         match action {
+            "guidance" => Ok(Json(Phase3Response {
+                guidance: Some(runtime_adoption_guidance()),
+                event: None,
+                events: Vec::new(),
+                stats: None,
+                gate: None,
+                research_plan: None,
+            })),
             "record" => {
                 let db = self.open_db()?;
                 let track = parse_runtime_adoption_track(required_string(
@@ -1373,6 +1466,7 @@ impl MempalMcpServer {
                     )
                 })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: Some(RuntimeAdoptionEventDto::from(event)),
                     events: Vec::new(),
                     stats: None,
@@ -1397,6 +1491,7 @@ impl MempalMcpServer {
                         )
                     })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: events
                         .into_iter()
@@ -1424,6 +1519,7 @@ impl MempalMcpServer {
                         )
                     })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: Some(runtime_adoption_stats(&events)),
@@ -1436,6 +1532,7 @@ impl MempalMcpServer {
                 let candidate = required_string(request.candidate.as_deref(), "candidate")?;
                 let gate = phase3_gate_report(&db, candidate)?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1448,6 +1545,7 @@ impl MempalMcpServer {
                     ErrorData::invalid_params("report is required for research_validate_plan", None)
                 })?;
                 Ok(Json(Phase3Response {
+                    guidance: None,
                     event: None,
                     events: Vec::new(),
                     stats: None,
@@ -1457,7 +1555,7 @@ impl MempalMcpServer {
             }
             other => Err(ErrorData::invalid_params(
                 format!(
-                    "unsupported phase3 action: {other}; actions are record, list, stats, gate, research_validate_plan"
+                    "unsupported phase3 action: {other}; actions are guidance, record, list, stats, gate, research_validate_plan"
                 ),
                 None,
             )),
@@ -3680,9 +3778,9 @@ mod tests {
             .await
             .expect_err("invalid action should fail");
         assert!(
-            error
-                .to_string()
-                .contains("actions are record, list, stats, gate, research_validate_plan")
+            error.to_string().contains(
+                "actions are guidance, record, list, stats, gate, research_validate_plan"
+            )
         );
 
         let db = Database::open(&db_path).expect("open db");
@@ -3691,6 +3789,63 @@ mod tests {
                 .expect("events")
                 .len(),
             before
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_phase3_guidance_action_is_read_only() {
+        let (_tempdir, db_path, server) = setup_server();
+        let baseline = {
+            let db = Database::open(&db_path).expect("open db");
+            (
+                db.drawer_count().expect("drawers"),
+                db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                    .expect("events")
+                    .len(),
+            )
+        };
+
+        let response = server
+            .phase3_json_for_test(serde_json::json!({
+                "action": "guidance"
+            }))
+            .await
+            .expect("guidance");
+        let guidance = response.guidance.expect("guidance");
+        assert_eq!(guidance.version, 1);
+        assert_eq!(
+            guidance.recording_rule,
+            "record only concrete runtime outcomes, not speculation"
+        );
+        assert!(guidance.required_fields.contains(&"track".to_string()));
+        assert!(guidance.required_fields.contains(&"signal".to_string()));
+        assert!(guidance.required_fields.contains(&"feature".to_string()));
+        assert!(
+            guidance
+                .signals
+                .iter()
+                .any(|signal| signal.signal == "used" && signal.when.contains("actually consumed"))
+        );
+        assert!(
+            guidance
+                .signals
+                .iter()
+                .any(|signal| signal.signal == "rollback" && signal.when.contains("reverted"))
+        );
+        assert!(guidance.tracks.iter().any(|track| {
+            track.track == "card_context"
+                && track
+                    .feature_examples
+                    .contains(&"include_cards".to_string())
+        }));
+
+        let db = Database::open(&db_path).expect("reopen db");
+        assert_eq!(db.drawer_count().expect("drawers"), baseline.0);
+        assert_eq!(
+            db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+                .expect("events")
+                .len(),
+            baseline.1
         );
     }
 
@@ -3704,8 +3859,18 @@ mod tests {
             .expect("mempal_phase3 tool exists");
         let description = tool.description.as_deref().unwrap_or_default();
         assert!(description.contains("Phase-3 runtime adoption evidence"));
-        assert!(description.contains("Actions: record/list/stats/gate/research_validate_plan"));
+        assert!(
+            description.contains("Actions: guidance/record/list/stats/gate/research_validate_plan")
+        );
         assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("mempal_phase3"));
+        assert!(crate::core::protocol::MEMORY_PROTOCOL.contains("action=guidance"));
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL
+                .contains("used when guidance was actually consumed")
+        );
+        assert!(
+            crate::core::protocol::MEMORY_PROTOCOL.contains("rollback when behavior was reverted")
+        );
         assert!(
             crate::core::protocol::MEMORY_PROTOCOL.contains("runtime adoption"),
             "protocol should explain the Phase-3 runtime evidence surface"

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1846,6 +1846,10 @@ impl MempalMcpServer {
             .ok_or_else(|| ErrorData::internal_error("embedder returned no query vector", None))?;
 
         let trigger = request.trigger.as_deref().map(parse_context_trigger);
+        let config = crate::core::config::ConfigHandle::current();
+        let include_cards = request
+            .include_cards
+            .unwrap_or(config.context.include_cards_default);
         let db = self.open_db()?;
         let pack = assemble_context_with_vector(
             &db,
@@ -1857,13 +1861,10 @@ impl MempalMcpServer {
                     .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
                 cwd,
                 include_evidence: request.include_evidence.unwrap_or(false),
-                include_cards: request.include_cards.unwrap_or(false),
+                include_cards,
                 max_items,
                 dao_tian_limit,
-                project_id: crate::core::config::ConfigHandle::current()
-                    .project
-                    .id
-                    .clone(),
+                project_id: config.project.id.clone(),
                 trigger,
                 context_cfg_override: None,
             },
@@ -5090,6 +5091,7 @@ mod tests {
 
     use super::*;
     use crate::core::types::BootstrapEvidenceArgs;
+    use crate::core::types::{KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole};
     use crate::embed::Embedder;
 
     #[derive(Clone)]
@@ -5150,6 +5152,94 @@ mod tests {
             }),
         );
         (tempdir, db_path, server)
+    }
+
+    fn knowledge_card(
+        id: &str,
+        tier: KnowledgeTier,
+        status: KnowledgeStatus,
+        field: &str,
+    ) -> KnowledgeCard {
+        KnowledgeCard {
+            id: id.to_string(),
+            statement: format!("Statement for {id}."),
+            content: format!("Content for {id}."),
+            tier,
+            status,
+            domain: MemoryDomain::Project,
+            field: field.to_string(),
+            anchor_kind: AnchorKind::Repo,
+            anchor_id: "repo://mempal".to_string(),
+            parent_anchor_id: None,
+            scope_constraints: Some("Only for MCP read tests.".to_string()),
+            trigger_hints: Some(TriggerHints {
+                intent_tags: vec!["memory".to_string()],
+                workflow_bias: vec!["inspect-first".to_string()],
+                tool_needs: vec!["mcp".to_string()],
+            }),
+            auto_generated: false,
+            crystallization_score: None,
+            source_drawer_ids: Vec::new(),
+            created_at: "1713000000".to_string(),
+            updated_at: "1713000000".to_string(),
+        }
+    }
+
+    fn insert_knowledge_card(db_path: &Path, card: KnowledgeCard) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_knowledge_card(&card)
+            .expect("insert knowledge card");
+    }
+
+    fn insert_knowledge_card_link(
+        db_path: &Path,
+        id: &str,
+        card_id: &str,
+        evidence_drawer_id: &str,
+        role: KnowledgeEvidenceRole,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+            id: id.to_string(),
+            card_id: card_id.to_string(),
+            evidence_drawer_id: evidence_drawer_id.to_string(),
+            role,
+            note: None,
+            created_at: "1713000000".to_string(),
+        })
+        .expect("insert knowledge card link");
+    }
+
+    /// Serializes tests that override the global `ConfigHandle` snapshot and
+    /// resets it to defaults on Drop so other parallel tests do not see leaked
+    /// overrides.
+    struct ConfigOverrideGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _tempdir: TempDir,
+    }
+
+    impl ConfigOverrideGuard {
+        fn install(toml_contents: &str) -> Self {
+            static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+            let lock = LOCK.lock().expect("config override lock poisoned");
+            let tempdir = tempfile::tempdir().expect("config override tempdir");
+            let path = tempdir.path().join("override.toml");
+            fs::write(&path, toml_contents).expect("write config override");
+            crate::core::config::ConfigHandle::harness_reload_from_path(&path);
+            Self {
+                _lock: lock,
+                _tempdir: tempdir,
+            }
+        }
+    }
+
+    impl Drop for ConfigOverrideGuard {
+        fn drop(&mut self) {
+            let tempdir = tempfile::tempdir().expect("config reset tempdir");
+            let path = tempdir.path().join("default.toml");
+            fs::write(&path, "").expect("write default config");
+            crate::core::config::ConfigHandle::harness_reload_from_path(&path);
+        }
     }
 
     fn insert_drawer(
@@ -5605,6 +5695,48 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["qi", "evidence"]);
         assert_eq!(response.sections[1].items[0].drawer_id, "drawer_evidence");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_include_cards_omitted_uses_config_default() {
+        let _guard = ConfigOverrideGuard::install("[context]\ninclude_cards_default = true\n");
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer_default_card_evidence",
+            "default card evidence",
+            "mempal",
+            Some("context"),
+            "/tmp/default-card-evidence.md",
+            2,
+        );
+        let mut card = knowledge_card(
+            "card_default_context",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "general",
+        );
+        card.anchor_id = anchor::LEGACY_REPO_ANCHOR_ID.to_string();
+        insert_knowledge_card(&db_path, card);
+        insert_knowledge_card_link(
+            &db_path,
+            "link_card_default_context",
+            "card_default_context",
+            "drawer_default_card_evidence",
+            KnowledgeEvidenceRole::Supporting,
+        );
+
+        let response = server
+            .context_json_for_test(serde_json::json!({ "query": "default card" }))
+            .await
+            .expect("context should succeed");
+        let card_item = response
+            .sections
+            .iter()
+            .flat_map(|section| section.items.iter())
+            .find(|item| item.card_id.as_deref() == Some("card_default_context"))
+            .expect("card item should appear when include_cards omitted and config default true");
+        assert_eq!(card_item.drawer_id, "card_default_context");
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,8 +1,8 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
-    MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, SearchResult, TaxonomyEntry,
-    TunnelEndpoint,
+    MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, RuntimeAdoptionEvent,
+    RuntimeAdoptionSignal, RuntimeAdoptionTrack, SearchResult, TaxonomyEntry, TunnelEndpoint,
 };
 use crate::field_taxonomy::FieldTaxonomyEntry;
 use crate::knowledge_anchor::PublishAnchorOutcome;
@@ -303,6 +303,128 @@ pub struct KnowledgeCardsResponse {
     pub promote: Option<KnowledgeCardPromoteDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub demote: Option<KnowledgeCardDemoteDto>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct Phase3Request {
+    pub action: String,
+    pub id: Option<String>,
+    pub track: Option<String>,
+    pub signal: Option<String>,
+    pub feature: Option<String>,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub limit: Option<usize>,
+    pub candidate: Option<String>,
+    pub report: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3Response {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<RuntimeAdoptionEventDto>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub events: Vec<RuntimeAdoptionEventDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats: Option<RuntimeAdoptionStatsDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gate: Option<Phase3GateDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub research_plan: Option<ResearchAdapterPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionEventDto {
+    pub id: String,
+    pub track: String,
+    pub signal: String,
+    pub feature: String,
+    pub query: Option<String>,
+    pub context_hash: Option<String>,
+    pub card_id: Option<String>,
+    pub evaluator_id: Option<String>,
+    pub research_report_id: Option<String>,
+    pub note: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionStatsDto {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3GateDto {
+    pub candidate: String,
+    pub ready: bool,
+    pub required_track: String,
+    pub stats: RuntimeAdoptionStatsDto,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchAdapterPlanDto {
+    pub valid: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub errors: Vec<String>,
+}
+
+impl From<RuntimeAdoptionEvent> for RuntimeAdoptionEventDto {
+    fn from(event: RuntimeAdoptionEvent) -> Self {
+        Self {
+            id: event.id,
+            track: runtime_adoption_track_slug(&event.track).to_string(),
+            signal: runtime_adoption_signal_slug(&event.signal).to_string(),
+            feature: event.feature,
+            query: event.query,
+            context_hash: event.context_hash,
+            card_id: event.card_id,
+            evaluator_id: event.evaluator_id,
+            research_report_id: event.research_report_id,
+            note: event.note,
+            metadata: event.metadata,
+            created_at: event.created_at,
+        }
+    }
+}
+
+fn runtime_adoption_track_slug(track: &RuntimeAdoptionTrack) -> &'static str {
+    match track {
+        RuntimeAdoptionTrack::RuntimeAdoption => "runtime_adoption",
+        RuntimeAdoptionTrack::CardContext => "card_context",
+        RuntimeAdoptionTrack::CardEmbedding => "card_embedding",
+        RuntimeAdoptionTrack::Evaluator => "evaluator",
+        RuntimeAdoptionTrack::ResearchAdapter => "research_adapter",
+    }
+}
+
+fn runtime_adoption_signal_slug(signal: &RuntimeAdoptionSignal) -> &'static str {
+    match signal {
+        RuntimeAdoptionSignal::Used => "used",
+        RuntimeAdoptionSignal::Accepted => "accepted",
+        RuntimeAdoptionSignal::Rejected => "rejected",
+        RuntimeAdoptionSignal::Miss => "miss",
+        RuntimeAdoptionSignal::Rollback => "rollback",
+        RuntimeAdoptionSignal::Contradiction => "contradiction",
+        RuntimeAdoptionSignal::Neutral => "neutral",
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -316,6 +316,8 @@ pub struct KnowledgeCardsResponse {
 pub struct Phase3Request {
     pub action: String,
     pub id: Option<String>,
+    pub surface: Option<String>,
+    pub outcome: Option<String>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -329,6 +331,7 @@ pub struct Phase3Request {
     pub limit: Option<usize>,
     pub candidate: Option<String>,
     pub report: Option<serde_json::Value>,
+    pub execute: Option<bool>,
     pub allow_warnings: Option<bool>,
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+    Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
+    ResearchIngestPlanReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
     RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
     RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
@@ -351,6 +352,8 @@ pub struct Phase3Response {
     pub gate: Option<Phase3GateDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_plan: Option<ResearchAdapterPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub research_ingest_plan: Option<ResearchIngestPlanDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -603,6 +606,89 @@ pub struct ResearchAdapterPlanDto {
     pub finding_count: usize,
     pub candidate_insight_count: usize,
     pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchIngestPlanDto {
+    pub valid: bool,
+    pub writes: bool,
+    pub report_id: String,
+    pub title: String,
+    pub source_count: usize,
+    pub finding_count: usize,
+    pub candidate_insight_count: usize,
+    pub planned_evidence_count: usize,
+    pub created_count: usize,
+    pub skipped_count: usize,
+    pub errors: Vec<String>,
+    pub evidence_drawers: Vec<ResearchEvidenceDrawerPlanDto>,
+    pub candidate_insights: Vec<ResearchCandidateInsightPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchEvidenceDrawerPlanDto {
+    pub drawer_id: String,
+    pub finding_index: usize,
+    pub source_file: String,
+    pub created: bool,
+    pub skipped: bool,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct ResearchCandidateInsightPlanDto {
+    pub statement: String,
+    pub supporting_refs: Vec<String>,
+    pub suggested_command: Vec<String>,
+}
+
+impl From<ResearchIngestPlanReport> for ResearchIngestPlanDto {
+    fn from(report: ResearchIngestPlanReport) -> Self {
+        Self {
+            valid: report.valid,
+            writes: report.writes,
+            report_id: report.report_id,
+            title: report.title,
+            source_count: report.source_count,
+            finding_count: report.finding_count,
+            candidate_insight_count: report.candidate_insight_count,
+            planned_evidence_count: report.planned_evidence_count,
+            created_count: report.created_count,
+            skipped_count: report.skipped_count,
+            errors: report.errors,
+            evidence_drawers: report
+                .evidence_drawers
+                .into_iter()
+                .map(ResearchEvidenceDrawerPlanDto::from)
+                .collect(),
+            candidate_insights: report
+                .candidate_insights
+                .into_iter()
+                .map(ResearchCandidateInsightPlanDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<ResearchEvidenceDrawerPlan> for ResearchEvidenceDrawerPlanDto {
+    fn from(plan: ResearchEvidenceDrawerPlan) -> Self {
+        Self {
+            drawer_id: plan.drawer_id,
+            finding_index: plan.finding_index,
+            source_file: plan.source_file,
+            created: plan.created,
+            skipped: plan.skipped,
+        }
+    }
+}
+
+impl From<ResearchCandidateInsightPlan> for ResearchCandidateInsightPlanDto {
+    fn from(plan: ResearchCandidateInsightPlan) -> Self {
+        Self {
+            statement: plan.statement,
+            supporting_refs: plan.supporting_refs,
+            suggested_command: plan.suggested_command,
+        }
+    }
 }
 
 impl From<RuntimeAdoptionEvent> for RuntimeAdoptionEventDto {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2,6 +2,7 @@ use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
     ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+    RuntimeAdoptionInstrumentationMode, RuntimeAdoptionInstrumentationPolicy,
     RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
     RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance,
     RuntimeAdoptionTrackGuidance,
@@ -347,6 +348,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guidance: Option<RuntimeAdoptionGuidanceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub instrumentation_policy: Option<RuntimeAdoptionInstrumentationPolicyDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
@@ -395,6 +398,25 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionInstrumentationPolicyDto {
+    pub version: u32,
+    pub writes: bool,
+    pub default_mode: String,
+    pub allowed_modes: Vec<RuntimeAdoptionInstrumentationModeDto>,
+    pub forbidden_modes: Vec<String>,
+    pub requirements: Vec<String>,
+    pub rollback_requirements: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionInstrumentationModeDto {
+    pub mode: String,
+    pub description: String,
+    pub requires_execute: bool,
+    pub requires_checked_capture: bool,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -657,6 +679,31 @@ impl From<RuntimeAdoptionTrackGuidance> for RuntimeAdoptionTrackGuidanceDto {
             track: guidance.track,
             when: guidance.when,
             feature_examples: guidance.feature_examples,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionInstrumentationPolicy> for RuntimeAdoptionInstrumentationPolicyDto {
+    fn from(policy: RuntimeAdoptionInstrumentationPolicy) -> Self {
+        Self {
+            version: policy.version,
+            writes: policy.writes,
+            default_mode: policy.default_mode,
+            allowed_modes: policy.allowed_modes.into_iter().map(Into::into).collect(),
+            forbidden_modes: policy.forbidden_modes,
+            requirements: policy.requirements,
+            rollback_requirements: policy.rollback_requirements,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionInstrumentationMode> for RuntimeAdoptionInstrumentationModeDto {
+    fn from(mode: RuntimeAdoptionInstrumentationMode) -> Self {
+        Self {
+            mode: mode.mode,
+            description: mode.description,
+            requires_execute: mode.requires_execute,
+            requires_checked_capture: mode.requires_checked_capture,
         }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,8 +1,8 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
-    RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts,
-    RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    Phase3ReadinessReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
+    RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
+    RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -340,6 +340,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_report: Option<RuntimeAdoptionReviewReportDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub readiness_report: Option<Phase3ReadinessReportDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -427,6 +429,18 @@ pub struct RuntimeAdoptionFeatureReviewDto {
     pub stats: RuntimeAdoptionSignalCountsDto,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct Phase3ReadinessReportDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub ready: bool,
+    pub decision: String,
+    pub required_track: String,
+    pub required_feature: String,
+    pub review: RuntimeAdoptionReviewReportDto,
+    pub reasons: Vec<String>,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
@@ -465,6 +479,21 @@ impl From<RuntimeAdoptionReviewReport> for RuntimeAdoptionReviewReportDto {
                 })
                 .collect(),
             conclusion: report.conclusion,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<Phase3ReadinessReport> for Phase3ReadinessReportDto {
+    fn from(report: Phase3ReadinessReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            ready: report.ready,
+            decision: report.decision,
+            required_track: report.required_track,
+            required_feature: report.required_feature,
+            review: report.review.into(),
             reasons: report.reasons,
         }
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -318,6 +318,12 @@ pub struct Phase3Request {
     pub id: Option<String>,
     pub surface: Option<String>,
     pub outcome: Option<String>,
+    pub subject_kind: Option<String>,
+    pub subject_id: Option<String>,
+    pub proposed_action: Option<String>,
+    pub evidence_refs: Option<Vec<String>>,
+    pub counterexample_refs: Option<Vec<String>>,
+    pub risk_notes: Option<Vec<String>>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -361,6 +367,8 @@ pub struct Phase3Response {
     pub research_plan: Option<ResearchAdapterPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_ingest_plan: Option<ResearchIngestPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator_advice: Option<EvaluatorAdviceDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -457,6 +465,45 @@ pub struct Phase3ReadinessReportDto {
     pub required_feature: String,
     pub review: RuntimeAdoptionReviewReportDto,
     pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct EvaluatorAdviceDto {
+    pub writes: bool,
+    pub evaluator_id: String,
+    pub subject_kind: String,
+    pub subject_id: String,
+    pub proposed_action: String,
+    pub recommendation: String,
+    pub lifecycle_authority: bool,
+    pub deterministic_gate_required: bool,
+    pub requires_human_review: bool,
+    pub evidence_refs: Vec<String>,
+    pub counterexample_refs: Vec<String>,
+    pub risk_notes: Vec<String>,
+    pub reasons: Vec<String>,
+    pub adoption_capture: RuntimeAdoptionRecordPlanDto,
+}
+
+impl From<crate::core::phase3::EvaluatorAdviceReport> for EvaluatorAdviceDto {
+    fn from(report: crate::core::phase3::EvaluatorAdviceReport) -> Self {
+        Self {
+            writes: report.writes,
+            evaluator_id: report.evaluator_id,
+            subject_kind: report.subject_kind,
+            subject_id: report.subject_id,
+            proposed_action: report.proposed_action,
+            recommendation: report.recommendation,
+            lifecycle_authority: report.lifecycle_authority,
+            deterministic_gate_required: report.deterministic_gate_required,
+            requires_human_review: report.requires_human_review,
+            evidence_refs: report.evidence_refs,
+            counterexample_refs: report.counterexample_refs,
+            risk_notes: report.risk_notes,
+            reasons: report.reasons,
+            adoption_capture: report.adoption_capture.into(),
+        }
+    }
 }
 
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionSignalGuidance,
+    RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -332,6 +333,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guidance: Option<RuntimeAdoptionGuidanceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -364,6 +367,23 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionRecordPlanDto {
+    pub writes: bool,
+    pub record_command: Vec<String>,
+    pub record_payload: serde_json::Value,
+}
+
+impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
+    fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
+        Self {
+            writes: plan.writes,
+            record_command: plan.record_command,
+            record_payload: plan.record_payload,
+        }
+    }
 }
 
 impl From<RuntimeAdoptionGuidance> for RuntimeAdoptionGuidanceDto {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -375,6 +375,8 @@ pub struct Phase3Response {
     pub evaluator_advice: Option<EvaluatorAdviceDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_proposal: Option<CardContextDefaultProposalDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_control: Option<CardContextRollbackControlDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -521,6 +523,19 @@ pub struct CardContextDefaultProposalDto {
     pub reasons: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CardContextRollbackControlDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub execute: bool,
+    pub rollback_required: bool,
+    pub applied: bool,
+    pub include_cards_default_before: bool,
+    pub include_cards_default_after: bool,
+    pub review: RuntimeAdoptionReviewReportDto,
+    pub reasons: Vec<String>,
+}
+
 impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContextDefaultProposalDto {
     fn from(report: crate::core::phase3::CardContextDefaultProposalReport) -> Self {
         Self {
@@ -530,6 +545,22 @@ impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContext
             decision: report.decision,
             readiness: report.readiness.into(),
             rollback_criteria: report.rollback_criteria,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<crate::core::phase3::CardContextRollbackControlReport> for CardContextRollbackControlDto {
+    fn from(report: crate::core::phase3::CardContextRollbackControlReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            execute: report.execute,
+            rollback_required: report.rollback_required,
+            applied: report.applied,
+            include_cards_default_before: report.include_cards_default_before,
+            include_cards_default_after: report.include_cards_default_after,
+            review: report.review.into(),
             reasons: report.reasons,
         }
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,4 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
+use crate::core::phase3::{
+    RuntimeAdoptionGuidance, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+};
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
     MemoryDomain, MemoryKind, NeighborChunk, RouteDecision, RuntimeAdoptionEvent,
@@ -361,6 +364,38 @@ pub struct RuntimeAdoptionTrackGuidanceDto {
     pub track: String,
     pub when: String,
     pub feature_examples: Vec<String>,
+}
+
+impl From<RuntimeAdoptionGuidance> for RuntimeAdoptionGuidanceDto {
+    fn from(guidance: RuntimeAdoptionGuidance) -> Self {
+        Self {
+            version: guidance.version,
+            recording_rule: guidance.recording_rule,
+            required_fields: guidance.required_fields,
+            optional_fields: guidance.optional_fields,
+            signals: guidance.signals.into_iter().map(Into::into).collect(),
+            tracks: guidance.tracks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<RuntimeAdoptionSignalGuidance> for RuntimeAdoptionSignalGuidanceDto {
+    fn from(guidance: RuntimeAdoptionSignalGuidance) -> Self {
+        Self {
+            signal: guidance.signal,
+            when: guidance.when,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionTrackGuidance> for RuntimeAdoptionTrackGuidanceDto {
+    fn from(guidance: RuntimeAdoptionTrackGuidance) -> Self {
+        Self {
+            track: guidance.track,
+            when: guidance.when,
+            feature_examples: guidance.feature_examples,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -324,6 +324,7 @@ pub struct Phase3Request {
     pub evidence_refs: Option<Vec<String>>,
     pub counterexample_refs: Option<Vec<String>>,
     pub risk_notes: Option<Vec<String>>,
+    pub rollback_criteria: Option<Vec<String>>,
     pub track: Option<String>,
     pub signal: Option<String>,
     pub feature: Option<String>,
@@ -369,6 +370,8 @@ pub struct Phase3Response {
     pub research_ingest_plan: Option<ResearchIngestPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evaluator_advice: Option<EvaluatorAdviceDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_proposal: Option<CardContextDefaultProposalDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -483,6 +486,31 @@ pub struct EvaluatorAdviceDto {
     pub risk_notes: Vec<String>,
     pub reasons: Vec<String>,
     pub adoption_capture: RuntimeAdoptionRecordPlanDto,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CardContextDefaultProposalDto {
+    pub writes: bool,
+    pub candidate: String,
+    pub proposal_ready: bool,
+    pub decision: String,
+    pub readiness: Phase3ReadinessReportDto,
+    pub rollback_criteria: Vec<String>,
+    pub reasons: Vec<String>,
+}
+
+impl From<crate::core::phase3::CardContextDefaultProposalReport> for CardContextDefaultProposalDto {
+    fn from(report: crate::core::phase3::CardContextDefaultProposalReport) -> Self {
+        Self {
+            writes: report.writes,
+            candidate: report.candidate,
+            proposal_ready: report.proposal_ready,
+            decision: report.decision,
+            readiness: report.readiness.into(),
+            rollback_criteria: report.rollback_criteria,
+            reasons: report.reasons,
+        }
+    }
 }
 
 impl From<crate::core::phase3::EvaluatorAdviceReport> for EvaluatorAdviceDto {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -327,6 +327,8 @@ pub struct Phase3Request {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub guidance: Option<RuntimeAdoptionGuidanceDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -336,6 +338,29 @@ pub struct Phase3Response {
     pub gate: Option<Phase3GateDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub research_plan: Option<ResearchAdapterPlanDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionGuidanceDto {
+    pub version: u32,
+    pub recording_rule: String,
+    pub required_fields: Vec<String>,
+    pub optional_fields: Vec<String>,
+    pub signals: Vec<RuntimeAdoptionSignalGuidanceDto>,
+    pub tracks: Vec<RuntimeAdoptionTrackGuidanceDto>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionSignalGuidanceDto {
+    pub signal: String,
+    pub when: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionTrackGuidanceDto {
+    pub track: String,
+    pub when: String,
+    pub feature_examples: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,9 +1,10 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     Phase3ReadinessReport, ResearchCandidateInsightPlan, ResearchEvidenceDrawerPlan,
-    ResearchIngestPlanReport, RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan,
-    RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport,
-    RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
+    ResearchIngestPlanReport, RuntimeAdoptionCheckedRecordReport, RuntimeAdoptionGuidance,
+    RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport, RuntimeAdoptionReviewFilters,
+    RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts, RuntimeAdoptionSignalGuidance,
+    RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -328,6 +329,7 @@ pub struct Phase3Request {
     pub limit: Option<usize>,
     pub candidate: Option<String>,
     pub report: Option<serde_json::Value>,
+    pub allow_warnings: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -338,6 +340,8 @@ pub struct Phase3Response {
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_checked: Option<RuntimeAdoptionCheckedRecordDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub review_report: Option<RuntimeAdoptionReviewReportDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -393,6 +397,14 @@ pub struct RuntimeAdoptionRecordQualityDto {
     pub quality: String,
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionCheckedRecordDto {
+    pub writes: bool,
+    pub blocked: bool,
+    pub record_quality: RuntimeAdoptionRecordQualityDto,
+    pub event: Option<RuntimeAdoptionEventDto>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -462,6 +474,17 @@ impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDt
             quality: report.quality,
             errors: report.errors,
             warnings: report.warnings,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionCheckedRecordReport> for RuntimeAdoptionCheckedRecordDto {
+    fn from(report: RuntimeAdoptionCheckedRecordReport) -> Self {
+        Self {
+            writes: report.writes,
+            blocked: report.blocked,
+            record_quality: report.record_quality.into(),
+            event: report.event.map(RuntimeAdoptionEventDto::from),
         }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,7 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
-    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionSignalGuidance,
-    RuntimeAdoptionTrackGuidance,
+    RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
+    RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
     AnchorKind, ChunkNeighbors, KnowledgeCard, KnowledgeCardEvent, KnowledgeStatus, KnowledgeTier,
@@ -335,6 +335,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_plan: Option<RuntimeAdoptionRecordPlanDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -376,12 +378,33 @@ pub struct RuntimeAdoptionRecordPlanDto {
     pub record_payload: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionRecordQualityDto {
+    pub writes: bool,
+    pub valid: bool,
+    pub quality: String,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
             writes: plan.writes,
             record_command: plan.record_command,
             record_payload: plan.record_payload,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDto {
+    fn from(report: RuntimeAdoptionRecordQualityReport) -> Self {
+        Self {
+            writes: report.writes,
+            valid: report.valid,
+            quality: report.quality,
+            errors: report.errors,
+            warnings: report.warnings,
         }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,7 @@
 use crate::context::{ContextItem, ContextPack, ContextSection};
 use crate::core::phase3::{
     RuntimeAdoptionGuidance, RuntimeAdoptionRecordPlan, RuntimeAdoptionRecordQualityReport,
+    RuntimeAdoptionReviewFilters, RuntimeAdoptionReviewReport, RuntimeAdoptionSignalCounts,
     RuntimeAdoptionSignalGuidance, RuntimeAdoptionTrackGuidance,
 };
 use crate::core::types::{
@@ -337,6 +338,8 @@ pub struct Phase3Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_quality: Option<RuntimeAdoptionRecordQualityDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_report: Option<RuntimeAdoptionReviewReportDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<RuntimeAdoptionEventDto>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub events: Vec<RuntimeAdoptionEventDto>,
@@ -387,6 +390,43 @@ pub struct RuntimeAdoptionRecordQualityDto {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionReviewReportDto {
+    pub writes: bool,
+    pub filters: RuntimeAdoptionReviewFiltersDto,
+    pub total: usize,
+    pub stats: RuntimeAdoptionSignalCountsDto,
+    pub features: Vec<RuntimeAdoptionFeatureReviewDto>,
+    pub conclusion: String,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionReviewFiltersDto {
+    pub track: Option<String>,
+    pub feature: Option<String>,
+    pub signal: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionSignalCountsDto {
+    pub total: usize,
+    pub used: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub misses: usize,
+    pub rollbacks: usize,
+    pub contradictions: usize,
+    pub neutral: usize,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct RuntimeAdoptionFeatureReviewDto {
+    pub feature: String,
+    pub stats: RuntimeAdoptionSignalCountsDto,
+}
+
 impl From<RuntimeAdoptionRecordPlan> for RuntimeAdoptionRecordPlanDto {
     fn from(plan: RuntimeAdoptionRecordPlan) -> Self {
         Self {
@@ -405,6 +445,53 @@ impl From<RuntimeAdoptionRecordQualityReport> for RuntimeAdoptionRecordQualityDt
             quality: report.quality,
             errors: report.errors,
             warnings: report.warnings,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionReviewReport> for RuntimeAdoptionReviewReportDto {
+    fn from(report: RuntimeAdoptionReviewReport) -> Self {
+        Self {
+            writes: report.writes,
+            filters: report.filters.into(),
+            total: report.total,
+            stats: report.stats.into(),
+            features: report
+                .features
+                .into_iter()
+                .map(|feature| RuntimeAdoptionFeatureReviewDto {
+                    feature: feature.feature,
+                    stats: feature.stats.into(),
+                })
+                .collect(),
+            conclusion: report.conclusion,
+            reasons: report.reasons,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionReviewFilters> for RuntimeAdoptionReviewFiltersDto {
+    fn from(filters: RuntimeAdoptionReviewFilters) -> Self {
+        Self {
+            track: filters.track,
+            feature: filters.feature,
+            signal: filters.signal,
+            limit: filters.limit,
+        }
+    }
+}
+
+impl From<RuntimeAdoptionSignalCounts> for RuntimeAdoptionSignalCountsDto {
+    fn from(stats: RuntimeAdoptionSignalCounts) -> Self {
+        Self {
+            total: stats.total,
+            used: stats.used,
+            accepted: stats.accepted,
+            rejected: stats.rejected,
+            misses: stats.misses,
+            rollbacks: stats.rollbacks,
+            contradictions: stats.contradictions,
+            neutral: stats.neutral,
         }
     }
 }

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -254,13 +254,27 @@ fn start_openai_embedding_stub(
 
 fn write_cli_api_config(home: &Path, endpoint: &str) {
     let config_path = home.join(".mempal").join("config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap_or_default();
+    let prefix = if existing.trim().is_empty() {
+        String::new()
+    } else {
+        format!("{}\n", existing.trim_end())
+    };
     fs::write(
         config_path,
         format!(
-            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+            "{prefix}[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
         ),
     )
     .expect("write cli config");
+}
+
+fn write_context_default_config(home: &Path, include_cards_default: bool) {
+    fs::write(
+        home.join(".mempal").join("config.toml"),
+        format!("[context]\ninclude_cards_default = {include_cards_default}\n"),
+    )
+    .expect("write context config");
 }
 
 fn run_context_json(home: &Path, query: &str, extra_args: &[&str]) -> Value {
@@ -759,6 +773,115 @@ fn test_cli_context_include_cards_json() {
         card["evidence_citations"][0]["source_file"],
         "tests://context/drawer_card_evidence"
     );
+}
+
+#[test]
+fn test_cli_context_config_default_false_omits_cards() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), false);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_default_false", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_default_false",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Config false keeps card context opt-in.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_default_false",
+        "card_default_false",
+        "drawer_card_default_false",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &[]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(items.iter().all(|item| item["card_id"].is_null()));
+}
+
+#[test]
+fn test_cli_context_config_default_true_includes_cards() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), true);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_default_true", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_default_true",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "Config true includes card context by default.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_default_true",
+        "card_default_true",
+        "drawer_card_default_true",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &[]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(
+        items
+            .iter()
+            .any(|item| item["card_id"] == "card_default_true")
+    );
+}
+
+#[test]
+fn test_cli_context_no_include_cards_overrides_config_default_true() {
+    let (tmp, db) = setup_cli_home();
+    write_context_default_config(tmp.path(), true);
+    insert_fixture(
+        &db,
+        &evidence_drawer("drawer_card_no_override", "card evidence source"),
+    );
+    insert_card(
+        &db,
+        &knowledge_card(
+            "card_no_override",
+            KnowledgeTier::Shu,
+            KnowledgeStatus::Promoted,
+            "No include cards flag overrides config true.",
+        ),
+    );
+    insert_card_link(
+        &db,
+        "link_card_no_override",
+        "card_no_override",
+        "drawer_card_no_override",
+        KnowledgeEvidenceRole::Supporting,
+    );
+
+    let value = run_context_json(tmp.path(), "card-aware", &["--no-include-cards"]);
+    let items = value["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    assert!(items.iter().all(|item| item["card_id"].is_null()));
 }
 
 #[test]

--- a/tests/knowledge_card_retrieval.rs
+++ b/tests/knowledge_card_retrieval.rs
@@ -174,7 +174,7 @@ fn start_openai_embedding_stub(
     let expected_query = expected_query.to_string();
 
     let handle = thread::spawn(move || {
-        let (mut stream, _) = (0..50)
+        let (mut stream, _) = (0..250)
             .find_map(|_| match listener.accept() {
                 Ok(pair) => Some(pair),
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -693,6 +693,90 @@ fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_instrumentation_policy_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "instrumentation-policy",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "instrumentation policy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let policy: Value = serde_json::from_slice(&output.stdout).expect("policy json");
+    assert_eq!(policy["writes"], false);
+    assert_eq!(policy["version"], 1);
+    assert_eq!(policy["default_mode"], "manual_only");
+    assert!(
+        policy["allowed_modes"]
+            .as_array()
+            .expect("allowed modes")
+            .iter()
+            .any(|mode| mode["mode"] == "opt_in_wrapper"
+                && mode["requires_execute"] == true
+                && mode["requires_checked_capture"] == true)
+    );
+    assert!(
+        policy["forbidden_modes"]
+            .as_array()
+            .expect("forbidden modes")
+            .iter()
+            .any(|mode| mode == "implicit_background_capture")
+    );
+    assert!(
+        policy["requirements"]
+            .as_array()
+            .expect("requirements")
+            .iter()
+            .any(|requirement| requirement
+                .as_str()
+                .expect("requirement")
+                .contains("opt-out"))
+    );
+    assert!(
+        policy["rollback_requirements"]
+            .as_array()
+            .expect("rollback requirements")
+            .iter()
+            .any(|requirement| requirement
+                .as_str()
+                .expect("rollback requirement")
+                .contains("rollback"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_instrumentation_policy_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "instrumentation-policy",
+            "--format",
+            "yaml",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 adoption format"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_prepare_record_json_is_read_only() {
     let home = setup_cli_home();
     let output = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1141,6 +1141,180 @@ fn test_cli_phase3_evaluator_gate_exists_and_is_read_only() {
 }
 
 #[test]
+fn test_cli_phase3_evaluator_advise_supportive_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--evidence-ref",
+            "e1",
+            "--evidence-ref",
+            "e2",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "advise failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("advice json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["lifecycle_authority"], false);
+    assert_eq!(report["deterministic_gate_required"], true);
+    assert_eq!(report["recommendation"], "advisory_support");
+    assert_eq!(
+        report["adoption_capture"]["record_payload"]["track"],
+        "evaluator"
+    );
+    assert_eq!(
+        report["adoption_capture"]["record_payload"]["feature"],
+        "advisory_gate"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_dao_tian_requires_human_review() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_tian",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "canonical",
+            "--evidence-ref",
+            "e1",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "advise failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("advice json");
+    assert_eq!(report["requires_human_review"], true);
+    assert_eq!(report["recommendation"], "requires_human_review");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .is_some_and(|value| value.contains("dao_tian canonicalization requires human review"))
+    }));
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_needs_evidence_and_blocks_risk() {
+    let home = setup_cli_home();
+    let weak = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        weak.status.success(),
+        "weak advise failed: {}",
+        String::from_utf8_lossy(&weak.stderr)
+    );
+    let weak_report: Value = serde_json::from_slice(&weak.stdout).expect("weak advice json");
+    assert_eq!(weak_report["recommendation"], "needs_evidence");
+
+    let risky = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--evaluator-id",
+            "eval_policy",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+            "--evidence-ref",
+            "e1",
+            "--counterexample-ref",
+            "c1",
+            "--risk-note",
+            "contradiction risk",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        risky.status.success(),
+        "risky advise failed: {}",
+        String::from_utf8_lossy(&risky.stderr)
+    );
+    let risky_report: Value = serde_json::from_slice(&risky.stdout).expect("risky advice json");
+    assert_eq!(risky_report["recommendation"], "do_not_promote");
+}
+
+#[test]
+fn test_cli_phase3_evaluator_advise_rejects_missing_evaluator() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "evaluator",
+            "advise",
+            "--subject-kind",
+            "dao_ren",
+            "--subject-id",
+            "k1",
+            "--proposed-action",
+            "promote",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("evaluator-id is required"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_record_rejects_invalid_track() {
     let home = setup_cli_home();
     let output = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -220,6 +220,102 @@ fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_prepare_record_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "prepare-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let plan: Value = serde_json::from_slice(&output.stdout).expect("prepare-record json");
+    assert_eq!(plan["writes"], false);
+    let command = plan["record_command"].as_array().expect("record command");
+    assert_eq!(command[0], "mempal");
+    assert_eq!(command[1], "phase3");
+    assert_eq!(command[2], "adoption");
+    assert_eq!(command[3], "record");
+    assert_eq!(plan["record_payload"]["action"], "record");
+    assert_eq!(plan["record_payload"]["track"], "card_context");
+    assert_eq!(plan["record_payload"]["signal"], "accepted");
+    assert_eq!(plan["record_payload"]["feature"], "include_cards");
+    assert_eq!(plan["record_payload"]["query"], "skill trigger");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_prepare_record_plain() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "used",
+            "--feature",
+            "include_cards",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "prepare-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("writes=false"));
+    assert!(stdout.contains("mempal phase3 adoption record"));
+    assert!(stdout.contains("action=record"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "prepare-record",
+            "--track",
+            "invalid",
+            "--signal",
+            "accepted",
+            "--feature",
+            "x",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported runtime adoption track"));
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -57,6 +57,32 @@ fn record_card_context_acceptance(home: &TempDir, id: &str) {
     );
 }
 
+fn record_card_context_rollback(home: &TempDir, id: &str) {
+    let output = run_mempal(
+        home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--id",
+            id,
+            "--track",
+            "card_context",
+            "--signal",
+            "rollback",
+            "--feature",
+            "include_cards",
+            "--note",
+            "reverted card context default",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn insert_test_card(home: &TempDir, card_id: &str) {
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
     db.insert_knowledge_card(&KnowledgeCard {
@@ -671,6 +697,161 @@ fn test_cli_phase3_default_control_disable_is_reversible() {
         .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
         .expect("list events");
     assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_check_is_read_only() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_check_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], false);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_disables_default() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_execute_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], true);
+    assert!(!read_include_cards_default(&home));
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_without_signal_is_noop() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], false);
+    assert_eq!(report["applied"], false);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_execute_already_disabled_is_noop() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = false\n",
+    )
+    .expect("write config");
+    record_card_context_rollback(&home, "rollback_disabled_1");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "card-context",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "rollback control execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("rollback json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["rollback_required"], true);
+    assert_eq!(report["applied"], false);
+    assert!(!read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_rollback_control_rejects_unknown_candidate_without_config_write() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "rollback-control",
+            "unknown",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 rollback-control candidate"));
+    assert!(!home.path().join(".mempal/config.toml").exists());
 }
 
 #[test]

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    MemoryKind, Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+    AnchorKind, KnowledgeCard, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
+    Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
     RuntimeAdoptionTrack,
 };
 use serde_json::{Value, json};
@@ -25,6 +26,27 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
         .env("HOME", home.path())
         .output()
         .expect("run mempal")
+}
+
+fn insert_test_card(home: &TempDir, card_id: &str) {
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    db.insert_knowledge_card(&KnowledgeCard {
+        id: card_id.to_string(),
+        statement: format!("Statement for {card_id}."),
+        content: format!("Content for {card_id}."),
+        tier: KnowledgeTier::Shu,
+        status: KnowledgeStatus::Promoted,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        scope_constraints: None,
+        trigger_hints: None,
+        created_at: "1713000000".to_string(),
+        updated_at: "1713000000".to_string(),
+    })
+    .expect("insert test card");
 }
 
 #[test]
@@ -480,6 +502,169 @@ fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported runtime adoption track"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_card_context_dry_run() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--card-id",
+            "card_1",
+            "--query",
+            "skill trigger",
+            "--note",
+            "card helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["execute"], false);
+    assert_eq!(report["surface"], "card-context");
+    assert_eq!(report["outcome"], "accepted");
+    assert_eq!(report["record_plan"]["writes"], false);
+    assert_eq!(
+        report["record_plan"]["record_payload"]["track"],
+        "card_context"
+    );
+    assert_eq!(
+        report["record_plan"]["record_payload"]["signal"],
+        "accepted"
+    );
+    assert_eq!(
+        report["record_plan"]["record_payload"]["feature"],
+        "include_cards"
+    );
+    assert_eq!(report["record_quality"]["quality"], "ready");
+    assert!(report["record_checked"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_execute_writes_ready_event() {
+    let home = setup_cli_home();
+    insert_test_card(&home, "card_1");
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--card-id",
+            "card_1",
+            "--query",
+            "skill trigger",
+            "--note",
+            "card helped",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["execute"], true);
+    assert_eq!(report["record_checked"]["writes"], true);
+    assert_eq!(report["record_checked"]["blocked"], false);
+    assert_eq!(
+        report["record_checked"]["record_quality"]["quality"],
+        "ready"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("events");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].feature, "include_cards");
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_blocks_warning_by_default() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "card-context",
+            "--outcome",
+            "accepted",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "capture warning should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("capture json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["execute"], true);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert_eq!(report["record_checked"]["writes"], false);
+    assert_eq!(report["record_checked"]["blocked"], true);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("events")
+            .is_empty()
+    );
+}
+
+#[test]
+fn test_cli_phase3_adoption_capture_rejects_unknown_surface() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "capture",
+            "--surface",
+            "unknown",
+            "--outcome",
+            "accepted",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported adoption capture surface"));
 }
 
 #[test]

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -127,6 +127,172 @@ fn test_cli_phase3_adoption_record_stats_and_gate() {
 }
 
 #[test]
+fn test_cli_phase3_readiness_card_context_default_ready() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        let id = format!("readiness_accept_{i}");
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                &id,
+                "--track",
+                "card_context",
+                "--signal",
+                "accepted",
+                "--feature",
+                "include_cards",
+                "--query",
+                "skill trigger context",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["ready"], true);
+    assert_eq!(report["decision"], "eligible_for_future_default_spec");
+    assert_eq!(report["review"]["stats"]["accepted"], 3);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_readiness_card_context_default_blocks_without_evidence() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["ready"], false);
+    assert_eq!(report["decision"], "keep_opt_in");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .expect("reason")
+            .contains("insufficient accepted evidence")
+    }));
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_readiness_card_context_default_blocks_rollback() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("readiness_accept_1", "accepted"),
+        ("readiness_accept_2", "accepted"),
+        ("readiness_accept_3", "accepted"),
+        ("readiness_rollback_1", "rollback"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "readiness",
+            "card-context-default",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "readiness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("readiness json");
+    assert_eq!(report["ready"], false);
+    assert_eq!(report["decision"], "keep_opt_in");
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .expect("reason")
+            .contains("rollback evidence")
+    }));
+}
+
+#[test]
+fn test_cli_phase3_readiness_rejects_unknown_candidate() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "readiness", "unknown", "--format", "json"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 readiness candidate"));
+}
+
+#[test]
 fn test_cli_phase3_adoption_guidance_json_is_read_only() {
     let home = setup_cli_home();
     let output = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -316,6 +316,140 @@ fn test_cli_phase3_adoption_prepare_record_rejects_invalid_track() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_check_record_json_accepts_supported_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger",
+            "--card-id",
+            "card_1",
+            "--note",
+            "card evidence helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["quality"], "ready");
+    assert!(report["errors"].as_array().expect("errors").is_empty());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_check_record_json_warns_on_weak_evidence() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["quality"], "warning");
+    let warnings = report["warnings"].as_array().expect("warnings");
+    assert!(warnings.iter().any(|warning| {
+        warning
+            .as_str()
+            .expect("warning")
+            .contains("concrete outcome context")
+    }));
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.as_str().expect("warning").contains("card_id"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "check-record",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "   ",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "check-record should report invalid input without failing: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("quality report json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["quality"], "invalid");
+    let errors = report["errors"].as_array().expect("errors");
+    assert!(errors.iter().any(|error| {
+        error
+            .as_str()
+            .expect("error")
+            .contains("feature must not be empty")
+    }));
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -1,11 +1,14 @@
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::process::Command;
+use std::thread;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    AnchorKind, KnowledgeCard, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
-    Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-    RuntimeAdoptionTrack,
+    AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+    KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
+    RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -28,6 +31,32 @@ fn run_mempal(home: &TempDir, args: &[&str]) -> std::process::Output {
         .expect("run mempal")
 }
 
+fn record_card_context_acceptance(home: &TempDir, id: &str) {
+    let output = run_mempal(
+        home,
+        &[
+            "phase3",
+            "adoption",
+            "record",
+            "--id",
+            id,
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "skill trigger context",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn insert_test_card(home: &TempDir, card_id: &str) {
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
     db.insert_knowledge_card(&KnowledgeCard {
@@ -47,6 +76,109 @@ fn insert_test_card(home: &TempDir, card_id: &str) {
         updated_at: "1713000000".to_string(),
     })
     .expect("insert test card");
+}
+
+fn evidence_drawer(id: &str, content: &str) -> Drawer {
+    Drawer {
+        id: id.to_string(),
+        content: content.to_string(),
+        wing: "mempal".to_string(),
+        room: Some("phase3".to_string()),
+        source_file: Some(format!("tests://phase3/{id}")),
+        source_type: SourceType::Manual,
+        added_at: "1710000000".to_string(),
+        chunk_index: Some(0),
+        normalize_version: 1,
+        importance: 2,
+        memory_kind: MemoryKind::Evidence,
+        domain: MemoryDomain::Project,
+        field: "general".to_string(),
+        anchor_kind: AnchorKind::Repo,
+        anchor_id: "repo://mempal".to_string(),
+        parent_anchor_id: None,
+        provenance: Some(Provenance::Human),
+        statement: None,
+        tier: None,
+        status: None,
+        supporting_refs: Vec::new(),
+        counterexample_refs: Vec::new(),
+        teaching_refs: Vec::new(),
+        verification_refs: Vec::new(),
+        scope_constraints: None,
+        trigger_hints: None,
+    }
+}
+
+fn insert_test_card_with_evidence(home: &TempDir, card_id: &str, evidence_id: &str) {
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let drawer = evidence_drawer(evidence_id, "card context evidence");
+    db.insert_drawer(&drawer).expect("insert evidence drawer");
+    db.insert_vector(evidence_id, &vec![0.25; 384])
+        .expect("insert evidence vector");
+    drop(db);
+    insert_test_card(home, card_id);
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    db.insert_knowledge_evidence_link(&KnowledgeEvidenceLink {
+        id: format!("link_{card_id}_{evidence_id}"),
+        card_id: card_id.to_string(),
+        evidence_drawer_id: evidence_id.to_string(),
+        role: KnowledgeEvidenceRole::Supporting,
+        note: None,
+        created_at: "1710000000".to_string(),
+    })
+    .expect("insert card evidence link");
+}
+
+fn start_openai_embedding_stub(query: &str) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let query = query.to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = (0..50)
+            .find_map(|_| match listener.accept() {
+                Ok(connection) => Some(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    None
+                }
+                Err(error) => panic!("accept request: {error}"),
+            })
+            .expect("embedding stub timed out waiting for request");
+        let mut request = [0_u8; 4096];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        let request = String::from_utf8_lossy(&request[..bytes_read]);
+        let (_, body) = request
+            .split_once("\r\n\r\n")
+            .expect("request should contain JSON body");
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request");
+        assert_eq!(payload["input"][0], query);
+        let body = serde_json::to_string(&json!({
+            "data": [{ "embedding": vec![0.25; 384] }]
+        }))
+        .expect("serialize embedding response");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write embedding response");
+    });
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &TempDir, endpoint: &str) {
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write config");
 }
 
 #[test]
@@ -242,6 +374,158 @@ fn test_cli_phase3_readiness_card_context_default_blocks_without_evidence() {
         .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
         .expect("list events");
     assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_card_context_ready() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_accept_{i}"));
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["candidate"], "card-context");
+    assert_eq!(report["proposal_ready"], true);
+    assert_eq!(report["decision"], "eligible_for_default_on_spec");
+    assert_eq!(report["readiness"]["ready"], true);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_requires_rollback_criteria() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_no_rollback_{i}"));
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["proposal_ready"], false);
+    let reasons = report["reasons"].as_array().expect("reasons");
+    assert!(reasons.iter().any(|reason| {
+        reason
+            .as_str()
+            .is_some_and(|value| value.contains("rollback criteria are required"))
+    }));
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_blocks_without_readiness() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("proposal json");
+    assert_eq!(report["proposal_ready"], false);
+    assert_eq!(report["readiness"]["ready"], false);
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_keeps_context_cards_opt_in() {
+    let home = setup_cli_home();
+    insert_test_card_with_evidence(&home, "card_default_off", "drawer_default_off_evidence");
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("proposal_default_off_{i}"));
+    }
+    let proposal = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-proposal",
+            "card-context",
+            "--rollback-criterion",
+            "rollback on contradiction or user-visible degradation",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        proposal.status.success(),
+        "proposal failed: {}",
+        String::from_utf8_lossy(&proposal.stderr)
+    );
+
+    let query = "card-aware";
+    let (endpoint, handle) = start_openai_embedding_stub(query);
+    write_cli_api_config(&home, &endpoint);
+    let context = run_mempal(&home, &["context", query, "--format", "json"]);
+    assert!(
+        context.status.success(),
+        "context failed: {}",
+        String::from_utf8_lossy(&context.stderr)
+    );
+    handle.join().expect("join embedding stub");
+    let context: Value = serde_json::from_slice(&context.stdout).expect("context json");
+    let has_card = context["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .any(|item| item["card_id"] == "card_default_off");
+    assert!(!has_card, "cards should remain opt-in by default");
+}
+
+#[test]
+fn test_cli_phase3_default_proposal_rejects_unknown_candidate() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "default-proposal", "unknown", "--format", "json"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 default proposal candidate"));
 }
 
 #[test]

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -617,6 +617,160 @@ fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_record_checked_writes_ready_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "runtime_adoption",
+            "--signal",
+            "accepted",
+            "--feature",
+            "context_pack",
+            "--query",
+            "skill trigger",
+            "--note",
+            "context guidance helped",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["blocked"], false);
+    assert_eq!(report["record_quality"]["quality"], "ready");
+    assert!(report["event"]["id"].as_str().expect("event id").len() > 8);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_blocks_warning_by_default() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["blocked"], true);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert!(report.get("event").is_none() || report["event"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_allow_warnings_writes_warning_event() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--allow-warnings",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["blocked"], false);
+    assert_eq!(report["record_quality"]["quality"], "warning");
+    assert!(report["event"]["id"].as_str().expect("event id").len() > 8);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn test_cli_phase3_adoption_record_checked_blocks_invalid_even_with_allow_warnings() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "   ",
+            "--allow-warnings",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "record-checked should return blocked JSON: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("checked record json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["blocked"], true);
+    assert_eq!(report["record_quality"]["quality"], "invalid");
+    assert!(report.get("event").is_none() || report["event"].is_null());
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_adoption_review_json_summarizes_events() {
     let home = setup_cli_home();
     for (id, signal) in [

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -3,7 +3,8 @@ use std::process::Command;
 
 use mempal::core::db::Database;
 use mempal::core::types::{
-    RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
+    MemoryKind, Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+    RuntimeAdoptionTrack,
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -883,4 +884,213 @@ fn test_cli_phase3_research_validate_plan_reports_missing_fields() {
     assert!(stdout.contains("valid=false"));
     assert!(stdout.contains("error=report_id is required"));
     assert!(stdout.contains("error=sources must contain at least one item"));
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_dry_run_json_no_write() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_001",
+            "title": "Agent self-evolution research",
+            "sources": [{"id": "src_1", "url": "https://example.invalid/research"}],
+            "findings": [{"summary": "Research findings must enter memory as evidence first."}],
+            "candidate_insights": [{"statement": "Research output should be distilled only from evidence refs."}]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "research-ingest-plan failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("ingest plan json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["planned_evidence_count"], 1);
+    assert_eq!(report["candidate_insight_count"], 1);
+    assert_eq!(
+        report["evidence_drawers"]
+            .as_array()
+            .expect("drawers")
+            .len(),
+        1
+    );
+    assert_eq!(
+        report["candidate_insights"]
+            .as_array()
+            .expect("insights")
+            .len(),
+        1
+    );
+    assert_eq!(
+        report["candidate_insights"][0]["suggested_command"][0],
+        "mempal"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 0);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_execute_writes_research_evidence() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_002",
+            "title": "Research adapter evidence",
+            "sources": [{"id": "src_1", "url": "https://example.invalid/a"}],
+            "findings": [
+                {"summary": "First finding becomes research evidence."},
+                {"summary": "Second finding becomes research evidence."}
+            ],
+            "candidate_insights": []
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "research-ingest-plan execute failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("ingest plan json");
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["writes"], true);
+    assert_eq!(report["created_count"], 2);
+    assert_eq!(report["skipped_count"], 0);
+    let drawers = report["evidence_drawers"].as_array().expect("drawers");
+    assert_eq!(drawers.len(), 2);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 2);
+    for drawer in drawers {
+        let drawer_id = drawer["drawer_id"].as_str().expect("drawer id");
+        let stored = db
+            .get_drawer(drawer_id)
+            .expect("load drawer")
+            .expect("drawer exists");
+        assert_eq!(stored.memory_kind, MemoryKind::Evidence);
+        assert_eq!(stored.provenance, Some(Provenance::Research));
+        assert!(stored.tier.is_none());
+        assert!(stored.status.is_none());
+    }
+
+    let second = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        second.status.success(),
+        "second execute failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_report: Value = serde_json::from_slice(&second.stdout).expect("second json");
+    assert_eq!(second_report["created_count"], 0);
+    assert_eq!(second_report["skipped_count"], 2);
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 2);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_invalid_report_no_write() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("bad-research-report.json");
+    fs::write(&report_path, "{}").expect("write bad report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "invalid ingest plan should report invalid input without failing: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("invalid json");
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["writes"], false);
+    assert!(
+        report["errors"]
+            .as_array()
+            .expect("errors")
+            .iter()
+            .any(|error| error.as_str().expect("error") == "report_id is required")
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 0);
+}
+
+#[test]
+fn test_cli_phase3_research_ingest_plan_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p67_003",
+            "title": "Research adapter evidence",
+            "sources": [{"url": "https://example.invalid/a"}],
+            "findings": [{"summary": "Finding."}]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--format",
+            "yaml",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 research ingest format"));
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -450,6 +450,156 @@ fn test_cli_phase3_adoption_check_record_rejects_empty_feature() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_review_json_summarizes_events() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("review_accept_1", "accepted"),
+        ("review_accept_2", "accepted"),
+        ("review_reject_1", "rejected"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "card_context",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["total"], 3);
+    assert_eq!(report["stats"]["accepted"], 2);
+    assert_eq!(report["stats"]["rejected"], 1);
+    assert_eq!(report["features"][0]["feature"], "include_cards");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
+fn test_cli_phase3_adoption_review_json_filters_signal() {
+    let home = setup_cli_home();
+    for (id, signal) in [
+        ("review_accept_1", "accepted"),
+        ("review_accept_2", "accepted"),
+        ("review_reject_1", "rejected"),
+    ] {
+        let output = run_mempal(
+            &home,
+            &[
+                "phase3",
+                "adoption",
+                "record",
+                "--id",
+                id,
+                "--track",
+                "card_context",
+                "--signal",
+                signal,
+                "--feature",
+                "include_cards",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "record failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["total"], 2);
+    assert_eq!(report["stats"]["accepted"], 2);
+    assert_eq!(report["stats"]["rejected"], 0);
+}
+
+#[test]
+fn test_cli_phase3_adoption_review_json_no_evidence_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "adoption",
+            "review",
+            "--track",
+            "evaluator",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("review json");
+    assert_eq!(report["writes"], false);
+    assert_eq!(report["total"], 0);
+    assert_eq!(report["conclusion"], "no_evidence");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -127,6 +127,99 @@ fn test_cli_phase3_adoption_record_stats_and_gate() {
 }
 
 #[test]
+fn test_cli_phase3_adoption_guidance_json_is_read_only() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "guidance", "--format", "json"],
+    );
+    assert!(
+        output.status.success(),
+        "guidance failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let guidance: Value = serde_json::from_slice(&output.stdout).expect("guidance json");
+    assert_eq!(guidance["version"], 1);
+    assert_eq!(
+        guidance["recording_rule"],
+        "record only concrete runtime outcomes, not speculation"
+    );
+    let required_fields = guidance["required_fields"]
+        .as_array()
+        .expect("required fields");
+    assert!(required_fields.iter().any(|field| field == "track"));
+    assert!(required_fields.iter().any(|field| field == "signal"));
+    assert!(required_fields.iter().any(|field| field == "feature"));
+    assert!(
+        guidance["signals"]
+            .as_array()
+            .expect("signals")
+            .iter()
+            .any(|signal| signal["signal"] == "used"
+                && signal["when"]
+                    .as_str()
+                    .expect("when")
+                    .contains("actually consumed"))
+    );
+    assert!(
+        guidance["signals"]
+            .as_array()
+            .expect("signals")
+            .iter()
+            .any(|signal| signal["signal"] == "rollback"
+                && signal["when"].as_str().expect("when").contains("reverted"))
+    );
+    assert!(
+        guidance["tracks"]
+            .as_array()
+            .expect("tracks")
+            .iter()
+            .any(|track| track["track"] == "card_context"
+                && track["feature_examples"]
+                    .as_array()
+                    .expect("feature examples")
+                    .iter()
+                    .any(|feature| feature == "include_cards"))
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
+}
+
+#[test]
+fn test_cli_phase3_adoption_guidance_plain() {
+    let home = setup_cli_home();
+    let output = run_mempal(&home, &["phase3", "adoption", "guidance"]);
+    assert!(
+        output.status.success(),
+        "guidance failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("version=1"));
+    assert!(
+        stdout.contains("recording_rule=record only concrete runtime outcomes, not speculation")
+    );
+    assert!(stdout.contains("signal=used"));
+    assert!(stdout.contains("track=card_context"));
+}
+
+#[test]
+fn test_cli_phase3_adoption_guidance_rejects_invalid_format() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &["phase3", "adoption", "guidance", "--format", "yaml"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 adoption format"));
+}
+
+#[test]
 fn test_cli_phase3_gate_blocks_card_embeddings_without_miss_evidence() {
     let home = setup_cli_home();
     let gate = run_mempal(

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -181,6 +181,12 @@ fn write_cli_api_config(home: &TempDir, endpoint: &str) {
     .expect("write config");
 }
 
+fn read_include_cards_default(home: &TempDir) -> bool {
+    let config = mempal::core::config::Config::load_from(&home.path().join(".mempal/config.toml"))
+        .expect("load config");
+    config.context.include_cards_default
+}
+
 #[test]
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
@@ -526,6 +532,145 @@ fn test_cli_phase3_default_proposal_rejects_unknown_candidate() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unsupported phase3 default proposal candidate"));
+}
+
+#[test]
+fn test_cli_phase3_default_control_enable_requires_ready_proposal() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], false);
+    assert_eq!(report["include_cards_default"], false);
+    assert!(!read_include_cards_default(&home));
+
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("control_accept_{i}"));
+    }
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control enable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], true);
+    assert_eq!(report["include_cards_default"], true);
+    assert!(read_include_cards_default(&home));
+}
+
+#[test]
+fn test_cli_phase3_default_control_enable_writes_config_file_output() {
+    let home = setup_cli_home();
+    for i in 0..3 {
+        record_card_context_acceptance(&home, &format!("control_file_accept_{i}"));
+    }
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control enable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let contents =
+        fs::read_to_string(home.path().join(".mempal/config.toml")).expect("read config");
+    assert!(contents.contains("include_cards_default = true"));
+}
+
+#[test]
+fn test_cli_phase3_default_control_rejects_unknown_candidate_without_config_write() {
+    let home = setup_cli_home();
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "unknown",
+            "--enable",
+            "--rollback-criterion",
+            "disable if rollbacks appear",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unsupported phase3 default-control candidate"));
+    assert!(!home.path().join(".mempal/config.toml").exists());
+}
+
+#[test]
+fn test_cli_phase3_default_control_disable_is_reversible() {
+    let home = setup_cli_home();
+    fs::write(
+        home.path().join(".mempal/config.toml"),
+        "[context]\ninclude_cards_default = true\n",
+    )
+    .expect("write config");
+    let output = run_mempal(
+        &home,
+        &[
+            "phase3",
+            "default-control",
+            "card-context",
+            "--disable",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "default control disable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("control json");
+    assert_eq!(report["applied"], true);
+    assert_eq!(report["include_cards_default"], false);
+    assert!(!read_include_cards_default(&home));
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("list events");
+    assert!(events.is_empty());
 }
 
 #[test]

--- a/tests/phase3_self_evolution_replay.rs
+++ b/tests/phase3_self_evolution_replay.rs
@@ -1,0 +1,408 @@
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::thread;
+
+use mempal::core::db::Database;
+use mempal::core::types::{
+    KnowledgeCardFilter, KnowledgeEvidenceRole, KnowledgeStatus, MemoryKind, RuntimeAdoptionFilter,
+};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_cli_home() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join(".mempal")).expect("create .mempal");
+    tmp
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .env("HOME", home)
+        .args(args)
+        .output()
+        .expect("run mempal")
+}
+
+fn stdout_json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("parse stdout json")
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn vector() -> Vec<f32> {
+    vec![0.25; 384]
+}
+
+fn start_embedding_stub(
+    expected_inputs: usize,
+    expected_fragment: &str,
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding stub");
+    listener
+        .set_nonblocking(true)
+        .expect("set embedding stub nonblocking");
+    let address = listener.local_addr().expect("local addr");
+    let expected_fragment = expected_fragment.to_string();
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = (0..50)
+            .find_map(|_| match listener.accept() {
+                Ok(connection) => Some(connection),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(std::time::Duration::from_millis(100));
+                    None
+                }
+                Err(error) => panic!("accept request: {error}"),
+            })
+            .expect("embedding stub timed out waiting for request");
+        let mut request = [0_u8; 8192];
+        let bytes_read = stream.read(&mut request).expect("read embedding request");
+        assert!(bytes_read > 0, "expected non-empty HTTP request");
+        let request = String::from_utf8_lossy(&request[..bytes_read]);
+        let (headers, body) = request
+            .split_once("\r\n\r\n")
+            .expect("request should contain HTTP headers and JSON body");
+        let request_line = headers.lines().next().expect("request line");
+        assert_eq!(request_line, "POST /v1/embeddings HTTP/1.1");
+
+        let payload: Value = serde_json::from_str(body).expect("parse embedding request body");
+        assert_eq!(payload["model"], "test-model");
+        let input = payload["input"]
+            .as_array()
+            .expect("input should be an array");
+        assert_eq!(input.len(), expected_inputs);
+        assert!(
+            input.iter().any(|value| value
+                .as_str()
+                .is_some_and(|raw| raw.contains(&expected_fragment))),
+            "expected embedding input to contain fragment {expected_fragment:?}, got {input:?}"
+        );
+
+        let body = serde_json::to_string(&json!({
+            "data": input.iter().map(|_| json!({ "embedding": vector() })).collect::<Vec<_>>()
+        }))
+        .expect("serialize response body");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write embedding response");
+    });
+
+    (format!("http://{address}/v1/embeddings"), handle)
+}
+
+fn write_cli_api_config(home: &Path, endpoint: &str) {
+    fs::write(
+        home.join(".mempal").join("config.toml"),
+        format!(
+            "[embed]\nbackend = \"api\"\napi_endpoint = \"{endpoint}\"\napi_model = \"test-model\"\n"
+        ),
+    )
+    .expect("write cli config");
+}
+
+fn run_with_embedding_stub(
+    home: &Path,
+    args: &[&str],
+    expected_inputs: usize,
+    expected_fragment: &str,
+) -> Output {
+    let (endpoint, handle) = start_embedding_stub(expected_inputs, expected_fragment);
+    write_cli_api_config(home, &endpoint);
+    let output = run_mempal(home, args);
+    handle.join().expect("join embedding stub");
+    output
+}
+
+#[test]
+fn test_cli_self_evolution_replay_research_to_context_to_adoption() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("research-report.json");
+    fs::write(
+        &report_path,
+        json!({
+            "report_id": "research_p71_loop",
+            "title": "Self-evolution loop replay",
+            "sources": [{"id": "src_1", "url": "https://example.invalid/p71"}],
+            "findings": [
+                {"summary": "Research findings must enter memory as evidence before runtime adoption."}
+            ],
+            "candidate_insights": [
+                {"statement": "Research-backed tool guidance should be promoted only through evidence gates."}
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write report");
+
+    let ingest = run_with_embedding_stub(
+        home.path(),
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+        1,
+        "Research findings must enter memory as evidence before runtime adoption.",
+    );
+    assert!(
+        ingest.status.success(),
+        "ingest failed: {}",
+        stderr_text(&ingest)
+    );
+    let ingest_json = stdout_json(&ingest);
+    assert_eq!(ingest_json["valid"], true);
+    assert_eq!(ingest_json["writes"], true);
+    assert_eq!(ingest_json["created_count"], 1);
+    let evidence_id = ingest_json["evidence_drawers"][0]["drawer_id"]
+        .as_str()
+        .expect("evidence drawer id");
+
+    let statement = "Research-backed tool guidance should be promoted only through evidence gates.";
+    let create = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "create",
+            "--id",
+            "card_p71_loop",
+            "--statement",
+            statement,
+            "--content",
+            "P71 replay card distilled from research evidence.",
+            "--tier",
+            "qi",
+            "--status",
+            "candidate",
+            "--field",
+            "general",
+            "--anchor-kind",
+            "repo",
+            "--anchor-id",
+            "repo://legacy",
+            "--intent-tag",
+            "research",
+            "--workflow-bias",
+            "evidence-gate",
+            "--tool-need",
+            "mempal",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        create.status.success(),
+        "card create failed: {}",
+        stderr_text(&create)
+    );
+    assert_eq!(stdout_json(&create)["status"], "candidate");
+
+    let link = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "link",
+            "card_p71_loop",
+            evidence_id,
+            "--role",
+            "supporting",
+        ],
+    );
+    assert!(
+        link.status.success(),
+        "card link failed: {}",
+        stderr_text(&link)
+    );
+
+    let promote = run_mempal(
+        home.path(),
+        &[
+            "knowledge-card",
+            "promote",
+            "card_p71_loop",
+            "--status",
+            "promoted",
+            "--verification-ref",
+            evidence_id,
+            "--reason",
+            "P71 replay verified the research-backed card.",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        promote.status.success(),
+        "card promote failed: {}",
+        stderr_text(&promote)
+    );
+    let promote_json = stdout_json(&promote);
+    assert_eq!(promote_json["old_status"], "candidate");
+    assert_eq!(promote_json["new_status"], "promoted");
+    assert_eq!(promote_json["gate"]["allowed"], true);
+
+    let context = run_with_embedding_stub(
+        home.path(),
+        &[
+            "context",
+            "research-backed tool guidance",
+            "--include-cards",
+            "--format",
+            "json",
+        ],
+        1,
+        "research-backed tool guidance",
+    );
+    assert!(
+        context.status.success(),
+        "context failed: {}",
+        stderr_text(&context)
+    );
+    let context_json = stdout_json(&context);
+    let items = context_json["sections"]
+        .as_array()
+        .expect("sections")
+        .iter()
+        .flat_map(|section| section["items"].as_array().expect("items"))
+        .collect::<Vec<_>>();
+    let card_item = items
+        .iter()
+        .find(|item| item["card_id"] == "card_p71_loop")
+        .expect("context contains promoted card");
+    assert_eq!(card_item["text"], statement);
+    assert!(
+        card_item["evidence_citations"]
+            .as_array()
+            .expect("citations")
+            .iter()
+            .any(|citation| citation["evidence_drawer_id"] == evidence_id
+                && citation["role"] == "supporting")
+    );
+
+    let adoption = run_mempal(
+        home.path(),
+        &[
+            "phase3",
+            "adoption",
+            "record-checked",
+            "--track",
+            "card_context",
+            "--signal",
+            "accepted",
+            "--feature",
+            "include_cards",
+            "--query",
+            "research-backed tool guidance",
+            "--card-id",
+            "card_p71_loop",
+            "--research-report-id",
+            "research_p71_loop",
+            "--note",
+            "P71 replay context returned the promoted research-backed card.",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        adoption.status.success(),
+        "record-checked failed: {}",
+        stderr_text(&adoption)
+    );
+    let adoption_json = stdout_json(&adoption);
+    assert_eq!(adoption_json["writes"], true);
+    assert_eq!(adoption_json["blocked"], false);
+    assert_eq!(adoption_json["record_quality"]["quality"], "ready");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let evidence = db
+        .get_drawer(evidence_id)
+        .expect("load evidence")
+        .expect("evidence exists");
+    assert_eq!(evidence.memory_kind, MemoryKind::Evidence);
+    let card = db
+        .get_knowledge_card("card_p71_loop")
+        .expect("load card")
+        .expect("card exists");
+    assert_eq!(card.status, KnowledgeStatus::Promoted);
+    let links = db
+        .knowledge_evidence_links("card_p71_loop")
+        .expect("card links");
+    assert!(
+        links
+            .iter()
+            .any(|link| link.evidence_drawer_id == evidence_id
+                && link.role == KnowledgeEvidenceRole::Supporting)
+    );
+    assert!(
+        links
+            .iter()
+            .any(|link| link.evidence_drawer_id == evidence_id
+                && link.role == KnowledgeEvidenceRole::Verification)
+    );
+    assert_eq!(
+        db.knowledge_events("card_p71_loop")
+            .expect("card events")
+            .len(),
+        1
+    );
+    let adoption_events = db
+        .list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+        .expect("adoption events");
+    assert_eq!(adoption_events.len(), 1);
+    assert_eq!(adoption_events[0].feature, "include_cards");
+}
+
+#[test]
+fn test_cli_self_evolution_replay_invalid_research_no_artifacts() {
+    let home = setup_cli_home();
+    let report_path = home.path().join("bad-research-report.json");
+    fs::write(&report_path, "{}").expect("write invalid report");
+
+    let output = run_mempal(
+        home.path(),
+        &[
+            "phase3",
+            "research-ingest-plan",
+            report_path.to_str().expect("report path"),
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "invalid plan should return a report: {}",
+        stderr_text(&output)
+    );
+    let report = stdout_json(&output);
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["writes"], false);
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert_eq!(db.top_drawers(10).expect("drawers").len(), 0);
+    assert!(
+        db.list_knowledge_cards(&KnowledgeCardFilter::default())
+            .expect("cards")
+            .is_empty()
+    );
+    assert!(
+        db.list_runtime_adoption_events(&RuntimeAdoptionFilter::default(), 10)
+            .expect("adoption events")
+            .is_empty()
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "e8ae1e6f202f5cf413a0f7dcfb1df45c3ddae5ef"
+commit = "b17cd2939d599c692336ad02357afe53d7723344"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Merges 25 upstream commits (P52-P81): Phase-3 runtime adoption evidence, evaluator advisory API, card-context default proposal/rollback, research adapter ingest, self-evolution audit
- Adds `mempal_phase3` MCP tool (~750 lines) + 7 Phase3 adoption CLI subcommands + `--no-include-cards` flag
- Fork-only code preserved: all fork-ext specs, hermes-agent-plugin, scripts, hooks, decay, compaction, intelligence modes, sleep cycle

## Conflict resolution
| File | Strategy |
|------|----------|
| AGENTS.md/CLAUDE.md | Excluded (fork uses local symlinks) |
| config.rs | Kept fork + added `include_cards_default`, `save_to/save_default` |
| main.rs | Kept fork + added all Phase3 CLI commands |
| server.rs | Kept fork + added `mempal_phase3` MCP tool + 11 helpers |
| protocol.rs | Merged fork rules (17-18) + upstream rule (19) |
| phase3_runtime.rs | Adapted types to fork (SourceType, Drawer, KnowledgeCard fields, embed dim) |

## Test plan
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — zero issues
- [x] `cargo fmt --check` — clean
- [x] `cargo test --test phase3_runtime` — 55/55 pass
- [x] `cargo test --test context_assembler` — 23/23 pass
- [x] `cargo test` — 297 unit tests pass
- [ ] CSA review skipped: diff too large (10K+ lines) for CSA session (turn_count=0, signal killed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)