### PR TITLE
fix(search): deterministic ordering via consistent effective_importance snapshot (#254)

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -441,6 +441,12 @@ pub fn search_with_vector_and_scope_options(
         retain_currently_valid_results(&mut results, &temporal_metadata, now_secs);
     }
 
+    // Read effective_importance from a single consistent snapshot before the
+    // importance pipeline (boost -> decay -> rerank) so a concurrent
+    // access-tracking update cannot tear the read across drawers and make the
+    // rerank nondeterministic (GitHub #254).
+    apply_consistent_effective_importance(db, &mut results);
+
     // Pattern boosting (P13): boost exemplar drawers of active patterns that
     // match the query vector. Fire-and-forget on error.
     apply_pattern_boost(db, query_vector, scope.project_id.as_deref(), &mut results);
@@ -536,6 +542,76 @@ fn retain_currently_valid_results(
     });
 }
 
+/// Re-read `effective_importance` for the result set in a single consistent
+/// SQLite snapshot and overwrite each result's value before the importance
+/// rerank.
+///
+/// Why this exists: every search fires a fire-and-forget `dispatch_access_update`
+/// that recomputes `effective_importance` for the hit drawers in one atomic
+/// batch. The per-result `hydrate_result_metadata` path reads each drawer with a
+/// *separate* `get_drawer` query, so a concurrent access-update commit landing
+/// between two of those reads produces a TORN read: two drawers that share the
+/// same base importance end up with inconsistent `effective_importance` (e.g.
+/// `0.0` pre-update vs `0.2` post-update). `rerank_by_effective_importance` then
+/// reorders them nondeterministically (GitHub #254). A single `IN (...)` query
+/// reads all rows from one snapshot, so batched-together drawers are always
+/// mutually consistent and the rerank stays a deterministic no-op for
+/// equal-importance results.
+///
+/// Tunnel cross-project results are skipped: they carry a deliberately
+/// penalty-scaled `effective_importance` that must not be overwritten by the raw
+/// stored value. Fail-soft: on any read error the existing (possibly torn)
+/// values are left in place rather than failing the search.
+fn apply_consistent_effective_importance(db: &Database, results: &mut [SearchResult]) {
+    let ids = results
+        .iter()
+        .filter(|result| result.source != SearchResultSource::TunnelCrossProject)
+        .map(|result| result.drawer_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    if ids.is_empty() {
+        return;
+    }
+
+    let placeholders = (1..=ids.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // Mirror `get_drawer`'s COALESCE so the snapshot value matches what the
+    // per-result hydrate would have produced absent a concurrent write.
+    let sql = format!(
+        "SELECT id, COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) \
+         FROM drawers WHERE id IN ({placeholders})"
+    );
+    let snapshot: std::collections::HashMap<String, f64> = match db.conn().prepare(&sql) {
+        Ok(mut statement) => {
+            let rows = statement
+                .query_map(params_from_iter(ids.iter().map(String::as_str)), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+                });
+            match rows.and_then(|mapped| mapped.collect::<std::result::Result<_, _>>()) {
+                Ok(map) => map,
+                Err(err) => {
+                    tracing::warn!(error = %err, "consistent effective_importance read failed");
+                    return;
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "consistent effective_importance read failed");
+            return;
+        }
+    };
+
+    for result in results.iter_mut() {
+        if result.source == SearchResultSource::TunnelCrossProject {
+            continue;
+        }
+        if let Some(&effective_importance) = snapshot.get(&result.drawer_id) {
+            result.effective_importance = effective_importance;
+        }
+    }
+}
+
 fn apply_temporal_decay(
     results: &mut [SearchResult],
     metadata: &std::collections::HashMap<String, TemporalMetadata>,
@@ -558,6 +634,7 @@ fn apply_temporal_decay(
         b.similarity
             .partial_cmp(&a.similarity)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.drawer_id.cmp(&b.drawer_id))
     });
 }
 
