### PR TITLE
fix(search): use cosine distance for drawer vector index (#274)

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -14,6 +14,7 @@ use super::types::IntelligenceMode;
 
 const DEFAULT_DB_PATH: &str = "~/.mempal/palace.db";
 const DEFAULT_EMBED_BACKEND: &str = "openai_compat";
+pub const DEFAULT_MODEL2VEC_FINGERPRINT_MODEL: &str = "model2vec/potion-multilingual-128M";
 const DEFAULT_CHUNKER_MAX_TOKENS: usize = 1024;
 const DEFAULT_CHUNKER_TARGET_TOKENS: usize = 512;
 const DEFAULT_CHUNKER_OVERLAP_TOKENS: usize = 64;
@@ -905,6 +906,32 @@ impl Default for EmbedConfig {
 }
 
 impl EmbedConfig {
+    pub fn vector_embedder_fingerprint(&self, backend: &str, dim: usize) -> String {
+        let base_url = self
+            .resolved_openai_base_url()
+            .unwrap_or_default()
+            .trim_end_matches('/');
+        let model = self.vector_fingerprint_model(backend);
+        format!("{backend}:{model}:{base_url}:{dim}")
+    }
+
+    pub fn current_vector_embedder_fingerprint(&self, dim: usize) -> String {
+        self.vector_embedder_fingerprint(self.backend.as_str(), dim)
+    }
+
+    fn vector_fingerprint_model(&self, backend: &str) -> String {
+        if backend == "model2vec" {
+            return self
+                .model
+                .clone()
+                .unwrap_or_else(|| DEFAULT_MODEL2VEC_FINGERPRINT_MODEL.to_string());
+        }
+        self.resolved_openai_model()
+            .or(self.model.as_deref())
+            .unwrap_or_default()
+            .to_string()
+    }
+
     pub fn resolved_openai_base_url(&self) -> Option<&str> {
         self.openai_compat
             .base_url

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -24,12 +24,12 @@ use super::anchor;
 use super::{
     types::{
         AnchorKind, ChunkNeighbors, CompactionStrategy, ConsolidationStats, Drawer, DrawerDetails,
-        DrawerSummary, ExplicitTunnel, KnowledgeCard, KnowledgeCardEvent, KnowledgeCardFilter,
-        KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole, KnowledgeStatus,
-        KnowledgeTier, MemoryDomain, MemoryKind, NeighborChunk, Provenance, ReindexSource,
-        RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
-        SleepStats, SourceType, TaxonomyEntry, Triple, TripleStats, TunnelDrawer, TunnelEndpoint,
-        TunnelFollowResult,
+        DrawerSummary, DrawerVectorDetails, ExplicitTunnel, KnowledgeCard, KnowledgeCardEvent,
+        KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
+        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, NeighborChunk, Provenance,
+        ReindexSource, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
+        RuntimeAdoptionTrack, SleepStats, SourceType, TaxonomyEntry, Triple, TripleStats,
+        TunnelDrawer, TunnelEndpoint, TunnelFollowResult,
     },
     utils::{
         build_drawer_id, build_scoped_drawer_id, build_tunnel_id, current_timestamp,
@@ -40,6 +40,8 @@ use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
 pub const CURRENT_SCHEMA_VERSION: u32 = 17;
+pub const CURRENT_VECTOR_INDEX_VERSION: &str = "v2";
+pub const VECTOR_DISTANCE_METRIC: &str = "cosine";
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
@@ -665,6 +667,7 @@ impl Database {
     ) -> Result<(), DbError> {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
+        let content_hash = content_hash_hex(merged_content);
         self.conn.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> Result<(), DbError> {
             self.conn.execute(
@@ -672,10 +675,11 @@ impl Database {
                 UPDATE drawers
                 SET content = ?2,
                     updated_at = ?3,
+                    content_hash = ?4,
                     merge_count = COALESCE(merge_count, 0) + 1
                 WHERE id = ?1
                 "#,
-                params![drawer_id, merged_content, updated_at],
+                params![drawer_id, merged_content, updated_at, content_hash],
             )?;
             self.conn
                 .execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
@@ -688,6 +692,7 @@ impl Database {
                 "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
                 params![drawer_id, vector_json, project_id],
             )?;
+            self.record_current_vector_metadata(drawer_id, vector.len())?;
             Ok(())
         })();
         match result {
@@ -969,7 +974,10 @@ impl Database {
             "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
             params![drawer_id, vector_json.as_str(), project_id],
         ) {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                self.record_current_vector_metadata(drawer_id, vector.len())?;
+                Ok(())
+            }
             // sqlite-vec's vec0 virtual table does not honor INSERT OR IGNORE
             // or INSERT OR REPLACE — it always raises a UNIQUE primary key
             // violation on duplicate id, regardless of conflict clause. Match
@@ -983,6 +991,74 @@ impl Database {
             }
             Err(e) => Err(DbError::Sqlite(e)),
         }
+    }
+
+    pub fn vector_table_distance_metric(&self) -> Result<Option<String>, DbError> {
+        if !self.table_exists("drawer_vectors")? {
+            return Ok(None);
+        }
+        let sql = self
+            .conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'drawer_vectors'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let Some(sql) = sql else {
+            return Ok(None);
+        };
+        let lower = sql.to_ascii_lowercase();
+        if lower.contains("distance_metric=cosine") {
+            Ok(Some("cosine".to_string()))
+        } else if lower.contains("distance_metric=l2") {
+            Ok(Some("l2".to_string()))
+        } else {
+            // sqlite-vec defaults vec0 float vectors to L2 when no metric is declared.
+            Ok(Some("l2".to_string()))
+        }
+    }
+
+    pub fn current_vector_embedder_fingerprint(dim: usize) -> String {
+        let config = super::config::ConfigHandle::current();
+        config.embed.current_vector_embedder_fingerprint(dim)
+    }
+
+    pub fn record_current_vector_metadata(
+        &self,
+        drawer_id: &str,
+        dim: usize,
+    ) -> Result<(), DbError> {
+        self.record_vector_metadata(
+            drawer_id,
+            CURRENT_VECTOR_INDEX_VERSION,
+            &Self::current_vector_embedder_fingerprint(dim),
+        )
+    }
+
+    pub fn record_vector_metadata(
+        &self,
+        drawer_id: &str,
+        index_version: &str,
+        embedder_fingerprint: &str,
+    ) -> Result<(), DbError> {
+        if !self.table_exists("fork_ext_meta")? {
+            return Ok(());
+        }
+        self.conn.execute(
+            r#"
+            INSERT INTO fork_ext_meta (key, value)
+            VALUES (?1, ?2), (?3, ?4)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            "#,
+            params![
+                vector_metadata_key(drawer_id, "index_version"),
+                index_version,
+                vector_metadata_key(drawer_id, "embedder_fingerprint"),
+                embedder_fingerprint,
+            ],
+        )?;
+        Ok(())
     }
 
     pub fn upsert_drawer_and_replace_vector(
@@ -1094,6 +1170,7 @@ impl Database {
                 "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, vec_f32(?2))",
                 params![drawer.id.as_str(), vector_json.as_str()],
             )?;
+            self.record_current_vector_metadata(&drawer.id, vector.len())?;
 
             Ok(())
         })();
@@ -1200,7 +1277,7 @@ impl Database {
             ""
         };
         self.conn.execute_batch(&format!(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}]{project_column});"
+            "CREATE VIRTUAL TABLE IF NOT EXISTS drawer_vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[{dim}] distance_metric={VECTOR_DISTANCE_METRIC}{project_column});"
         ))?;
         Ok(())
     }
@@ -1533,6 +1610,67 @@ impl Database {
         table_exists_conn(&self.conn, table_name)
     }
 
