### PR TITLE
feat(xurl): output/pagination consistency — stats --json, --format enum, search --page (#269)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1000,6 +1000,9 @@ enum XurlCommands {
         /// Maximum number of results to return.
         #[arg(long, default_value_t = 10)]
         limit: usize,
+        /// Page number (0-based).
+        #[arg(long, default_value_t = 0)]
+        page: usize,
         /// Also include CSA-delegated turns (excluded by default).
         #[arg(long)]
         include_csa: bool,
@@ -1010,8 +1013,8 @@ enum XurlCommands {
         #[arg(long, default_value_t = 0.70)]
         min_score: f32,
         /// Output format: markdown (default) or json.
-        #[arg(long, default_value = "markdown")]
-        format: String,
+        #[arg(long, value_enum, default_value_t = XurlFormat::Markdown)]
+        format: XurlFormat,
     },
     /// Show conversation turns in reverse-chronological order.
     Timeline {
@@ -1037,11 +1040,15 @@ enum XurlCommands {
         #[arg(long)]
         include_agent_prompts: bool,
         /// Output format: markdown (default) or json.
-        #[arg(long, default_value = "markdown")]
-        format: String,
+        #[arg(long, value_enum, default_value_t = XurlFormat::Markdown)]
+        format: XurlFormat,
     },
     /// Show per-tool turn counts and date ranges.
-    Stats,
+    Stats {
+        /// Print result as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// Embed all turns that still lack a vector (drains the historical backlog).
     Reindex {
         /// Print progress as JSON.
@@ -1064,6 +1071,28 @@ enum XurlTool {
     Cc,
     Codex,
     Hermes,
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum XurlFormat {
+    Markdown,
+    Json,
+}
+
+#[derive(Serialize)]
+struct XurlStatsJson {
+    tools: Vec<XurlStatsToolJson>,
+    unindexed_remaining: i64,
+}
+
+#[derive(Serialize)]
+struct XurlStatsToolJson {
+    tool: String,
+    count: i64,
+    first: String,
+    last: String,
+    min_timestamp: f64,
+    max_timestamp: f64,
 }
 
 impl From<XurlTool> for mempal::xurl::model::Tool {
@@ -8561,6 +8590,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             session,
             since,
             limit,
+            page,
             include_csa,
             include_agent_prompts,
             min_score,
@@ -8572,7 +8602,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 session_id: session,
                 since_epoch,
                 limit,
-                offset: 0,
+                offset: page * limit,
             };
             let embedder = build_embedder(config).await?;
             let result = mempal::xurl::search::search(
@@ -8590,13 +8620,16 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             .await
             .context("xurl search failed")?;
 
-            if format == "json" {
-                println!(
-                    "{}",
-                    serde_json::to_string(&result).context("json serialize")?
-                );
-            } else {
-                mempal::xurl::search::print_hits_markdown(&result);
+            match format {
+                XurlFormat::Json => {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&result).context("json serialize")?
+                    );
+                }
+                XurlFormat::Markdown => {
+                    mempal::xurl::search::print_hits_markdown(&result);
+                }
             }
             Ok(())
         }
@@ -8627,33 +8660,60 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             )
             .context("xurl timeline query failed")?;
 
-            if format == "json" {
-                let json_turns = mempal::xurl::store::timeline_json_turns(&turns);
-                println!(
-                    "{}",
-                    serde_json::to_string(&json_turns).context("json serialize")?
-                );
-            } else {
-                if turns.is_empty() {
-                    println!("No turns found.");
-                } else {
-                    for t in &turns {
+            match format {
+                XurlFormat::Json => {
+                    let json_turns = mempal::xurl::store::timeline_json_turns(&turns);
+                    println!(
+                        "{}",
+                        serde_json::to_string(&json_turns).context("json serialize")?
+                    );
+                }
+                XurlFormat::Markdown => {
+                    if turns.is_empty() {
+                        println!("No turns found.");
+                    } else {
+                        for t in &turns {
+                            println!("---");
+                            println!("{}", mempal::xurl::store::format_timeline_header(t));
+                            println!();
+                            let preview = char_safe_preview(&t.content, 300);
+                            println!("{}", preview.trim());
+                            println!();
+                        }
                         println!("---");
-                        println!("{}", mempal::xurl::store::format_timeline_header(t));
-                        println!();
-                        let preview = char_safe_preview(&t.content, 300);
-                        println!("{}", preview.trim());
-                        println!();
                     }
-                    println!("---");
                 }
             }
             Ok(())
         }
 
-        XurlCommands::Stats => {
+        XurlCommands::Stats { json } => {
             let stats =
                 mempal::xurl::store::get_stats(db.conn()).context("xurl stats query failed")?;
+            let unindexed_remaining = mempal::xurl::store::count_unindexed_turns(db.conn())
+                .context("xurl unindexed count failed")?;
+            if json {
+                let tools: Vec<XurlStatsToolJson> = stats
+                    .iter()
+                    .map(|s| XurlStatsToolJson {
+                        tool: s.tool.clone(),
+                        count: s.count,
+                        first: mempal::xurl::search::format_timestamp(s.min_timestamp),
+                        last: mempal::xurl::search::format_timestamp(s.max_timestamp),
+                        min_timestamp: s.min_timestamp,
+                        max_timestamp: s.max_timestamp,
+                    })
+                    .collect();
+                let report = XurlStatsJson {
+                    tools,
+                    unindexed_remaining,
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string(&report).context("json serialize")?
+                );
+                return Ok(());
+            }
             if stats.is_empty() {
                 println!("No conversation turns indexed yet. Run `mempal xurl ingest` first.");
                 return Ok(());
@@ -8665,8 +8725,6 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 let last = mempal::xurl::search::format_timestamp(s.max_timestamp);
                 println!("| {:<6} | {:>5} | {} | {} |", s.tool, s.count, first, last);
             }
-            let unindexed_remaining = mempal::xurl::store::count_unindexed_turns(db.conn())
-                .context("xurl unindexed count failed")?;
             println!();
             println!("unindexed_remaining: {unindexed_remaining}");
             if unindexed_remaining > 0 {

--- a/src/xurl/search.rs
+++ b/src/xurl/search.rs
@@ -115,6 +115,7 @@ pub async fn search<E: Embedder + ?Sized>(
 
     let conn = db.conn();
     let filter = filter.unwrap_or_default();
+    let offset = filter.offset;
 
     // Build WHERE clause and parameter list dynamically.
     let mut conditions: Vec<String> = Vec::new();
@@ -245,20 +246,19 @@ pub async fn search<E: Embedder + ?Sized>(
     let total_candidates = deduped.len();
 
     // Apply min_score floor, then truncate.
-    let (mut passing, below_floor): (Vec<SearchHit>, Vec<SearchHit>) =
-        if let Some(floor) = min_score {
-            deduped.into_iter().partition(|h| h.score >= floor)
-        } else {
-            (deduped, Vec::new())
-        };
+    let (passing, below_floor): (Vec<SearchHit>, Vec<SearchHit>) = if let Some(floor) = min_score {
+        deduped.into_iter().partition(|h| h.score >= floor)
+    } else {
+        (deduped, Vec::new())
+    };
 
     // below_floor is sorted desc by score (partitioned from a sorted vec), so first = highest.
     let best_score_below_floor = below_floor.into_iter().next().map(|h| h.score);
 
-    passing.truncate(limit);
+    let hits = passing.into_iter().skip(offset).take(limit).collect();
 
     Ok(SearchResult {
-        hits: passing,
+        hits,
         best_score_below_floor,
         total_candidates,
         min_score_floor: min_score,

--- a/tests/xurl_search.rs
+++ b/tests/xurl_search.rs
@@ -3,6 +3,8 @@ use mempal::embed::Embedder;
 use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
 use mempal::xurl::search::{self, SearchOptions};
 use mempal::xurl::store::{self, TurnFilter};
+use std::path::Path;
+use std::process::{Command, Output};
 use tempfile::TempDir;
 
 // ── test DB helper ────────────────────────────────────────────────────────────
@@ -26,6 +28,23 @@ fn open_temp_db() -> TestDb {
         _dir: dir,
         inner: db,
     }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn run_xurl_search(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .args(["xurl", "search"])
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal xurl search")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr utf8")
 }
 
 // ── mock embedders ────────────────────────────────────────────────────────────
@@ -101,6 +120,23 @@ impl Embedder for SemanticEmbedder {
     }
 }
 
+struct AxisEmbedder;
+
+#[async_trait::async_trait]
+impl Embedder for AxisEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![1.0, 0.0]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        2
+    }
+
+    fn name(&self) -> &str {
+        "axis"
+    }
+}
+
 // ── fixture helpers ───────────────────────────────────────────────────────────
 
 fn make_turn(session_id: &str, tool: Tool, turn_index: u32, role: Role, content: &str) -> RawTurn {
@@ -135,7 +171,45 @@ async fn seed_turn<E: Embedder + ?Sized>(
         .unwrap();
 }
 
+fn seed_scored_turn(db: &TestDb, turn_index: u32, score: f32) -> String {
+    let content = format!("ranked search turn {turn_index}");
+    let turn = make_turn("paged-search", Tool::Cc, turn_index, Role::User, &content);
+    store::insert_turns(db.conn(), &[turn]).unwrap();
+    let turn_id: String = db
+        .conn()
+        .query_row(
+            "SELECT id FROM conversation_turns WHERE session_id='paged-search' AND turn_index=?1",
+            rusqlite::params![turn_index],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let y = (1.0 - score * score).sqrt();
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&score.to_le_bytes());
+    blob.extend_from_slice(&y.to_le_bytes());
+    db.conn()
+        .execute(
+            "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) VALUES (?1, 0, ?2)",
+            rusqlite::params![&turn_id, &blob],
+        )
+        .unwrap();
+    turn_id
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn search_rejects_invalid_format_at_parse_time() {
+    let home = TempDir::new().expect("home");
+    let output = run_xurl_search(home.path(), &["needle", "--format", "bogus"]);
+
+    assert!(!output.status.success(), "search format should fail");
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid value") && err.contains("markdown") && err.contains("json"),
+        "clap error should list valid formats, got: {err}"
+    );
+}
 
 #[tokio::test]
 async fn search_returns_semantically_relevant_turn() {
@@ -196,6 +270,60 @@ async fn search_returns_semantically_relevant_turn() {
         "top result should be database-related, got: {}",
         top.content
     );
+}
+
+#[tokio::test]
+async fn search_paginates_ranked_results_with_filter_offset() {
+    let db = open_temp_db();
+    let embedder = AxisEmbedder;
+    let ids = [
+        seed_scored_turn(&db, 0, 0.99),
+        seed_scored_turn(&db, 1, 0.90),
+        seed_scored_turn(&db, 2, 0.80),
+        seed_scored_turn(&db, 3, 0.70),
+        seed_scored_turn(&db, 4, 0.60),
+    ];
+
+    let page0 = search::search(
+        &db.inner,
+        &embedder,
+        "needle",
+        SearchOptions {
+            limit: 2,
+            filter: Some(TurnFilter {
+                limit: 2,
+                offset: 0,
+                ..Default::default()
+            }),
+            min_score: Some(0.0),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let page1 = search::search(
+        &db.inner,
+        &embedder,
+        "needle",
+        SearchOptions {
+            limit: 2,
+            filter: Some(TurnFilter {
+                limit: 2,
+                offset: 2,
+                ..Default::default()
+            }),
+            min_score: Some(0.0),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let page0_ids: Vec<&str> = page0.hits.iter().map(|hit| hit.turn_id.as_str()).collect();
+    let page1_ids: Vec<&str> = page1.hits.iter().map(|hit| hit.turn_id.as_str()).collect();
+    assert_eq!(page0_ids, vec![ids[0].as_str(), ids[1].as_str()]);
+    assert_eq!(page1_ids, vec![ids[2].as_str(), ids[3].as_str()]);
+    assert!(page0_ids.iter().all(|id| !page1_ids.contains(id)));
 }
 
 #[tokio::test]

--- a/tests/xurl_timeline.rs
+++ b/tests/xurl_timeline.rs
@@ -49,6 +49,15 @@ fn run_xurl_timeline(home: &Path, args: &[&str]) -> Output {
         .expect("run mempal xurl timeline")
 }
 
+fn run_xurl_stats(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .args(["xurl", "stats"])
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal xurl stats")
+}
+
 // ── fixture helpers ───────────────────────────────────────────────────────────
 
 struct RawTurnRow<'a> {
@@ -247,6 +256,19 @@ fn timeline_markdown_shows_source_path_segment_only_when_present() {
         without_header.matches(" · ").count(),
         2,
         "NULL header should only contain session/timestamp/role separators: {without_header}"
+    );
+}
+
+#[test]
+fn timeline_rejects_invalid_format_at_parse_time() {
+    let home = TempDir::new().expect("home");
+    let output = run_xurl_timeline(home.path(), &["--format", "bogus"]);
+
+    assert!(!output.status.success(), "timeline format should fail");
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid value") && err.contains("markdown") && err.contains("json"),
+        "clap error should list valid formats, got: {err}"
     );
 }
 
@@ -477,6 +499,67 @@ fn stats_includes_date_range() {
     let cc = stats.iter().find(|s| s.tool == "cc").unwrap();
     assert_eq!(cc.min_timestamp, 1000.0);
     assert_eq!(cc.max_timestamp, 9000.0);
+}
+
+#[test]
+fn stats_cli_json_reports_tools_and_unindexed_remaining() {
+    let home = TempDir::new().expect("home");
+    let db = open_home_db(home.path());
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "cc-stat",
+            session_id: "s1",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "hi",
+            timestamp_epoch: 1_000.0,
+        },
+        None,
+    );
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "codex-stat",
+            session_id: "s2",
+            tool: "codex",
+            turn_index: 0,
+            role: "assistant",
+            content: "bye",
+            timestamp_epoch: 2_000.0,
+        },
+        None,
+    );
+
+    let json_output = run_xurl_stats(home.path(), &["--json"]);
+    assert!(
+        json_output.status.success(),
+        "stats json failed: {}",
+        stderr(&json_output)
+    );
+    let report: Value = serde_json::from_str(&stdout(&json_output)).expect("stats json");
+    assert_eq!(report["unindexed_remaining"], Value::from(2));
+    let tools = report["tools"].as_array().expect("tools array");
+    let cc = tools
+        .iter()
+        .find(|tool| tool["tool"] == "cc")
+        .expect("cc stats");
+    assert_eq!(cc["count"], Value::from(1));
+    assert_eq!(cc["min_timestamp"], Value::from(1_000.0));
+    assert_eq!(cc["max_timestamp"], Value::from(1_000.0));
+    assert!(cc["first"].as_str().expect("first").contains('T'));
+    assert!(cc["last"].as_str().expect("last").contains('T'));
+
+    let human_output = run_xurl_stats(home.path(), &[]);
+    assert!(
+        human_output.status.success(),
+        "stats human failed: {}",
+        stderr(&human_output)
+    );
+    let human = stdout(&human_output);
+    assert!(human.contains("| tool"));
+    assert!(human.contains("unindexed_remaining: 2"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #269. Three read-path / CLI-contract consistency gaps across the `mempal xurl` subcommands,
surfaced while exercising the full xurl surface (and during #267). One theme, one PR.

## Changes

- **`stats --json`**: `stats` was the only xurl *read* command with no structured output
  (`ingest` / `reindex` / `backfill` have `--json`; `search` / `timeline` have `--format json`). It
  now emits a JSON object — per-tool counts, date ranges, and `unindexed_remaining`. Default
  human-readable output is unchanged.
- **`--format` → `ValueEnum`**: `search` / `timeline` declared `format: String`; replaced with an
  `XurlFormat { Markdown, Json }` clap `ValueEnum`. Invalid values (`--format xml`) are now rejected
  at parse time, and `--help` lists the choices. Behavior for valid values is unchanged.
- **`search --page`**: `search` had only `--limit` while `timeline` had `--limit` + `--page`. Added
  `--page` (0-based, default 0), mirroring timeline's `page * limit` OFFSET. `--page 0` preserves
  current behavior.

## Scope

- `src/main.rs` (xurl clap defs + search / timeline / stats handlers), `src/xurl/search.rs` (page
  offset), `tests/xurl_search.rs`, `tests/xurl_timeline.rs`.
- No schema change; no change to ingest, the daemon, or the MCP layer.

## Tests

`cargo test` — **1225 passed**, including new cases: stats-json shape, `--format` enum rejection of
an invalid value, and search `--page` offset correctness (page 0 vs 1 disjoint + correctly ordered).
`clippy --all-targets` clean.

## Review

Tier-4-critical review (claude-code, non-synthetic, session `01KSXPN1M5WVWS4S9C7KGQKVYK`): **PASS / CLEAN** — 0 findings across all severities. The reviewer verified each change individually — clap 4.6 `default_value_t + value_enum` compile-correctness (proven via in-file precedent), `page * limit` OFFSET semantics matching `timeline`, and the `stats --json` DTO shape — alongside the lefthook commit gate (clippy clean, 1225 tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
