### PR TITLE
feat(xurl): stats filters + reindex --dry-run (#272)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1054,12 +1054,24 @@ enum XurlCommands {
     },
     /// Show per-tool turn counts and date ranges.
     Stats {
+        /// Filter by tool: cc, codex, or hermes.
+        #[arg(long, value_enum)]
+        tool: Option<XurlTool>,
+        /// Filter to a specific session ID.
+        #[arg(long)]
+        session: Option<String>,
+        /// Only include turns newer than this duration (e.g. 7d, 24h, 10m).
+        #[arg(long)]
+        since: Option<String>,
         /// Print result as JSON.
         #[arg(long)]
         json: bool,
     },
     /// Embed all turns that still lack a vector (drains the historical backlog).
     Reindex {
+        /// Show how many threads/turns would be embedded without writing vectors.
+        #[arg(long)]
+        dry_run: bool,
         /// Print progress as JSON.
         #[arg(long)]
         json: bool,
@@ -8835,11 +8847,24 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             Ok(())
         }
 
-        XurlCommands::Stats { json } => {
-            let stats =
-                mempal::xurl::store::get_stats(db.conn()).context("xurl stats query failed")?;
-            let unindexed_remaining = mempal::xurl::store::count_unindexed_turns(db.conn())
-                .context("xurl unindexed count failed")?;
+        XurlCommands::Stats {
+            tool,
+            session,
+            since,
+            json,
+        } => {
+            let since_epoch = since.as_deref().map(parse_since_to_epoch).transpose()?;
+            let filter = mempal::xurl::store::TurnFilter {
+                tool: tool.map(Into::into),
+                session_id: session,
+                since_epoch,
+                ..Default::default()
+            };
+            let stats = mempal::xurl::store::get_stats_filtered(db.conn(), &filter)
+                .context("xurl stats query failed")?;
+            let unindexed_remaining =
+                mempal::xurl::store::count_unindexed_turns_filtered(db.conn(), &filter)
+                    .context("xurl unindexed count failed")?;
             if json {
                 let tools: Vec<XurlStatsToolJson> = stats
                     .iter()
@@ -8881,7 +8906,27 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             Ok(())
         }
 
-        XurlCommands::Reindex { json } => {
+        XurlCommands::Reindex { dry_run, json } => {
+            if dry_run {
+                let summary = mempal::xurl::store::summarize_unindexed_turns(db.conn())
+                    .context("xurl reindex dry-run query failed")?;
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "dry_run": true,
+                            "threads_would_process": summary.threads,
+                            "turns_would_process": summary.turns,
+                        })
+                    );
+                } else {
+                    println!("dry-run: true");
+                    println!("threads would process: {}", summary.threads);
+                    println!("turns would process:   {}", summary.turns);
+                    println!("vectors written:       0");
+                }
+                return Ok(());
+            }
             let embedder = build_embedder(config).await?;
             let embed_cb = |done: usize, total: usize| {
                 if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8659,18 +8659,28 @@ async fn serve_mcp_and_rest_command(config: &Config) -> Result<()> {
 
 /// Parse a duration string like "7d", "24h", "10m" into a Unix epoch threshold.
 fn parse_since_to_epoch(since: &str) -> Result<f64> {
+    const VALID_FORMS: &str = r#"valid forms are "7d", "24h", or "30m""#;
+
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| anyhow::anyhow!("system clock error: {e}"))?
         .as_secs_f64();
-    let (value, unit) = since.split_at(since.len() - 1);
-    let n: f64 = value.parse().context("invalid duration value")?;
-    let secs = match unit {
-        "d" => n * 86400.0,
-        "h" => n * 3600.0,
-        "m" => n * 60.0,
-        other => anyhow::bail!("unknown duration unit '{}'; use d/h/m", other),
+    let (value, unit_secs) = if let Some(value) = since.strip_suffix('d') {
+        (value, 86400.0)
+    } else if let Some(value) = since.strip_suffix('h') {
+        (value, 3600.0)
+    } else if let Some(value) = since.strip_suffix('m') {
+        (value, 60.0)
+    } else {
+        anyhow::bail!("invalid --since duration '{since}'; {VALID_FORMS}");
     };
+    if value.is_empty() {
+        anyhow::bail!("invalid --since duration '{since}'; {VALID_FORMS}");
+    }
+    let n: f64 = value
+        .parse()
+        .with_context(|| format!("invalid --since duration '{since}'; {VALID_FORMS}"))?;
+    let secs = n * unit_secs;
     Ok(now - secs)
 }
 

--- a/src/xurl/store.rs
+++ b/src/xurl/store.rs
@@ -44,6 +44,12 @@ pub struct ToolStat {
     pub max_timestamp: f64,
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnindexedTurnSummary {
+    pub threads: i64,
+    pub turns: i64,
+}
+
 #[derive(Debug, Serialize)]
 pub struct TimelineTurn {
     pub id: String,
@@ -113,14 +119,47 @@ pub fn turn_id_for(turn: &RawTurn) -> String {
 /// Count turns that still lack a vector (no row in `conversation_turn_vectors`).
 /// Surfaced by `xurl stats` so the recall gap is visible.
 pub fn count_unindexed_turns(conn: &Connection) -> XurlResult<i64> {
-    conn.query_row(
-        "SELECT COUNT(*) \
+    count_unindexed_turns_filtered(conn, &TurnFilter::default())
+}
+
+pub fn count_unindexed_turns_filtered(conn: &Connection, filter: &TurnFilter) -> XurlResult<i64> {
+    summarize_unindexed_turns_filtered(conn, filter).map(|summary| summary.turns)
+}
+
+pub fn summarize_unindexed_turns(conn: &Connection) -> XurlResult<UnindexedTurnSummary> {
+    summarize_unindexed_turns_filtered(conn, &TurnFilter::default())
+}
+
+pub fn summarize_unindexed_turns_filtered(
+    conn: &Connection,
+    filter: &TurnFilter,
+) -> XurlResult<UnindexedTurnSummary> {
+    let mut conditions = vec!["ctv.turn_id IS NULL".to_string()];
+    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut idx = 1usize;
+    push_filter_conditions(
+        filter,
+        Some("ct"),
+        &mut conditions,
+        &mut params_vec,
+        &mut idx,
+    );
+
+    let sql = format!(
+        "SELECT COUNT(DISTINCT ct.session_id), COUNT(*) \
          FROM conversation_turns ct \
          LEFT JOIN conversation_turn_vectors ctv ON ctv.turn_id = ct.id AND ctv.chunk_index = 0 \
-         WHERE ctv.turn_id IS NULL",
-        [],
-        |row| row.get(0),
-    )
+         WHERE {}",
+        conditions.join(" AND ")
+    );
+    let refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
+
+    conn.query_row(&sql, refs.as_slice(), |row| {
+        Ok(UnindexedTurnSummary {
+            threads: row.get(0)?,
+            turns: row.get(1)?,
+        })
+    })
     .map_err(XurlError::Database)
 }
 
@@ -393,20 +432,77 @@ pub fn get_turns_filtered(
     Ok(turns)
 }
 
+fn filter_column(prefix: Option<&str>, column: &str) -> String {
+    prefix.map_or_else(|| column.to_string(), |prefix| format!("{prefix}.{column}"))
+}
+
+fn push_filter_conditions(
+    filter: &TurnFilter,
+    column_prefix: Option<&str>,
+    conditions: &mut Vec<String>,
+    params_vec: &mut Vec<Box<dyn rusqlite::ToSql>>,
+    idx: &mut usize,
+) {
+    if let Some(ref tool) = filter.tool {
+        conditions.push(format!(
+            "{} = ?{}",
+            filter_column(column_prefix, "tool"),
+            *idx
+        ));
+        params_vec.push(Box::new(tool.as_str().to_string()));
+        *idx += 1;
+    }
+    if let Some(ref sid) = filter.session_id {
+        conditions.push(format!(
+            "{} = ?{}",
+            filter_column(column_prefix, "session_id"),
+            *idx
+        ));
+        params_vec.push(Box::new(sid.clone()));
+        *idx += 1;
+    }
+    if let Some(since) = filter.since_epoch {
+        conditions.push(format!(
+            "{} >= ?{}",
+            filter_column(column_prefix, "timestamp_epoch"),
+            *idx
+        ));
+        params_vec.push(Box::new(since));
+        *idx += 1;
+    }
+}
+
 /// Per-tool aggregate statistics.
 pub fn get_stats(conn: &Connection) -> XurlResult<Vec<ToolStat>> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT tool, COUNT(*) as count, \
-             MIN(timestamp_epoch), MAX(timestamp_epoch) \
-             FROM conversation_turns \
-             GROUP BY tool \
-             ORDER BY tool",
-        )
-        .map_err(XurlError::Database)?;
+    get_stats_filtered(conn, &TurnFilter::default())
+}
+
+pub fn get_stats_filtered(conn: &Connection, filter: &TurnFilter) -> XurlResult<Vec<ToolStat>> {
+    let mut conditions = Vec::<String>::new();
+    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut idx = 1usize;
+    push_filter_conditions(filter, None, &mut conditions, &mut params_vec, &mut idx);
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+
+    let sql = format!(
+        "SELECT tool, COUNT(*) as count, \
+         MIN(timestamp_epoch), MAX(timestamp_epoch) \
+         FROM conversation_turns \
+         {where_clause} \
+         GROUP BY tool \
+         ORDER BY tool"
+    );
+    let refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
+
+    let mut stmt = conn.prepare(&sql).map_err(XurlError::Database)?;
 
     let rows = stmt
-        .query_map([], |row| {
+        .query_map(refs.as_slice(), |row| {
             Ok(ToolStat {
                 tool: row.get(0)?,
                 count: row.get(1)?,

--- a/tests/xurl_embed.rs
+++ b/tests/xurl_embed.rs
@@ -2,6 +2,9 @@ use mempal::core::db::Database;
 use mempal::embed::Embedder;
 use mempal::xurl::embed;
 use rusqlite::params;
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
 use tempfile::TempDir;
 
 struct TestDb {
@@ -23,6 +26,26 @@ fn open_temp_db_at_fork_ext(_version: u32) -> TestDb {
         _dir: dir,
         inner: db,
     }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn open_home_db(home: &Path) -> Database {
+    let mempal_home = home.join(".mempal");
+    std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+    Database::open(&mempal_home.join("palace.db")).expect("open home db")
+}
+
+fn run_xurl_reindex(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .args(["xurl", "reindex"])
+        .args(args)
+        .env("HOME", home)
+        .env("MEMPAL_EMBED_BACKEND", "unsupported-dry-run-backend")
+        .output()
+        .expect("run mempal xurl reindex")
 }
 
 /// A mock embedder that always returns fixed-value vectors of the given dimension.
@@ -135,6 +158,15 @@ fn insert_raw_turn_row(conn: &rusqlite::Connection, row: TurnRow<'_>) {
         ],
     )
     .expect("insert test row");
+}
+
+fn vector_count(conn: &rusqlite::Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM conversation_turn_vectors",
+        [],
+        |row| row.get(0),
+    )
+    .expect("count vectors")
 }
 
 #[tokio::test]
@@ -497,4 +529,93 @@ async fn test_reindex_path_drains_all_unindexed() {
 
     let after = mempal::xurl::store::count_unindexed_turns(db.conn()).unwrap();
     assert_eq!(after, 0, "reindex must drain the entire backlog");
+}
+
+#[test]
+fn test_xurl_reindex_dry_run_reports_without_embed_or_writes() {
+    let home = TempDir::new().expect("home");
+    let db = open_home_db(home.path());
+
+    insert_raw_turn_row(
+        db.conn(),
+        TurnRow {
+            id: "turn-dry-a",
+            session: "thread-a",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "dry run pending a",
+            timestamp: 1.0,
+            token_count: None,
+        },
+    );
+    insert_raw_turn_row(
+        db.conn(),
+        TurnRow {
+            id: "turn-dry-b",
+            session: "thread-a",
+            tool: "cc",
+            turn_index: 1,
+            role: "assistant",
+            content: "dry run pending b",
+            timestamp: 2.0,
+            token_count: None,
+        },
+    );
+    insert_raw_turn_row(
+        db.conn(),
+        TurnRow {
+            id: "turn-dry-c",
+            session: "thread-b",
+            tool: "codex",
+            turn_index: 0,
+            role: "user",
+            content: "dry run pending c",
+            timestamp: 3.0,
+            token_count: None,
+        },
+    );
+    insert_raw_turn_row(
+        db.conn(),
+        TurnRow {
+            id: "turn-indexed",
+            session: "thread-indexed",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "already indexed",
+            timestamp: 4.0,
+            token_count: None,
+        },
+    );
+    db.conn()
+        .execute(
+            "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) VALUES (?1, 0, ?2)",
+            params!["turn-indexed", vec![0_u8; 8]],
+        )
+        .expect("insert existing vector");
+
+    let before_vectors = vector_count(db.conn());
+    let output = run_xurl_reindex(home.path(), &["--dry-run", "--json"]);
+    assert!(
+        output.status.success(),
+        "dry-run reindex failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run reindex json report");
+
+    assert_eq!(report["dry_run"], Value::from(true));
+    assert_eq!(report["threads_would_process"], Value::from(2));
+    assert_eq!(report["turns_would_process"], Value::from(3));
+    assert_eq!(
+        vector_count(db.conn()),
+        before_vectors,
+        "dry-run must not write vectors"
+    );
+    assert_eq!(
+        mempal::xurl::store::count_unindexed_turns(db.conn()).unwrap(),
+        3,
+        "dry-run must leave candidate turns unindexed"
+    );
 }

--- a/tests/xurl_timeline.rs
+++ b/tests/xurl_timeline.rs
@@ -118,6 +118,13 @@ fn json_turn_by_id<'a>(turns: &'a [Value], id: &str) -> &'a Value {
         .unwrap_or_else(|| panic!("missing turn {id}: {turns:?}"))
 }
 
+fn now_epoch() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .as_secs_f64()
+}
+
 fn make_raw_turn(
     session_id: &str,
     tool: Tool,
@@ -560,6 +567,122 @@ fn stats_cli_json_reports_tools_and_unindexed_remaining() {
     let human = stdout(&human_output);
     assert!(human.contains("| tool"));
     assert!(human.contains("unindexed_remaining: 2"));
+}
+
+#[test]
+fn stats_cli_filters_tool_session_and_since_counts() {
+    let home = TempDir::new().expect("home");
+    let db = open_home_db(home.path());
+    let now = now_epoch();
+    let recent = now - 60.0 * 60.0;
+    let old = now - 10.0 * 24.0 * 60.0 * 60.0;
+
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "cc-recent-keep",
+            session_id: "keep",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "recent cc keep",
+            timestamp_epoch: recent,
+        },
+        None,
+    );
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "cc-old-keep",
+            session_id: "keep",
+            tool: "cc",
+            turn_index: 1,
+            role: "user",
+            content: "old cc keep",
+            timestamp_epoch: old,
+        },
+        None,
+    );
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "cc-recent-other-session",
+            session_id: "other",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "recent cc other",
+            timestamp_epoch: recent,
+        },
+        None,
+    );
+    insert_home_turn(
+        &db,
+        RawTurnRow {
+            id: "codex-recent-keep",
+            session_id: "keep",
+            tool: "codex",
+            turn_index: 0,
+            role: "assistant",
+            content: "recent codex keep",
+            timestamp_epoch: recent,
+        },
+        None,
+    );
+
+    let global_output = run_xurl_stats(home.path(), &["--json"]);
+    assert!(
+        global_output.status.success(),
+        "global stats failed: {}",
+        stderr(&global_output)
+    );
+    let global: Value = serde_json::from_str(&stdout(&global_output)).expect("global stats json");
+    assert_eq!(global["unindexed_remaining"], Value::from(4));
+    let global_tools = global["tools"].as_array().expect("global tools");
+    let global_cc = global_tools
+        .iter()
+        .find(|tool| tool["tool"] == "cc")
+        .expect("global cc stat");
+    assert_eq!(global_cc["count"], Value::from(3));
+
+    let filtered_output = run_xurl_stats(
+        home.path(),
+        &[
+            "--tool",
+            "cc",
+            "--session",
+            "keep",
+            "--since",
+            "2d",
+            "--json",
+        ],
+    );
+    assert!(
+        filtered_output.status.success(),
+        "filtered stats failed: {}",
+        stderr(&filtered_output)
+    );
+    let filtered: Value =
+        serde_json::from_str(&stdout(&filtered_output)).expect("filtered stats json");
+    assert_eq!(filtered["unindexed_remaining"], Value::from(1));
+    let filtered_tools = filtered["tools"].as_array().expect("filtered tools");
+    assert_eq!(filtered_tools.len(), 1);
+    assert_eq!(filtered_tools[0]["tool"], Value::from("cc"));
+    assert_eq!(filtered_tools[0]["count"], Value::from(1));
+    let min_timestamp = filtered_tools[0]["min_timestamp"]
+        .as_f64()
+        .expect("min timestamp");
+    let max_timestamp = filtered_tools[0]["max_timestamp"]
+        .as_f64()
+        .expect("max timestamp");
+    assert!(
+        (min_timestamp - recent).abs() < 0.001,
+        "unexpected min timestamp: {min_timestamp}"
+    );
+    assert!(
+        (max_timestamp - recent).abs() < 0.001,
+        "unexpected max timestamp: {max_timestamp}"
+    );
 }
 
 #[test]

