### PR TITLE
feat(fts): CJK tokenization for BM25/FTS5 with jieba segmentation

### DIFF
--- a/src/aaak/codec.rs
+++ b/src/aaak/codec.rs
@@ -9,6 +9,14 @@ fn jieba() -> &'static Jieba {
     INSTANCE.get_or_init(Jieba::new)
 }
 
+pub fn jieba_cut_for_search(text: &str) -> Vec<String> {
+    jieba()
+        .cut_for_search(text, true)
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
 use super::model::{
     AaakDocument, AaakHeader, AaakLine, AaakMeta, EncodeOutput, EncodeReport, RoundtripReport,
     Zettel,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -39,7 +39,7 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-const CURRENT_SCHEMA_VERSION: u32 = 16;
+const CURRENT_SCHEMA_VERSION: u32 = 17;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
@@ -399,6 +399,19 @@ impl Database {
                 valid_until,
             ],
         )?;
+
+        if self.table_exists("drawers_fts")? {
+            let rowid: i64 = self.conn.query_row(
+                "SELECT rowid FROM drawers WHERE id = ?1",
+                [drawer.id.as_str()],
+                |row| row.get(0),
+            )?;
+            let tokenized = fts_tokenize_content(&drawer.content);
+            self.conn.execute(
+                "INSERT INTO drawers_fts(rowid, content) VALUES (?1, ?2)",
+                params![rowid, tokenized],
+            )?;
+        }
 
         Ok(())
     }
@@ -1487,9 +1500,10 @@ impl Database {
 
             for (rowid, id, content) in &rows {
                 if fts_exists {
+                    let tokenized = fts_tokenize_content(content);
                     self.conn.execute(
                         "INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', ?1, ?2)",
-                        params![rowid, content],
+                        params![rowid, tokenized],
                     )?;
                 }
                 if vectors_exist {
@@ -1713,9 +1727,10 @@ impl Database {
 
             let fts_exists = self.table_exists("drawers_fts")?;
             if fts_exists {
+                let old_tokenized = fts_tokenize_content(&old_content);
                 self.conn.execute(
                     "INSERT INTO drawers_fts(drawers_fts, rowid, content) VALUES ('delete', ?1, ?2)",
-                    params![target_rowid, old_content],
+                    params![target_rowid, old_tokenized],
                 )?;
             }
 
@@ -1745,9 +1760,10 @@ impl Database {
             }
 
             if fts_exists {
+                let tokenized = fts_tokenize_content(merged_content);
                 self.conn.execute(
                     "INSERT INTO drawers_fts(rowid, content) VALUES (?1, ?2)",
-                    params![target_rowid, merged_content],
+                    params![target_rowid, tokenized],
                 )?;
             }
 
@@ -3936,6 +3952,9 @@ fn apply_migrations(conn: &Connection) -> Result<(), DbError> {
             continue;
         }
         apply_migration_atomic(conn, migration)?;
+        if migration.version == 17 {
+            repopulate_fts_contentless(conn)?;
+        }
     }
 
     if current_version >= 5 {
@@ -3970,6 +3989,23 @@ fn apply_migration_atomic(conn: &Connection, migration: &Migration) -> Result<()
     })() {
         let _ = conn.execute_batch("ROLLBACK;");
         return Err(error);
+    }
+    Ok(())
+}
+
+fn repopulate_fts_contentless(conn: &Connection) -> Result<(), DbError> {
+    let mut stmt = conn.prepare("SELECT rowid, content FROM drawers WHERE deleted_at IS NULL")?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for (rowid, content) in rows {
+        let tokenized = fts_tokenize_content(&content);
+        conn.execute(
+            "INSERT INTO drawers_fts(rowid, content) VALUES (?1, ?2)",
+            params![rowid, tokenized],
+        )?;
     }
     Ok(())
 }
@@ -4900,6 +4936,18 @@ CREATE TABLE IF NOT EXISTS leases (
 );
 CREATE INDEX IF NOT EXISTS idx_leases_expires ON leases(expires_at);
 "#;
+
+const V17_MIGRATION_SQL: &str = r#"
+DROP TRIGGER IF EXISTS drawers_ai;
+DROP TRIGGER IF EXISTS drawers_au_softdelete;
+DROP TABLE IF EXISTS drawers_fts;
+CREATE VIRTUAL TABLE IF NOT EXISTS drawers_fts USING fts5(
+    content,
+    content='drawers',
+    content_rowid='rowid'
+);
+"#;
+
 const V12_COMPACTION_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_drawers_compacted_into
     ON drawers(compacted_into)
@@ -5046,6 +5094,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 16,
             sql: V16_MIGRATION_SQL,
+        },
+        Migration {
+            version: 17,
+            sql: V17_MIGRATION_SQL,
         },
     ];
     MIGRATIONS
