### PR TITLE
fix(daemon): route restart through orphan-aware stop unconditionally (#260)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8398,6 +8398,17 @@ fn process_is_running(_pid: i32) -> Result<bool> {
     Ok(false)
 }
 
+#[derive(Debug)]
+struct DaemonNotRunning;
+
+impl std::fmt::Display for DaemonNotRunning {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("daemon is not running")
+    }
+}
+
+impl std::error::Error for DaemonNotRunning {}
+
 async fn serve_command(config: &Config, mcp: bool) -> Result<()> {
     if mcp {
         return serve_mcp_command(config).await;
@@ -8896,7 +8907,7 @@ fn run_daemon_stop(db_path: &Path) -> Result<()> {
 
     if targets.is_empty() {
         let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
-        bail!("daemon is not running");
+        return Err(DaemonNotRunning.into());
     }
 
     let reaped = targets.len();
@@ -8946,16 +8957,10 @@ fn run_daemon_stop(_db_path: &Path) -> Result<()> {
 
 fn run_daemon_restart(config_path: PathBuf) -> Result<()> {
     let db_path = daemon_config_db_path(&config_path)?;
-    match read_daemon_pid(&db_path)? {
-        Some(pid) if process_is_running(pid)? => {
-            run_daemon_stop(&db_path)?;
-        }
-        Some(_) => {
-            if let Some(mempal_home) = db_path.parent() {
-                let _ = std::fs::remove_file(mempal_home.join("daemon.pid"));
-            }
-        }
-        None => {}
+    if let Err(error) = run_daemon_stop(&db_path)
+        && !error.is::<DaemonNotRunning>()
+    {
+        return Err(error);
     }
     mempal::daemon::run_command(config_path, false)
 }

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -46,6 +46,94 @@ log_path = "{}"
     (tmp, db_path, config_path)
 }
 
+#[cfg(unix)]
+struct DaemonHomeCleanup {
+    home: PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for DaemonHomeCleanup {
+    fn drop(&mut self) {
+        let mempal_home = self.home.join(".mempal");
+        for pid in mempal::daemon_singleton::enumerate_daemon_pids("mempal", &mempal_home) {
+            // SAFETY: this test owns the temporary mempal_home being enumerated;
+            // the signal is restricted to processes holding that exact lock fd.
+            let _ = unsafe { libc::kill(pid, libc::SIGKILL) };
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running_for_test(pid: i32) -> bool {
+    // SAFETY: kill(2) with signal 0 probes liveness without delivering a
+    // signal. EPERM still means a process exists.
+    let rc = unsafe { libc::kill(pid, 0) };
+    if rc == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn wait_for_pid_file(pid_path: &std::path::Path, timeout: Duration) -> Option<i32> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(content) = fs::read_to_string(pid_path)
+            && let Ok(pid) = content.trim().parse::<i32>()
+        {
+            return Some(pid);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    None
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !process_is_running_for_test(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+#[cfg(unix)]
+fn spawn_lock_holding_fake_daemon(mempal_home: &std::path::Path) -> i32 {
+    let lock_path = mempal_home.join(mempal::daemon_singleton::DAEMON_LOCK_FILE);
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(
+            r#"(exec 9>"$LOCK_PATH"; flock -x 9; exec -a mempal yes daemon >/dev/null 2>&1) & echo $!"#,
+        )
+        .env("LOCK_PATH", &lock_path)
+        .stdin(Stdio::null())
+        .output()
+        .expect("spawn fake daemon");
+    assert!(
+        output.status.success(),
+        "fake daemon spawn failed: status={:?}, stdout={}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let pid = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<i32>()
+        .expect("fake daemon pid");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        let pids = mempal::daemon_singleton::enumerate_daemon_pids("mempal", mempal_home);
+        if pids.contains(&pid) {
+            return pid;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("fake daemon pid {pid} was not enumerated");
+}
+
 #[test]
 fn test_daemon_context_bootstrap_ordering() {
     let (_tmp, _db_path, config_path) = setup_daemon_home();
@@ -83,6 +171,54 @@ fn test_daemon_context_bootstrap_ordering() {
     );
     drop(context);
     assert!(!pid_path.exists(), "pid file must be removed on drop");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_daemon_restart_reaps_orphan_without_pidfile() {
+    let (tmp, _db_path, _config_path) = setup_daemon_home();
+    let _cleanup = DaemonHomeCleanup {
+        home: tmp.path().to_path_buf(),
+    };
+    let pid_path = tmp.path().join(".mempal/daemon.pid");
+    let mempal_home = tmp.path().join(".mempal");
+
+    let orphan_pid = spawn_lock_holding_fake_daemon(&mempal_home);
+    assert!(
+        process_is_running_for_test(orphan_pid),
+        "fake orphan daemon pid {orphan_pid} should be running"
+    );
+    assert!(
+        !pid_path.exists(),
+        "fake orphan must hold the singleton lock without a pidfile"
+    );
+
+    let output = Command::new(mempal_bin())
+        .args(["daemon", "restart"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("run daemon restart");
+    assert!(
+        output.status.success(),
+        "daemon restart failed: status={:?}, stdout={}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        wait_for_process_exit(orphan_pid, Duration::from_secs(10)),
+        "orphan daemon pid {orphan_pid} should be reaped by restart"
+    );
+
+    let restarted_pid =
+        wait_for_pid_file(&pid_path, Duration::from_secs(10)).expect("restarted daemon pidfile");
+    assert_ne!(restarted_pid, orphan_pid);
+    assert!(
+        process_is_running_for_test(restarted_pid),
+        "restarted daemon pid {restarted_pid} should be running"
+    );
 }
 
 #[cfg(unix)]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "6eefd0577a69a39241369528f1d925c5e30f5018"
+commit = "2ae6e88f45446fccabebc2f8af47d398b4247223"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes A1 of the #257 review follow-up (#260): `daemon restart` could fail to reap a no-pidfile orphan.

## Root cause

`run_daemon_restart` invoked the orphan-aware `run_daemon_stop` only when the pidfile PID was live. The #257 singleton lock introduced a new orphan shape — a daemon holding `<mempal_home>/daemon.lock` with a missing/stale pidfile. In that state `restart` skipped stop, proceeded to bootstrap, `try_acquire` returned `AlreadyHeld`, and it exited `"daemon already running; exiting"` **without restarting**. Recoverable only via `daemon stop` (which enumerates + reaps orphans) then `start`.

## Change

- `src/main.rs`: add a typed `DaemonNotRunning`; `run_daemon_restart` now calls `run_daemon_stop` **unconditionally** and ignores only `DaemonNotRunning` ("nothing to stop"), preserving real stop failures and the non-Unix unsupported-stop path.
- `tests/daemon_lifecycle.rs`: add `test_daemon_restart_reaps_orphan_without_pidfile` — an orphan holds the real `daemon.lock` flock under a temp home with no pidfile; `restart` must reap it and produce a fresh daemon pidfile. Fails under the old skip-stop-when-no-pidfile logic.

## Tests

- New `test_daemon_restart_reaps_orphan_without_pidfile` (fails before, passes after).
- `daemon_singleton` + `daemon_lifecycle` suites green; clippy clean via the pre-commit gate (run with `CARGO_BUILD_JOBS=2`).

## Scope

- A2 (Windows singleton no-op) intentionally deferred — accepted Unix-first limitation, already documented in the `daemon_singleton` module.
- Does not touch the singleton lock / `/proc` enumeration internals or the ingest lock.

## Review

- Final tier-4 review (gemini-cli, session `01KSX0V0T58MN1H40MVM9V8FS4`): **PASS**, 0 findings. Confirmed the `DaemonNotRunning` typed downcast (no string parsing), the unconditional `run_daemon_stop` correctly leveraging `/proc` enumeration, and the `DaemonHomeCleanup` Drop-guard test hygiene. Non-blocking accepted note: `restart` now fails on Windows like `stop` — consistent with the Unix-first daemon.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
