### PR TITLE
docs(xurl): clarify mempal xurl subcommand vs standalone xurl tool (#271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ api_model = "nomic-embed-text"
 | `mempal fact-check [PATH\|-] [--wing W] [--room R] [--now <UNIX_SECS>]` | Offline contradiction check against KG triples + known entities |
 | `mempal bench longmemeval <FILE>` | LongMemEval retrieval benchmark |
 
+> **Heads-up — two different `xurl`s.** `mempal xurl` is a mempal subcommand: an `ingest` / `search` / `timeline` / `stats` / `reindex` / `backfill` pipeline over agent session transcripts. It is **not** the standalone `xurl` CLI (Xuanwo's "Resolve and read code-agent threads", invoked as `xurl …` with `agents://` URIs). The two are independent projects that happen to share a name — neither is an alias for the other.
+
 ## MCP Server (10 tools)
 
 `mempal serve --mcp` exposes these tools via Model Context Protocol:

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,6 +85,8 @@ api_model = "nomic-embed-text"
 | `mempal fact-check [PATH\|-] [--wing W] [--room R] [--now <UNIX_SECS>]` | 离线矛盾检查（对照 KG 三元组 + 已知 entity） |
 | `mempal bench longmemeval <FILE>` | LongMemEval 检索 benchmark |
 
+> **注意 —— 两个不同的 `xurl`。** `mempal xurl` 是 mempal 的子命令：针对 agent session transcript 的 `ingest` / `search` / `timeline` / `stats` / `reindex` / `backfill` 管道。它**不是**那个独立的 `xurl` CLI 工具（Xuanwo 的 "Resolve and read code-agent threads"，调用形如 `xurl …`、用 `agents://` URI）。两者是恰好同名的独立项目，互不为别名。
+
 ## MCP 服务器（10 个工具）
 
 `mempal serve --mcp` 通过 Model Context Protocol 暴露：


### PR DESCRIPTION
## Summary

Closes #271. Docs-only clarification of the `xurl` naming collision surfaced during the post-reconnect regression sweep.

## Changes

- `README.md` / `README_zh.md`: a short note distinguishing **`mempal xurl`** (mempal's ingest / search / timeline / stats / reindex / backfill subcommand for agent-thread URLs) from the unrelated **standalone `xurl` CLI** (Xuanwo's "resolve and read code-agent threads"). No code or `--help` change → stays in the docs-only FAST_PATH, no binary reinstall needed.

## Scope

Docs only. No `src/` changes, no schema change, no behavior change.

## Review

Tier-4-critical review (claude-code, non-synthetic, session `01KSXR1VVQ7M7B212HB7XZX6DE`): **PASS / CLEAN** — 0 findings. The reviewer verified the README notes accurately distinguish the two `xurl` programs and that the diff is docs-only (no `src/` change, FAST_PATH preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