+    pub fn drawer_vector_details(&self, drawer_id: &str) -> Result<DrawerVectorDetails, DbError> {
+        let metric = self.vector_table_distance_metric()?;
+        let dimension = if metric.is_some() {
+            self.conn
+                .query_row(
+                    "SELECT vec_length(embedding) FROM drawer_vectors WHERE id = ?1",
+                    [drawer_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?
+                .map(|value| value as usize)
+        } else {
+            None
+        };
+        let has_vector = dimension.is_some();
+        let index_version = self
+            .load_vector_metadata(drawer_id, "index_version")?
+            .or(self.load_vector_metadata(drawer_id, "normalize_version")?);
+        let embedder_fingerprint = self.load_vector_metadata(drawer_id, "embedder_fingerprint")?;
+        let current_embedder_fingerprint = dimension.map(Self::current_vector_embedder_fingerprint);
+        let (embedder, model) = embedder_fingerprint
+            .as_deref()
+            .map(parse_vector_fingerprint)
+            .unwrap_or((None, None));
+        let stale = !has_vector
+            || metric.as_deref() != Some(VECTOR_DISTANCE_METRIC)
+            || index_version.as_deref() != Some(CURRENT_VECTOR_INDEX_VERSION)
+            || embedder_fingerprint.as_deref() != current_embedder_fingerprint.as_deref();
+
+        Ok(DrawerVectorDetails {
+            has_vector,
+            dimension,
+            embedder,
+            model,
+            embedder_fingerprint,
+            index_version,
+            current_embedder_fingerprint,
+            current_index_version: CURRENT_VECTOR_INDEX_VERSION.to_string(),
+            distance_metric: metric,
+            stale,
+        })
+    }
+
+    fn load_vector_metadata(
+        &self,
+        drawer_id: &str,
+        field: &str,
+    ) -> Result<Option<String>, DbError> {
+        if !self.table_exists("fork_ext_meta")? {
+            return Ok(None);
+        }
+        self.conn
+            .query_row(
+                "SELECT value FROM fork_ext_meta WHERE key = ?1",
+                [vector_metadata_key(drawer_id, field)],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(DbError::Sqlite)
+    }
+
     pub fn taxonomy_count(&self) -> Result<i64, DbError> {
         Ok(self
             .conn
@@ -1597,18 +1735,30 @@ impl Database {
             let updated_at = row.get::<_, Option<String>>(32)?;
             let merge_count = row.get::<_, u32>(33)?;
             let project_id = row.get::<_, Option<String>>(34)?;
-            Ok(DrawerDetails {
-                drawer,
-                updated_at,
-                merge_count,
-                project_id,
-            })
+            Ok((drawer, updated_at, merge_count, project_id))
         })?;
 
-        match rows.next() {
-            Some(row) => Ok(Some(row?)),
-            None => Ok(None),
-        }
+        let details = match rows.next() {
+            Some(row) => {
+                let (drawer, updated_at, merge_count, project_id) = row?;
+                Some((drawer, updated_at, merge_count, project_id))
+            }
+            None => None,
+        };
+        drop(rows);
+        drop(statement);
+        details
+            .map(|(drawer, updated_at, merge_count, project_id)| {
+                let vector = self.drawer_vector_details(&drawer.id)?;
+                Ok(DrawerDetails {
+                    drawer,
+                    updated_at,
+                    merge_count,
+                    project_id,
+                    vector,
+                })
+            })
+            .transpose()
     }
 
     pub fn get_drawer_details_batch(
@@ -1654,17 +1804,27 @@ impl Database {
                 let project_id = row.get::<_, Option<String>>(34)?;
                 Ok((
                     drawer.id.clone(),
-                    DrawerDetails {
-                        drawer,
-                        updated_at,
-                        merge_count,
-                        project_id,
-                    },
+                    drawer,
+                    updated_at,
+                    merge_count,
+                    project_id,
                 ))
             })?;
 
+            let mut base_rows = Vec::new();
             for row in rows {
-                let (id, details) = row?;
+                base_rows.push(row?);
+            }
+            drop(statement);
+            for (id, drawer, updated_at, merge_count, project_id) in base_rows {
+                let vector = self.drawer_vector_details(&id)?;
+                let details = DrawerDetails {
+                    drawer,
+                    updated_at,
+                    merge_count,
+                    project_id,
+                    vector,
+                };
                 found_by_id.insert(id, details);
             }
         }
@@ -3218,7 +3378,7 @@ impl Database {
             DROP TABLE IF EXISTS drawer_vectors;
             CREATE VIRTUAL TABLE drawer_vectors USING vec0(
                 id TEXT PRIMARY KEY,
-                embedding FLOAT[{dim}]{project_column}
+                embedding FLOAT[{dim}] distance_metric={VECTOR_DISTANCE_METRIC}{project_column}
             );
             "#
         ))?;
@@ -5133,6 +5293,23 @@ fn register_sqlite_vec() -> Result<(), DbError> {
 
 fn source_type_as_str(source_type: &SourceType) -> &'static str {
     source_type.as_str()
+}
+
+pub fn vector_metadata_key(drawer_id: &str, field: &str) -> String {
+    format!("reindex:{drawer_id}:{field}")
+}
+
+fn parse_vector_fingerprint(value: &str) -> (Option<String>, Option<String>) {
+    let mut parts = value.splitn(3, ':');
+    let embedder = parts
+        .next()
+        .filter(|part| !part.is_empty())
+        .map(str::to_string);
+    let model = parts
+        .next()
+        .filter(|part| !part.is_empty())
+        .map(str::to_string);
+    (embedder, model)
 }
 
 fn source_type_from_str(source_type: &str) -> Result<SourceType, DbError> {

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -747,10 +747,11 @@ fn recreate_drawer_vectors_with_project_id(conn: &Connection) -> rusqlite::Resul
         r#"
         CREATE VIRTUAL TABLE drawer_vectors USING vec0(
             id TEXT PRIMARY KEY,
-            embedding FLOAT[{dimension}],
+            embedding FLOAT[{dimension}] distance_metric={metric},
             +project_id TEXT
         );
-        "#
+        "#,
+        metric = super::VECTOR_DISTANCE_METRIC
     ))?;
     conn.execute_batch(
         r#"

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -576,6 +576,21 @@ pub struct DrawerDetails {
     pub updated_at: Option<String>,
     pub merge_count: u32,
     pub project_id: Option<String>,
+    pub vector: DrawerVectorDetails,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DrawerVectorDetails {
+    pub has_vector: bool,
+    pub dimension: Option<usize>,
+    pub embedder: Option<String>,
+    pub model: Option<String>,
+    pub embedder_fingerprint: Option<String>,
+    pub index_version: Option<String>,
+    pub current_embedder_fingerprint: Option<String>,
+    pub current_index_version: String,
+    pub distance_metric: Option<String>,
+    pub stale: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,10 @@ use mempal::core::{
     anchor,
     compaction::merge_cluster,
     config::{CompiledPrivacyConfig, Config, ConfigHandle, default_config_path},
-    db::{Database, find_similar_clusters},
+    db::{
+        CURRENT_VECTOR_INDEX_VERSION, Database, VECTOR_DISTANCE_METRIC, find_similar_clusters,
+        vector_metadata_key,
+    },
     phase3::{
         CardContextDefaultProposalReport, CardContextRollbackControlReport, EvaluatorAdviceInput,
         EvaluatorAdviceReport, Phase3ReadinessReport, ResearchIngestPlanReport,
@@ -431,6 +434,9 @@ enum Commands {
         force: bool,
         #[arg(long, default_value_t = false)]
         dry_run: bool,
+        /// With --embedder/--from-config --stale: number of stale/new drawers to embed per write batch.
+        #[arg(long)]
+        batch_size: Option<usize>,
         /// Return failed embed-queue messages to pending for daemon retry.
         #[arg(long, default_value_t = false)]
         failed: bool,
@@ -2386,6 +2392,7 @@ fn run() -> Result<()> {
             stale,
             force,
             dry_run,
+            batch_size,
             failed,
             recompute_importance,
             only_zero,
@@ -2398,6 +2405,7 @@ fn run() -> Result<()> {
                     || stale
                     || force
                     || dry_run
+                    || batch_size.is_some()
                     || recompute_importance
                     || only_zero
                     || normalize_added_at
@@ -2415,6 +2423,11 @@ fn run() -> Result<()> {
             } else if recompute_importance {
                 recompute_importance_command(&db, only_zero)
             } else if embedder.is_some() || from_config {
+                if dry_run {
+                    bail!(
+                        "--dry-run is only supported by source reindex (`mempal reindex --stale --dry-run`)"
+                    );
+                }
                 let backend = match (embedder.as_deref(), from_config) {
                     (Some(name), false) => name.to_string(),
                     (None, true) => config.embed.backend.clone(),
@@ -2429,8 +2442,12 @@ fn run() -> Result<()> {
                     &backend,
                     resume,
                     stale,
+                    batch_size.unwrap_or(1000),
                 ))
             } else {
+                if batch_size.is_some() {
+                    bail!("--batch-size requires --embedder or --from-config with --stale");
+                }
                 block_on_result(reindex_command_sources(
                     &db,
                     config.as_ref(),
@@ -4942,13 +4959,19 @@ async fn reindex_command_by_embedder(
     embedder_name: &str,
     resume: bool,
     stale_only: bool,
+    batch_size: usize,
 ) -> Result<()> {
     let embedder = build_specific_embedder(config, embedder_name).await?;
     let new_dim = embedder.dimensions();
     let current_dim = current_vector_dim(db).context("failed to read embedding dim")?;
+    let current_metric = db
+        .vector_table_distance_metric()
+        .context("failed to read vector distance metric")?;
     let progress_store = ReindexProgressStore::new(db.path());
-    let target_fingerprint = reindex_embedder_fingerprint(config, embedder_name, new_dim);
-    let resume_checkpoint = if resume {
+    let target_fingerprint = config
+        .embed
+        .vector_embedder_fingerprint(embedder_name, new_dim);
+    let mut resume_checkpoint = if resume {
         progress_store
             .latest_resumable(Some(embedder_name))
             .context("failed to load reindex checkpoint")?
@@ -4961,7 +4984,24 @@ async fn reindex_command_by_embedder(
     } else {
         println!("current vector dim: (empty table)");
     }
-    if resume_checkpoint.is_none() && (!stale_only || current_dim != Some(new_dim)) {
+    println!(
+        "current vector metric: {}",
+        current_metric.as_deref().unwrap_or("(empty table)")
+    );
+    let metric_is_current = current_metric.as_deref() == Some(VECTOR_DISTANCE_METRIC);
+    let table_layout_is_current = current_dim == Some(new_dim) && metric_is_current;
+    let should_recreate_table = if stale_only {
+        !table_layout_is_current
+    } else {
+        resume_checkpoint.is_none() || !table_layout_is_current
+    };
+    if should_recreate_table {
+        if resume_checkpoint.is_some() {
+            println!(
+                "resume checkpoint ignored because drawer_vectors metric or dimension is stale"
+            );
+            resume_checkpoint = None;
+        }
         println!("recreating drawer_vectors with {new_dim} dimensions...");
         db.recreate_vectors_table(new_dim)
             .context("failed to recreate vectors table")?;
@@ -4969,6 +5009,16 @@ async fn reindex_command_by_embedder(
         println!("stale-only reindex preserving existing drawer_vectors table");
     } else {
         println!("resume checkpoint found; preserving existing drawer_vectors table");
+    }
+    if stale_only && resume_checkpoint.is_none() {
+        return reindex_stale_batches(
+            db,
+            embedder.as_ref(),
+            embedder_name,
+            &target_fingerprint,
+            batch_size,
+        )
+        .await;
     }
     let mut drawers = reindex_rows(db).context("failed to load active drawers for reindex")?;
     if stale_only {
@@ -5013,12 +5063,12 @@ async fn reindex_command_by_embedder(
         db.conn()
             .execute("DELETE FROM drawer_vectors WHERE id = ?1", [&row.id])
             .with_context(|| format!("failed to clear existing vector for {}", row.id))?;
-        db.insert_vector(&row.id, &vector)
+        db.insert_vector_with_project(&row.id, &vector, row.project_id.as_deref())
             .with_context(|| format!("failed to insert vector for {}", row.id))?;
         record_reindex_metadata(
             db,
             &row.id,
-            CURRENT_REINDEX_NORMALIZE_VERSION,
+            CURRENT_VECTOR_INDEX_VERSION,
             &target_fingerprint,
         )
         .with_context(|| format!("failed to record reindex metadata for {}", row.id))?;
@@ -5041,6 +5091,74 @@ async fn reindex_command_by_embedder(
             .context("failed to finalize reindex checkpoint")?;
     }
     println!("reindex complete: {total} drawers, {new_dim}d vectors");
+    Ok(())
+}
+
+async fn reindex_stale_batches(
+    db: &Database,
+    embedder: &dyn Embedder,
+    embedder_name: &str,
+    target_fingerprint: &str,
+    batch_size: usize,
+) -> Result<()> {
+    if batch_size == 0 {
+        bail!("--batch-size must be greater than 0");
+    }
+    println!("stale-only reindex batch size: {batch_size}");
+    let mut processed = 0usize;
+    let mut skipped_concurrent_update = 0usize;
+    let mut batch_index = 0usize;
+    loop {
+        let rows = reindex_stale_batch_rows(db, target_fingerprint, batch_size)
+            .context("failed to load stale reindex batch")?;
+        if rows.is_empty() {
+            break;
+        }
+        let texts = rows
+            .iter()
+            .map(|row| row.content.as_str())
+            .collect::<Vec<_>>();
+        let vectors = embedder
+            .embed(&texts)
+            .await
+            .context("embedding failed during stale batch reindex")?;
+        if vectors.len() != rows.len() {
+            bail!(
+                "embedder returned {} vectors for {} stale drawers",
+                vectors.len(),
+                rows.len()
+            );
+        }
+        let stats = write_reindex_vector_batch(db, &rows, &vectors, target_fingerprint)
+            .context("failed to write stale reindex batch")?;
+        batch_index += 1;
+        processed += stats.reindexed;
+        skipped_concurrent_update += stats.skipped_concurrent_update;
+        if stats.skipped_concurrent_update == 0 {
+            println!(
+                "batch {batch_index}: re-embedded {} stale/new drawers (total {processed})",
+                stats.reindexed
+            );
+        } else {
+            println!(
+                "batch {batch_index}: re-embedded {} stale/new drawers, skipped {} concurrent updates (total {processed})",
+                stats.reindexed, stats.skipped_concurrent_update
+            );
+        }
+        let progress_store = ReindexProgressStore::new(db.path());
+        if let Some(last) = rows.last() {
+            progress_store
+                .upsert_running(&last.source_path, Some(last.chunk_index), embedder_name)
+                .context("failed to persist reindex checkpoint")?;
+        }
+    }
+    if skipped_concurrent_update == 0 {
+        println!("stale reindex complete: {processed} drawers");
+    } else {
+        println!(
+            "stale reindex complete: {processed} drawers ({skipped_concurrent_update} skipped due to concurrent updates)"
+        );
+    }
     Ok(())
 }
 
@@ -8858,20 +8976,29 @@ async fn build_specific_embedder(config: &Config, backend: &str) -> Result<Box<d
 struct ReindexRow {
     id: String,
     content: String,
+    content_hash: Option<String>,
     source_path: String,
     chunk_index: i64,
+    project_id: Option<String>,
 }
-const CURRENT_REINDEX_NORMALIZE_VERSION: &str = "v1";
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ReindexBatchWriteStats {
+    reindexed: usize,
+    skipped_concurrent_update: usize,
+}
 
 fn reindex_rows(db: &Database) -> Result<Vec<ReindexRow>> {
-    let mut stmt = db.conn().prepare(r#"SELECT id, content, COALESCE(source_file, id) AS source_path, COALESCE(chunk_index, 0) AS chunk_index FROM drawers WHERE deleted_at IS NULL ORDER BY source_path ASC, chunk_index ASC, id ASC"#).context("failed to prepare reindex query")?;
+    let mut stmt = db.conn().prepare(r#"SELECT id, content, content_hash, COALESCE(source_file, id) AS source_path, COALESCE(chunk_index, 0) AS chunk_index, project_id FROM drawers WHERE deleted_at IS NULL ORDER BY source_path ASC, chunk_index ASC, id ASC"#).context("failed to prepare reindex query")?;
     let rows = stmt
         .query_map([], |row| {
             Ok(ReindexRow {
                 id: row.get(0)?,
                 content: row.get(1)?,
-                source_path: row.get(2)?,
-                chunk_index: row.get(3)?,
+                content_hash: row.get(2)?,
+                source_path: row.get(3)?,
+                chunk_index: row.get(4)?,
+                project_id: row.get(5)?,
             })
         })
         .context("failed to query reindex rows")?
@@ -8879,6 +9006,166 @@ fn reindex_rows(db: &Database) -> Result<Vec<ReindexRow>> {
         .context("failed to collect reindex rows")?;
     Ok(rows)
 }
+
+fn reindex_stale_batch_rows(
+    db: &Database,
+    target_fingerprint: &str,
+    batch_size: usize,
+) -> Result<Vec<ReindexRow>> {
+    let limit = i64::try_from(batch_size).context("batch size is too large")?;
+    let vectors_exist = db
+        .conn()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .context("failed to query vector table presence")?;
+    let rows = if vectors_exist {
+        let mut stmt = db
+            .conn()
+            .prepare(
+                r#"
+                SELECT d.id,
+                       d.content,
+                       d.content_hash,
+                       COALESCE(d.source_file, d.id) AS source_path,
+                       COALESCE(d.chunk_index, 0) AS chunk_index,
+                       d.project_id
+                FROM drawers d
+                LEFT JOIN drawer_vectors v ON v.id = d.id
+                LEFT JOIN fork_ext_meta idx
+                  ON idx.key = 'reindex:' || d.id || ':index_version'
+                LEFT JOIN fork_ext_meta legacy_idx
+                  ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
+                LEFT JOIN fork_ext_meta fp
+                  ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
+                WHERE d.deleted_at IS NULL
+                  AND (
+                      v.id IS NULL
+                      OR COALESCE(idx.value, legacy_idx.value, '') != ?1
+                      OR COALESCE(fp.value, '') != ?2
+                  )
+                ORDER BY source_path ASC, chunk_index ASC, d.id ASC
+                LIMIT ?3
+                "#,
+            )
+            .context("failed to prepare stale vector batch query")?;
+        stmt.query_map(
+            (CURRENT_VECTOR_INDEX_VERSION, target_fingerprint, limit),
+            |row| {
+                Ok(ReindexRow {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                    content_hash: row.get(2)?,
+                    source_path: row.get(3)?,
+                    chunk_index: row.get(4)?,
+                    project_id: row.get(5)?,
+                })
+            },
+        )
+        .context("failed to query stale vector batch")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect stale vector batch")?
+    } else {
+        let mut stmt = db
+            .conn()
+            .prepare(
+                r#"
+                SELECT id,
+                       content,
+                       content_hash,
+                       COALESCE(source_file, id) AS source_path,
+                       COALESCE(chunk_index, 0) AS chunk_index,
+                       project_id
+                FROM drawers
+                WHERE deleted_at IS NULL
+                ORDER BY source_path ASC, chunk_index ASC, id ASC
+                LIMIT ?1
+                "#,
+            )
+            .context("failed to prepare missing-vector batch query")?;
+        stmt.query_map([limit], |row| {
+            Ok(ReindexRow {
+                id: row.get(0)?,
+                content: row.get(1)?,
+                content_hash: row.get(2)?,
+                source_path: row.get(3)?,
+                chunk_index: row.get(4)?,
+                project_id: row.get(5)?,
+            })
+        })
+        .context("failed to query missing-vector batch")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect missing-vector batch")?
+    };
+    Ok(rows)
+}
+
+fn write_reindex_vector_batch(
+    db: &Database,
+    rows: &[ReindexRow],
+    vectors: &[Vec<f32>],
+    target_fingerprint: &str,
+) -> Result<ReindexBatchWriteStats> {
+    use rusqlite::OptionalExtension;
+
+    db.conn()
+        .busy_timeout(std::time::Duration::from_millis(0))
+        .context("failed to set fail-fast busy timeout")?;
+    let begin = db.conn().execute_batch("BEGIN IMMEDIATE;");
+    db.conn()
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .context("failed to restore busy timeout")?;
+    begin.context("failed to begin stale reindex batch transaction")?;
+
+    let result = (|| -> Result<ReindexBatchWriteStats> {
+        let mut stats = ReindexBatchWriteStats::default();
+        for (row, vector) in rows.iter().zip(vectors) {
+            let current_token = db
+                .conn()
+                .query_row(
+                    "SELECT content_hash FROM drawers WHERE id = ?1 AND deleted_at IS NULL",
+                    [&row.id],
+                    |db_row| db_row.get::<_, Option<String>>(0),
+                )
+                .optional()
+                .with_context(|| format!("failed to verify current drawer token for {}", row.id))?;
+            if current_token != Some(row.content_hash.clone()) {
+                stats.skipped_concurrent_update += 1;
+                continue;
+            }
+            db.conn()
+                .execute("DELETE FROM drawer_vectors WHERE id = ?1", [&row.id])
+                .with_context(|| format!("failed to clear existing vector for {}", row.id))?;
+            db.insert_vector_with_project(&row.id, vector, row.project_id.as_deref())
+                .with_context(|| format!("failed to insert vector for {}", row.id))?;
+            record_reindex_metadata(
+                db,
+                &row.id,
+                CURRENT_VECTOR_INDEX_VERSION,
+                target_fingerprint,
+            )
+            .with_context(|| format!("failed to record reindex metadata for {}", row.id))?;
+            stats.reindexed += 1;
+        }
+        Ok(stats)
+    })();
+
+    match result {
+        Ok(stats) => {
+            db.conn()
+                .execute_batch("COMMIT;")
+                .context("failed to commit stale reindex batch")?;
+            Ok(stats)
+        }
+        Err(error) => {
+            let _ = db.conn().execute_batch("ROLLBACK;");
+            Err(error)
+        }
+    }
+}
+
 fn should_skip_reindex_row(
     checkpoint: Option<&mempal::core::reindex::ReindexProgressRow>,
     source_path: &str,
@@ -8914,24 +9201,12 @@ fn current_vector_dim(db: &Database) -> Result<Option<usize>> {
         .map(|v| v as usize);
     Ok(dim)
 }
-fn reindex_embedder_fingerprint(config: &Config, backend: &str, dim: usize) -> String {
-    let base_url = config
-        .embed
-        .resolved_openai_base_url()
-        .unwrap_or_default()
-        .trim_end_matches('/');
-    let model = config.embed.resolved_openai_model().unwrap_or_default();
-    format!("{backend}:{model}:{base_url}:{dim}")
-}
-fn reindex_metadata_key(drawer_id: &str, field: &str) -> String {
-    format!("reindex:{drawer_id}:{field}")
-}
 fn load_reindex_metadata(db: &Database, drawer_id: &str, field: &str) -> Result<Option<String>> {
     use rusqlite::OptionalExtension;
     db.conn()
         .query_row(
             "SELECT value FROM fork_ext_meta WHERE key = ?1",
-            [reindex_metadata_key(drawer_id, field)],
+            [vector_metadata_key(drawer_id, field)],
             |row| row.get::<_, String>(0),
         )
         .optional()
@@ -8943,7 +9218,7 @@ fn record_reindex_metadata(
     normalize_version: &str,
     embedder_fingerprint: &str,
 ) -> Result<()> {
-    db.conn().execute(r#"INSERT INTO fork_ext_meta (key, value) VALUES (?1, ?2), (?3, ?4) ON CONFLICT(key) DO UPDATE SET value = excluded.value"#, rusqlite::params![reindex_metadata_key(drawer_id, "normalize_version"), normalize_version, reindex_metadata_key(drawer_id, "embedder_fingerprint"), embedder_fingerprint]).context("failed to write reindex metadata")?;
+    db.conn().execute(r#"INSERT INTO fork_ext_meta (key, value) VALUES (?1, ?2), (?3, ?4), (?5, ?6) ON CONFLICT(key) DO UPDATE SET value = excluded.value"#, rusqlite::params![vector_metadata_key(drawer_id, "index_version"), normalize_version, vector_metadata_key(drawer_id, "normalize_version"), normalize_version, vector_metadata_key(drawer_id, "embedder_fingerprint"), embedder_fingerprint]).context("failed to write reindex metadata")?;
     Ok(())
 }
 fn drawer_vector_exists(db: &Database, drawer_id: &str) -> Result<bool> {
@@ -8962,8 +9237,15 @@ fn reindex_row_is_stale(db: &Database, row: &ReindexRow, target_fingerprint: &st
     if !drawer_vector_exists(db, &row.id)? {
         return Ok(true);
     }
-    let nv = load_reindex_metadata(db, &row.id, "normalize_version")?;
-    if nv.as_deref() != Some(CURRENT_REINDEX_NORMALIZE_VERSION) {
+    if db.vector_table_distance_metric()?.as_deref() != Some(VECTOR_DISTANCE_METRIC) {
+        return Ok(true);
+    }
+    let nv = load_reindex_metadata(db, &row.id, "index_version")?.or(load_reindex_metadata(
+        db,
+        &row.id,
+        "normalize_version",
+    )?);
+    if nv.as_deref() != Some(CURRENT_VECTOR_INDEX_VERSION) {
         return Ok(true);
     }
     let fp = load_reindex_metadata(db, &row.id, "embedder_fingerprint")?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6023,6 +6023,7 @@ fn intelligence_llm_state(config: &crate::core::config::Config, reachable: bool)
 fn read_drawer_response(details: crate::core::types::DrawerDetails) -> ReadDrawerResponse {
     let signals = crate::aaak::analyze(&details.drawer.content);
     let original_content_bytes = details.drawer.content.len() as u64;
+    let vector = details.vector;
     let drawer = details.drawer;
     ReadDrawerResponse {
         drawer_id: drawer.id.clone(),
@@ -6036,6 +6037,16 @@ fn read_drawer_response(details: crate::core::types::DrawerDetails) -> ReadDrawe
         updated_at: details.updated_at,
         merge_count: details.merge_count,
         importance_stars: signals.importance_stars,
+        has_vector: vector.has_vector,
+        vector_dimension: vector.dimension,
+        vector_embedder: vector.embedder,
+        vector_model: vector.model,
+        vector_embedder_fingerprint: vector.embedder_fingerprint,
+        vector_index_version: vector.index_version,
+        vector_current_embedder_fingerprint: vector.current_embedder_fingerprint,
+        vector_current_index_version: vector.current_index_version,
+        vector_distance_metric: vector.distance_metric,
+        vector_stale: vector.stale,
     }
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1459,6 +1459,16 @@ pub struct ReadDrawerResponse {
     pub updated_at: Option<String>,
     pub merge_count: u32,
     pub importance_stars: u8,
+    pub has_vector: bool,
+    pub vector_dimension: Option<usize>,
+    pub vector_embedder: Option<String>,
+    pub vector_model: Option<String>,
+    pub vector_embedder_fingerprint: Option<String>,
+    pub vector_index_version: Option<String>,
+    pub vector_current_embedder_fingerprint: Option<String>,
+    pub vector_current_index_version: String,
+    pub vector_distance_metric: Option<String>,
+    pub vector_stale: bool,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -401,6 +401,31 @@ pub fn view_command(db: &Database, config: &Config, options: ViewOptions<'_>) ->
         details.updated_at.as_deref().unwrap_or("none")
     );
     println!("merge_count: {}", details.merge_count);
+    println!("has_vector: {}", details.vector.has_vector);
+    println!(
+        "vector_dimension: {}",
+        details
+            .vector
+            .dimension
+            .map_or_else(|| "none".to_string(), |value| value.to_string())
+    );
+    println!(
+        "vector_distance_metric: {}",
+        details.vector.distance_metric.as_deref().unwrap_or("none")
+    );
+    println!(
+        "vector_embedder: {}",
+        details.vector.embedder.as_deref().unwrap_or("unknown")
+    );
+    println!(
+        "vector_model: {}",
+        details.vector.model.as_deref().unwrap_or("unknown")
+    );
+    println!(
+        "vector_index_version: {}",
+        details.vector.index_version.as_deref().unwrap_or("unknown")
+    );
+    println!("vector_stale: {}", details.vector.stale);
     println!(
         "source_file: {}",
         maybe_escape(

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use blake3::Hasher;
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_VECTOR_INDEX_VERSION, Database};
 use mempal::core::project::ProjectSearchScope;
 use mempal::core::queue::PendingMessageStore;
 use mempal::core::types::{Drawer, SourceType};
@@ -846,6 +846,15 @@ fn test_view_prints_full_drawer() {
             4,
         ),
     );
+    let db = Database::open(&env.db_path).expect("open db");
+    db.insert_vector("view-full", &[0.1, 0.2, 0.3, 0.4])
+        .expect("insert view vector");
+    db.record_vector_metadata(
+        "view-full",
+        CURRENT_VECTOR_INDEX_VERSION,
+        "model2vec:model2vec/potion-multilingual-128M::4",
+    )
+    .expect("record view vector metadata");
 
     let output = run_mempal(&env.home, env.cwd(), &["view", "view-full"]);
     assert!(
@@ -858,6 +867,19 @@ fn test_view_prints_full_drawer() {
     assert!(stdout.contains("drawer_id: view-full"), "{stdout}");
     assert!(stdout.contains("scope: default/view"), "{stdout}");
     assert!(stdout.contains("created_at:"), "{stdout}");
+    assert!(stdout.contains("has_vector: true"), "{stdout}");
+    assert!(stdout.contains("vector_dimension: 4"), "{stdout}");
+    assert!(
+        stdout.contains("vector_distance_metric: cosine"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("vector_embedder: model2vec"), "{stdout}");
+    assert!(
+        stdout.contains("vector_model: model2vec/potion-multilingual-128M"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("vector_index_version: v2"), "{stdout}");
+    assert!(stdout.contains("vector_stale: false"), "{stdout}");
     assert!(stdout.contains("content_truncated: false"), "{stdout}");
     assert!(stdout.contains("original_content_bytes:"), "{stdout}");
     assert!(stdout.contains("Decision: use CLI dashboard"), "{stdout}");

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -4,14 +4,15 @@ mod common;
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use common::harness::start as start_mock;
-use mempal::core::config::{Config, ConfigHandle};
-use mempal::core::db::Database;
+use mempal::core::config::{Config, ConfigHandle, DEFAULT_MODEL2VEC_FINGERPRINT_MODEL};
+use mempal::core::db::{Database, VECTOR_DISTANCE_METRIC};
+use mempal::core::reindex::ReindexProgressStore;
 use mempal::core::types::{Drawer, SourceType};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
 use mempal::ingest::{IngestError, IngestOptions, ingest_file_with_options};
@@ -70,6 +71,18 @@ block_writes_when_degraded = {}
     )
 }
 
+fn model2vec_reindex_config(db_path: &Path) -> String {
+    format!(
+        r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+"#,
+        db_path.display()
+    )
+}
+
 struct TestHome {
     _tmp: TempDir,
     home: PathBuf,
@@ -125,12 +138,58 @@ fn seed_drawers(db_path: &Path, count: usize, vector_dim: usize) {
 fn run_reindex(home: &Path, args: &[&str], extra_env: &[(&str, String)]) -> Output {
     let mut command = Command::new(mempal_bin());
     command.env("HOME", home);
+    for key in [
+        "MEMPAL_EMBED_BACKEND",
+        "MEMPAL_EMBED_BASE_URL",
+        "MEMPAL_EMBED_MODEL",
+        "MEMPAL_EMBED_DIM",
+    ] {
+        command.env_remove(key);
+    }
     command.arg("reindex");
     command.args(args);
     for (key, value) in extra_env {
         command.env(key, value);
     }
     command.output().expect("run reindex")
+}
+
+fn replace_vectors_with_metricless_l2(db_path: &Path, count: usize, dim: usize) {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .execute_batch(&format!(
+            r#"
+            DROP TABLE drawer_vectors;
+            CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+                id TEXT PRIMARY KEY,
+                embedding FLOAT[{dim}]
+            );
+            "#
+        ))
+        .expect("recreate metricless vector table");
+    let vector = vec![0.2_f32; dim];
+    let vector_json = serde_json::to_string(&vector).expect("serialize vector");
+    for index in 0..count {
+        let id = format!("drawer-{index:02}");
+        db.conn()
+            .execute(
+                "INSERT INTO drawer_vectors (id, embedding) VALUES (?1, vec_f32(?2))",
+                rusqlite::params![id, vector_json.as_str()],
+            )
+            .expect("insert metricless vector");
+    }
+}
+
+fn read_vector(db: &Database, drawer_id: &str) -> Vec<f32> {
+    let json = db
+        .conn()
+        .query_row(
+            "SELECT vec_to_json(embedding) FROM drawer_vectors WHERE id = ?1",
+            [drawer_id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read vector json");
+    serde_json::from_str(&json).expect("parse vector json")
 }
 
 async fn wait_for_request_count(handle: &common::harness::MockEmbedHandle, expected: u32) {
@@ -366,10 +425,10 @@ async fn test_reindex_stale_only() {
     let db = Database::open(&env.db_path).expect("open db");
     db.conn()
         .execute(
-            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:drawer-01:normalize_version'",
+            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:drawer-01:index_version'",
             [],
         )
-        .expect("mark normalize stale");
+        .expect("mark index stale");
     db.conn()
         .execute(
             "UPDATE fork_ext_meta SET value = 'other' WHERE key = 'reindex:drawer-04:embedder_fingerprint'",
@@ -383,7 +442,223 @@ async fn test_reindex_stale_only() {
         "stderr: {}",
         String::from_utf8_lossy(&second.stderr)
     );
-    assert_eq!(handle.request_count(), 8);
+    assert_eq!(handle.request_count(), 7);
+    assert!(
+        String::from_utf8_lossy(&second.stdout)
+            .contains("batch 1: re-embedded 2 stale/new drawers"),
+        "stdout: {}",
+        String::from_utf8_lossy(&second.stdout)
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stale_reindex_skips_concurrent_content_update() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    handle.pause();
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-stale-concurrent-update.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        true,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, true),
+    );
+    seed_drawers(&env.db_path, 1, 4);
+
+    let db = Database::open(&env.db_path).expect("open db");
+    db.conn()
+        .execute(
+            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:drawer-00:index_version'",
+            [],
+        )
+        .expect("mark index stale");
+
+    let mut child = TokioCommand::new(mempal_bin());
+    child
+        .arg("reindex")
+        .arg("--from-config")
+        .arg("--stale")
+        .arg("--batch-size")
+        .arg("1")
+        .env("HOME", &env.home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = child.spawn().expect("spawn stale reindex child");
+    wait_for_request_count(&handle, 1).await;
+
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
+    let fresh_vector = vec![0.25_f32, 0.5, 0.75, 1.0];
+    db.upsert_drawer_and_replace_vector(
+        &Drawer {
+            id: "drawer-00".to_string(),
+            content: "drawer content changed while stale embed was in flight".to_string(),
+            wing: "test".to_string(),
+            room: Some("reindex".to_string()),
+            source_file: Some("fixtures/source.txt".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+            ..Drawer::default()
+        },
+        &fresh_vector,
+    )
+    .expect("simulate concurrent ingest update");
+
+    handle.resume();
+    let output = tokio::time::timeout(Duration::from_secs(3), child.wait_with_output())
+        .await
+        .expect("child wait timeout")
+        .expect("wait stale reindex child");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("skipped 1 concurrent updates"),
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        handle.request_count(),
+        1,
+        "stale command should not re-embed the freshly updated drawer"
+    );
+    assert_eq!(read_vector(&db, "drawer-00"), fresh_vector);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stale_reindex_skips_concurrent_real_merge_update() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    handle.pause();
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-stale-concurrent-merge.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        true,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, true),
+    );
+    seed_drawers(&env.db_path, 1, 4);
+
+    let db = Database::open(&env.db_path).expect("open db");
+    db.conn()
+        .execute(
+            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:drawer-00:index_version'",
+            [],
+        )
+        .expect("mark index stale");
+
+    let mut child = TokioCommand::new(mempal_bin());
+    child
+        .arg("reindex")
+        .arg("--from-config")
+        .arg("--stale")
+        .arg("--batch-size")
+        .arg("1")
+        .env("HOME", &env.home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = child.spawn().expect("spawn stale reindex child");
+    wait_for_request_count(&handle, 1).await;
+
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
+    let fresh_vector = vec![0.25_f32, 0.5, 0.75, 1.0];
+    db.update_drawer_after_merge(
+        "drawer-00",
+        "drawer content 0\n\nSUPPLEMENTARY (test): merged while stale embed was in flight",
+        "1713009999",
+        &fresh_vector,
+    )
+    .expect("simulate concurrent novelty merge update");
+
+    handle.resume();
+    let output = tokio::time::timeout(Duration::from_secs(3), child.wait_with_output())
+        .await
+        .expect("child wait timeout")
+        .expect("wait stale reindex child");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("skipped 1 concurrent updates"),
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        handle.request_count(),
+        1,
+        "stale command should not re-embed the freshly merged drawer"
+    );
+    assert_eq!(read_vector(&db, "drawer-00"), fresh_vector);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reindex_stale_resume_rebuilds_metricless_vector_table() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-stale-resume-l2.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        true,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, true),
+    );
+    seed_drawers(&env.db_path, 6, 4);
+    replace_vectors_with_metricless_l2(&env.db_path, 6, 4);
+    ReindexProgressStore::new(&env.db_path)
+        .upsert_running("fixtures/source.txt", Some(5), "openai_compat")
+        .expect("write resume checkpoint");
+
+    let output = run_reindex(&env.home, &["--from-config", "--stale", "--resume"], &[]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(
+            "resume checkpoint ignored because drawer_vectors metric or dimension is stale"
+        ),
+        "stdout: {stdout}"
+    );
+    assert_eq!(handle.request_count(), 6);
+
+    let db = Database::open(&env.db_path).expect("open db");
+    assert_eq!(
+        db.vector_table_distance_metric()
+            .expect("read vector metric")
+            .as_deref(),
+        Some(VECTOR_DISTANCE_METRIC)
+    );
+    let count = db
+        .conn()
+        .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count vectors");
+    assert_eq!(count, 6);
 
     handle.shutdown().await;
 }
@@ -440,6 +715,43 @@ async fn test_reindex_dim_change_invalidates_existing() {
 
     handle4.shutdown().await;
     handle6.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_default_model2vec_reindex_records_non_stale_fingerprint() {
+    let _guard = test_guard().await;
+    let env = TestHome::new(&model2vec_reindex_config(Path::new(
+        "/tmp/mempal-model2vec-fingerprint.db",
+    )));
+    write_config(&env.config_path, &model2vec_reindex_config(&env.db_path));
+    seed_drawers(&env.db_path, 1, 2);
+
+    let output = run_reindex(
+        &env.home,
+        &["--from-config"],
+        &[("MEMPAL_EMBED_BACKEND", "model2vec".to_string())],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap model2vec config");
+    let db = Database::open(&env.db_path).expect("open db");
+    let details = db
+        .drawer_vector_details("drawer-00")
+        .expect("load vector details");
+    assert!(details.has_vector);
+    assert_eq!(
+        details.embedder_fingerprint.as_deref(),
+        details.current_embedder_fingerprint.as_deref()
+    );
+    assert_eq!(
+        details.model.as_deref(),
+        Some(DEFAULT_MODEL2VEC_FINGERPRINT_MODEL)
+    );
+    assert!(!details.stale, "{details:?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/knn_k_bound.rs
+++ b/tests/knn_k_bound.rs
@@ -82,6 +82,53 @@ fn search_by_vector_succeeds_with_more_than_4096_drawers() {
 }
 
 #[test]
+fn search_by_vector_large_index_uses_cosine_not_l2() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("test.db")).expect("open db");
+
+    for i in 0..DRAWER_COUNT {
+        let drawer = make_drawer(i);
+        db.insert_drawer_with_project(&drawer, None)
+            .expect("insert decoy drawer");
+        db.insert_vector(&drawer.id, &[1.0, 0.20, 0.0, 0.0])
+            .expect("insert decoy vector");
+    }
+
+    let target = Drawer {
+        id: "target-cosine".to_string(),
+        content: "semantic target".to_string(),
+        wing: "test".to_string(),
+        room: Some("room".to_string()),
+        source_file: None,
+        source_type: SourceType::AgentInference,
+        added_at: "1700000000".to_string(),
+        chunk_index: None,
+        importance: 0,
+        ..Drawer::default()
+    };
+    db.insert_drawer_with_project(&target, None)
+        .expect("insert target drawer");
+    db.insert_vector(&target.id, &[10.0, 0.0, 0.0, 0.0])
+        .expect("insert target vector");
+
+    let route = RouteDecision {
+        wing: None,
+        room: None,
+        confidence: 0.0,
+        reason: "test".to_string(),
+    };
+    let scope = ProjectSearchScope::from_request(None, true, false, false);
+
+    let results = search_by_vector(&db, &[1.0, 0.0, 0.0, 0.0], route, &scope, 10)
+        .expect("large-index vector search");
+    assert_eq!(
+        results.first().map(|result| result.drawer_id.as_str()),
+        Some("target-cosine"),
+        "sqlite-vec KNN must use cosine distance, not L2 distance"
+    );
+}
+
+#[test]
 fn search_by_vector_succeeds_with_20000_drawers() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("test.db")).expect("open db");

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -284,6 +284,17 @@ fn drawer_content(db_path: &Path, drawer_id: &str) -> String {
         .expect("drawer content")
 }
 
+fn drawer_content_hash(db_path: &Path, drawer_id: &str) -> String {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT content_hash FROM drawers WHERE id = ?1",
+            [drawer_id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("drawer content_hash")
+}
+
 fn merge_state(db_path: &Path, drawer_id: &str) -> (i64, Option<String>) {
     Connection::open(db_path)
         .expect("open sqlite")
@@ -659,6 +670,13 @@ async fn test_medium_similarity_candidate_merged() {
     assert!(content.contains("Decision: use Arc<Mutex<>>"));
     assert!(content.contains("SUPPLEMENTARY ("));
     assert!(content.contains(candidate));
+    let stored_hash = drawer_content_hash(&env.db_path, "existing");
+    let expected_hash = blake3::hash(content.as_bytes()).to_hex().to_string();
+    let original_hash = blake3::hash("Decision: use Arc<Mutex<>>".as_bytes())
+        .to_hex()
+        .to_string();
+    assert_eq!(stored_hash, expected_hash);
+    assert_ne!(stored_hash, original_hash);
     let (merge_count, updated_at) = merge_state(&env.db_path, "existing");
     assert_eq!(merge_count, 1);
     assert!(updated_at.is_some(), "merge must set updated_at");

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -405,6 +405,13 @@ async fn test_read_drawer_returns_full_verbatim() {
     assert_eq!(response.content, content);
     assert!(!response.content_truncated);
     assert_eq!(response.original_content_bytes, content.len() as u64);
+    assert!(response.has_vector);
+    assert_eq!(response.vector_dimension, Some(3));
+    assert_eq!(response.vector_distance_metric.as_deref(), Some("cosine"));
+    assert_eq!(response.vector_embedder.as_deref(), Some("api"));
+    assert_eq!(response.vector_model.as_deref(), Some("test-model"));
+    assert_eq!(response.vector_index_version.as_deref(), Some("v2"));
+    assert!(!response.vector_stale);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -25,6 +25,7 @@ use mempal::core::project::{
     infer_project_id_from_path, infer_project_id_from_root_uri, migrate_null_project_ids,
     validate_project_id,
 };
+use mempal::core::reindex::ReindexProgressStore;
 use mempal::core::types::{Drawer, SourceType};
 use mempal::cowork::{PeekRequest, Tool, peek_partner};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
@@ -368,6 +369,8 @@ fn drawer_project_ids(conn: &Connection, table: &str) -> Vec<Option<String>> {
 fn downgrade_to_v4(conn: &Connection, drop_vector_table: bool) {
     conn.execute_batch("DROP INDEX IF EXISTS idx_drawers_project_id;")
         .expect("drop project index");
+    conn.execute_batch("DROP INDEX IF EXISTS idx_drawers_project_id_active;")
+        .expect("drop active project index");
     if column_names(conn, "drawers")
         .iter()
         .any(|column| column == "project_id")
@@ -649,6 +652,223 @@ fn test_lazy_create_after_v5_has_project_id_column() {
         "lazy-created drawer_vectors missing project_id: {vector_sql}"
     );
     assert_eq!(stored.as_deref(), Some("proj-lazy"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stale_reindex_preserves_project_id() {
+    let _guard = config_guard().await;
+    let (addr, handle) = start_embed_mock(0).await.expect("start mock");
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let config_path = home.join(".mempal").join("config.toml");
+    write_config_atomic(
+        &config_path,
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), Some("proj-A")),
+    );
+
+    let db = Database::open(&db_path).expect("open db");
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: "stale-project-drawer".to_string(),
+            content: "project scoped stale unique".to_string(),
+            wing: "code".to_string(),
+            room: Some("room".to_string()),
+            source_file: Some("stale-project.md".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+            ..Drawer::default()
+        },
+        Some("proj-A"),
+    )
+    .expect("insert project drawer");
+    db.insert_vector_with_project(
+        "stale-project-drawer",
+        &[0.1, 0.2, 0.3, 0.4],
+        Some("proj-A"),
+    )
+    .expect("insert project vector");
+    db.conn()
+        .execute(
+            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:stale-project-drawer:index_version'",
+            [],
+        )
+        .expect("mark vector stale");
+
+    let mut command = Command::new(mempal_bin());
+    for key in [
+        "MEMPAL_EMBED_BACKEND",
+        "MEMPAL_EMBED_BASE_URL",
+        "MEMPAL_EMBED_MODEL",
+        "MEMPAL_EMBED_DIM",
+    ] {
+        command.env_remove(key);
+    }
+    let output = command
+        .env("HOME", &home)
+        .args(["reindex", "--from-config", "--stale", "--batch-size", "1"])
+        .output()
+        .expect("run stale reindex");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stored_project_id = db
+        .conn()
+        .query_row(
+            "SELECT project_id FROM drawer_vectors WHERE id = 'stale-project-drawer'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read vector project_id");
+    let null_project_count = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM drawer_vectors WHERE id = 'stale-project-drawer' AND project_id IS NULL",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count null-project vectors");
+    assert_eq!(stored_project_id.as_deref(), Some("proj-A"));
+    assert_eq!(null_project_count, 0);
+
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap search config");
+    let server = MempalMcpServer::new_with_factory(
+        db_path.clone(),
+        Arc::new(StaticEmbedderFactory {
+            vector: vec![0.0, 0.0, 0.0, 0.0],
+        }),
+    );
+    let project_ids = parse_search_ids(
+        &search_response_json_with_request(
+            &server,
+            SearchRequest {
+                query: "project scoped stale unique".to_string(),
+                top_k: Some(5),
+                project_id: Some("proj-A".to_string()),
+                include_global: None,
+                ..SearchRequest::default()
+            },
+        )
+        .await,
+    );
+    assert_eq!(project_ids, vec!["stale-project-drawer".to_string()]);
+    let other_project_ids = parse_search_ids(
+        &search_response_json_with_request(
+            &server,
+            SearchRequest {
+                query: "project scoped stale unique".to_string(),
+                top_k: Some(5),
+                project_id: Some("proj-B".to_string()),
+                include_global: Some(true),
+                ..SearchRequest::default()
+            },
+        )
+        .await,
+    );
+    assert!(other_project_ids.is_empty(), "{other_project_ids:?}");
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stale_reindex_resume_preserves_project_id() {
+    let _guard = config_guard().await;
+    let (addr, handle) = start_embed_mock(0).await.expect("start mock");
+    let tmp = TempDir::new().expect("tempdir");
+    let home = install_cli_home(&tmp);
+    let db_path = home.join(".mempal").join("palace.db");
+    let config_path = home.join(".mempal").join("config.toml");
+    write_config_atomic(
+        &config_path,
+        &cli_embed_config(&db_path, &format!("http://{addr}/v1"), Some("proj-A")),
+    );
+
+    let db = Database::open(&db_path).expect("open db");
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: "resume-stale-project-drawer".to_string(),
+            content: "project scoped stale resume unique".to_string(),
+            wing: "code".to_string(),
+            room: Some("room".to_string()),
+            source_file: Some("resume-stale-project.md".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 0,
+            ..Drawer::default()
+        },
+        Some("proj-A"),
+    )
+    .expect("insert project drawer");
+    db.insert_vector_with_project(
+        "resume-stale-project-drawer",
+        &[0.1, 0.2, 0.3, 0.4],
+        Some("proj-A"),
+    )
+    .expect("insert project vector");
+    db.conn()
+        .execute(
+            "UPDATE fork_ext_meta SET value = 'old' WHERE key = 'reindex:resume-stale-project-drawer:index_version'",
+            [],
+        )
+        .expect("mark vector stale");
+    ReindexProgressStore::new(&db_path)
+        .upsert_running("aaa-prior-source.md", Some(0), "openai_compat")
+        .expect("write resume checkpoint");
+
+    let mut command = Command::new(mempal_bin());
+    for key in [
+        "MEMPAL_EMBED_BACKEND",
+        "MEMPAL_EMBED_BASE_URL",
+        "MEMPAL_EMBED_MODEL",
+        "MEMPAL_EMBED_DIM",
+    ] {
+        command.env_remove(key);
+    }
+    let output = command
+        .env("HOME", &home)
+        .args(["reindex", "--from-config", "--stale", "--resume"])
+        .output()
+        .expect("run stale resume reindex");
+    assert!(
+        output.status.success(),
+        "stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("re-embedding 1 drawers"),
+        "resume stale path should use row-by-row resume writer, stdout: {stdout}"
+    );
+    assert_eq!(handle.request_count(), 1);
+
+    let stored_project_id = db
+        .conn()
+        .query_row(
+            "SELECT project_id FROM drawer_vectors WHERE id = 'resume-stale-project-drawer'",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read vector project_id");
+    let null_project_count = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM drawer_vectors WHERE id = 'resume-stale-project-drawer' AND project_id IS NULL",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count null-project vectors");
+    assert_eq!(stored_project_id.as_deref(), Some("proj-A"));
+    assert_eq!(null_project_count, 0);
+
+    handle.shutdown().await;
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f396e3cfd724f7729fe0d08901770556cb271172"
+commit = "0ed1071259cfc031b3e6afd6bb215f9a7a4892f7"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #274. Production-scale semantic recall over the **main drawer store**
(`mempal search` over decision/evidence/discovery drawers) had collapsed to
anisotropy-baseline noise. Root cause: a **distance-metric mismatch** — the
`drawer_vectors` sqlite-vec `vec0` table was created without a distance metric,
so it defaulted to **L2**, while the query logic (small-candidate exact path and
direct-curl health checks) sorts by **cosine**. At scale the search takes the
large-candidate KNN path (`embedding MATCH vec_f32(?)`), where 4096-dim Qwen
vectors are dominated by norm/L2 noise → the vector arm matched effectively
nothing. Single-tool checks looked healthy, masking the bug.

## Root cause (diagnosis-first, csa-codex)

- **A — not a live ingest bug.** New ingests do write `drawer_vectors`
  (`main.rs`, `mcp/server.rs`, `daemon.rs`). The "unretrievable fresh drawer"
  was partly a project-scope artifact (`project_id=cn-llm-censor-research`
  filtered out when viewed from the mempal repo cwd).
- **B — `reindex --stale` flags 512320/515376 because of `normalize_version`
  staleness** (`normalize_version=1 < CURRENT`), a *separate* axis — NOT missing
  vectors.
- **C — the real breakage: L2-vs-cosine metric mismatch** (`search/filter.rs`
  KNN path vs `search/mod.rs` exact path). Fixed by creating/rebuilding the vec0
  table with `distance_metric=cosine`.

## Changes

- vec0 drawer-vector table now created/rebuilt with `distance_metric=cosine`
  (`src/core/db.rs`, `src/core/db_fork_ext.rs`); migration on the `fork_ext`
  axis, idempotent.
- Per-drawer vector diagnostics — `has_vector`, dimension, metric,
  embedder/model, index version, stale — added to `mempal view --raw`, the
  drawer DTO, and `mempal_read_drawer` (`src/observability`, `src/mcp`), so an
  operator can tell per-drawer whether it has a current-space vector.
- Batched incremental `mempal reindex --stale --batch-size N` (`BEGIN IMMEDIATE`
  + bounded LIMIT loop, fail-fast, does not block concurrent ingest) so recovery
  is safe on the 515K-scale DB without an all-or-nothing pass. Builds on #275's
  `reindex --failed`.
- Reindex correctness hardening (tier-4 review): every reindex-reachable vector
  write — batch **and** resume/row-by-row — preserves each drawer's original
  `project_id` (no project-isolation regression, #28/#139); the stale rebuild
  re-validates drawer content under the write lock and skips any row a concurrent
  ingest/merge updated between selection and write (no lost-update overwrite of a
  fresh vector with a stale-content embedding); and `update_drawer_after_merge`
  now updates `content_hash` so that version token is sound across every content
  writer (including MCP novelty merge), with a dedup-safety regression test.

## Operational recovery (maintainer-run — heavy, user-owned)

The code fix guarantees newly built/rebuilt vector tables use cosine. The
**existing 515K-drawer production DB still needs a one-time maintainer-run bulk
reindex** to rebuild vectors into the cosine table (this re-embeds stale drawers
against the LAN embedder; NOT run by this PR):

```bash
# only if status/stats still show #275-era failed embed-queue items
mempal reindex --failed

# main drawer store recovery: batch-rebuild stale/new vectors (old L2 table
# rebuilt as cosine)
mempal reindex --from-config --stale --batch-size 1000

# if interrupted, resume from checkpoint
mempal reindex --from-config --resume
```

Verify a single drawer in its project scope:

```bash
mempal view --raw drawer_cn_llm_censor_research_decision_28af3c2a
mempal search --all-projects "<paraphrase>" --top-k 25
```

## Scope / constraints

No actual reindex run; no embedding requests issued at scale. Embedder default +
endpoint unchanged. `drawers` remain raw verbatim. Focused tests pass (incl.
`search_by_vector_large_index_uses_cosine_not_l2`); the full suite passed at the
pre-commit gate.

## Review

Cumulative tier-4 review on `main...HEAD`; every in-scope finding re-verified and
resolved (full suite green at the pre-commit gate each round):

- **r0 — root cause:** L2-vs-cosine metric mismatch on the `drawer_vectors` vec0
  table. Fixed: created/rebuilt with `distance_metric=cosine`.
- **r1:** `--stale --resume` could skip the cosine rebuild and re-embed into the
  old L2 table; CLI reindex wrote a divergent default-model2vec fingerprint
  (perpetual `vector_stale`). Fixed: force cosine rebuild on resume; one shared
  fingerprint builder across insert / diagnostics / reindex.
- **r2:** stale batch reindex dropped `project_id` (project rows → global) and had
  a lost-update race. Fixed: preserve `project_id` through the batch; optimistic-
  concurrency guard (re-validate under `BEGIN IMMEDIATE`, skip concurrently-updated
  rows).
- **r3:** the resume/row-by-row path still dropped `project_id`; the guard's
  `content_hash` token went stale on the merge path. Fixed: resume path preserves
  `project_id`; `update_drawer_after_merge` now updates `content_hash` (token sound
  across every content writer, incl. MCP novelty merge) + dedup-safety test.
- **r4:** re-verified r0–r3 clean. Surfaced one **pre-existing** project-isolation
  bug in the **source-based** reindex path (`reindex_one_source` /
  `replace_active_source_drawers`), which #274 does not modify. Per tier-4 debate
  `01KT1S5AVF1W6F7XH70DYSXV1T` it is **out of scope** (pre-existing, separate
  mechanism, design-nuanced) and filed as **#278**; #274's embedder-based recovery
  is project-safe.

**Deploy-time migration safety:** the v5 `drawer_vectors` recreate snapshots and
restores rows (non-destructive); migration is on the `fork_ext` axis, idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
