### PR TITLE
fix(reindex): fail-fast + race-safe project-scoped source reindex (#278)

### DIFF
--- a/scripts/hooks/review-check.sh
+++ b/scripts/hooks/review-check.sh
@@ -61,11 +61,10 @@ SAFE_BRANCH="$(_sanitize_branch "${CURRENT_BRANCH}")"
 MARKER=".csa/state/review-gate/${SAFE_BRANCH}-${SHORT_SHA}.pass"
 
 if [ -f "${MARKER}" ]; then
-  echo "pre-push: Review gate passed (marker) for ${CURRENT_BRANCH} at ${SHORT_SHA}."
-  exit 0
+  echo "pre-push: Review gate marker found for ${CURRENT_BRANCH} at ${SHORT_SHA}; validating session."
 fi
 
-# ── Slow path: session-store scan ────────────────────────────────────────────
+# ── Session-store validation ─────────────────────────────────────────────────
 if csa review --check-verdict; then
   echo "pre-push: Full-diff review verified for HEAD ${SHORT_SHA}."
   exit 0

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1593,6 +1593,7 @@ impl Database {
         source_file: &str,
         wing: &str,
         room: Option<&str>,
+        project_id: Option<&str>,
     ) -> Result<u64, DbError> {
         let mut statement = self.conn.prepare(
             r#"
@@ -1602,11 +1603,12 @@ impl Database {
               AND source_file = ?1
               AND wing = ?2
               AND ((?3 IS NULL AND room IS NULL) OR room = ?3)
+              AND ((?4 IS NULL AND project_id IS NULL) OR project_id = ?4)
             ORDER BY rowid
             "#,
         )?;
         let rows = statement
-            .query_map((source_file, wing, room), |row| {
+            .query_map((source_file, wing, room, project_id), |row| {
                 Ok((
                     row.get::<_, i64>(0)?,
                     row.get::<_, String>(1)?,
@@ -1634,11 +1636,23 @@ impl Database {
                     )?;
                 }
                 if vectors_exist {
-                    self.conn
-                        .execute("DELETE FROM drawer_vectors WHERE id = ?1", [id])?;
+                    self.conn.execute(
+                        r#"
+                        DELETE FROM drawer_vectors
+                        WHERE id = ?1
+                          AND ((?2 IS NULL AND project_id IS NULL) OR project_id = ?2)
+                        "#,
+                        params![id, project_id],
+                    )?;
                 }
-                self.conn
-                    .execute("DELETE FROM drawers WHERE rowid = ?1", [rowid])?;
+                self.conn.execute(
+                    r#"
+                    DELETE FROM drawers
+                    WHERE rowid = ?1
+                      AND ((?2 IS NULL AND project_id IS NULL) OR project_id = ?2)
+                    "#,
+                    params![rowid, project_id],
+                )?;
             }
 
             Ok(rows.len() as u64)
@@ -5959,6 +5973,135 @@ mod tests {
     fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
         db.insert_drawer_with_project(&test_drawer(id, content), project_id)
             .expect("insert drawer");
+    }
+
+    fn insert_test_source_drawer_with_vector(
+        db: &Database,
+        id: &str,
+        content: &str,
+        source_file: &str,
+        project_id: Option<&str>,
+    ) {
+        let mut drawer = test_drawer(id, content);
+        drawer.source_file = Some(source_file.to_string());
+        db.insert_drawer_with_project(&drawer, project_id)
+            .expect("insert drawer");
+        db.insert_vector_with_project(id, &[1.0_f32, 0.0, 0.0], project_id)
+            .expect("insert vector");
+    }
+
+    fn active_drawer_project_id(db: &Database, id: &str) -> Option<Option<String>> {
+        db.conn()
+            .query_row(
+                "SELECT project_id FROM drawers WHERE id = ?1 AND deleted_at IS NULL",
+                [id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .expect("read active drawer project_id")
+    }
+
+    fn vector_project_id(db: &Database, id: &str) -> Option<Option<String>> {
+        db.conn()
+            .query_row(
+                "SELECT project_id FROM drawer_vectors WHERE id = ?1",
+                [id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .expect("read vector project_id")
+    }
+
+    #[test]
+    fn test_replace_active_source_drawers_global_scope_preserves_project_drawers_and_vectors() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        let source_file = "shared-note.md";
+
+        insert_test_source_drawer_with_vector(
+            &db,
+            "global-source",
+            "global content",
+            source_file,
+            None,
+        );
+        insert_test_source_drawer_with_vector(
+            &db,
+            "project-source",
+            "project content",
+            source_file,
+            Some("proj-a"),
+        );
+
+        let replaced = db
+            .replace_active_source_drawers(source_file, "test-wing", Some("test-room"), None)
+            .expect("replace global source drawers");
+
+        assert_eq!(replaced, 1);
+        assert_eq!(active_drawer_project_id(&db, "global-source"), None);
+        assert_eq!(vector_project_id(&db, "global-source"), None);
+        assert_eq!(
+            active_drawer_project_id(&db, "project-source"),
+            Some(Some("proj-a".to_string()))
+        );
+        assert_eq!(
+            vector_project_id(&db, "project-source"),
+            Some(Some("proj-a".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_replace_active_source_drawers_project_scope_preserves_other_scopes() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        let source_file = "shared-note.md";
+
+        insert_test_source_drawer_with_vector(
+            &db,
+            "global-source",
+            "global content",
+            source_file,
+            None,
+        );
+        insert_test_source_drawer_with_vector(
+            &db,
+            "project-a-source",
+            "project a content",
+            source_file,
+            Some("proj-a"),
+        );
+        insert_test_source_drawer_with_vector(
+            &db,
+            "project-b-source",
+            "project b content",
+            source_file,
+            Some("proj-b"),
+        );
+
+        let replaced = db
+            .replace_active_source_drawers(
+                source_file,
+                "test-wing",
+                Some("test-room"),
+                Some("proj-a"),
+            )
+            .expect("replace project source drawers");
+
+        assert_eq!(replaced, 1);
+        assert_eq!(active_drawer_project_id(&db, "project-a-source"), None);
+        assert_eq!(vector_project_id(&db, "project-a-source"), None);
+        assert_eq!(
+            active_drawer_project_id(&db, "project-b-source"),
+            Some(Some("proj-b".to_string()))
+        );
+        assert_eq!(
+            vector_project_id(&db, "project-b-source"),
+            Some(Some("proj-b".to_string()))
+        );
+        assert_eq!(active_drawer_project_id(&db, "global-source"), Some(None));
+        assert_eq!(vector_project_id(&db, "global-source"), Some(None));
     }
 
     #[test]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -212,6 +212,12 @@ pub enum DbError {
     LlmCompactionNotImplemented,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct ReindexSourceScopeSummary {
+    pub(crate) drawer_count: u64,
+    pub(crate) source_count: u64,
+}
+
 pub struct Database {
     conn: Connection,
     path: PathBuf,
@@ -1523,6 +1529,30 @@ impl Database {
         Ok(rows)
     }
 
+    pub(crate) fn project_scoped_reindex_sources_stale(
+        &self,
+        current_normalize_version: u32,
+    ) -> Result<ReindexSourceScopeSummary, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT COALESCE(SUM(drawer_count), 0), COUNT(*)
+            FROM (
+                SELECT source_file, wing, room, COUNT(*) AS drawer_count
+                FROM drawers
+                WHERE deleted_at IS NULL
+                  AND normalize_version < ?1
+                  AND project_id IS NOT NULL
+                GROUP BY source_file, wing, room
+            )
+            "#,
+        )?;
+        let summary = statement.query_row(
+            [i64::from(current_normalize_version)],
+            reindex_source_scope_summary_from_row,
+        )?;
+        Ok(summary)
+    }
+
     pub fn reindex_sources_force(&self) -> Result<Vec<ReindexSource>, DbError> {
         let mut statement = self.conn.prepare(
             r#"
@@ -1537,6 +1567,25 @@ impl Database {
             .query_map([], reindex_source_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+
+    pub(crate) fn project_scoped_reindex_sources_force(
+        &self,
+    ) -> Result<ReindexSourceScopeSummary, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT COALESCE(SUM(drawer_count), 0), COUNT(*)
+            FROM (
+                SELECT source_file, wing, room, COUNT(*) AS drawer_count
+                FROM drawers
+                WHERE deleted_at IS NULL
+                  AND project_id IS NOT NULL
+                GROUP BY source_file, wing, room
+            )
+            "#,
+        )?;
+        let summary = statement.query_row([], reindex_source_scope_summary_from_row)?;
+        Ok(summary)
     }
 
     pub fn replace_active_source_drawers(
@@ -4725,6 +4774,17 @@ fn reindex_source_from_row(row: &Row<'_>) -> rusqlite::Result<ReindexSource> {
         wing: row.get(1)?,
         room: row.get(2)?,
         drawer_count: drawer_count as u64,
+    })
+}
+
+fn reindex_source_scope_summary_from_row(
+    row: &Row<'_>,
+) -> rusqlite::Result<ReindexSourceScopeSummary> {
+    let drawer_count = row.get::<_, i64>(0)?;
+    let source_count = row.get::<_, i64>(1)?;
+    Ok(ReindexSourceScopeSummary {
+        drawer_count: drawer_count as u64,
+        source_count: source_count as u64,
     })
 }
 

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -386,11 +386,16 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         .confidence
         .unwrap_or_else(|| default_confidence(source_type));
     if options.replace_existing_source && !options.dry_run {
-        db.replace_active_source_drawers(&source_file, wing, Some(resolved_room.as_str()))
-            .map_err(|source| IngestError::ReplaceSource {
-                source_file: source_file.clone(),
-                source,
-            })?;
+        db.replace_active_source_drawers(
+            &source_file,
+            wing,
+            Some(resolved_room.as_str()),
+            options.project_id,
+        )
+        .map_err(|source| IngestError::ReplaceSource {
+            source_file: source_file.clone(),
+            source,
+        })?;
     }
 
     let scrubbed_replace_text = options

--- a/src/ingest/reindex.rs
+++ b/src/ingest/reindex.rs
@@ -37,6 +37,13 @@ pub struct ReindexReport {
 pub enum ReindexError {
     #[error(transparent)]
     Db(#[from] crate::core::db::DbError),
+    #[error(
+        "project-scoped source reindex is unsupported for isolation safety: {candidate_drawers} candidate drawers across {candidate_sources} source identities have project_id; use `mempal reindex --from-config --stale` for project-safe embedder/vector reindex"
+    )]
+    ProjectScopedSourceReindexUnsupported {
+        candidate_drawers: u64,
+        candidate_sources: u64,
+    },
     #[error("failed to reindex source {source_file}")]
     Ingest {
         source_file: String,
@@ -50,6 +57,17 @@ pub async fn reindex_sources<E: Embedder + ?Sized>(
     embedder: &E,
     options: ReindexOptions,
 ) -> Result<ReindexReport, ReindexError> {
+    let project_scoped = match options.mode {
+        ReindexMode::Stale => db.project_scoped_reindex_sources_stale(CURRENT_NORMALIZE_VERSION)?,
+        ReindexMode::Force => db.project_scoped_reindex_sources_force()?,
+    };
+    if project_scoped.drawer_count > 0 {
+        return Err(ReindexError::ProjectScopedSourceReindexUnsupported {
+            candidate_drawers: project_scoped.drawer_count,
+            candidate_sources: project_scoped.source_count,
+        });
+    }
+
     let sources = match options.mode {
         ReindexMode::Stale => db.reindex_sources_stale(CURRENT_NORMALIZE_VERSION)?,
         ReindexMode::Force => db.reindex_sources_force()?,

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -3,10 +3,11 @@ use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::ingest::lock::{acquire_source_lock, source_key};
 use mempal::ingest::normalize::CURRENT_NORMALIZE_VERSION;
-use mempal::ingest::reindex::{ReindexMode, ReindexOptions, reindex_sources};
+use mempal::ingest::reindex::{ReindexError, ReindexMode, ReindexOptions, reindex_sources};
 use mempal::ingest::{IngestOptions, ingest_file_with_options};
 use mempal::mcp::MempalMcpServer;
 use rusqlite::Connection;
+use std::collections::BTreeMap;
 use std::process::Command;
 use std::sync::Arc;
 use std::thread;
@@ -213,6 +214,72 @@ fn stale_drawer_count_raw(db: &Database) -> i64 {
             |row| row.get(0),
         )
         .expect("count stale drawers")
+}
+
+fn active_drawer_rows_for_source(
+    db: &Database,
+    source_file: &str,
+) -> Vec<(String, String, Option<String>)> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT id, content, project_id
+            FROM drawers
+            WHERE deleted_at IS NULL AND source_file = ?1
+            ORDER BY project_id, id
+            "#,
+        )
+        .expect("prepare active drawer rows");
+    statement
+        .query_map([source_file], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })
+        .expect("query active drawer rows")
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .expect("collect active drawer rows")
+}
+
+fn active_vector_project_ids_for_source(
+    db: &Database,
+    source_file: &str,
+) -> BTreeMap<String, Option<String>> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT v.id, v.project_id
+            FROM drawer_vectors v
+            JOIN drawers d ON d.id = v.id
+            WHERE d.deleted_at IS NULL AND d.source_file = ?1
+            ORDER BY v.id
+            "#,
+        )
+        .expect("prepare vector project rows");
+    statement
+        .query_map([source_file], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .expect("query vector project rows")
+        .collect::<std::result::Result<BTreeMap<_, _>, _>>()
+        .expect("collect vector project rows")
+}
+
+fn assert_project_source_reindex_unsupported(error: ReindexError) {
+    match error {
+        ReindexError::ProjectScopedSourceReindexUnsupported {
+            candidate_drawers,
+            candidate_sources,
+        } => {
+            assert_eq!(candidate_drawers, 2);
+            assert_eq!(candidate_sources, 1);
+        }
+        other => panic!("unexpected reindex error: {other:?}"),
+    }
 }
 
 fn mempal_bin() -> String {
@@ -444,6 +511,111 @@ async fn test_reindex_force_reprocesses_all() {
     assert_eq!(report.candidate_sources, 2);
     assert_eq!(report.processed_sources, 2);
     assert_eq!(stale_drawer_count_raw(&db), 0);
+}
+
+#[tokio::test]
+async fn test_project_scoped_source_reindex_rejects_stale_and_force_without_mutation() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let project_a = tmp.path().join("project-a");
+    let project_b = tmp.path().join("project-b");
+    std::fs::create_dir_all(&project_a).expect("create project-a");
+    std::fs::create_dir_all(&project_b).expect("create project-b");
+    let source_a = project_a.join("note.md");
+    let source_b = project_b.join("note.md");
+    std::fs::write(&source_a, "project a original").expect("write project-a source");
+    std::fs::write(&source_b, "project b original").expect("write project-b source");
+
+    for (path, root, project_id) in [
+        (&source_a, &project_a, "project-a"),
+        (&source_b, &project_b, "project-b"),
+    ] {
+        ingest_file_with_options(
+            &db,
+            &StubEmbedder,
+            path,
+            "mempal",
+            IngestOptions {
+                room: Some("normalize"),
+                source_root: Some(root),
+                dry_run: false,
+                project_id: Some(project_id),
+                source_file_override: None,
+                replace_existing_source: false,
+                no_strip_noise: false,
+                ..IngestOptions::default()
+            },
+        )
+        .await
+        .expect("ingest project source");
+    }
+
+    db.conn()
+        .execute(
+            "UPDATE drawers SET normalize_version = 0 WHERE source_file = 'note.md'",
+            [],
+        )
+        .expect("mark project drawers stale");
+    std::fs::write(&source_a, "project a replacement").expect("rewrite project-a source");
+    std::fs::write(&source_b, "project b replacement").expect("rewrite project-b source");
+
+    let before_drawers = active_drawer_rows_for_source(&db, "note.md");
+    assert_eq!(before_drawers.len(), 2);
+    assert_eq!(
+        before_drawers
+            .iter()
+            .map(|(_, _, project_id)| project_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("project-a"), Some("project-b")]
+    );
+    let before_vectors = active_vector_project_ids_for_source(&db, "note.md");
+    assert_eq!(before_vectors.len(), 2);
+
+    let stale_error = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect_err("project-scoped stale reindex must fail fast");
+    assert_project_source_reindex_unsupported(stale_error);
+    assert_eq!(
+        active_drawer_rows_for_source(&db, "note.md"),
+        before_drawers
+    );
+    assert_eq!(
+        active_vector_project_ids_for_source(&db, "note.md"),
+        before_vectors
+    );
+
+    let force_error = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Force,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect_err("project-scoped force reindex must fail fast");
+    assert_project_source_reindex_unsupported(force_error);
+    assert_eq!(
+        active_drawer_rows_for_source(&db, "note.md"),
+        before_drawers
+    );
+    assert_eq!(
+        active_vector_project_ids_for_source(&db, "note.md"),
+        before_vectors
+    );
+
+    let drawer_project_ids: BTreeMap<_, _> = before_drawers
+        .iter()
+        .map(|(id, _, project_id)| (id.clone(), project_id.clone()))
+        .collect();
+    assert_eq!(before_vectors, drawer_project_ids);
 }
 
 #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "0ed1071259cfc031b3e6afd6bb215f9a7a4892f7"
+commit = "3b9a042dad3171a8a8e0a7b3efb0debf0ee8a1ad"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #278. The **source-based** `mempal reindex --stale/--force` path grouped
candidates only by `(source_file, wing, room)` and reingested with
`project_id=None`, so it deleted project-scoped drawers and recreated them as
**global** rows/vectors — a project-isolation leak (#28/#139). Because directory
ingest stores `source_file` *relative* to the ingested root (with `project_id`
tracked separately), two projects can share `note.md` under one `(wing, room)`;
without persisted source-root provenance, source reindex cannot even re-read the
correct project's file — so re-enabling project-scoped source reindex is deferred.

Per a tier-4 design debate (`VERDICT: HYBRID` — Option 2 now, Option 1 later),
this PR ships **Option 2 (fail-fast)**, hardened against a TOCTOU race found in
review (see Review).

## Changes

- **Preflight guard.** A new crate-private `ReindexSourceScopeSummary` counts
  active candidates with `project_id IS NOT NULL` using the *same* `(source_file,
  wing, room)` predicate as source reindex (plus `normalize_version` for the
  stale path). It runs **before** candidate selection, dry-run, file-existence
  checks, deletes, or reingest.
- **Typed refusal.** New `ReindexError::ProjectScopedSourceReindexUnsupported`;
  when any project-scoped candidate exists, the whole run aborts with **zero
  mutations** and directs the user to the project-safe `mempal reindex
  --from-config --stale` embedder reindex.
- **Project-scoped replace delete (race fix).** `replace_active_source_drawers`
  now takes `project_id: Option<&str>` and scopes its SELECT, drawer DELETE and
  vector DELETE with a NULL-safe predicate
  `((? IS NULL AND project_id IS NULL) OR project_id = ?)`. A global source
  reindex (`None`) deletes only `project_id IS NULL` rows, so it can **never**
  delete a project-scoped drawer regardless of timing; a project-scoped ingest
  (`Some(X)`) deletes only `project_id = X`. `ingest_file_with_options` threads
  `options.project_id` in.

## Scope (Option 2 only)

No schema/`fork_ext` migration; no source-root provenance persistence (that is
the deferred Option 1, filed as a follow-up). The CRITICAL
`replace_active_source_drawers` **is modified** — its delete is now project-scoped
(NULL-safe) so the fail-fast guard is race-safe at the data layer, not just by a
non-atomic preflight count. This also fixes a latent bug where a project-`X`
re-ingest deleted **other** projects'/global drawers sharing the same
`(source_file, wing, room)`. The embedder reindex (`--from-config` /
`--embedder`), already project-safe, is untouched.
Pre-production: removing source reindex for project rows is acceptable because
project isolation is a hard invariant and `--from-config --stale` covers
project-safe vector/embedder refresh.

GitNexus impact run before editing: `replace_active_source_drawers` CRITICAL (48
impacted symbols, 1 direct caller `ingest_file_with_options`); the change is a
NULL-safe narrowing of the delete predicate — every caller's intended scope is
preserved (global ingest/source reindex → `NULL`-only; project ingest → that
project only) and all ingest/reindex tests still pass.

## Tests

- `test_project_scoped_source_reindex_rejects_stale_and_force_without_mutation`
  (tests/normalize_version.rs): two projects sharing the same relative source
  under one `(wing, room)`, distinct `project_id`, `normalize_version` forced
  stale — both `--stale` and `--force` return the new error (2 candidate drawers
  / 1 source identity), and drawer content + `project_id` and
  `drawer_vectors.project_id` are all unchanged after the refused run.
- `test_replace_active_source_drawers_global_scope_preserves_project_drawers_and_vectors`
  (src/core/db.rs): a global + a `proj-a` drawer share one `(source_file, wing,
  room)`; a **global** replace deletes only the global drawer/vector and leaves
  `proj-a` intact — the race-closing property (a project drawer present at delete
  time survives a global source reindex).
- `test_replace_active_source_drawers_project_scope_preserves_other_scopes`
  (src/core/db.rs): a `proj-a` replace deletes only `proj-a`, leaving global +
  `proj-b` untouched.

Full suite + clippy + fmt green at the pre-commit lefthook gate.

## Also in this branch

A small `chore` commit picks up pre-existing working-tree drift carried on
`main`: `scripts/hooks/review-check.sh` (csa review-gate hook now re-validates via
`csa review --check-verdict` even when a marker is found — a stricter gate) and a
`weave.lock` pointer bump. Committed here per the commit-dirty-with-feature rule.

## Follow-up

Option 1 (persist canonical source-root provenance to re-enable project-scoped
source reindex) is filed separately; design is ready from the debate. Existing
project-scoped relative rows without provenance will continue to fail-fast.

## Review

Tier-4 (`csa review`, gemini→codex failover) reviewed `main...HEAD` cumulatively.
- **Round 1** found a real **HIGH** correctness issue: the fail-fast preflight
  was not atomic with the replace (the per-source lock is acquired only inside
  `ingest_file_with_options` after file processing), and
  `replace_active_source_drawers` deleted project-blind — a concurrent
  project-scoped ingest landing between preflight and delete could lose its
  drawer. Fixed by project-scoping the delete (above).
- **Round 2** — clean PASS, no blocking findings. Verified `project_id` is threaded
  from `IngestOptions` and the NULL-safe predicate is applied to candidate
  selection, the `drawer_vectors` delete and the `drawers` delete; `None` matches
  only global rows, `Some(X)` only that project; the fail-fast preflight still
  trips before any mutation; the two new tests are genuine row-state assertions;
  and no schema/`fork_ext`/provenance/embedder-reindex changes were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
