### PR TITLE
fix(mcp): advertise object schema for Phase3Request.metadata/.report (#246)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8833,6 +8833,63 @@ mod tests {
             auto_inbox_dir.display()
         );
     }
+
+    /// Regression guard: every property schema emitted in `tools/list` must be
+    /// a JSON object, never a bare boolean.  Claude Code's MCP client rejects
+    /// the *entire* tool list when any property schema is a boolean `true`, so
+    /// a single bad field silently drops all 30+ tools.
+    ///
+    /// Specifically guards `mempal_phase3.metadata` and `.report`, which were
+    /// emitting `true` because schemars 1.x generates boolean schemas for
+    /// `serde_json::Value` fields.
+    #[test]
+    fn test_no_boolean_property_schemas_in_tools_list() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+
+        let mut violations: Vec<String> = Vec::new();
+
+        for tool in &tools {
+            if let Some(serde_json::Value::Object(props)) = tool.input_schema.get("properties") {
+                for (prop_name, schema) in props {
+                    if schema.is_boolean() {
+                        violations.push(format!("{}.{}", tool.name, prop_name));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "tools/list contains boolean property schemas (Claude Code rejects these):\n  {}",
+            violations.join("\n  ")
+        );
+
+        // Specific regression: mempal_phase3.metadata and .report must be objects.
+        let phase3 = tools
+            .iter()
+            .find(|t| t.name == "mempal_phase3")
+            .expect("mempal_phase3 tool must be registered");
+        let props = phase3
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .expect("mempal_phase3 must have a properties object");
+
+        assert!(
+            props
+                .get("metadata")
+                .map(|v| v.is_object())
+                .unwrap_or(false),
+            "mempal_phase3.metadata property schema must be a JSON object, got: {:?}",
+            props.get("metadata")
+        );
+        assert!(
+            props.get("report").map(|v| v.is_object()).unwrap_or(false),
+            "mempal_phase3.report property schema must be a JSON object, got: {:?}",
+            props.get("report")
+        );
+    }
 }
 #[cfg(any())]
 mod tests_duplicate_conflict_artifact {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -31,6 +31,14 @@ use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
+
+/// schemars 1.x emits boolean `true` for `serde_json::Value`, which MCP clients
+/// (e.g. Claude Code) reject when validating `tools/list`. Use this helper via
+/// `#[schemars(schema_with = "json_object_schema")]` to advertise an object schema
+/// instead, without changing the field's runtime Rust type.
+fn json_object_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({ "type": "object" })
+}
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
@@ -523,9 +531,11 @@ pub struct Phase3Request {
     pub evaluator_id: Option<String>,
     pub research_report_id: Option<String>,
     pub note: Option<String>,
+    #[schemars(schema_with = "json_object_schema")]
     pub metadata: Option<serde_json::Value>,
     pub limit: Option<usize>,
     pub candidate: Option<String>,
+    #[schemars(schema_with = "json_object_schema")]
     pub report: Option<serde_json::Value>,
     pub execute: Option<bool>,
     pub allow_warnings: Option<bool>,

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "80bd09512dfbe6ca2890a75590edd7a26455fe4f"
+commit = "30f2f414423d434c538af807f5952955b6393eda"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #246 — `mempal serve --mcp` advertised an invalid input schema for one tool, causing
Claude Code to reject the **entire** 30-tool list on connect (every mempal MCP tool became
unavailable after a reconnect).

Tool `mempal_phase3` exposed `inputSchema.properties.metadata` and `.report` as the bare
boolean schema `true` (schemars 1.x emits `true` for `serde_json::Value` fields). Claude
Code's MCP client validates each property as a schema **object** and rejects a bare boolean,
so it dropped all tools.

## What changed

- **`src/mcp/tools.rs`** — `Phase3Request.metadata` and `.report` (both
  `Option<serde_json::Value>`) now advertise a `{"type":"object"}` schema via a
  `#[schemars(schema_with = "json_object_schema")]` helper, instead of the bare boolean `true`.
  The Rust type is unchanged (`serde_json::Value`), so deserialization still accepts any JSON —
  only the advertised schema is now a valid object.
- **Regression guard** (`mcp::server::tests::test_no_boolean_property_schemas_in_tools_list`)
  — asserts **no** advertised MCP tool has a boolean property schema (every
  `inputSchema.properties.*` must be a JSON object), plus specifically that
  `mempal_phase3.metadata`/`.report` are objects. Runs in the default `cargo test` (pre-commit)
  tier. The test inspects `tool_router.list_all()`, which serves the exact same
  `Arc<JsonObject>` that the wire `tools/list` serializes (rmcp `schema_for_type` caches by
  `TypeId`), so it is a faithful proxy for what Claude Code sees.

## Verification

- Live `tools/list` wire dump (`MEMPAL_EMBED_BACKEND=stub mempal serve --mcp`) shows
  `mempal_phase3.metadata`/`.report` as `{"type":"object"}`, **30 tools**, and **zero**
  non-object property schemas across all tools (previously: both were `true`).
- Regression test fails on the pre-fix code (naming the exact offending properties) and passes
  after — confirmed by reverting the helper to emit boolean `true`.
- `just pre-commit` exits 0 (fmt + clippy `-D warnings` + test).

## Scope

Tightly scoped to the schema fix + guard. A pre-existing, never-compiled ~2720-line dead-code
block (`#[cfg(any())] mod tests_duplicate_conflict_artifact` in `server.rs`) was found nearby
and filed as #247 for a separate cleanup PR (kept out of here to preserve atomic commits).

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
