### PR TITLE
fix(embed): retry transient embed-queue failures, surface failed count, targeted re-embed (#275)

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -53,6 +53,15 @@ pub struct QueueConfig {
     pub max_retries: u32,
 }
 
+/// Controls whether a processing failure is retried or dead-lettered immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueFailureDisposition {
+    /// Retry with bounded queue backoff until `QueueConfig::max_retries` is exhausted.
+    Retryable,
+    /// Move directly to the failed/dead-letter state without another attempt.
+    Terminal,
+}
+
 impl Default for QueueConfig {
     fn default() -> Self {
         Self {
@@ -303,6 +312,16 @@ impl PendingMessageStore {
     }
 
     pub fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
+        self.mark_failed_with_disposition(id, error, QueueFailureDisposition::Retryable)
+    }
+
+    /// Record a failed processing attempt with explicit retry/dead-letter policy.
+    pub fn mark_failed_with_disposition(
+        &self,
+        id: &str,
+        error: &str,
+        disposition: QueueFailureDisposition,
+    ) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let redacted_error = sanitize_last_error(error);
@@ -317,9 +336,18 @@ impl PendingMessageStore {
         let next_retry = current_retry.saturating_add(1);
         let next_retry_u32 = u32::try_from(next_retry)
             .map_err(|_| QueueError::RetryCountOverflow { id: id.to_string() })?;
-        let backoff_ms = self.compute_backoff_ms(next_retry_u32);
-        let next_attempt_at = now_secs().saturating_add(div_ceil(backoff_ms, 1_000));
-        let terminal = next_retry_u32 > self.config.max_retries;
+        let terminal = disposition == QueueFailureDisposition::Terminal
+            || next_retry_u32 > self.config.max_retries;
+        let backoff_ms = if terminal {
+            0
+        } else {
+            self.compute_backoff_ms(next_retry_u32)
+        };
+        let next_attempt_at = if terminal {
+            now_secs()
+        } else {
+            now_secs().saturating_add(div_ceil(backoff_ms, 1_000))
+        };
         let status = if terminal { "failed" } else { "pending" };
 
         let updated = tx.execute(
@@ -350,6 +378,32 @@ impl PendingMessageStore {
 
         tx.commit()?;
         Ok(())
+    }
+
+    /// Return dead-lettered embed-queue messages to pending for a targeted retry.
+    ///
+    /// LLM tasks share the same storage table but are not embed queue work, so
+    /// they are intentionally left untouched.
+    pub fn retry_failed_embed_messages(&self) -> Result<u64> {
+        let now = now_secs();
+        let conn = self.open_connection()?;
+        let updated = conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'pending',
+                retry_count = 0,
+                retry_backoff_ms = 0,
+                next_attempt_at = ?1,
+                claim_token = NULL,
+                claimed_at = NULL,
+                heartbeat_at = NULL,
+                last_error = NULL
+            WHERE status = 'failed'
+              AND kind != 'llm_task'
+            "#,
+            [now],
+        )?;
+        Ok(updated as u64)
     }
 
     /// Return a claimed message to pending without counting it as a failure.
@@ -504,6 +558,10 @@ fn compute_queue_stats(conn: &Connection) -> Result<QueueStats> {
         avg_processing_ms,
         eta_secs,
     })
+}
+
+pub fn failure_headline_count(live_fail_count: u64, queue_stats: &QueueStats) -> u64 {
+    live_fail_count.max(queue_stats.failed)
 }
 
 fn reclaim_stale_tx(conn: &rusqlite::Transaction<'_>, stale_cutoff: i64) -> rusqlite::Result<u64> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,7 @@ use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     db::Database,
     project::resolve_project_id,
-    queue::{ClaimedMessage, PendingMessageStore},
+    queue::{ClaimedMessage, PendingMessageStore, QueueFailureDisposition},
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{BootstrapEvidenceArgs, Drawer, SourceType},
     utils::{current_timestamp, route_room_from_taxonomy, synthetic_source_file},
@@ -243,9 +243,14 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                     Err(error) => {
                         tracing::error!("daemon message {message_id} failed: {error}");
                         context.write_observer.record_error(error.to_string());
+                        let disposition = queue_failure_disposition(&error);
                         context
                             .store
-                            .mark_failed(&message_id, &error.to_string())
+                            .mark_failed_with_disposition(
+                                &message_id,
+                                &error.to_string(),
+                                disposition,
+                            )
                             .with_context(|| format!("failed to mark_failed {message_id}"))?;
                     }
                 }
@@ -454,6 +459,22 @@ async fn embed_text_with_heartbeat<E: Embedder + ?Sized>(
         .into_iter()
         .next()
         .ok_or_else(|| EmbedError::Runtime("embedder returned no vectors".to_string()))
+}
+
+fn queue_failure_disposition(error: &anyhow::Error) -> QueueFailureDisposition {
+    for cause in error.chain() {
+        if let Some(embed_error) = cause.downcast_ref::<EmbedError>() {
+            return if embed_error.is_retryable() {
+                QueueFailureDisposition::Retryable
+            } else {
+                QueueFailureDisposition::Terminal
+            };
+        }
+        if cause.downcast_ref::<serde_json::Error>().is_some() {
+            return QueueFailureDisposition::Terminal;
+        }
+    }
+    QueueFailureDisposition::Retryable
 }
 
 #[derive(Debug, Clone)]

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -119,16 +119,31 @@ pub enum EmbedError {
 
 impl EmbedError {
     pub fn is_retryable(&self) -> bool {
-        !matches!(
-            self,
-            Self::InvalidResponse(_)
-                | Self::EmptyVectors
-                | Self::InvalidDimensions { .. }
-                | Self::UnsupportedBackend(_)
-                | Self::MissingConfiguration(_)
-                | Self::InvalidConfiguration(_)
-                | Self::ReadApiKeyEnv { .. }
-        )
+        match self {
+            Self::HttpRequest { source, .. } => source.status().is_none_or(is_retryable_status),
+            Self::HttpStatus { source, .. } | Self::DownloadStatus { source, .. } => {
+                source.status().is_some_and(is_retryable_status)
+            }
+            Self::Download { .. }
+            | Self::ReadDownloadBody { .. }
+            | Self::Runtime(_)
+            | Self::WorkerPanic(_) => true,
+            Self::CreateModelDir { .. }
+            | Self::CheckPathExists { .. }
+            | Self::WriteFile { .. }
+            | Self::RenameFile { .. }
+            | Self::SessionBuilder(_)
+            | Self::LoadModel { .. }
+            | Self::Tokenizer(_)
+            | Self::DecodeResponse { .. }
+            | Self::InvalidResponse(_)
+            | Self::EmptyVectors
+            | Self::InvalidDimensions { .. }
+            | Self::UnsupportedBackend(_)
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::ReadApiKeyEnv { .. } => false,
+        }
     }
 
     pub fn endpoint(&self) -> Option<&str> {
@@ -139,6 +154,12 @@ impl EmbedError {
             _ => None,
         }
     }
+}
+
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
 }
 
 #[async_trait::async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,6 +431,9 @@ enum Commands {
         force: bool,
         #[arg(long, default_value_t = false)]
         dry_run: bool,
+        /// Return failed embed-queue messages to pending for daemon retry.
+        #[arg(long, default_value_t = false)]
+        failed: bool,
         /// Recompute importance scores for existing drawers using rule-based heuristics.
         /// Mutually exclusive with embedder-based reindex; does not re-embed.
         #[arg(long, default_value_t = false)]
@@ -2383,11 +2386,26 @@ fn run() -> Result<()> {
             stale,
             force,
             dry_run,
+            failed,
             recompute_importance,
             only_zero,
             normalize_added_at,
         } => {
-            if normalize_added_at {
+            if failed {
+                if embedder.is_some()
+                    || from_config
+                    || resume
+                    || stale
+                    || force
+                    || dry_run
+                    || recompute_importance
+                    || only_zero
+                    || normalize_added_at
+                {
+                    bail!("--failed is mutually exclusive with other reindex modes and modifiers");
+                }
+                reindex_failed_queue_command(&db)
+            } else if normalize_added_at {
                 if recompute_importance || embedder.is_some() || from_config {
                     bail!(
                         "--normalize-added-at is mutually exclusive with --embedder, --from-config, and --recompute-importance"
@@ -4814,6 +4832,16 @@ fn recompute_importance_command(db: &Database, only_zero: bool) -> Result<()> {
         .bulk_update_importance(&updates)
         .context("failed to apply importance scores")?;
     println!("updated {updated} drawers with recomputed importance scores");
+    Ok(())
+}
+
+fn reindex_failed_queue_command(db: &Database) -> Result<()> {
+    let store = mempal::core::queue::PendingMessageStore::new(db.path())
+        .context("failed to open pending message queue")?;
+    let retried = store
+        .retry_failed_embed_messages()
+        .context("failed to requeue failed embed messages")?;
+    println!("requeued failed embed queue items: {retried}");
     Ok(())
 }
 
@@ -8234,7 +8262,9 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         "config: version={} loaded_unix_ms={}",
         cfg_meta.version, cfg_meta.loaded_at_unix_ms
     );
-    println!("embed_fail_count: {}", embed_status.fail_count);
+    let embed_failure_headline =
+        mempal::core::queue::failure_headline_count(embed_status.fail_count, &queue_stats);
+    println!("embed_fail_count: {embed_failure_headline}");
     println!("embed_degraded: {}", embed_status.degraded);
     if let Some(last_error) = embed_status.last_error {
         println!("embed_last_error: {last_error}");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1327,6 +1327,9 @@ impl MempalMcpServer {
             });
         }
 
+        let embed_failure_headline =
+            crate::core::queue::failure_headline_count(embed_snapshot.fail_count, &queue_stats);
+
         Ok(Json(StatusResponse {
             schema_version,
             normalize_version_current: CURRENT_NORMALIZE_VERSION,
@@ -1368,8 +1371,8 @@ impl MempalMcpServer {
                 claimed_count: queue_stats.claimed,
                 failed_count: queue_stats.failed,
                 degraded: embed_snapshot.degraded,
-                fail_count: embed_snapshot.fail_count,
-                failure_count: embed_snapshot.fail_count,
+                fail_count: embed_failure_headline,
+                failure_count: embed_failure_headline,
                 last_error: embed_snapshot.last_error,
                 last_success_at_unix_ms: embed_snapshot.last_success_at_unix_ms,
             },

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -145,6 +145,35 @@ async fn test_mcp_status_surfaces_queue_stats() {
 }
 
 #[tokio::test]
+async fn test_mcp_status_headline_reflects_failed_queue() {
+    let (_tmp, db_path, config) = setup_env();
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            max_retries: 0,
+        },
+    )
+    .expect("create store");
+
+    store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let failed = store
+        .claim_next("worker-failed", 60)
+        .expect("claim")
+        .expect("failed row");
+    store.mark_failed(&failed.id, "boom").expect("mark failed");
+
+    let server = MempalMcpServer::new(db_path, config);
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(response.queue_stats.failed, 1);
+    assert_eq!(response.embed_status.failed_count, 1);
+    assert_eq!(response.embed_status.fail_count, 1);
+    assert_eq!(response.embed_status.failure_count, 1);
+}
+
+#[tokio::test]
 async fn test_mcp_status_surfaces_source_type_distribution() {
     let (_tmp, db_path, config) = setup_env();
     insert_drawer_with_source_type(&db_path, "drawer-user", SourceType::UserExplicit);

--- a/tests/openai_compat_embedder.rs
+++ b/tests/openai_compat_embedder.rs
@@ -72,6 +72,28 @@ async fn test_openai_compat_embed_api_error() {
 
     mock.assert();
     assert!(matches!(error, EmbedError::HttpStatus { .. }));
+    assert!(error.is_retryable());
+}
+
+#[tokio::test]
+async fn test_openai_compat_embed_client_error_is_not_retryable() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/embeddings")
+        .with_status(400)
+        .with_body("bad input")
+        .create();
+    let config = config_for(&server, "");
+    let embedder = OpenAiCompatibleEmbedder::from_config(&config).expect("build embedder");
+
+    let error = embedder
+        .embed(&["bad input"])
+        .await
+        .expect_err("client error");
+
+    mock.assert();
+    assert!(matches!(error, EmbedError::HttpStatus { .. }));
+    assert!(!error.is_retryable());
 }
 
 #[tokio::test]
@@ -92,6 +114,7 @@ async fn test_openai_compat_embed_malformed_response() {
 
     mock.assert();
     assert!(matches!(error, EmbedError::DecodeResponse { .. }));
+    assert!(!error.is_retryable());
 }
 
 #[tokio::test]

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mempal::core::db::Database;
-use mempal::core::queue::{LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig};
+use mempal::core::queue::{
+    LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig, QueueFailureDisposition,
+};
 use rusqlite::Connection;
 use tempfile::TempDir;
 use tokio::sync::Barrier;
@@ -122,6 +124,67 @@ fn test_mark_failed_sets_backoff_next_attempt() {
 }
 
 #[test]
+fn test_retryable_failure_is_retried_not_dead_lettered_first() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    store
+        .mark_failed_with_disposition(&id, "transport timeout", QueueFailureDisposition::Retryable)
+        .expect("mark retryable failure");
+
+    let (status, retry_count): (String, i64) = Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT status, retry_count FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read queue row");
+    assert_eq!(status, "pending");
+    assert_eq!(retry_count, 1);
+}
+
+#[test]
+fn test_terminal_failure_dead_letters_immediately() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    store
+        .claim_next("worker-a", 60)
+        .expect("claim")
+        .expect("message");
+
+    store
+        .mark_failed_with_disposition(
+            &id,
+            "invalid embedding input",
+            QueueFailureDisposition::Terminal,
+        )
+        .expect("mark terminal failure");
+
+    let (status, retry_count, next_attempt_at): (String, i64, i64) = Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT status, retry_count, next_attempt_at FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read queue row");
+    assert_eq!(status, "failed");
+    assert_eq!(retry_count, 1);
+    assert!(next_attempt_at <= now_secs());
+    assert!(
+        store
+            .claim_next("worker-b", 60)
+            .expect("claim after terminal")
+            .is_none()
+    );
+}
+
+#[test]
 fn test_max_retries_marks_failed_permanently() {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
@@ -161,6 +224,61 @@ fn test_max_retries_marks_failed_permanently() {
             .expect("claim after failed")
             .is_none()
     );
+}
+
+#[test]
+fn test_retry_failed_embed_messages_requeues_only_failed_embed_items() {
+    let (_tmp, db_path, store) = new_store();
+    let failed_embed = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue failed embed");
+    let failed_llm = store
+        .enqueue("llm_task", r#"{"n":2}"#)
+        .expect("enqueue failed llm");
+    let pending_embed = store
+        .enqueue("hook_event", r#"{"n":3}"#)
+        .expect("enqueue pending embed");
+    let claimed_embed = store
+        .enqueue("hook_event", r#"{"n":4}"#)
+        .expect("enqueue claimed embed");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom' WHERE id IN (?1, ?2)",
+        rusqlite::params![failed_embed, failed_llm],
+    )
+    .expect("mark failed rows");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'claimed', claim_token = 'worker:claim', claimed_at = ?2, heartbeat_at = ?2 WHERE id = ?1",
+        rusqlite::params![claimed_embed, now_secs()],
+    )
+    .expect("mark claimed row");
+    drop(conn);
+
+    let retried = store
+        .retry_failed_embed_messages()
+        .expect("retry failed embed messages");
+    assert_eq!(retried, 1);
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let rows = [
+        (&failed_embed, "pending", 0_i64, None),
+        (&failed_llm, "failed", 7_i64, Some("boom")),
+        (&pending_embed, "pending", 0_i64, None),
+        (&claimed_embed, "claimed", 0_i64, None),
+    ];
+    for (id, expected_status, expected_retry_count, expected_error) in rows {
+        let (status, retry_count, last_error): (String, i64, Option<String>) = conn
+            .query_row(
+                "SELECT status, retry_count, last_error FROM pending_messages WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read row");
+        assert_eq!(status, expected_status, "{id}");
+        assert_eq!(retry_count, expected_retry_count, "{id}");
+        assert_eq!(last_error.as_deref(), expected_error, "{id}");
+    }
 }
 
 /// Verifies concurrent enqueue doesn't deadlock or starve.

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -314,6 +314,7 @@ fn test_status_command_shows_queue_stats() {
     assert!(output.status.success(), "{output:?}");
     let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
     assert!(stdout.contains("Queue:"), "{stdout}");
+    assert!(stdout.contains("embed_fail_count: 1"), "{stdout}");
     assert!(stdout.contains("pending: 1"), "{stdout}");
     assert!(stdout.contains("claimed: 1"), "{stdout}");
     assert!(stdout.contains("failed: 1"), "{stdout}");
@@ -323,6 +324,55 @@ fn test_status_command_shows_queue_stats() {
     assert!(stdout.contains("oldest_pending_age_secs:"), "{stdout}");
     assert!(stdout.contains("Source Types:"), "{stdout}");
     assert!(stdout.contains("user_explicit: 1"), "{stdout}");
+}
+
+#[test]
+fn test_reindex_failed_requeues_only_failed_embed_queue_items() {
+    let (home, db_path) = setup_home();
+    let store = PendingMessageStore::new(&db_path).expect("create store");
+    let failed_embed = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue failed embed");
+    let failed_llm = store
+        .enqueue("llm_task", r#"{"n":2}"#)
+        .expect("enqueue failed llm");
+    let pending_embed = store
+        .enqueue("hook_event", r#"{"n":3}"#)
+        .expect("enqueue pending embed");
+
+    Connection::open(&db_path)
+        .expect("open sqlite")
+        .execute(
+            "UPDATE pending_messages SET status = 'failed', retry_count = 4, last_error = 'boom' WHERE id IN (?1, ?2)",
+            params![failed_embed, failed_llm],
+        )
+        .expect("mark failed rows");
+
+    let output = Command::new(mempal_bin())
+        .args(["reindex", "--failed"])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal reindex --failed");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("reindex stdout utf8");
+    assert!(
+        stdout.contains("requeued failed embed queue items: 1"),
+        "{stdout}"
+    );
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let status_for = |id: &str| -> (String, i64) {
+        conn.query_row(
+            "SELECT status, retry_count FROM pending_messages WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read queue row")
+    };
+    assert_eq!(status_for(&failed_embed), ("pending".to_string(), 0));
+    assert_eq!(status_for(&failed_llm), ("failed".to_string(), 4));
+    assert_eq!(status_for(&pending_embed), ("pending".to_string(), 0));
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "74a0f969ea6b4cd4b4e793c6455211e49015559c"
+commit = "f396e3cfd724f7729fe0d08901770556cb271172"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #275. Transient embed-endpoint failures were permanently dead-lettered with
no retry; the `status` headline reported `embed_fail_count: 0` while the embed
queue held `failed: 566`; and there was no targeted recovery short of the
all-or-nothing `reindex --stale` (~512K drawers). Each orphaned item is a drawer
left with no current-space vector (companion to #274).

## Changes

- **Retry transient failures with bounded backoff** before dead-lettering — a
  single `consecutive=1` connection blip no longer permanently orphans an item.
  Non-transient (4xx/content) errors still dead-letter immediately.
- **Surface `queue.failed` in the `status` headline** (CLI `--full`/default and
  MCP `mempal_status`), so operators no longer see `0` next to a 566-item failed
  queue.
- **`mempal reindex --failed`** re-embeds just the failed set (mutually exclusive
  with other reindex modes; requeues only failed non-`llm_task` rows), independent
  of the 512K `reindex --stale` path.

## Scope

Embed queue / pending-message store, status surfacing, reindex CLI. No attempt at
#274 (recall-space / 512K staleness). No actual reindex run / no embedder load.
Fork-ext migrations (if any) use the `fork_ext_version` axis, idempotent.

## Review

Tier-4-critical review, read-only, scope `main...HEAD` (gemini-cli auto-filtered
for known quota exhaustion → fell back to codex). Verdict **PASS / CLEAN**, 0
findings at all severities (`review-verdict.json` decision=pass, `findings = []`).

Reviewer confirmed:
- Queue failure-disposition split is coherent — `EmbedError::is_retryable()`
  distinguishes transient HTTP 5xx/timeout (bounded retry) from terminal
  4xx/config/shape errors (immediate dead-letter); changed tests cover
  representative 5xx/400/malformed-response paths.
- `reindex --failed` is mutually exclusive with other reindex modes and requeues
  only failed non-`llm_task` rows.
- Status headline derives from live embed failures + durable failed queue rows;
  raw queue failed count remains separately exposed, so the headline change is a
  documented API-semantics choice, not a contract bug.
- The embedder's own live-retry loop remains infinite-2s + heartbeat-per-iteration
  (mempal invariant intact); bounded retry-before-dead-letter lives at the queue
  worker level.
- Security pass clean (no exploit/data-loss/credential-path regression);
  AGENTS.md checklist all `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
