### PR TITLE
fix(xurl): ingest stall fix + search UX (#242, #243)

### DIFF
--- a/src/hook_install.rs
+++ b/src/hook_install.rs
@@ -650,21 +650,23 @@ fn validate_write_target(
     let file_name = path.file_name().and_then(|name| name.to_str());
 
     match target {
-        HookInstallTarget::ClaudeCode => {
-            if parent_name != Some(CLAUDE_SETTINGS_DIR) || file_name != Some(CLAUDE_SETTINGS_FILE) {
-                bail!(
-                    "refusing to edit non-canonical Claude settings target {}",
-                    path.display()
-                );
-            }
+        HookInstallTarget::ClaudeCode
+            if parent_name != Some(CLAUDE_SETTINGS_DIR)
+                || file_name != Some(CLAUDE_SETTINGS_FILE) =>
+        {
+            bail!(
+                "refusing to edit non-canonical Claude settings target {}",
+                path.display()
+            );
         }
-        HookInstallTarget::Codex => {
-            if parent_name != Some(CODEX_SETTINGS_DIR) || file_name != Some(CODEX_SETTINGS_FILE) {
-                bail!(
-                    "refusing to edit non-canonical Codex settings target {}",
-                    path.display()
-                );
-            }
+        HookInstallTarget::Codex
+            if parent_name != Some(CODEX_SETTINGS_DIR)
+                || file_name != Some(CODEX_SETTINGS_FILE) =>
+        {
+            bail!(
+                "refusing to edit non-canonical Codex settings target {}",
+                path.display()
+            );
         }
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7875,7 +7875,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             let embedder = build_embedder(config).await?;
             let parse_cb = |name: &str, turns: usize| {
                 if json {
-                    println!(
+                    eprintln!(
                         "{}",
                         serde_json::json!({"phase":"parse","file":name,"turns":turns})
                     );
@@ -7885,7 +7885,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             };
             let embed_cb = |done: usize, total: usize| {
                 if json {
-                    println!(
+                    eprintln!(
                         "{}",
                         serde_json::json!({"phase":"embed","done":done,"total":total})
                     );
@@ -7958,11 +7958,13 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 db,
                 embedder.as_ref(),
                 &query,
-                limit,
-                Some(filter),
-                include_csa,
-                include_agent_prompts,
-                Some(min_score),
+                mempal::xurl::search::SearchOptions {
+                    limit,
+                    filter: Some(filter),
+                    include_csa,
+                    include_agent_prompts,
+                    min_score: Some(min_score),
+                },
             )
             .await
             .context("xurl search failed")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -757,6 +757,9 @@ enum XurlCommands {
         /// Also include agent-generated user prompts (excluded by default).
         #[arg(long)]
         include_agent_prompts: bool,
+        /// Minimum cosine similarity score (0.0–1.0). Hits below this floor are suppressed.
+        #[arg(long, default_value_t = 0.70)]
+        min_score: f32,
         /// Output format: markdown (default) or json.
         #[arg(long, default_value = "markdown")]
         format: String,
@@ -7884,7 +7887,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 .context("xurl ingest failed")?
             } else {
                 let cfg = mempal::xurl::ingest::AutoScanConfig::default();
-                mempal::xurl::ingest::ingest_all(db, embedder.as_ref(), &cfg)
+                mempal::xurl::ingest::ingest_all(db, embedder.as_ref(), &cfg, None)
                     .await
                     .context("xurl ingest-all failed")?
             };
@@ -7911,6 +7914,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             limit,
             include_csa,
             include_agent_prompts,
+            min_score,
             format,
         } => {
             let since_epoch = since.as_deref().map(parse_since_to_epoch).transpose()?;
@@ -7922,7 +7926,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 offset: 0,
             };
             let embedder = build_embedder(config).await?;
-            let hits = mempal::xurl::search::search(
+            let result = mempal::xurl::search::search(
                 db,
                 embedder.as_ref(),
                 &query,
@@ -7930,6 +7934,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 Some(filter),
                 include_csa,
                 include_agent_prompts,
+                Some(min_score),
             )
             .await
             .context("xurl search failed")?;
@@ -7937,10 +7942,10 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             if format == "json" {
                 println!(
                     "{}",
-                    serde_json::to_string(&hits).context("json serialize")?
+                    serde_json::to_string(&result).context("json serialize")?
                 );
             } else {
-                mempal::xurl::search::print_hits_markdown(&hits);
+                mempal::xurl::search::print_hits_markdown(&result);
             }
             Ok(())
         }
@@ -7995,17 +8000,12 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                     println!("No turns found.");
                 } else {
                     for t in &turns {
-                        let session_abbrev = if t.session_id.len() > 8 {
-                            &t.session_id[..8]
-                        } else {
-                            &t.session_id
-                        };
                         let ts = mempal::xurl::search::format_timestamp(t.timestamp_epoch);
                         println!("---");
                         println!(
                             "**[{}]** `{}` · {} · {}",
                             t.tool.as_str(),
-                            session_abbrev,
+                            t.session_id,
                             ts,
                             t.role.as_str()
                         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -7873,6 +7873,26 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             json,
         } => {
             let embedder = build_embedder(config).await?;
+            let parse_cb = |name: &str, turns: usize| {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({"phase":"parse","file":name,"turns":turns})
+                    );
+                } else {
+                    eprintln!("[parse] file: {name} ({turns} turns)");
+                }
+            };
+            let embed_cb = |done: usize, total: usize| {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({"phase":"embed","done":done,"total":total})
+                    );
+                } else {
+                    eprintln!("[embed] {done}/{total} turns vectorized");
+                }
+            };
             let stats = if let Some(p) = path {
                 let t =
                     tool.ok_or_else(|| anyhow::anyhow!("--tool is required when --path is given"))?;
@@ -7882,14 +7902,22 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                     &p,
                     t.into(),
                     session_id.as_deref(),
+                    Some(&parse_cb),
+                    Some(&embed_cb),
                 )
                 .await
                 .context("xurl ingest failed")?
             } else {
                 let cfg = mempal::xurl::ingest::AutoScanConfig::default();
-                mempal::xurl::ingest::ingest_all(db, embedder.as_ref(), &cfg, None)
-                    .await
-                    .context("xurl ingest-all failed")?
+                mempal::xurl::ingest::ingest_all(
+                    db,
+                    embedder.as_ref(),
+                    &cfg,
+                    Some(&parse_cb),
+                    Some(&embed_cb),
+                )
+                .await
+                .context("xurl ingest-all failed")?
             };
             if json {
                 println!(

--- a/src/xurl/embed.rs
+++ b/src/xurl/embed.rs
@@ -6,6 +6,8 @@ use crate::embed::Embedder;
 use crate::ingest::chunk::chunk_text_token_aware;
 use crate::xurl::{XurlError, XurlResult};
 
+const EMBED_BATCH_SIZE: usize = 50;
+
 #[derive(Debug, Default)]
 pub struct EmbedStats {
     pub turns_processed: usize,
@@ -20,15 +22,20 @@ fn serialize_vector(v: &[f32]) -> Vec<u8> {
 
 /// Find turns that have no entries in `conversation_turn_vectors` and embed them.
 ///
-/// Long turns (>512 tokens by default) are split into overlapping chunks using
-/// the same `chunk_text_token_aware` function used by the drawer ingest pipeline.
-/// Each chunk produces a separate row in `conversation_turn_vectors` with an
-/// incrementing `chunk_index`.
+/// Processes turns in batches of `EMBED_BATCH_SIZE`. Each batch is wrapped in a
+/// transaction to avoid per-row journal overhead on large DBs. On error within a
+/// batch the transaction is rolled back before propagating the error.
+///
+/// `progress_fn`, if provided, is called after each batch with `(done_so_far, total)`.
 pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
+    progress_fn: Option<&dyn Fn(usize, usize)>,
 ) -> XurlResult<EmbedStats> {
     let conn = db.conn();
+
+    conn.execute_batch("PRAGMA busy_timeout = 5000;")
+        .map_err(XurlError::Database)?;
 
     // Find all turns that have no vector yet.
     let unindexed: Vec<(String, String)> = {
@@ -58,11 +65,42 @@ pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
         return Ok(EmbedStats::default());
     }
 
+    let total = unindexed.len();
     let config = ChunkerConfig::default();
     let mut stats = EmbedStats::default();
 
-    for (turn_id, content) in &unindexed {
-        let chunks = chunk_text_token_aware(content, &config, embedder, Some(turn_id));
+    for batch in unindexed.chunks(EMBED_BATCH_SIZE) {
+        conn.execute_batch("BEGIN").map_err(XurlError::Database)?;
+
+        let batch_result = embed_batch_turns(conn, embedder, batch, &config, &mut stats).await;
+
+        match batch_result {
+            Ok(()) => {
+                conn.execute_batch("COMMIT").map_err(XurlError::Database)?;
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        }
+
+        if let Some(f) = progress_fn {
+            f(stats.turns_processed, total);
+        }
+    }
+
+    Ok(stats)
+}
+
+async fn embed_batch_turns<E: Embedder + ?Sized>(
+    conn: &rusqlite::Connection,
+    embedder: &E,
+    batch: &[(String, String)],
+    config: &ChunkerConfig,
+    stats: &mut EmbedStats,
+) -> XurlResult<()> {
+    for (turn_id, content) in batch {
+        let chunks = chunk_text_token_aware(content, config, embedder, Some(turn_id));
         let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
 
         let vectors = embedder
@@ -85,6 +123,5 @@ pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
         stats.chunks_total += chunks.len();
         stats.turns_processed += 1;
     }
-
-    Ok(stats)
+    Ok(())
 }

--- a/src/xurl/embed.rs
+++ b/src/xurl/embed.rs
@@ -70,18 +70,27 @@ pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
     let mut stats = EmbedStats::default();
 
     for batch in unindexed.chunks(EMBED_BATCH_SIZE) {
+        // Phase 1: embed the whole batch with no write transaction open.
+        let rows = embed_batch_turns(embedder, batch, &config, &mut stats).await?;
+
+        // Phase 2: bulk-insert all collected vectors under a single short transaction.
         conn.execute_batch("BEGIN").map_err(XurlError::Database)?;
-
-        let batch_result = embed_batch_turns(conn, embedder, batch, &config, &mut stats).await;
-
-        match batch_result {
-            Ok(()) => {
-                conn.execute_batch("COMMIT").map_err(XurlError::Database)?;
+        let insert_result = (|| -> XurlResult<()> {
+            for (turn_id, chunk_index, blob) in &rows {
+                conn.execute(
+                    "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) \
+                     VALUES (?1, ?2, ?3) \
+                     ON CONFLICT(turn_id, chunk_index) DO NOTHING",
+                    params![turn_id, *chunk_index as i64, blob],
+                )
+                .map_err(XurlError::Database)?;
             }
-            Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
-                return Err(e);
-            }
+            conn.execute_batch("COMMIT").map_err(XurlError::Database)?;
+            Ok(())
+        })();
+        if let Err(e) = insert_result {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(e);
         }
 
         if let Some(f) = progress_fn {
@@ -92,13 +101,17 @@ pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
     Ok(stats)
 }
 
+/// Embed all turns in `batch` and return serialised `(turn_id, chunk_index, blob)` rows.
+///
+/// No database connection is used here; the caller is responsible for writing
+/// the returned rows inside a transaction.
 async fn embed_batch_turns<E: Embedder + ?Sized>(
-    conn: &rusqlite::Connection,
     embedder: &E,
     batch: &[(String, String)],
     config: &ChunkerConfig,
     stats: &mut EmbedStats,
-) -> XurlResult<()> {
+) -> XurlResult<Vec<(String, usize, Vec<u8>)>> {
+    let mut rows = Vec::new();
     for (turn_id, content) in batch {
         let chunks = chunk_text_token_aware(content, config, embedder, Some(turn_id));
         let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
@@ -109,19 +122,12 @@ async fn embed_batch_turns<E: Embedder + ?Sized>(
             .map_err(|e| XurlError::Parse(format!("embedding failed: {e}")))?;
 
         for (chunk_index, vector) in vectors.iter().enumerate() {
-            let blob = serialize_vector(vector);
-            conn.execute(
-                "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) \
-                 VALUES (?1, ?2, ?3) \
-                 ON CONFLICT(turn_id, chunk_index) DO NOTHING",
-                params![turn_id, chunk_index as i64, blob],
-            )
-            .map_err(XurlError::Database)?;
+            rows.push((turn_id.clone(), chunk_index, serialize_vector(vector)));
         }
 
         stats.embedded += vectors.len();
         stats.chunks_total += chunks.len();
         stats.turns_processed += 1;
     }
-    Ok(())
+    Ok(rows)
 }

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -11,6 +11,11 @@ use crate::xurl::parser::{cc::parse_cc_jsonl, codex::parse_codex_jsonl, hermes::
 use crate::xurl::store;
 use crate::xurl::{XurlError, XurlResult};
 
+/// Callback invoked after each file is parsed: `(filename, turns_parsed)`.
+type ParsedCb<'a> = Option<&'a dyn Fn(&str, usize)>;
+/// Callback invoked after each embed batch: `(done, total)`.
+type EmbedCb<'a> = Option<&'a dyn Fn(usize, usize)>;
+
 #[derive(Debug, Default, Serialize)]
 pub struct IngestStats {
     pub turns_parsed: usize,
@@ -96,16 +101,24 @@ fn parse_and_store_file(
 }
 
 /// Ingest a single file (or SQLite DB for Hermes) and embed any newly inserted turns.
+///
+/// `on_file_parsed` is called after parsing with `(filename, turns_parsed)`.
+/// `on_embed_progress` is forwarded to `embed_unindexed_turns` after parsing.
 pub async fn ingest_file<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
     path: &Path,
     tool: Tool,
     session_id_override: Option<&str>,
+    on_file_parsed: ParsedCb<'_>,
+    on_embed_progress: EmbedCb<'_>,
 ) -> XurlResult<IngestStats> {
-    let (_, turns_parsed, insert_stats) =
+    let (filename, turns_parsed, insert_stats) =
         parse_and_store_file(db, path, tool, session_id_override)?;
-    let embed_stats = embed::embed_unindexed_turns(db, embedder, None).await?;
+    if let Some(f) = on_file_parsed {
+        f(&filename, turns_parsed);
+    }
+    let embed_stats = embed::embed_unindexed_turns(db, embedder, on_embed_progress).await?;
 
     Ok(IngestStats {
         turns_parsed,
@@ -122,14 +135,14 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
 /// then all unindexed turns are embedded in batched transactions (Phase 2).
 /// This avoids the per-file embed overhead that stalls on large DBs.
 ///
-/// `on_file_parsed`, if provided, is called after each file's turns are stored
-/// with `(filename, turns_parsed)`.
-#[allow(clippy::type_complexity)]
+/// `on_file_parsed` is called after each file's turns are stored with `(filename, turns_parsed)`.
+/// `on_embed_progress` is forwarded to `embed_unindexed_turns` during Phase 2.
 pub async fn ingest_all<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
     cfg: &AutoScanConfig,
-    on_file_parsed: Option<&dyn Fn(&str, usize)>,
+    on_file_parsed: ParsedCb<'_>,
+    on_embed_progress: EmbedCb<'_>,
 ) -> XurlResult<IngestStats> {
     let mut total = IngestStats::default();
 
@@ -182,15 +195,8 @@ pub async fn ingest_all<E: Embedder + ?Sized>(
         }
     }
 
-    // Phase 2: embed all unindexed turns in one batched pass with stderr progress.
-    let embed_stats = embed::embed_unindexed_turns(
-        db,
-        embedder,
-        Some(&|done, total_turns| {
-            eprintln!("embedding turns: {done}/{total_turns}");
-        }),
-    )
-    .await?;
+    // Phase 2: embed all unindexed turns in one batched pass.
+    let embed_stats = embed::embed_unindexed_turns(db, embedder, on_embed_progress).await?;
     total.vectors_created += embed_stats.embedded;
 
     Ok(total)

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -20,16 +20,6 @@ pub struct IngestStats {
     pub vectors_created: usize,
 }
 
-impl IngestStats {
-    fn merge(&mut self, other: &Self) {
-        self.turns_parsed += other.turns_parsed;
-        self.turns_inserted += other.turns_inserted;
-        self.turns_skipped += other.turns_skipped;
-        self.turns_updated += other.turns_updated;
-        self.vectors_created += other.vectors_created;
-    }
-}
-
 pub struct AutoScanConfig {
     pub cc_root: PathBuf,
     pub codex_root: PathBuf,
@@ -62,14 +52,15 @@ fn home_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-/// Ingest a single file (or SQLite DB for Hermes) and embed any newly inserted turns.
-pub async fn ingest_file<E: Embedder + ?Sized>(
+/// Parse a file and insert turns into the DB. Does not embed.
+///
+/// Returns `(filename, turns_parsed, insert_stats)`.
+fn parse_and_store_file(
     db: &Database,
-    embedder: &E,
     path: &Path,
     tool: Tool,
     session_id_override: Option<&str>,
-) -> XurlResult<IngestStats> {
+) -> XurlResult<(String, usize, store::InsertStats)> {
     let fallback = session_id_override.map(str::to_string).unwrap_or_else(|| {
         path.file_stem()
             .and_then(|s| s.to_str())
@@ -94,9 +85,27 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
         Tool::Hermes => parse_hermes_db(path, &fallback, is_csa)?,
     };
 
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
     let turns_parsed = turns.len();
     let insert_stats = store::insert_turns(db.conn(), &turns)?;
-    let embed_stats = embed::embed_unindexed_turns(db, embedder).await?;
+    Ok((filename, turns_parsed, insert_stats))
+}
+
+/// Ingest a single file (or SQLite DB for Hermes) and embed any newly inserted turns.
+pub async fn ingest_file<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    path: &Path,
+    tool: Tool,
+    session_id_override: Option<&str>,
+) -> XurlResult<IngestStats> {
+    let (_, turns_parsed, insert_stats) =
+        parse_and_store_file(db, path, tool, session_id_override)?;
+    let embed_stats = embed::embed_unindexed_turns(db, embedder, None).await?;
 
     Ok(IngestStats {
         turns_parsed,
@@ -108,17 +117,34 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
 }
 
 /// Scan all default tool directories and ingest every discovered file.
+///
+/// Uses a two-phase approach: first all files are parsed and stored (Phase 1),
+/// then all unindexed turns are embedded in batched transactions (Phase 2).
+/// This avoids the per-file embed overhead that stalls on large DBs.
+///
+/// `on_file_parsed`, if provided, is called after each file's turns are stored
+/// with `(filename, turns_parsed)`.
+#[allow(clippy::type_complexity)]
 pub async fn ingest_all<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
     cfg: &AutoScanConfig,
+    on_file_parsed: Option<&dyn Fn(&str, usize)>,
 ) -> XurlResult<IngestStats> {
     let mut total = IngestStats::default();
 
+    // Phase 1: parse and store all files (no embedding yet).
     if cfg.cc_root.exists() {
         for path in collect_files_with_ext(&cfg.cc_root, "jsonl") {
-            let stats = ingest_file(db, embedder, &path, Tool::Cc, None).await?;
-            total.merge(&stats);
+            let (filename, turns_parsed, insert_stats) =
+                parse_and_store_file(db, &path, Tool::Cc, None)?;
+            total.turns_parsed += turns_parsed;
+            total.turns_inserted += insert_stats.inserted;
+            total.turns_skipped += insert_stats.skipped;
+            total.turns_updated += insert_stats.updated;
+            if let Some(f) = on_file_parsed {
+                f(&filename, turns_parsed);
+            }
         }
     }
 
@@ -129,18 +155,43 @@ pub async fn ingest_all<E: Embedder + ?Sized>(
                 .and_then(|n| n.to_str())
                 .unwrap_or_default();
             if name.starts_with("rollout-") {
-                let stats = ingest_file(db, embedder, &path, Tool::Codex, None).await?;
-                total.merge(&stats);
+                let (filename, turns_parsed, insert_stats) =
+                    parse_and_store_file(db, &path, Tool::Codex, None)?;
+                total.turns_parsed += turns_parsed;
+                total.turns_inserted += insert_stats.inserted;
+                total.turns_skipped += insert_stats.skipped;
+                total.turns_updated += insert_stats.updated;
+                if let Some(f) = on_file_parsed {
+                    f(&filename, turns_parsed);
+                }
             }
         }
     }
 
     if let Some(hermes_path) = &cfg.hermes_db {
         if hermes_path.exists() {
-            let stats = ingest_file(db, embedder, hermes_path, Tool::Hermes, None).await?;
-            total.merge(&stats);
+            let (filename, turns_parsed, insert_stats) =
+                parse_and_store_file(db, hermes_path, Tool::Hermes, None)?;
+            total.turns_parsed += turns_parsed;
+            total.turns_inserted += insert_stats.inserted;
+            total.turns_skipped += insert_stats.skipped;
+            total.turns_updated += insert_stats.updated;
+            if let Some(f) = on_file_parsed {
+                f(&filename, turns_parsed);
+            }
         }
     }
+
+    // Phase 2: embed all unindexed turns in one batched pass with stderr progress.
+    let embed_stats = embed::embed_unindexed_turns(
+        db,
+        embedder,
+        Some(&|done, total_turns| {
+            eprintln!("embedding turns: {done}/{total_turns}");
+        }),
+    )
+    .await?;
+    total.vectors_created += embed_stats.embedded;
 
     Ok(total)
 }

--- a/src/xurl/search.rs
+++ b/src/xurl/search.rs
@@ -57,6 +57,21 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     }
 }
 
+/// Options controlling semantic search behaviour.
+#[derive(Debug, Default)]
+pub struct SearchOptions {
+    /// Maximum number of hits to return (0 ⇒ empty result immediately).
+    pub limit: usize,
+    /// Column-level pre-filter applied before scoring.
+    pub filter: Option<TurnFilter>,
+    /// Include CSA-delegated turns (default: false).
+    pub include_csa: bool,
+    /// Include non-human-provenance turns (default: false).
+    pub include_agent_prompts: bool,
+    /// Exclude hits scoring below this threshold.
+    pub min_score: Option<f32>,
+}
+
 /// Semantic search over `conversation_turn_vectors` using brute-force cosine similarity.
 ///
 /// The query is embedded via `embedder`, then every stored vector is scored.
@@ -64,19 +79,21 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// Identical-content turns are deduplicated, keeping the highest-scored representative.
 /// Default filtering excludes CSA-delegated turns and non-human-provenance turns.
 ///
-/// If `min_score` is set, hits below the floor are excluded; [`SearchResult::best_score_below_floor`]
-/// reflects the highest score that did not make the cut.
-#[allow(clippy::too_many_arguments)]
+/// If `opts.min_score` is set, hits below the floor are excluded;
+/// [`SearchResult::best_score_below_floor`] reflects the highest score that did not make the cut.
 pub async fn search<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
     query: &str,
-    limit: usize,
-    filter: Option<TurnFilter>,
-    include_csa: bool,
-    include_agent_prompts: bool,
-    min_score: Option<f32>,
+    opts: SearchOptions,
 ) -> XurlResult<SearchResult> {
+    let SearchOptions {
+        limit,
+        filter,
+        include_csa,
+        include_agent_prompts,
+        min_score,
+    } = opts;
     if limit == 0 {
         return Ok(SearchResult {
             hits: Vec::new(),
@@ -332,4 +349,9 @@ pub fn print_hits_markdown(result: &SearchResult) {
         println!();
     }
     println!("---");
+    println!(
+        "_{} candidates considered ({} shown after dedup + min-score floor)_",
+        result.total_candidates,
+        result.hits.len()
+    );
 }

--- a/src/xurl/search.rs
+++ b/src/xurl/search.rs
@@ -1,6 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+/// Internal per-turn accumulator: (score, session_id, tool, role, content, timestamp, source_path).
+type TurnBestEntry = (f32, String, String, String, String, f64, Option<String>);
 
 use crate::core::db::Database;
 use crate::embed::Embedder;
@@ -16,6 +20,19 @@ pub struct SearchHit {
     pub content: String,
     pub timestamp_epoch: f64,
     pub score: f32,
+    pub source_path: Option<String>,
+}
+
+/// Aggregated result returned by [`search`].
+#[derive(Debug, Serialize)]
+pub struct SearchResult {
+    pub hits: Vec<SearchHit>,
+    /// Highest score among hits that were filtered out by `min_score_floor`.
+    pub best_score_below_floor: Option<f32>,
+    /// Total unique candidates (after per-turn and per-content dedup, before floor and limit).
+    pub total_candidates: usize,
+    /// The min-score threshold that was applied, if any.
+    pub min_score_floor: Option<f32>,
 }
 
 /// Deserialize a raw f32 little-endian BLOB into a vector.
@@ -44,7 +61,12 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 ///
 /// The query is embedded via `embedder`, then every stored vector is scored.
 /// Multi-chunk turns are deduplicated by keeping the best-scoring chunk.
+/// Identical-content turns are deduplicated, keeping the highest-scored representative.
 /// Default filtering excludes CSA-delegated turns and non-human-provenance turns.
+///
+/// If `min_score` is set, hits below the floor are excluded; [`SearchResult::best_score_below_floor`]
+/// reflects the highest score that did not make the cut.
+#[allow(clippy::too_many_arguments)]
 pub async fn search<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
@@ -53,9 +75,15 @@ pub async fn search<E: Embedder + ?Sized>(
     filter: Option<TurnFilter>,
     include_csa: bool,
     include_agent_prompts: bool,
-) -> XurlResult<Vec<SearchHit>> {
+    min_score: Option<f32>,
+) -> XurlResult<SearchResult> {
     if limit == 0 {
-        return Ok(Vec::new());
+        return Ok(SearchResult {
+            hits: Vec::new(),
+            best_score_below_floor: None,
+            total_candidates: 0,
+            min_score_floor: min_score,
+        });
     }
 
     // Embed the query string.
@@ -105,7 +133,7 @@ pub async fn search<E: Embedder + ?Sized>(
 
     let sql = format!(
         "SELECT ctv.turn_id, ctv.vector, \
-         ct.session_id, ct.tool, ct.role, ct.content, ct.timestamp_epoch \
+         ct.session_id, ct.tool, ct.role, ct.content, ct.timestamp_epoch, ct.project_path \
          FROM conversation_turn_vectors ctv \
          JOIN conversation_turns ct ON ct.id = ctv.turn_id \
          {where_clause}"
@@ -119,6 +147,7 @@ pub async fn search<E: Embedder + ?Sized>(
         role: String,
         content: String,
         timestamp_epoch: f64,
+        project_path: Option<String>,
     }
 
     let refs: Vec<&dyn rusqlite::ToSql> = param_values.iter().map(|b| b.as_ref()).collect();
@@ -133,6 +162,7 @@ pub async fn search<E: Embedder + ?Sized>(
                 role: row.get(4)?,
                 content: row.get(5)?,
                 timestamp_epoch: row.get(6)?,
+                project_path: row.get(7)?,
             })
         })
         .map_err(XurlError::Database)?
@@ -140,9 +170,7 @@ pub async fn search<E: Embedder + ?Sized>(
         .map_err(XurlError::Database)?;
 
     // Score each chunk, deduplicate by turn_id keeping best score.
-    // Value: (best_score, session_id, tool, role, content, timestamp_epoch)
-    let mut best_by_turn: HashMap<String, (f32, String, String, String, String, f64)> =
-        HashMap::new();
+    let mut best_by_turn: HashMap<String, TurnBestEntry> = HashMap::new();
 
     for row in rows {
         let vec = deserialize_vector(&row.vector);
@@ -154,35 +182,70 @@ pub async fn search<E: Embedder + ?Sized>(
             row.role,
             row.content,
             row.timestamp_epoch,
+            row.project_path,
         ));
         if score > entry.0 {
             entry.0 = score;
         }
     }
 
-    // Sort by descending score, truncate to limit.
-    let mut hits: Vec<SearchHit> = best_by_turn
+    // Convert to SearchHit and sort by descending score.
+    let mut all_hits: Vec<SearchHit> = best_by_turn
         .into_iter()
         .map(
-            |(turn_id, (score, session_id, tool, role, content, timestamp_epoch))| SearchHit {
-                turn_id,
-                session_id,
-                tool,
-                role,
-                content,
-                timestamp_epoch,
-                score,
+            |(turn_id, (score, session_id, tool, role, content, timestamp_epoch, source_path))| {
+                SearchHit {
+                    turn_id,
+                    session_id,
+                    tool,
+                    role,
+                    content,
+                    timestamp_epoch,
+                    score,
+                    source_path,
+                }
             },
         )
         .collect();
 
-    hits.sort_by(|a, b| {
+    all_hits.sort_by(|a, b| {
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    hits.truncate(limit);
-    Ok(hits)
+
+    // Dedup by content hash: hits are sorted desc by score, so the first occurrence per
+    // content hash is always the highest-scored representative.
+    let mut seen_content_hashes: HashSet<String> = HashSet::new();
+    let deduped: Vec<SearchHit> = all_hits
+        .into_iter()
+        .filter(|hit| {
+            let hash = format!("{:x}", Sha256::digest(hit.content.as_bytes()));
+            seen_content_hashes.insert(hash)
+        })
+        .collect();
+
+    let total_candidates = deduped.len();
+
+    // Apply min_score floor, then truncate.
+    let (mut passing, below_floor): (Vec<SearchHit>, Vec<SearchHit>) =
+        if let Some(floor) = min_score {
+            deduped.into_iter().partition(|h| h.score >= floor)
+        } else {
+            (deduped, Vec::new())
+        };
+
+    // below_floor is sorted desc by score (partitioned from a sorted vec), so first = highest.
+    let best_score_below_floor = below_floor.into_iter().next().map(|h| h.score);
+
+    passing.truncate(limit);
+
+    Ok(SearchResult {
+        hits: passing,
+        best_score_below_floor,
+        total_candidates,
+        min_score_floor: min_score,
+    })
 }
 
 /// Format a Unix timestamp as a compact ISO 8601 date-time string.
@@ -244,23 +307,26 @@ fn is_leap(y: u64) -> bool {
 }
 
 /// Print search hits in markdown format to stdout.
-pub fn print_hits_markdown(hits: &[SearchHit]) {
-    if hits.is_empty() {
-        println!("No results found.");
+pub fn print_hits_markdown(result: &SearchResult) {
+    if result.hits.is_empty() {
+        if let Some(best) = result.best_score_below_floor {
+            let floor = result.min_score_floor.unwrap_or(0.0);
+            println!("No confident match (best score {best:.3} < floor {floor:.2})");
+        } else {
+            println!("No results found.");
+        }
         return;
     }
-    for hit in hits {
-        let session_abbrev = if hit.session_id.len() > 8 {
-            &hit.session_id[..8]
-        } else {
-            &hit.session_id
-        };
+    for hit in &result.hits {
         let ts = format_timestamp(hit.timestamp_epoch);
         println!("---");
         println!(
             "**[{}]** `{}` · {} · {} (score: {:.3})",
-            hit.tool, session_abbrev, ts, hit.role, hit.score
+            hit.tool, hit.session_id, ts, hit.role, hit.score
         );
+        if let Some(ref path) = hit.source_path {
+            println!("  source: {path}");
+        }
         println!();
         println!("{}", hit.content.trim());
         println!();

--- a/tests/xurl_embed.rs
+++ b/tests/xurl_embed.rs
@@ -105,7 +105,7 @@ async fn long_assistant_turn_produces_multiple_vectors() {
     );
 
     let embedder = MockEmbedder::new_fixed_dim(256);
-    embed::embed_unindexed_turns(&db.inner, &embedder)
+    embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
 
@@ -142,7 +142,7 @@ async fn short_turn_produces_exactly_one_vector() {
     );
 
     let embedder = MockEmbedder::new_fixed_dim(256);
-    embed::embed_unindexed_turns(&db.inner, &embedder)
+    embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
 
@@ -178,13 +178,13 @@ async fn re_embed_already_indexed_turns_is_noop() {
     let embedder = MockEmbedder::new_fixed_dim(256);
 
     // First run: should embed
-    let stats1 = embed::embed_unindexed_turns(&db.inner, &embedder)
+    let stats1 = embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
     assert_eq!(stats1.turns_processed, 1);
 
     // Second run: already indexed, should be a noop
-    let stats2 = embed::embed_unindexed_turns(&db.inner, &embedder)
+    let stats2 = embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
     assert_eq!(stats2.embedded, 0, "re-embedding should be a noop");
@@ -223,10 +223,65 @@ async fn embed_stats_counts_chunks() {
     );
 
     let embedder = MockEmbedder::new_fixed_dim(64);
-    let stats = embed::embed_unindexed_turns(&db.inner, &embedder)
+    let stats = embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
     assert_eq!(stats.turns_processed, 2);
     assert_eq!(stats.chunks_total, 2);
     assert_eq!(stats.embedded, 2);
+}
+
+#[tokio::test]
+async fn test_embed_batch_progress() {
+    let db = open_temp_db_at_fork_ext(16);
+
+    // 120 turns → 3 batches of 50 (EMBED_BATCH_SIZE=50): progress_fn fires 3 times.
+    for i in 0..120usize {
+        insert_raw_turn_row(
+            db.conn(),
+            TurnRow {
+                id: &format!("turn-bp-{i:03}"),
+                session: "sess-bp",
+                tool: "cc",
+                turn_index: i as i64,
+                role: "user",
+                content: &format!("batch progress test turn {i}"),
+                timestamp: i as f64,
+                token_count: None,
+            },
+        );
+    }
+
+    let call_count = std::sync::atomic::AtomicUsize::new(0);
+    let embedder = MockEmbedder::new_fixed_dim(256);
+
+    let stats = embed::embed_unindexed_turns(
+        &db.inner,
+        &embedder,
+        Some(&|_done, _total| {
+            call_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }),
+    )
+    .await
+    .expect("embed_unindexed_turns should succeed");
+
+    let calls = call_count.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        calls > 1,
+        "expected multiple progress callbacks for 120 turns, got {calls}"
+    );
+    assert_eq!(
+        stats.turns_processed, 120,
+        "all 120 turns should be processed"
+    );
+
+    let indexed_count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(DISTINCT turn_id) FROM conversation_turn_vectors",
+            [],
+            |r| r.get(0),
+        )
+        .expect("count indexed turns");
+    assert_eq!(indexed_count, 120, "all 120 turns should have vectors");
 }

--- a/tests/xurl_ingest.rs
+++ b/tests/xurl_ingest.rs
@@ -115,7 +115,7 @@ async fn ingest_cc_file_end_to_end() {
     let file = write_cc_fixture(&dir, 10, 8, 12);
     let embedder = MockEmbedder::new_fixed_dim(256);
 
-    let stats = ingest::ingest_file(&db.inner, &embedder, &file, Tool::Cc, None)
+    let stats = ingest::ingest_file(&db.inner, &embedder, &file, Tool::Cc, None, None, None)
         .await
         .unwrap();
     assert_eq!(
@@ -127,7 +127,7 @@ async fn ingest_cc_file_end_to_end() {
     assert_eq!(stats.turns_skipped, 0);
 
     // Re-ingest the same file → no new turns, all skipped
-    let stats2 = ingest::ingest_file(&db.inner, &embedder, &file, Tool::Cc, None)
+    let stats2 = ingest::ingest_file(&db.inner, &embedder, &file, Tool::Cc, None, None, None)
         .await
         .unwrap();
     assert_eq!(stats2.turns_inserted, 0);
@@ -142,7 +142,7 @@ async fn ingest_empty_file_succeeds() {
     std::fs::write(&path, "").unwrap();
     let embedder = MockEmbedder::new_fixed_dim(64);
 
-    let stats = ingest::ingest_file(&db.inner, &embedder, &path, Tool::Cc, None)
+    let stats = ingest::ingest_file(&db.inner, &embedder, &path, Tool::Cc, None, None, None)
         .await
         .unwrap();
     assert_eq!(stats.turns_parsed, 0);

--- a/tests/xurl_search.rs
+++ b/tests/xurl_search.rs
@@ -1,7 +1,7 @@
 use mempal::core::db::Database;
 use mempal::embed::Embedder;
 use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
-use mempal::xurl::search;
+use mempal::xurl::search::{self, SearchOptions};
 use mempal::xurl::store::{self, TurnFilter};
 use tempfile::TempDir;
 
@@ -177,11 +177,10 @@ async fn search_returns_semantically_relevant_turn() {
         &db.inner,
         &embedder,
         "database migration",
-        5,
-        None,
-        false,
-        false,
-        None,
+        SearchOptions {
+            limit: 5,
+            ..Default::default()
+        },
     )
     .await
     .unwrap();
@@ -230,15 +229,15 @@ async fn search_with_tool_filter() {
         &db.inner,
         &embedder,
         "rust ownership",
-        10,
-        Some(TurnFilter {
-            tool: Some(Tool::Cc),
+        SearchOptions {
             limit: 10,
+            filter: Some(TurnFilter {
+                tool: Some(Tool::Cc),
+                limit: 10,
+                ..Default::default()
+            }),
             ..Default::default()
-        }),
-        false,
-        false,
-        None,
+        },
     )
     .await
     .unwrap();
@@ -292,7 +291,13 @@ async fn search_deduplicates_multi_chunk_turns() {
     ).unwrap();
 
     let results = search::search(
-        &db.inner, &embedder, "anything", 10, None, false, false, None,
+        &db.inner,
+        &embedder,
+        "anything",
+        SearchOptions {
+            limit: 10,
+            ..Default::default()
+        },
     )
     .await
     .unwrap();
@@ -320,16 +325,33 @@ async fn search_excludes_csa_by_default() {
         .unwrap();
 
     // Default search (exclude CSA)
-    let results = search::search(&db.inner, &embedder, "turn", 10, None, false, false, None)
-        .await
-        .unwrap();
+    let results = search::search(
+        &db.inner,
+        &embedder,
+        "turn",
+        SearchOptions {
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
     assert_eq!(results.hits.len(), 1, "should exclude CSA turn by default");
     assert_eq!(results.hits[0].content, "normal turn");
 
     // With include_csa=true
-    let results_all = search::search(&db.inner, &embedder, "turn", 10, None, true, false, None)
-        .await
-        .unwrap();
+    let results_all = search::search(
+        &db.inner,
+        &embedder,
+        "turn",
+        SearchOptions {
+            limit: 10,
+            include_csa: true,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
     assert_eq!(
         results_all.hits.len(),
         2,
@@ -342,7 +364,13 @@ async fn search_empty_db_returns_empty() {
     let db = open_temp_db();
     let embedder = FixedEmbedder { dim: 16 };
     let results = search::search(
-        &db.inner, &embedder, "anything", 10, None, false, false, None,
+        &db.inner,
+        &embedder,
+        "anything",
+        SearchOptions {
+            limit: 10,
+            ..Default::default()
+        },
     )
     .await
     .unwrap();
@@ -382,11 +410,11 @@ async fn test_search_min_score_filters_low_hits() {
         &db.inner,
         &embedder,
         "database migration",
-        10,
-        None,
-        false,
-        false,
-        Some(0.9),
+        SearchOptions {
+            limit: 10,
+            min_score: Some(0.9),
+            ..Default::default()
+        },
     )
     .await
     .unwrap();
@@ -425,11 +453,10 @@ async fn test_search_dedup_identical_content() {
         &db.inner,
         &embedder,
         "identical",
-        10,
-        None,
-        false,
-        false,
-        None,
+        SearchOptions {
+            limit: 10,
+            ..Default::default()
+        },
     )
     .await
     .unwrap();

--- a/tests/xurl_search.rs
+++ b/tests/xurl_search.rs
@@ -130,7 +130,7 @@ async fn seed_turn<E: Embedder + ?Sized>(
 ) {
     let turn = make_turn(session_id, tool, turn_index, role, content);
     store::insert_turns(db.conn(), &[turn]).unwrap();
-    mempal::xurl::embed::embed_unindexed_turns(&db.inner, embedder)
+    mempal::xurl::embed::embed_unindexed_turns(&db.inner, embedder, None)
         .await
         .unwrap();
 }
@@ -181,13 +181,14 @@ async fn search_returns_semantically_relevant_turn() {
         None,
         false,
         false,
+        None,
     )
     .await
     .unwrap();
 
-    assert!(!results.is_empty(), "expected at least one result");
+    assert!(!results.hits.is_empty(), "expected at least one result");
     // Top result should be about database/migration, not bread
-    let top = &results[0];
+    let top = &results.hits[0];
     let is_database = top.content.contains("database")
         || top.content.contains("migration")
         || top.content.contains("flyway");
@@ -237,15 +238,20 @@ async fn search_with_tool_filter() {
         }),
         false,
         false,
+        None,
     )
     .await
     .unwrap();
 
-    assert!(!results.is_empty());
+    assert!(!results.hits.is_empty());
     assert!(
-        results.iter().all(|r| r.tool == "cc"),
+        results.hits.iter().all(|r| r.tool == "cc"),
         "all results should be cc, got: {:?}",
-        results.iter().map(|r| r.tool.as_str()).collect::<Vec<_>>()
+        results
+            .hits
+            .iter()
+            .map(|r| r.tool.as_str())
+            .collect::<Vec<_>>()
     );
 }
 
@@ -285,12 +291,14 @@ async fn search_deduplicates_multi_chunk_turns() {
         rusqlite::params![&turn_id, &blob],
     ).unwrap();
 
-    let results = search::search(&db.inner, &embedder, "anything", 10, None, false, false)
-        .await
-        .unwrap();
+    let results = search::search(
+        &db.inner, &embedder, "anything", 10, None, false, false, None,
+    )
+    .await
+    .unwrap();
 
     // Even though there are two chunks, the turn should appear exactly once
-    let ids: Vec<&str> = results.iter().map(|r| r.turn_id.as_str()).collect();
+    let ids: Vec<&str> = results.hits.iter().map(|r| r.turn_id.as_str()).collect();
     let unique_ids: std::collections::HashSet<&&str> = ids.iter().collect();
     assert_eq!(ids.len(), unique_ids.len(), "duplicate turn_ids in results");
 }
@@ -307,23 +315,23 @@ async fn search_excludes_csa_by_default() {
     csa.is_csa_delegated = true;
 
     store::insert_turns(db.conn(), &[normal, csa]).unwrap();
-    mempal::xurl::embed::embed_unindexed_turns(&db.inner, &embedder)
+    mempal::xurl::embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
 
     // Default search (exclude CSA)
-    let results = search::search(&db.inner, &embedder, "turn", 10, None, false, false)
+    let results = search::search(&db.inner, &embedder, "turn", 10, None, false, false, None)
         .await
         .unwrap();
-    assert_eq!(results.len(), 1, "should exclude CSA turn by default");
-    assert_eq!(results[0].content, "normal turn");
+    assert_eq!(results.hits.len(), 1, "should exclude CSA turn by default");
+    assert_eq!(results.hits[0].content, "normal turn");
 
     // With include_csa=true
-    let results_all = search::search(&db.inner, &embedder, "turn", 10, None, true, false)
+    let results_all = search::search(&db.inner, &embedder, "turn", 10, None, true, false, None)
         .await
         .unwrap();
     assert_eq!(
-        results_all.len(),
+        results_all.hits.len(),
         2,
         "should include CSA turn when flag is set"
     );
@@ -333,8 +341,105 @@ async fn search_excludes_csa_by_default() {
 async fn search_empty_db_returns_empty() {
     let db = open_temp_db();
     let embedder = FixedEmbedder { dim: 16 };
-    let results = search::search(&db.inner, &embedder, "anything", 10, None, false, false)
+    let results = search::search(
+        &db.inner, &embedder, "anything", 10, None, false, false, None,
+    )
+    .await
+    .unwrap();
+    assert!(results.hits.is_empty());
+}
+
+#[tokio::test]
+async fn test_search_min_score_filters_low_hits() {
+    let db = open_temp_db();
+    // Use a SemanticEmbedder so the query "database migration" gets score ~1.0 for
+    // database-matching content and score 0.0 for unrelated content.
+    let embedder = SemanticEmbedder::new(16);
+
+    seed_turn(
+        &db,
+        &embedder,
+        "sess1",
+        Tool::Cc,
+        0,
+        Role::User,
+        "database migration strategy",
+    )
+    .await;
+    seed_turn(
+        &db,
+        &embedder,
+        "sess2",
+        Tool::Cc,
+        0,
+        Role::User,
+        "how to bake bread",
+    )
+    .await;
+
+    // With a high floor, only the relevant result should pass
+    let result = search::search(
+        &db.inner,
+        &embedder,
+        "database migration",
+        10,
+        None,
+        false,
+        false,
+        Some(0.9),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.hits.len(),
+        1,
+        "only the high-score hit should pass the floor"
+    );
+    assert!(
+        result.hits[0].content.contains("database") || result.hits[0].content.contains("migration"),
+        "passing hit should be database-related"
+    );
+    // bread hit should be captured as best_score_below_floor
+    assert!(
+        result.best_score_below_floor.is_some(),
+        "low-score hit should be captured in best_score_below_floor"
+    );
+    assert_eq!(result.min_score_floor, Some(0.9));
+}
+
+#[tokio::test]
+async fn test_search_dedup_identical_content() {
+    let db = open_temp_db();
+    let embedder = FixedEmbedder { dim: 16 };
+
+    // Two different turns with identical content (simulates overlapping session ingestion)
+    let turn_a = make_turn("sess-a", Tool::Cc, 0, Role::User, "identical content here");
+    let turn_b = make_turn("sess-b", Tool::Cc, 0, Role::User, "identical content here");
+    store::insert_turns(db.conn(), &[turn_a, turn_b]).unwrap();
+    mempal::xurl::embed::embed_unindexed_turns(&db.inner, &embedder, None)
         .await
         .unwrap();
-    assert!(results.is_empty());
+
+    let result = search::search(
+        &db.inner,
+        &embedder,
+        "identical",
+        10,
+        None,
+        false,
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Despite two stored turns, identical content should yield only one hit
+    assert_eq!(
+        result.hits.len(),
+        1,
+        "identical-content turns should be deduped to one hit, got: {}",
+        result.hits.len()
+    );
+    assert_eq!(result.hits[0].content, "identical content here");
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "b0e4c1d0ff69947ff851767a9fb769f0de4d075d"
+commit = "e33e3d1cda5123e24b17c19f5af294f209a20ba9"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "8900611748f937f65d3860b0057551a1b9bf315a"
+commit = "b0e4c1d0ff69947ff851767a9fb769f0de4d075d"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "b8cbfba98500ea12b8346cdfcd46e0282a76106e"
+commit = "8900611748f937f65d3860b0057551a1b9bf315a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes two xurl issues found while running full conversation ingest on a large palace.db (9.1GB, concurrent serve daemons):

- **#242 — ingest stall + no progress**: `embed_unindexed_turns` embedded turns
  one-by-one with per-row INSERT, stalling on large DBs under concurrent daemon
  access (futex wait, ~0 CPU). Now batches into groups of 50 with per-batch
  transactions, sets `busy_timeout(5000)`, and reports progress via a callback.
  `ingest_all` separates the parse phase from the embed phase (parse all files
  first, then one batched embed pass) and streams progress to stderr.
- **#243 — search UX**: added `--min-score` floor (default 0.70) with a
  "no confident match" message when all hits are filtered; content-hash dedup
  collapses identical turns from overlapping sessions; markdown output now prints
  the full session_id (was truncated to 8 chars) and the source path when
  available.

## Changes
- `src/xurl/embed.rs` — batch embed (size 50) + per-batch transactions + busy_timeout + progress callback
- `src/xurl/ingest.rs` — two-phase parse/embed, stderr progress
- `src/xurl/search.rs` — min-score floor, content dedup, full session_id
- `src/main.rs` — `--min-score` flag, CLI ingest progress, full session_id in timeline
- tests: `tests/xurl_embed.rs` (batch progress), `tests/xurl_search.rs` (min-score + dedup)

## Verification
- `cargo test --test xurl_embed --test xurl_search --test xurl_store`
- `just pre-commit` green

Closes #242
Closes #243
