### PR TITLE
fix(daemon): atomic singleton lock + orphan sibling reaping (#257)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,7 +48,17 @@ pub fn run_command_with_bootstrap_events(
     bootstrap_events: Option<mpsc::Sender<BootstrapEvent>>,
 ) -> Result<()> {
     // harness-point: PR0
-    let context = DaemonContext::bootstrap_with_events(config_path, foreground, bootstrap_events)?;
+    let context =
+        match DaemonContext::bootstrap_with_events(config_path, foreground, bootstrap_events) {
+            Ok(context) => context,
+            // A concurrent daemon already holds the singleton lock (#257): this is
+            // a clean no-op, not a failure. Exit success without daemonizing.
+            Err(error) if error.is::<crate::daemon_singleton::DaemonAlreadyRunning>() => {
+                eprintln!("daemon already running; exiting");
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
     context.runtime.block_on(run_loop(&context))
 }
 

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -49,7 +49,11 @@ pub struct DaemonContext {
     pub config: std::sync::Arc<crate::core::config::Config>,
     pub mempal_home: PathBuf,
     pub log_path: PathBuf,
+    // Drop order matters: remove the pidfile (pid_guard) BEFORE releasing the
+    // singleton lock (lock_guard), so a successor that wins the lock never
+    // observes a stale pidfile pointing at the just-stopped daemon.
     _pid_guard: PidFileGuard,
+    _lock_guard: crate::daemon_singleton::DaemonLockGuard,
 }
 
 impl DaemonWriteObserver {
@@ -184,6 +188,23 @@ fn bootstrap_inner(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
+    // Atomic singleton gate (#257): acquire the exclusive daemon lock BEFORE
+    // daemonizing. A race loser that cannot get the lock concludes a healthy
+    // daemon already holds it and returns `DaemonAlreadyRunning` so the caller
+    // can exit cleanly WITHOUT daemonizing. The lock's open file description
+    // survives the double-fork in `perform_daemonize`, keeping the singleton
+    // guarantee through the daemon's whole lifetime.
+    let lock_guard = match crate::daemon_singleton::try_acquire(&mempal_home)
+        .context("failed to acquire daemon singleton lock")?
+    {
+        crate::daemon_singleton::DaemonLockAcquisition::Acquired(guard) => guard,
+        crate::daemon_singleton::DaemonLockAcquisition::AlreadyHeld => {
+            return Err(anyhow::Error::new(
+                crate::daemon_singleton::DaemonAlreadyRunning,
+            ));
+        }
+    };
+
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::Daemonize);
     perform_daemonize(foreground, &mempal_home, &log_path)?;
@@ -227,6 +248,7 @@ fn bootstrap_inner(
         mempal_home,
         log_path,
         _pid_guard: pid_guard,
+        _lock_guard: lock_guard,
     })
 }
 

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -1,0 +1,351 @@
+//! Atomic singleton enforcement and orphan reaping for the background daemon.
+//!
+//! Two concerns live here, both keyed off the daemon's own argv / a lock file
+//! next to `daemon.pid` (#257):
+//!
+//!   1. **Atomic singleton gate** — the running daemon holds a
+//!      process-lifetime `flock(LOCK_EX | LOCK_NB)` on `daemon.lock`. A second
+//!      daemon that tries to start while a healthy daemon already holds the
+//!      lock gets `EWOULDBLOCK`/`EAGAIN` and exits immediately instead of
+//!      daemonizing. The pidfile (written non-atomically) could not provide
+//!      this: two `serve --mcp` ensure-checks could both observe "no live
+//!      daemon" and both daemonize, converging on duplicate orphans.
+//!
+//!   2. **Sibling enumeration** — `daemon status` / `daemon stop` scan
+//!      `/proc/<pid>/cmdline` for every live `<binary> daemon …` invocation so
+//!      `status` reports the true count and `stop` reaps orphans the single
+//!      pidfile PID could never see.
+//!
+//! The `flock` primitive mirrors the proven inline-extern pattern in
+//! `src/ingest/lock.rs` (no libc dep on Unix; Windows no-op fallback). The
+//! lock is associated with the open file description, so it survives the
+//! double-`fork` performed by `daemonize` as long as the guard fd stays open,
+//! and is released automatically when the process dies — even on `SIGKILL`,
+//! which is precisely how an orphaned daemon's lock frees up for its successor.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Lock file name, written next to `daemon.pid` inside `mempal_home`.
+pub const DAEMON_LOCK_FILE: &str = "daemon.lock";
+
+/// Sentinel error meaning a healthy daemon already holds the singleton lock.
+///
+/// Returned (wrapped in `anyhow::Error`) by daemon bootstrap so the race loser
+/// can be turned into a clean success exit at the single production call site
+/// without disturbing the `Result<DaemonContext>` signature the integration
+/// tests depend on. Downcast with [`anyhow::Error::is`].
+#[derive(Debug, Error)]
+#[error("daemon already running (singleton lock held)")]
+pub struct DaemonAlreadyRunning;
+
+#[derive(Debug, Error)]
+pub enum DaemonLockError {
+    #[error("io error on daemon lock {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Outcome of a non-blocking attempt to acquire the daemon singleton lock.
+#[derive(Debug)]
+pub enum DaemonLockAcquisition {
+    /// This process now exclusively owns the daemon lock.
+    Acquired(DaemonLockGuard),
+    /// A healthy daemon already holds the lock; the caller must NOT daemonize.
+    AlreadyHeld,
+}
+
+/// RAII guard holding the daemon singleton lock for the process lifetime.
+///
+/// The lock is released only once every duplicate fd (across `fork` /
+/// daemonize) is closed, so keeping this guard alive in the running daemon
+/// keeps the lock held; dropping it (or process exit, including `SIGKILL`)
+/// releases it.
+#[derive(Debug)]
+pub struct DaemonLockGuard {
+    _file: File,
+    path: PathBuf,
+}
+
+impl DaemonLockGuard {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Try to acquire the daemon singleton lock at `<mempal_home>/daemon.lock`.
+///
+/// Non-blocking: on contention returns [`DaemonLockAcquisition::AlreadyHeld`]
+/// (no retry) so the race loser can exit instead of spinning. The open file
+/// description backing the returned guard survives `fork`/daemonize, so the
+/// lock persists into the final daemon process as long as the guard is held.
+pub fn try_acquire(mempal_home: &Path) -> Result<DaemonLockAcquisition, DaemonLockError> {
+    let lock_path = mempal_home.join(DAEMON_LOCK_FILE);
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|source| DaemonLockError::Io {
+            path: lock_path.clone(),
+            source,
+        })?;
+
+    match imp::try_lock_exclusive(&file) {
+        Ok(true) => Ok(DaemonLockAcquisition::Acquired(DaemonLockGuard {
+            _file: file,
+            path: lock_path,
+        })),
+        Ok(false) => Ok(DaemonLockAcquisition::AlreadyHeld),
+        Err(source) => Err(DaemonLockError::Io {
+            path: lock_path,
+            source,
+        }),
+    }
+}
+
+/// Basename of the currently running executable (e.g. `"mempal"`), used to
+/// match sibling daemon processes precisely. Falls back to `None` if the path
+/// cannot be resolved; callers should substitute a sensible default.
+pub fn current_binary_name() -> Option<String> {
+    std::env::current_exe().ok().and_then(|path| {
+        path.file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+    })
+}
+
+/// Split a raw `/proc/<pid>/cmdline` blob (NUL-separated argv) into argv parts,
+/// dropping empty trailing fields.
+pub fn parse_proc_cmdline(raw: &[u8]) -> Vec<String> {
+    raw.split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| std::str::from_utf8(part).ok().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// Precise predicate: is `argv` a `<binary_name> daemon …` invocation?
+///
+/// Matches only when argv[0]'s basename equals `binary_name` AND argv[1] is
+/// exactly `daemon`. This intentionally excludes `mempal serve --mcp`
+/// (argv[1] = `serve`), `mempal status` (argv[1] = `status`), and unrelated
+/// programs such as `claude -p …` (different basename). Pure and unit-testable;
+/// the `/proc` scan in [`enumerate_daemon_pids`] feeds parsed argv through it.
+pub fn is_daemon_argv<S: AsRef<str>>(argv: &[S], binary_name: &str) -> bool {
+    let Some(program) = argv.first() else {
+        return false;
+    };
+    let Some(subcommand) = argv.get(1) else {
+        return false;
+    };
+    let program_base = Path::new(program.as_ref())
+        .file_name()
+        .and_then(|name| name.to_str());
+    program_base == Some(binary_name) && subcommand.as_ref() == "daemon"
+}
+
+/// Enumerate the PIDs of every live `<binary_name> daemon …` process, excluding
+/// the calling process itself.
+///
+/// Linux: scans `/proc/<pid>/cmdline`. Non-Linux: returns empty (the pidfile
+/// path still applies; robust sibling reaping is a Linux-only refinement).
+#[cfg(target_os = "linux")]
+pub fn enumerate_daemon_pids(binary_name: &str) -> Vec<i32> {
+    let self_pid = std::process::id() as i32;
+    let mut pids = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return pids;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<i32>() else {
+            continue; // skip non-numeric /proc entries
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let Ok(raw) = std::fs::read(entry.path().join("cmdline")) else {
+            continue; // process exited or unreadable; skip
+        };
+        if raw.is_empty() {
+            continue; // kernel threads expose an empty cmdline
+        }
+        let argv = parse_proc_cmdline(&raw);
+        if is_daemon_argv(&argv, binary_name) {
+            pids.push(pid);
+        }
+    }
+    pids.sort_unstable();
+    pids
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn enumerate_daemon_pids(_binary_name: &str) -> Vec<i32> {
+    Vec::new()
+}
+
+#[cfg(unix)]
+mod imp {
+    use std::fs::File;
+    use std::io;
+    use std::os::fd::AsRawFd;
+
+    const LOCK_EX: i32 = 2;
+    const LOCK_NB: i32 = 4;
+    const EWOULDBLOCK: i32 = 35; // macOS; Linux uses EAGAIN (11)
+
+    unsafe extern "C" {
+        fn flock(fd: i32, operation: i32) -> i32;
+    }
+
+    /// Returns `Ok(true)` when the exclusive lock was acquired, `Ok(false)` on
+    /// contention (`EWOULDBLOCK`/`EAGAIN`), and `Err` for any other OS error.
+    pub fn try_lock_exclusive(file: &File) -> Result<bool, io::Error> {
+        let fd = file.as_raw_fd();
+        // SAFETY: `fd` is a valid open file descriptor owned by `file` for the
+        // duration of this call; `flock` only inspects it and does not retain
+        // it past return.
+        let ret = unsafe { flock(fd, LOCK_EX | LOCK_NB) };
+        if ret == 0 {
+            return Ok(true);
+        }
+        let err = io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(code) if code == EWOULDBLOCK || code == 11 => Ok(false),
+            _ => Err(err),
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::fs::File;
+    use std::io;
+
+    /// Windows fallback: always "acquires". Singleton enforcement via
+    /// `LockFileEx` is follow-up work; the pidfile path still applies.
+    pub fn try_lock_exclusive(_file: &File) -> Result<bool, io::Error> {
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_second_acquire_blocked_until_first_dropped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let guard1 = match try_acquire(tmp.path()).expect("first acquire") {
+            DaemonLockAcquisition::Acquired(guard) => guard,
+            DaemonLockAcquisition::AlreadyHeld => panic!("first acquire should win"),
+        };
+        assert!(guard1.path().ends_with(DAEMON_LOCK_FILE));
+
+        // A second acquisition while the first guard is held must observe the
+        // lock as already held (distinct open file descriptions conflict under
+        // flock even within the same process).
+        match try_acquire(tmp.path()).expect("second acquire attempt") {
+            DaemonLockAcquisition::AlreadyHeld => {}
+            DaemonLockAcquisition::Acquired(_) => {
+                panic!("second acquire must not win while first guard is held")
+            }
+        }
+
+        drop(guard1);
+
+        // After release the lock is acquirable again.
+        match try_acquire(tmp.path()).expect("third acquire after drop") {
+            DaemonLockAcquisition::Acquired(_) => {}
+            DaemonLockAcquisition::AlreadyHeld => {
+                panic!("acquire after drop should win")
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_daemon_argv_matches_daemon_and_rejects_siblings() {
+        // Matches the daemon's own invocations (bare path and absolute path,
+        // with and without a subcommand).
+        assert!(is_daemon_argv(
+            &argv(&["mempal", "daemon", "--foreground"]),
+            "mempal"
+        ));
+        assert!(is_daemon_argv(&argv(&["mempal", "daemon"]), "mempal"));
+        assert!(is_daemon_argv(
+            &argv(&["/usr/local/bin/mempal", "daemon", "start", "--foreground"]),
+            "mempal"
+        ));
+        assert!(is_daemon_argv(
+            &argv(&["target/release/mempal", "daemon", "restart"]),
+            "mempal"
+        ));
+
+        // Must NOT match the MCP server, the top-level status command, the stop
+        // command's own argv pattern aside, or unrelated programs.
+        assert!(!is_daemon_argv(
+            &argv(&["mempal", "serve", "--mcp"]),
+            "mempal"
+        ));
+        assert!(!is_daemon_argv(&argv(&["mempal", "status"]), "mempal"));
+        assert!(!is_daemon_argv(
+            &argv(&["claude", "-p", "mempal daemon --foreground"]),
+            "mempal"
+        ));
+        assert!(!is_daemon_argv(
+            &argv(&["/usr/bin/python3", "daemon.py"]),
+            "mempal"
+        ));
+
+        // Defensive edges: too-short argv and a different binary name.
+        assert!(!is_daemon_argv(&argv(&["mempal"]), "mempal"));
+        assert!(!is_daemon_argv::<&str>(&[], "mempal"));
+        assert!(!is_daemon_argv(&argv(&["other-tool", "daemon"]), "mempal"));
+    }
+
+    #[test]
+    fn test_parse_proc_cmdline_splits_nul_separated_argv() {
+        assert_eq!(
+            parse_proc_cmdline(b"mempal\0daemon\0--foreground\0"),
+            vec![
+                "mempal".to_string(),
+                "daemon".to_string(),
+                "--foreground".to_string()
+            ]
+        );
+        // A trailing/duplicate NUL must not yield empty argv entries.
+        assert_eq!(
+            parse_proc_cmdline(b"mempal\0\0daemon\0"),
+            vec!["mempal".to_string(), "daemon".to_string()]
+        );
+        assert!(parse_proc_cmdline(b"").is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_enumerate_excludes_self() {
+        // The test runner's argv is not `<name> daemon …`, so scanning for a
+        // binary name that matches this process's basename must not return our
+        // own PID (enumerate filters self out regardless).
+        let self_pid = std::process::id() as i32;
+        let name = current_binary_name().unwrap_or_else(|| "mempal".to_string());
+        assert!(!enumerate_daemon_pids(&name).contains(&self_pid));
+        // Sanity: a binary name that cannot match anything yields no PIDs.
+        assert!(enumerate_daemon_pids("\0no-such-binary").is_empty());
+    }
+}

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -12,9 +12,10 @@
 //!      daemon" and both daemonize, converging on duplicate orphans.
 //!
 //!   2. **Sibling enumeration** — `daemon status` / `daemon stop` scan
-//!      `/proc/<pid>/cmdline` for every live `<binary> daemon …` invocation so
-//!      `status` reports the true count and `stop` reaps orphans the single
-//!      pidfile PID could never see.
+//!      `/proc/<pid>/cmdline` for every live `<binary> daemon …` invocation, then
+//!      keep only processes that hold this home's `daemon.lock` fd. That home
+//!      filter keeps stop/status isolated when multiple mempal homes run on the
+//!      same host.
 //!
 //! The `flock` primitive mirrors the proven inline-extern pattern in
 //! `src/ingest/lock.rs` (no libc dep on Unix; Windows no-op fallback). The
@@ -136,7 +137,8 @@ pub fn parse_proc_cmdline(raw: &[u8]) -> Vec<String> {
 /// exactly `daemon`. This intentionally excludes `mempal serve --mcp`
 /// (argv[1] = `serve`), `mempal status` (argv[1] = `status`), and unrelated
 /// programs such as `claude -p …` (different basename). Pure and unit-testable;
-/// the `/proc` scan in [`enumerate_daemon_pids`] feeds parsed argv through it.
+/// the `/proc` scan in [`enumerate_daemon_pids`] feeds parsed argv through it
+/// before checking the candidate's lock fd.
 pub fn is_daemon_argv<S: AsRef<str>>(argv: &[S], binary_name: &str) -> bool {
     let Some(program) = argv.first() else {
         return false;
@@ -150,18 +152,32 @@ pub fn is_daemon_argv<S: AsRef<str>>(argv: &[S], binary_name: &str) -> bool {
     program_base == Some(binary_name) && subcommand.as_ref() == "daemon"
 }
 
-/// Enumerate the PIDs of every live `<binary_name> daemon …` process, excluding
-/// the calling process itself.
+/// Enumerate the PIDs of every live `<binary_name> daemon …` process for
+/// `mempal_home`, excluding the calling process itself.
 ///
 /// Linux: scans `/proc/<pid>/cmdline`. Non-Linux: returns empty (the pidfile
 /// path still applies; robust sibling reaping is a Linux-only refinement).
 #[cfg(target_os = "linux")]
-pub fn enumerate_daemon_pids(binary_name: &str) -> Vec<i32> {
+pub fn enumerate_daemon_pids(binary_name: &str, mempal_home: &Path) -> Vec<i32> {
     let self_pid = std::process::id() as i32;
+    enumerate_daemon_pids_in_proc(binary_name, mempal_home, Path::new("/proc"), self_pid)
+}
+
+#[cfg(target_os = "linux")]
+fn enumerate_daemon_pids_in_proc(
+    binary_name: &str,
+    mempal_home: &Path,
+    proc_root: &Path,
+    self_pid: i32,
+) -> Vec<i32> {
     let mut pids = Vec::new();
-    let Ok(entries) = std::fs::read_dir("/proc") else {
+    let Some(lock_path) = canonical_daemon_lock_path(mempal_home) else {
         return pids;
     };
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return pids;
+    };
+
     for entry in entries.flatten() {
         let file_name = entry.file_name();
         let Some(name) = file_name.to_str() else {
@@ -180,7 +196,8 @@ pub fn enumerate_daemon_pids(binary_name: &str) -> Vec<i32> {
             continue; // kernel threads expose an empty cmdline
         }
         let argv = parse_proc_cmdline(&raw);
-        if is_daemon_argv(&argv, binary_name) {
+        if is_daemon_argv(&argv, binary_name) && process_holds_lock_file(&entry.path(), &lock_path)
+        {
             pids.push(pid);
         }
     }
@@ -188,8 +205,26 @@ pub fn enumerate_daemon_pids(binary_name: &str) -> Vec<i32> {
     pids
 }
 
+#[cfg(target_os = "linux")]
+fn canonical_daemon_lock_path(mempal_home: &Path) -> Option<PathBuf> {
+    std::fs::canonicalize(mempal_home.join(DAEMON_LOCK_FILE)).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn process_holds_lock_file(proc_pid_dir: &Path, lock_path: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(proc_pid_dir.join("fd")) else {
+        return false;
+    };
+
+    entries.flatten().any(|entry| {
+        std::fs::read_link(entry.path())
+            .map(|target| target == lock_path)
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(not(target_os = "linux"))]
-pub fn enumerate_daemon_pids(_binary_name: &str) -> Vec<i32> {
+pub fn enumerate_daemon_pids(_binary_name: &str, _mempal_home: &Path) -> Vec<i32> {
     Vec::new()
 }
 
@@ -344,8 +379,44 @@ mod tests {
         // own PID (enumerate filters self out regardless).
         let self_pid = std::process::id() as i32;
         let name = current_binary_name().unwrap_or_else(|| "mempal".to_string());
-        assert!(!enumerate_daemon_pids(&name).contains(&self_pid));
+        let tmp = tempfile::tempdir().expect("tempdir");
+        File::create(tmp.path().join(DAEMON_LOCK_FILE)).expect("lock file");
+        assert!(!enumerate_daemon_pids(&name, tmp.path()).contains(&self_pid));
         // Sanity: a binary name that cannot match anything yields no PIDs.
-        assert!(enumerate_daemon_pids("\0no-such-binary").is_empty());
+        assert!(enumerate_daemon_pids("\0no-such-binary", tmp.path()).is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_enumerate_filters_daemons_by_matching_home_lock_fd() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let home_a = tmp.path().join("home-a");
+        let home_b = tmp.path().join("home-b");
+        let proc_root = tmp.path().join("proc");
+        std::fs::create_dir_all(&home_a).expect("home a");
+        std::fs::create_dir_all(&home_b).expect("home b");
+        std::fs::create_dir_all(&proc_root).expect("proc root");
+        let lock_a = home_a.join(DAEMON_LOCK_FILE);
+        let lock_b = home_b.join(DAEMON_LOCK_FILE);
+        File::create(&lock_a).expect("lock a");
+        File::create(&lock_b).expect("lock b");
+
+        write_fake_proc_daemon(&proc_root, 101, &lock_a);
+        write_fake_proc_daemon(&proc_root, 202, &lock_b);
+
+        let pids = enumerate_daemon_pids_in_proc("mempal", &home_a, &proc_root, 0);
+
+        assert_eq!(pids, vec![101]);
+
+        fn write_fake_proc_daemon(proc_root: &Path, pid: i32, lock_path: &Path) {
+            let pid_dir = proc_root.join(pid.to_string());
+            let fd_dir = pid_dir.join("fd");
+            std::fs::create_dir_all(&fd_dir).expect("fd dir");
+            std::fs::write(pid_dir.join("cmdline"), b"mempal\0daemon\0--foreground\0")
+                .expect("cmdline");
+            symlink(lock_path, fd_dir.join("3")).expect("lock fd symlink");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cowork;
 pub mod crystallize;
 pub mod daemon;
 pub mod daemon_bootstrap;
+pub mod daemon_singleton;
 pub mod doctor;
 pub mod embed;
 pub mod endpoint_health;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8870,29 +8870,69 @@ fn run_daemon_start(config_path: PathBuf, foreground: bool) -> Result<()> {
 fn run_daemon_stop(db_path: &Path) -> Result<()> {
     use std::time::{Duration, Instant};
 
-    let pid = read_daemon_pid(db_path)?
-        .ok_or_else(|| anyhow::anyhow!("daemon is not running (no pid file)"))?;
-    if !process_is_running(pid)? {
+    // Reap EVERY live `mempal daemon` sibling, not just the pidfile PID (#257).
+    // Orphans (e.g. a race-duplicate that outlived its pidfile) are only
+    // visible through a /proc enumeration of the daemon's own argv.
+    let binary =
+        mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
+    let mut targets = mempal::daemon_singleton::enumerate_daemon_pids(&binary);
+
+    // Defensively include the pidfile PID if it is live but escaped the scan
+    // (e.g. a transient /proc read race), so stop never misses it.
+    if let Some(pid) = read_daemon_pid(db_path)?
+        && process_is_running(pid)?
+        && !targets.contains(&pid)
+    {
+        targets.push(pid);
+    }
+
+    if targets.is_empty() {
         if let Some(mempal_home) = db_path.parent() {
             let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
         }
-        bail!("daemon is not running (stale pid {pid})");
+        bail!("daemon is not running");
     }
-    // SAFETY: kill(2) with SIGTERM is safe; we only write the signal number.
-    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
-    if rc != 0 {
-        let error = std::io::Error::last_os_error();
-        bail!("failed to send SIGTERM to daemon (pid {pid}): {error}");
+
+    let reaped = targets.len();
+    for pid in &targets {
+        // SAFETY: kill(2) with SIGTERM only writes the signal number. ESRCH
+        // (the process already exited between enumeration and now) is benign.
+        let rc = unsafe { libc::kill(*pid, libc::SIGTERM) };
+        if rc != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                bail!("failed to send SIGTERM to daemon (pid {pid}): {error}");
+            }
+        }
     }
+
     let deadline = Instant::now() + Duration::from_secs(30);
+    let mut remaining = targets.clone();
     while Instant::now() < deadline {
-        if !process_is_running(pid)? {
-            println!("daemon stopped");
-            return Ok(());
+        remaining.retain(|pid| process_is_running(*pid).unwrap_or(false));
+        if remaining.is_empty() {
+            break;
         }
         std::thread::sleep(Duration::from_millis(100));
     }
-    bail!("daemon (pid {pid}) did not exit within 30s")
+    if !remaining.is_empty() {
+        let pids = remaining
+            .iter()
+            .map(i32::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("daemon(s) did not exit within 30s: {pids}");
+    }
+
+    if let Some(mempal_home) = db_path.parent() {
+        let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
+    }
+    if reaped > 1 {
+        println!("daemon stopped ({reaped} processes reaped)");
+    } else {
+        println!("daemon stopped");
+    }
+    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -8917,9 +8957,20 @@ fn run_daemon_restart(config_path: PathBuf) -> Result<()> {
 }
 
 fn run_daemon_status(db_path: &Path) -> Result<()> {
+    // Enumerate ALL live `mempal daemon` siblings so status reports the true
+    // process count and can warn on duplicates the single pidfile PID hides
+    // (#257). The scan excludes this `daemon status` process itself.
+    let binary =
+        mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
+    let siblings = mempal::daemon_singleton::enumerate_daemon_pids(&binary);
+
     match read_daemon_pid(db_path)? {
         None => {
-            println!("status: stopped");
+            if siblings.is_empty() {
+                println!("status: stopped");
+            } else {
+                println!("status: running (no pid file; orphaned daemon)");
+            }
         }
         Some(pid) => {
             if process_is_running(pid)? {
@@ -8942,10 +8993,30 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
                         println!("queue.failed: {}", stats.failed);
                     }
                 }
-            } else {
+            } else if siblings.is_empty() {
                 println!("status: stopped (stale pid file, pid {pid} not running)");
+            } else {
+                println!(
+                    "status: running (stale pid file, pid {pid} not running; orphaned daemon)"
+                );
             }
         }
+    }
+
+    if !siblings.is_empty() {
+        let pids = siblings
+            .iter()
+            .map(i32::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("live_daemons: {}", siblings.len());
+        println!("daemon_pids: {pids}");
+    }
+    if siblings.len() > 1 {
+        println!(
+            "warning: {} duplicate daemon processes detected (expected 1); run `mempal daemon stop` to reap orphans",
+            siblings.len()
+        );
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8852,6 +8852,13 @@ fn daemon_config_db_path(config_path: &Path) -> Result<PathBuf> {
     Ok(expand_home(&config.db_path))
 }
 
+fn daemon_home_from_db_path(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
 fn run_daemon_start(config_path: PathBuf, foreground: bool) -> Result<()> {
     let db_path = daemon_config_db_path(&config_path)?;
     if let Some(pid) = read_daemon_pid(&db_path)? {
@@ -8875,7 +8882,8 @@ fn run_daemon_stop(db_path: &Path) -> Result<()> {
     // visible through a /proc enumeration of the daemon's own argv.
     let binary =
         mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
-    let mut targets = mempal::daemon_singleton::enumerate_daemon_pids(&binary);
+    let mempal_home = daemon_home_from_db_path(db_path);
+    let mut targets = mempal::daemon_singleton::enumerate_daemon_pids(&binary, &mempal_home);
 
     // Defensively include the pidfile PID if it is live but escaped the scan
     // (e.g. a transient /proc read race), so stop never misses it.
@@ -8887,9 +8895,7 @@ fn run_daemon_stop(db_path: &Path) -> Result<()> {
     }
 
     if targets.is_empty() {
-        if let Some(mempal_home) = db_path.parent() {
-            let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
-        }
+        let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
         bail!("daemon is not running");
     }
 
@@ -8924,9 +8930,7 @@ fn run_daemon_stop(db_path: &Path) -> Result<()> {
         bail!("daemon(s) did not exit within 30s: {pids}");
     }
 
-    if let Some(mempal_home) = db_path.parent() {
-        let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
-    }
+    let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
     if reaped > 1 {
         println!("daemon stopped ({reaped} processes reaped)");
     } else {
@@ -8962,7 +8966,8 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
     // (#257). The scan excludes this `daemon status` process itself.
     let binary =
         mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
-    let siblings = mempal::daemon_singleton::enumerate_daemon_pids(&binary);
+    let mempal_home = daemon_home_from_db_path(db_path);
+    let siblings = mempal::daemon_singleton::enumerate_daemon_pids(&binary, &mempal_home);
 
     match read_daemon_pid(db_path)? {
         None => {
@@ -8976,13 +8981,11 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
             if process_is_running(pid)? {
                 println!("status: running");
                 println!("pid: {pid}");
-                if let Some(mempal_home) = db_path.parent() {
-                    let pid_path = mempal_home.join("daemon.pid");
-                    if let Ok(meta) = std::fs::metadata(&pid_path) {
-                        if let Ok(modified) = meta.modified() {
-                            if let Ok(age) = std::time::SystemTime::now().duration_since(modified) {
-                                println!("uptime_secs: {}", age.as_secs());
-                            }
+                let pid_path = mempal_home.join("daemon.pid");
+                if let Ok(meta) = std::fs::metadata(&pid_path) {
+                    if let Ok(modified) = meta.modified() {
+                        if let Ok(age) = std::time::SystemTime::now().duration_since(modified) {
+                            println!("uptime_secs: {}", age.as_secs());
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #257. Two parts:
1. **Atomic singleton** — replaces the pidfile-presence liveness check with an atomic advisory `flock` held for the daemon's entire lifetime, so a race between two `daemon --foreground` invocations can no longer spawn duplicate daemons. `stop`/`status` enumerate and reap *all* live daemon siblings.
2. **Cross-home isolation** (found during review) — scopes the `daemon stop`/`status` `/proc` sibling enumeration to the current `mempal_home`, so one config can no longer reap or miscount another config's daemon on the same host.

## Root cause

The original singleton gate (`PidFileGuard::create(daemon.pid)`) treated *pidfile presence* as the authority on liveness. Two `daemon --foreground` invocations racing between "check pidfile" and "write pidfile" could both pass the gate. `daemon stop` only acted on the single PID in the pidfile, leaving racing siblings orphaned.

A review pass then found that the new sibling enumeration matched every `mempal daemon …` argv process regardless of `mempal_home` — so on a host running multiple mempal instances with different homes, `daemon stop`/`status` could reap or miscount the *other* config's daemon.

## Changes

**Commit 1 — atomic singleton lock + orphan reaping**
- `src/daemon_singleton.rs` (new): exclusive advisory `flock(LOCK_EX)` on `<mempal_home>/daemon.lock`, held for the daemon's whole lifetime — the lock, not pidfile presence, is the liveness authority. Mirrors the `src/ingest/lock.rs` flock pattern (ingest lock untouched). Plus a `/proc` sibling-enumeration helper whose argv predicate matches `mempal daemon --foreground` and never `serve --mcp` / `claude -p`.
- `src/daemon_bootstrap.rs`: `DaemonContext` gains `_pid_guard` + `_lock_guard` (drop order: pidfile before lock); lock acquired before daemonize; race loser surfaces `DaemonAlreadyRunning` and exits gracefully.
- `src/daemon.rs`: `run_command_with_bootstrap_events` downcasts `DaemonAlreadyRunning`; race loser exits 0.
- `src/main.rs`: `run_daemon_stop` / `run_daemon_status` enumerate all live daemon siblings — reap orphans, report the true count, warn on duplicates.
- `src/lib.rs`: register `pub mod daemon_singleton`.

**Commit 2 — scope enumeration to current mempal_home**
- `src/daemon_singleton.rs`: `enumerate_daemon_pids` now takes `mempal_home`; a candidate PID must also hold the current home's `daemon.lock` fd (verified via `/proc/<pid>/fd`), not just match argv. New regression test `test_enumerate_filters_daemons_by_matching_home_lock_fd` (two fake PIDs, identical argv, different `daemon.lock` fd targets → only the current-home PID is returned).
- `src/main.rs`: add `daemon_home_from_db_path`; scope `daemon stop`/`status` enumeration to the current home.

## Tests

- `daemon_singleton::tests`: `test_second_acquire_blocked_until_first_dropped`, `test_enumerate_excludes_self`, `test_is_daemon_argv_matches_daemon_and_rejects_siblings`, `test_parse_proc_cmdline_splits_nul_separated_argv`, `test_enumerate_filters_daemons_by_matching_home_lock_fd`.
- `daemon_lifecycle`: `test_daemon_context_bootstrap_ordering`, `test_daemon_sigterm_graceful`.
- Full lib suite green; clippy clean via the pre-commit gate (run with `CARGO_BUILD_JOBS=2`).

## Boundaries

- Does **not** modify the ingest `flock` (`src/ingest/lock.rs`) — only reuses its pattern.
- The argv predicate is deliberately narrow: matches only `mempal daemon --foreground`, never the MCP `serve` path or unrelated processes.

## Review

- An earlier tier-4 review surfaced the cross-home enumeration concern; csa-codex verified it was a real isolation bug and fixed it (commit 2) with a dedicated regression test.
- Final tier-4 review (session `01KSWXQVG1AZKXX8VSRMXMQM6W`, iteration 4): **PASS**. Verified the lock fd survives the `daemonize 0.5.0` double-fork (read crate source), the pidfile-before-lock drop order, cross-platform errno handling, the home-scoping `/proc` fd filter, and the SIGTERM reap loop. Tests: `daemon_singleton` 5/5, `daemon_lifecycle` 2/2; diff compiles clean. Two LOW non-blocking advisories (`restart` orphan-reap; Windows no-op) filed as follow-up #260, deliberately kept out of this PR's scope.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