@@ -5550,18 +5602,63 @@ fn parse_keywords(raw: Option<&str>) -> Result<Vec<String>, DbError> {
 }
 
 fn build_fts_match_query(query: &str) -> Option<String> {
-    let terms = query
-        .split_whitespace()
-        .map(str::trim)
+    let segments = segment_cjk_query(query);
+    let terms: Vec<String> = segments
+        .iter()
         .filter(|term| !term.is_empty())
         .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
-        .collect::<Vec<_>>();
+        .collect();
 
     if terms.is_empty() {
         None
     } else {
         Some(terms.join(" AND "))
     }
+}
+
+fn fts_tokenize_content(content: &str) -> String {
+    if !contains_cjk(content) {
+        return content.to_string();
+    }
+    crate::aaak::codec::jieba_cut_for_search(content)
+        .into_iter()
+        .filter(|w| !w.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn contains_cjk(s: &str) -> bool {
+    s.chars()
+        .any(|c| matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}' | '\u{F900}'..='\u{FAFF}'))
+}
+
+fn segment_cjk_query(query: &str) -> Vec<String> {
+    let raw_terms: Vec<&str> = query.split_whitespace().collect();
+    let mut result = Vec::new();
+    for term in raw_terms {
+        if contains_cjk(term) {
+            let words: Vec<String> = crate::aaak::codec::jieba_cut_for_search(term)
+                .into_iter()
+                .filter(|w| !w.trim().is_empty())
+                .map(|w| w.to_string())
+                .collect();
+            // Filter out compound words whose characters are fully covered by
+            // shorter segments (cut_for_search emits both sub-words and the
+            // original compound; only sub-words match the tokenized index).
+            for w in &words {
+                let is_compound = w.chars().count() > 1
+                    && words
+                        .iter()
+                        .any(|other| other != w && w.contains(other.as_str()));
+                if !is_compound {
+                    result.push(w.clone());
+                }
+            }
+        } else {
+            result.push(term.to_string());
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -6127,6 +6224,58 @@ mod tests {
         assert_eq!(
             repaired.6.as_deref(),
             Some(blake3::hash(b"legacy body").to_hex().to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn cjk_segmentation_splits_chinese_query() {
+        let segments = segment_cjk_query("记忆系统设计");
+        assert!(
+            segments.len() > 1,
+            "should split CJK into multiple words: {:?}",
+            segments
+        );
+    }
+
+    #[test]
+    fn cjk_segmentation_preserves_english() {
+        let segments = segment_cjk_query("hello world");
+        assert_eq!(segments, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn cjk_segmentation_handles_mixed() {
+        let segments = segment_cjk_query("mempal 记忆系统 design");
+        assert!(segments.contains(&"mempal".to_string()));
+        assert!(segments.contains(&"design".to_string()));
+        assert!(
+            segments.len() > 3,
+            "CJK part should be split: {:?}",
+            segments
+        );
+    }
+
+    #[test]
+    fn build_fts_match_query_segments_cjk() {
+        let query = build_fts_match_query("记忆系统").unwrap();
+        assert!(
+            query.contains("AND"),
+            "CJK query should have multiple terms: {}",
+            query
+        );
+    }
+
+    #[test]
+    fn fts_chinese_content_matches_segmented_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("test.db")).unwrap();
+        insert_test_drawer(&db, "zh1", "这是一个记忆系统的设计方案", None);
+        let results = db
+            .search_fts("记忆系统", None, None, "all", None, 10)
+            .unwrap();
+        assert!(
+            !results.is_empty(),
+            "CJK search should find Chinese content"
         );
     }
 }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -624,6 +624,6 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 16);
+        assert_eq!(db.schema_version().expect("schema version"), 17);
     }
 }

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -1122,10 +1122,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 16);
+    assert_eq!(db.schema_version().expect("schema"), 17);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 16);
+    assert_eq!(db.schema_version().expect("schema"), 17);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -259,10 +259,10 @@ fn insert_event(
 }
 
 #[test]
-fn test_new_database_schema_version_is_16() {
+fn test_new_database_schema_version_is_17() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
     for table in [
         "knowledge_cards",
         "knowledge_evidence_links",
@@ -291,7 +291,7 @@ fn test_migration_v7_to_v10_adds_phase2_phase3_and_validity_without_data_loss() 
 
     let db = Database::open(&db_path).expect("migrate v7 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let taxonomy_count: i64 = db

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -562,7 +562,7 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
 
     let drawer = db
         .get_drawer("drawer_legacy_001")

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -245,7 +245,7 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -233,7 +233,7 @@ fn read_include_cards_default(home: &TempDir) -> bool {
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
 
     let event = RuntimeAdoptionEvent {
         id: "adoption_test".to_string(),

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -293,7 +293,7 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -203,7 +203,7 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 16);
+    assert_eq!(db.schema_version().expect("schema version"), 17);
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "2989bdf0e23371b0bef2b834220f5eb96513b02c"
+commit = "80bd6f0ecadb1b689d1a121bfe7ae3a53249a780"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- V17 migration rebuilds FTS5 table as content-synced (no triggers), repopulates with jieba-segmented content on upgrade
- `segment_cjk_query` filters compound words from `cut_for_search` output so only atomic tokens match the index
- FTS delete operations now consistently tokenize content before removal
- Memory lease mechanism for multi-agent coordination (V16 migration)

## Migration
- Automatic: V16 adds leases table, V17 rebuilds FTS index with CJK tokenization
- Existing data repopulated automatically during schema upgrade
- No manual intervention required

## Test plan
- [x] All 1038 tests pass (303 lib + 735 integration)
- [x] Clippy clean, rustfmt clean
- [x] CJK segmentation unit tests (splits, preserves English, handles mixed)
- [x] FTS5 end-to-end test with Chinese content + segmented query
- [x] CSA full-diff review: PASS/CLEAN (session 01KRVFBY6T21W1BJBZH15YTBXX)

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)