--- a/tests/xurl_timeline.rs
+++ b/tests/xurl_timeline.rs
@@ -111,6 +111,31 @@ fn stderr(output: &Output) -> String {
     String::from_utf8(output.stderr.clone()).expect("stderr utf8")
 }
 
+fn count_home_turns(home: &Path) -> i64 {
+    let db = open_home_db(home);
+    db.conn()
+        .query_row("SELECT COUNT(*) FROM conversation_turns", [], |row| {
+            row.get(0)
+        })
+        .expect("count conversation turns")
+}
+
+fn assert_since_duration_error(output: &Output, label: &str) {
+    assert!(!output.status.success(), "{label} should fail");
+    let err = stderr(output);
+    assert!(
+        err.contains("invalid --since duration")
+            && err.contains(r#""7d""#)
+            && err.contains(r#""24h""#)
+            && err.contains(r#""30m""#),
+        "error should name valid --since forms, got: {err}"
+    );
+    assert!(
+        !err.contains("panicked"),
+        "{label} should return an error, not panic: {err}"
+    );
+}
+
 fn json_turn_by_id<'a>(turns: &'a [Value], id: &str) -> &'a Value {
     turns
         .iter()
@@ -277,6 +302,52 @@ fn timeline_rejects_invalid_format_at_parse_time() {
         err.contains("invalid value") && err.contains("markdown") && err.contains("json"),
         "clap error should list valid formats, got: {err}"
     );
+}
+
+#[test]
+fn stats_and_timeline_since_empty_return_cli_error_without_mutating_turns() {
+    let home = TempDir::new().expect("home");
+    {
+        let db = open_home_db(home.path());
+        insert_home_turn(
+            &db,
+            RawTurnRow {
+                id: "empty-since-kept",
+                session_id: "sess1",
+                tool: "cc",
+                turn_index: 0,
+                role: "user",
+                content: "existing turn",
+                timestamp_epoch: 1.0,
+            },
+            None,
+        );
+    }
+    let before = count_home_turns(home.path());
+
+    let stats_output = run_xurl_stats(home.path(), &["--since", ""]);
+    assert_since_duration_error(&stats_output, "xurl stats --since empty");
+    assert_eq!(
+        count_home_turns(home.path()),
+        before,
+        "stats error path must not mutate turns"
+    );
+
+    let timeline_output = run_xurl_timeline(home.path(), &["--since", ""]);
+    assert_since_duration_error(&timeline_output, "xurl timeline --since empty");
+    assert_eq!(
+        count_home_turns(home.path()),
+        before,
+        "timeline error path must not mutate turns"
+    );
+}
+
+#[test]
+fn stats_since_malformed_returns_cli_error() {
+    let home = TempDir::new().expect("home");
+    let output = run_xurl_stats(home.path(), &["--since", "abc"]);
+
+    assert_since_duration_error(&output, "xurl stats --since malformed");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements **parts 1 and 2** of #272 (xurl backlog). Part 3 (`min_score`
default tuning) is intentionally left for a separate decision — it is a
product-default that needs an empirical benchmark with ground truth plus a
maintainer call, so no scoring default is touched here. This PR does **not**
close #272; it clears the two mechanical CLI-surface items.

## Part 1 — `mempal xurl stats` filters

`xurl stats` reported globally with no way to scope it, while `xurl timeline`
already supported filtering — an inconsistency. `stats` now accepts the **same
filter flags the current `timeline` exposes**: `--tool <cc|codex|hermes>`,
`--session <id>`, `--since <duration>`.

- The branch's `timeline` does **not** expose `--source` / `--until`, so those
  aliases were deliberately not invented. Consistency means matching timeline's
  *real* surface; inventing divergent flags would reintroduce the very
  inconsistency the issue is about.
- Filters narrow the aggregation (`tools`, `unindexed_remaining`) over the
  filtered subset. With no filter, behavior is the unchanged global default.
- The `--json` / `--format` stats schema (from #269) is unchanged — filters
  narrow the data, not the shape.

## Part 2 — `mempal xurl reindex --dry-run`

`reindex` had no preview mode. `--dry-run` now reports what *would* be
re-embedded with zero side effects:

- Takes an early read-only path **before** `build_embedder` — no embedder
  calls, no `drawer_vectors` writes, no progress-store mutations.
- Reports the would-process candidates: JSON `dry_run` /
  `threads_would_process` / `turns_would_process`; human output marks the dry
  run and prints `vectors written: 0`.
- Candidate selection (stale/all) is unchanged — `--dry-run` only suppresses
  writes + embeds.

## Scope / constraints

CLI / read-surface only — no schema migration. GitNexus impact analysis run
before editing (`get_stats`, `TurnFilter` MEDIUM, no HIGH/CRITICAL callers).
`drawers` stay raw; no external LLM API; CLI-only (no Web UI). `min_score` and
all scoring defaults are unchanged.

## Tests

`stats_cli_filters_tool_session_and_since_counts` (filtered vs global counts),
`test_xurl_reindex_dry_run_reports_without_embed_or_writes` (asserts no embed +
no DB/vector write + correct would-process counts). Full suite + clippy + fmt
green at the pre-commit lefthook gate.

## Review

Tier-4 cumulative review of `main...HEAD`, **PASS / CLEAN** (round 3; no
correctness, security, contract, or test-coverage findings).

Round 2 caught a real **medium correctness** finding: the new `xurl stats
--since` flag routed into the shared `parse_since_to_epoch` parser, which did
`split_at(since.len() - 1)` with no empty-input guard — `--since ""` panicked
(usize underflow / out-of-bounds split), and the pre-existing `xurl timeline
--since` shared the same latent crash. Fixed in `d290261` by hardening the
parser (`strip_suffix` + `anyhow::bail!` on empty / missing-unit / non-numeric,
naming valid forms) and adding two regression tests; one parser change covers
both entry points.

Round 3 verified: the `--since` panic path is gone and valid `7d`/`24h`/`30m`
inputs are unchanged; stats filter parity with timeline; dry-run takes the
read-only path before `build_embedder` and writes nothing; scope guard
(`min_score`/scoring/RRF/schema untouched); security pass (SQL values are bound
parameters, no injection); AGENTS.md checklist clean across all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