@@ -731,6 +808,9 @@ pub fn search_bm25_only_with_options(
     if !options.include_expired {
         retain_currently_valid_results(&mut results, &temporal_metadata, now_secs);
     }
+    // Consistent-snapshot effective_importance read before the importance
+    // pipeline, mirroring the hybrid path — see GitHub #254.
+    apply_consistent_effective_importance(db, &mut results);
     apply_temporal_decay(
         &mut results,
         &temporal_metadata,
@@ -1038,6 +1118,7 @@ fn rrf_merge(
         b.similarity
             .partial_cmp(&a.similarity)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.drawer_id.cmp(&b.drawer_id))
     });
     merged.truncate(top_k);
     merged
@@ -1389,7 +1470,12 @@ where
         let (a_dist, a_row) = (&a.0, &a.1);
         let (b_dist, b_row) = (&b.0, &b.1);
         match (a_dist, b_dist) {
-            (Ok(left), Ok(right)) => left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal),
+            (Ok(left), Ok(right)) => left
+                .partial_cmp(right)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                // Tie-break equal cosine distances by drawer_id so the exact
+                // vector ranking is reproducible regardless of SQL row order.
+                .then_with(|| a_row.0.cmp(&b_row.0)),
             (Ok(_), Err(_)) => std::cmp::Ordering::Less,
             (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
             // Tie-break two invalid-blob candidates by drawer_id, matching the

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -2015,6 +2015,13 @@ async fn test_search_filters_by_memory_kind_and_tier_without_rerank_changes() {
         .map(|result| result.drawer_id.as_str())
         .collect();
 
+    // Order is the deterministic RRF ranking (evidence > shu > qi by RRF
+    // score). All three drawers share importance=2, so the post-RRF importance
+    // rerank is a stable no-op that preserves this order — provided
+    // effective_importance is read consistently across drawers (see
+    // `apply_consistent_effective_importance`; GitHub #254). The drawers are NOT
+    // reordered to drawer_id order: the rerank tie preserves RRF order, it does
+    // not impose an alphabetic one.
     assert_eq!(
         unfiltered_ids,
         vec![
@@ -2028,6 +2035,96 @@ async fn test_search_filters_by_memory_kind_and_tier_without_rerank_changes() {
         vec!["drawer_search_knowledge_shu", "drawer_search_knowledge_qi"]
     );
     assert_eq!(shu_only_ids, vec!["drawer_search_knowledge_shu"]);
+}
+
+/// Determinism regression for RRF fusion ties (GitHub #254).
+///
+/// Constructs two drawers with deliberately symmetric ranks so their RRF scores
+/// are EXACTLY equal: `tie_a` is rank 0 in the vector list (its stored embedding
+/// equals the stub query vector) and rank 1 in BM25; `tie_b` is the mirror image
+/// (rank 1 vector, rank 0 BM25, via a higher term frequency). Both therefore
+/// accumulate `1/(60+0+1) + 1/(60+1+1)`.
+///
+/// Before the fix, `rrf_merge` collected scores from a `HashMap` and sorted with
+/// no tiebreaker, so the tied pair surfaced in randomized hash-iteration order.
+/// With the `drawer_id` tiebreaker the tie resolves to ascending `drawer_id`
+/// (`tie_a` before `tie_b`) on every call. Running the search many times
+/// in-process (each `rrf_merge` builds a fresh `HashMap` with a fresh seed)
+/// must yield byte-identical ordering every time.
+#[tokio::test]
+async fn test_rrf_tie_orders_deterministically_by_drawer_id() {
+    let (_tmp, db, server) = setup_mcp_server();
+
+    // Stub query vector is [0.1, 0.2, 0.3]. `tie_a`'s embedding matches it
+    // exactly (cosine distance 0 -> vector rank 0); `tie_b`'s is far (vector
+    // rank 1). `tie_b` has the higher "zeta" term frequency (BM25 rank 0) while
+    // `tie_a` has the lower (BM25 rank 1). Symmetric ranks => equal RRF score.
+    let tie_a = bootstrap_drawer(
+        "drawer_rrf_tie_a",
+        "zeta aaa bbb ccc",
+        MemoryKind::Evidence,
+        None,
+        None,
+        None,
+    );
+    let tie_b = bootstrap_drawer(
+        "drawer_rrf_tie_b",
+        "zeta zeta zeta zeta",
+        MemoryKind::Evidence,
+        None,
+        None,
+        None,
+    );
+    insert_search_fixture(&db, &tie_a, &[0.1, 0.2, 0.3]);
+    insert_search_fixture(&db, &tie_b, &[0.95, 0.05, 0.0]);
+
+    let mut observed_orders = Vec::new();
+    for _ in 0..25 {
+        let response = server
+            .search_json_for_test(json!({
+                "query": "zeta",
+                "wing": "mempal",
+                "room": "bootstrap",
+                "top_k": 5
+            }))
+            .await
+            .expect("tie search should succeed");
+        let ids: Vec<String> = response
+            .results
+            .iter()
+            .map(|result| result.drawer_id.clone())
+            .collect();
+        // Confirm the RRF tie is genuine: equal similarity for the two drawers.
+        let sim_a = response
+            .results
+            .iter()
+            .find(|r| r.drawer_id == "drawer_rrf_tie_a")
+            .map(|r| r.similarity)
+            .expect("tie_a present");
+        let sim_b = response
+            .results
+            .iter()
+            .find(|r| r.drawer_id == "drawer_rrf_tie_b")
+            .map(|r| r.similarity)
+            .expect("tie_b present");
+        assert_eq!(
+            sim_a, sim_b,
+            "RRF scores must be exactly equal for the tie to exercise the tiebreaker"
+        );
+        observed_orders.push(ids);
+    }
+
+    // Every run must produce the same drawer_id-ascending order.
+    let expected = vec![
+        "drawer_rrf_tie_a".to_string(),
+        "drawer_rrf_tie_b".to_string(),
+    ];
+    for (run, order) in observed_orders.iter().enumerate() {
+        assert_eq!(
+            order, &expected,
+            "run {run} returned a non-deterministic RRF tie order: {order:?}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Makes hybrid-search result ordering deterministic, fixing the flaky test
`test_search_filters_by_memory_kind_and_tier_without_rerank_changes` (the `qi`/`shu`
drawers intermittently swapped order under full-suite parallelism while passing in
isolation). **Closes #254.**

## Root cause

It was **not** an RRF-score tie. The three drawers (`evidence`, `shu`, `qi`) have
*distinct* RRF scores, so their fused order is well-defined. The flake came from a
**torn read of `effective_importance`**:

- Every search fires a fire-and-forget `dispatch_access_update` that recomputes
  `effective_importance` for the hit drawers in **one atomic batch**.
- Per-result `hydrate_result_metadata` reads each drawer back with a **separate**
  `get_drawer` query.
- When a concurrent access-update commit lands *between* two of those per-result
  reads, two drawers sharing the same base importance get **inconsistent**
  `effective_importance` (e.g. `0.0` pre-update vs `0.2` post-update).
  `rerank_by_effective_importance` then reorders the equal-base pair
  nondeterministically — surfacing as the `qi`/`shu` swap.

## Fix

`apply_consistent_effective_importance` re-reads `effective_importance` for the
whole result set in a **single SQLite snapshot** (`IN (...)` query) before the
importance rerank, so all batched-together drawers are mutually consistent and the
rerank stays a deterministic no-op for equal-importance results. Applied on **both**
the hybrid and BM25-only search paths. Tunnel cross-project results keep their
deliberately penalty-scaled value; the read is fail-soft (a read error leaves
existing values in place rather than failing the search).

### Defense in depth

Added `drawer_id` tiebreakers so every search sort is reproducible regardless of
`HashMap` iteration or SQL row order:

- the post-RRF importance/temporal sort,
- the `rrf_merge` fusion sort,
- the exact-vector cosine-distance comparator.

## Tests

- Kept the existing `[evidence, shu, qi]` expectation (distinct RRF scores — never
  a tie) and documented *why* the rerank must preserve RRF order rather than impose
  alphabetic order.
- Added `test_rrf_tie_orders_deterministically_by_drawer_id`: constructs a genuine
  equal-RRF-score tie (symmetric vector/BM25 ranks), asserts the two similarities
  are exactly equal, and asserts a stable `drawer_id`-ascending order across 25
  in-process runs.
- `just fmt` / `just clippy` clean; full suite green (1199 passed); both the
  previously-flaky test and the new determinism test pass.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
