### PR TITLE
feat(reindex): persist source-root provenance to re-enable project-scoped source reindex (#283)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -837,6 +837,7 @@ async fn process_ingest_request(
             db.insert_drawer_with_project_validity(
                 &drawer,
                 project_id.as_deref(),
+                None,
                 request.valid_from.as_deref(),
                 request.valid_until.as_deref(),
             )

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -317,13 +317,14 @@ impl Database {
         drawer: &Drawer,
         project_id: Option<&str>,
     ) -> Result<(), DbError> {
-        self.insert_drawer_with_project_validity(drawer, project_id, None, None)
+        self.insert_drawer_with_project_validity(drawer, project_id, None, None, None)
     }
 
     pub fn insert_drawer_with_project_validity(
         &self,
         drawer: &Drawer,
         project_id: Option<&str>,
+        source_root: Option<&str>,
         valid_from: Option<&str>,
         valid_until: Option<&str>,
     ) -> Result<(), DbError> {
@@ -339,6 +340,7 @@ impl Database {
                 wing,
                 room,
                 source_file,
+                source_root,
                 source_type,
                 confidence,
                 added_at,
@@ -369,7 +371,7 @@ impl Database {
                 valid_from,
                 valid_until
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35)
             "#,
             params![
                 drawer.id.as_str(),
@@ -377,6 +379,7 @@ impl Database {
                 drawer.wing.as_str(),
                 drawer.room.as_deref(),
                 drawer.source_file.as_deref(),
+                source_root,
                 source_type_as_str(&drawer.source_type),
                 drawer.confidence,
                 drawer.added_at.as_str(),
@@ -1513,11 +1516,11 @@ impl Database {
     ) -> Result<Vec<ReindexSource>, DbError> {
         let mut statement = self.conn.prepare(
             r#"
-            SELECT source_file, wing, room, COUNT(*)
+            SELECT source_root, source_file, project_id, wing, room, COUNT(*)
             FROM drawers
             WHERE deleted_at IS NULL AND normalize_version < ?1
-            GROUP BY source_file, wing, room
-            ORDER BY source_file, wing, room
+            GROUP BY project_id, source_root, source_file, wing, room
+            ORDER BY project_id, source_root, source_file, wing, room
             "#,
         )?;
         let rows = statement
@@ -1537,12 +1540,13 @@ impl Database {
             r#"
             SELECT COALESCE(SUM(drawer_count), 0), COUNT(*)
             FROM (
-                SELECT source_file, wing, room, COUNT(*) AS drawer_count
+                SELECT source_root, source_file, project_id, wing, room, COUNT(*) AS drawer_count
                 FROM drawers
                 WHERE deleted_at IS NULL
                   AND normalize_version < ?1
                   AND project_id IS NOT NULL
-                GROUP BY source_file, wing, room
+                  AND source_root IS NULL
+                GROUP BY project_id, source_root, source_file, wing, room
             )
             "#,
         )?;
@@ -1556,11 +1560,11 @@ impl Database {
     pub fn reindex_sources_force(&self) -> Result<Vec<ReindexSource>, DbError> {
         let mut statement = self.conn.prepare(
             r#"
-            SELECT source_file, wing, room, COUNT(*)
+            SELECT source_root, source_file, project_id, wing, room, COUNT(*)
             FROM drawers
             WHERE deleted_at IS NULL
-            GROUP BY source_file, wing, room
-            ORDER BY source_file, wing, room
+            GROUP BY project_id, source_root, source_file, wing, room
+            ORDER BY project_id, source_root, source_file, wing, room
             "#,
         )?;
         let rows = statement
@@ -1576,11 +1580,12 @@ impl Database {
             r#"
             SELECT COALESCE(SUM(drawer_count), 0), COUNT(*)
             FROM (
-                SELECT source_file, wing, room, COUNT(*) AS drawer_count
+                SELECT source_root, source_file, project_id, wing, room, COUNT(*) AS drawer_count
                 FROM drawers
                 WHERE deleted_at IS NULL
                   AND project_id IS NOT NULL
-                GROUP BY source_file, wing, room
+                  AND source_root IS NULL
+                GROUP BY project_id, source_root, source_file, wing, room
             )
             "#,
         )?;
@@ -1594,6 +1599,7 @@ impl Database {
         wing: &str,
         room: Option<&str>,
         project_id: Option<&str>,
+        source_root: Option<&str>,
     ) -> Result<u64, DbError> {
         let mut statement = self.conn.prepare(
             r#"
@@ -1604,11 +1610,12 @@ impl Database {
               AND wing = ?2
               AND ((?3 IS NULL AND room IS NULL) OR room = ?3)
               AND ((?4 IS NULL AND project_id IS NULL) OR project_id = ?4)
+              AND ((?5 IS NULL AND source_root IS NULL) OR source_root = ?5)
             ORDER BY rowid
             "#,
         )?;
         let rows = statement
-            .query_map((source_file, wing, room, project_id), |row| {
+            .query_map((source_file, wing, room, project_id, source_root), |row| {
                 Ok((
                     row.get::<_, i64>(0)?,
                     row.get::<_, String>(1)?,
@@ -1641,8 +1648,16 @@ impl Database {
                         DELETE FROM drawer_vectors
                         WHERE id = ?1
                           AND ((?2 IS NULL AND project_id IS NULL) OR project_id = ?2)
+                          AND EXISTS (
+                              SELECT 1
+                              FROM drawers
+                              WHERE rowid = ?3
+                                AND id = ?1
+                                AND ((?2 IS NULL AND project_id IS NULL) OR project_id = ?2)
+                                AND ((?4 IS NULL AND source_root IS NULL) OR source_root = ?4)
+                          )
                         "#,
-                        params![id, project_id],
+                        params![id, project_id, rowid, source_root],
                     )?;
                 }
                 self.conn.execute(
@@ -1650,8 +1665,9 @@ impl Database {
                     DELETE FROM drawers
                     WHERE rowid = ?1
                       AND ((?2 IS NULL AND project_id IS NULL) OR project_id = ?2)
+                      AND ((?3 IS NULL AND source_root IS NULL) OR source_root = ?3)
                     "#,
-                    params![rowid, project_id],
+                    params![rowid, project_id, source_root],
                 )?;
             }
 
@@ -4782,11 +4798,13 @@ fn explicit_tunnel_from_row(row: &Row<'_>) -> rusqlite::Result<ExplicitTunnel> {
 }
 
 fn reindex_source_from_row(row: &Row<'_>) -> rusqlite::Result<ReindexSource> {
-    let drawer_count = row.get::<_, i64>(3)?;
+    let drawer_count = row.get::<_, i64>(5)?;
     Ok(ReindexSource {
-        source_file: row.get(0)?,
-        wing: row.get(1)?,
-        room: row.get(2)?,
+        source_root: row.get(0)?,
+        source_file: row.get(1)?,
+        project_id: row.get(2)?,
+        wing: row.get(3)?,
+        room: row.get(4)?,
         drawer_count: drawer_count as u64,
     })
 }
@@ -5982,9 +6000,27 @@ mod tests {
         source_file: &str,
         project_id: Option<&str>,
     ) {
+        insert_test_source_drawer_with_vector_and_root(
+            db,
+            id,
+            content,
+            source_file,
+            project_id,
+            None,
+        );
+    }
+
+    fn insert_test_source_drawer_with_vector_and_root(
+        db: &Database,
+        id: &str,
+        content: &str,
+        source_file: &str,
+        project_id: Option<&str>,
+        source_root: Option<&str>,
+    ) {
         let mut drawer = test_drawer(id, content);
         drawer.source_file = Some(source_file.to_string());
-        db.insert_drawer_with_project(&drawer, project_id)
+        db.insert_drawer_with_project_validity(&drawer, project_id, source_root, None, None)
             .expect("insert drawer");
         db.insert_vector_with_project(id, &[1.0_f32, 0.0, 0.0], project_id)
             .expect("insert vector");
@@ -6012,6 +6048,17 @@ mod tests {
             .expect("read vector project_id")
     }
 
+    fn active_drawer_source_root(db: &Database, id: &str) -> Option<Option<String>> {
+        db.conn()
+            .query_row(
+                "SELECT source_root FROM drawers WHERE id = ?1 AND deleted_at IS NULL",
+                [id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .expect("read active drawer source_root")
+    }
+
     #[test]
     fn test_replace_active_source_drawers_global_scope_preserves_project_drawers_and_vectors() {
         let tempdir = tempfile::tempdir().expect("tempdir");
@@ -6035,7 +6082,7 @@ mod tests {
         );
 
         let replaced = db
-            .replace_active_source_drawers(source_file, "test-wing", Some("test-room"), None)
+            .replace_active_source_drawers(source_file, "test-wing", Some("test-room"), None, None)
             .expect("replace global source drawers");
 
         assert_eq!(replaced, 1);
@@ -6086,6 +6133,7 @@ mod tests {
                 "test-wing",
                 Some("test-room"),
                 Some("proj-a"),
+                None,
             )
             .expect("replace project source drawers");
 
@@ -6102,6 +6150,65 @@ mod tests {
         );
         assert_eq!(active_drawer_project_id(&db, "global-source"), Some(None));
         assert_eq!(vector_project_id(&db, "global-source"), Some(None));
+    }
+
+    #[test]
+    fn test_replace_active_source_drawers_scopes_source_root() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        let source_file = "note.md";
+        let root_a = tempdir.path().join("root-a");
+        let root_b = tempdir.path().join("root-b");
+        std::fs::create_dir_all(&root_a).expect("create root-a");
+        std::fs::create_dir_all(&root_b).expect("create root-b");
+        let root_a = root_a.canonicalize().expect("canonical root-a");
+        let root_b = root_b.canonicalize().expect("canonical root-b");
+        let root_a = root_a.to_string_lossy().to_string();
+        let root_b = root_b.to_string_lossy().to_string();
+
+        insert_test_source_drawer_with_vector_and_root(
+            &db,
+            "project-a-root-a",
+            "root a content",
+            source_file,
+            Some("proj-a"),
+            Some(&root_a),
+        );
+        insert_test_source_drawer_with_vector_and_root(
+            &db,
+            "project-a-root-b",
+            "root b content",
+            source_file,
+            Some("proj-a"),
+            Some(&root_b),
+        );
+
+        let replaced = db
+            .replace_active_source_drawers(
+                source_file,
+                "test-wing",
+                Some("test-room"),
+                Some("proj-a"),
+                Some(&root_a),
+            )
+            .expect("replace source-root scoped drawers");
+
+        assert_eq!(replaced, 1);
+        assert_eq!(active_drawer_project_id(&db, "project-a-root-a"), None);
+        assert_eq!(vector_project_id(&db, "project-a-root-a"), None);
+        assert_eq!(
+            active_drawer_project_id(&db, "project-a-root-b"),
+            Some(Some("proj-a".to_string()))
+        );
+        assert_eq!(
+            active_drawer_source_root(&db, "project-a-root-b"),
+            Some(Some(root_b))
+        );
+        assert_eq!(
+            vector_project_id(&db, "project-a-root-b"),
+            Some(Some("proj-a".to_string()))
+        );
     }
 
     #[test]

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 16;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 17;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -46,6 +46,12 @@ CREATE TABLE IF NOT EXISTS conversation_turn_vectors (
 CREATE INDEX IF NOT EXISTS idx_ct_session   ON conversation_turns(session_id, tool);
 CREATE INDEX IF NOT EXISTS idx_ct_timestamp ON conversation_turns(timestamp_epoch DESC);
 CREATE INDEX IF NOT EXISTS idx_ct_project   ON conversation_turns(project_path);
+"#;
+
+pub const FORK_EXT_V17_SCHEMA_SQL: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_drawers_reindex_source_identity_active
+    ON drawers(project_id, source_root, source_file, wing, room, normalize_version)
+    WHERE deleted_at IS NULL;
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -354,6 +360,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 16,
             up: apply_v16,
         },
+        Migration {
+            version: 17,
+            up: apply_v17,
+        },
     ]
 }
 
@@ -465,6 +475,11 @@ fn apply_v15(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v16(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V16_SCHEMA_SQL)
+}
+
+fn apply_v17(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_nullable_column(conn, "drawers", "source_root", "TEXT")?;
+    conn.execute_batch(FORK_EXT_V17_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -417,7 +417,9 @@ pub struct TunnelFollowResult {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReindexSource {
+    pub source_root: Option<String>,
     pub source_file: Option<String>,
+    pub project_id: Option<String>,
     pub wing: String,
     pub room: Option<String>,
     pub drawer_count: u64,

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -105,6 +105,12 @@ pub enum IngestError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to canonicalize source root {path}")]
+    CanonicalizeSourceRoot {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("failed to normalize {path}")]
     Normalize {
         path: PathBuf,
@@ -223,7 +229,7 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
         wing,
         IngestOptions {
             room,
-            source_root: path.parent(),
+            source_root: None,
             dry_run: false,
             project_id: None,
             gating: None,
@@ -367,6 +373,21 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         .source_file_override
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| normalize_source_file(path, options.source_root));
+    let persisted_source_root = if options.dry_run {
+        None
+    } else {
+        options
+            .source_root
+            .map(|root| {
+                root.canonicalize()
+                    .map(|path| path.to_string_lossy().to_string())
+                    .map_err(|source| IngestError::CanonicalizeSourceRoot {
+                        path: root.to_path_buf(),
+                        source,
+                    })
+            })
+            .transpose()?
+    };
 
     // Per-source ingest lock (P9-B). Guards dedup-check + insert critical
     // section against concurrent Claude↔Codex ingests of the same source.
@@ -391,6 +412,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             wing,
             Some(resolved_room.as_str()),
             options.project_id,
+            persisted_source_root.as_deref(),
         )
         .map_err(|source| IngestError::ReplaceSource {
             source_file: source_file.clone(),
@@ -613,6 +635,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         db.insert_drawer_with_project_validity(
             &drawer,
             options.project_id,
+            persisted_source_root.as_deref(),
             options.valid_from,
             options.valid_until,
         )

--- a/src/ingest/reindex.rs
+++ b/src/ingest/reindex.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -89,7 +89,10 @@ pub async fn reindex_sources<E: Embedder + ?Sized>(
             report.skipped_missing_drawers += source.drawer_count;
             continue;
         };
-        let source_path = PathBuf::from(source_file);
+        let source_path = match source.source_root.as_deref() {
+            Some(source_root) => PathBuf::from(source_root).join(source_file),
+            None => PathBuf::from(source_file),
+        };
         if !source_path.is_file() {
             report.skipped_missing_sources += 1;
             report.skipped_missing_drawers += source.drawer_count;
@@ -120,7 +123,8 @@ async fn reindex_one_source<E: Embedder + ?Sized>(
         &source.wing,
         IngestOptions {
             room: source.room.as_deref(),
-            source_root: source_path.parent(),
+            project_id: source.project_id.as_deref(),
+            source_root: source.source_root.as_deref().map(Path::new),
             dry_run: false,
             source_file_override: Some(source_file),
             replace_existing_source: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2915,11 +2915,7 @@ async fn ingest_command(
     let confidence = resolve_confidence_bound("--confidence", source_type, options.confidence)?;
     let base_options = IngestOptions {
         room: options.room,
-        source_root: if path.is_file() {
-            path.parent()
-        } else {
-            Some(path)
-        },
+        source_root: if path.is_file() { None } else { Some(path) },
         dry_run: options.dry_run,
         project_id: project_id.as_deref(),
         gating: None,
@@ -2955,11 +2951,7 @@ async fn ingest_command(
         let embedder = build_embedder(config).await?;
         let live_options = IngestOptions {
             room: options.room,
-            source_root: if path.is_file() {
-                path.parent()
-            } else {
-                Some(path)
-            },
+            source_root: if path.is_file() { None } else { Some(path) },
             dry_run: false,
             project_id: project_id.as_deref(),
             gating: (!options.no_gate).then_some(&config.ingest_gating),
@@ -3390,8 +3382,14 @@ async fn ingest_stdin_command(
         link_superseded_drawer(&mut drawer, old_id);
     }
 
-    db.insert_drawer_with_project_validity(&drawer, project_id.as_deref(), valid_from, valid_until)
-        .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
+    db.insert_drawer_with_project_validity(
+        &drawer,
+        project_id.as_deref(),
+        None,
+        valid_from,
+        valid_until,
+    )
+    .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
     db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -472,6 +472,7 @@ impl MempalMcpServer {
             db.insert_drawer_with_project_validity(
                 &drawer,
                 project_id,
+                None,
                 request.valid_from.as_deref(),
                 request.valid_until.as_deref(),
             )
@@ -2818,6 +2819,7 @@ impl MempalMcpServer {
                     db.insert_drawer_with_project_validity(
                         &drawer,
                         project_id.as_deref(),
+                        None,
                         request.valid_from.as_deref(),
                         request.valid_until.as_deref(),
                     )

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1816,9 +1816,9 @@ mod tests {
         let mut expired = make_drawer("expired", "alpha", "decision");
         expired.content = "needle expired".to_string();
 
-        db.insert_drawer_with_project_validity(&active, None, None, None)
+        db.insert_drawer_with_project_validity(&active, None, None, None, None)
             .expect("insert active");
-        db.insert_drawer_with_project_validity(&expired, None, Some("0"), Some("1"))
+        db.insert_drawer_with_project_validity(&expired, None, None, Some("0"), Some("1"))
             .expect("insert expired");
 
         let results = search_bm25_only_with_options(
@@ -1864,7 +1864,7 @@ mod tests {
         let mut future = make_drawer("future", "alpha", "decision");
         future.content = "needle future".to_string();
 
-        db.insert_drawer_with_project_validity(&future, None, Some("4102444800"), None)
+        db.insert_drawer_with_project_validity(&future, None, None, Some("4102444800"), None)
             .expect("insert future");
 
         let results = search_bm25_only_with_options(

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -79,6 +79,68 @@ fn test_upstream_user_version_preserved_after_fork_ext_init() {
 }
 
 #[test]
+fn test_fork_ext_v16_to_v17_adds_drawers_source_root_idempotently() {
+    let conn = Connection::open_in_memory().expect("open sqlite connection");
+    let schema_version = current_schema_version();
+    conn.execute_batch(&format!(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '16');
+        CREATE TABLE drawers (
+            id TEXT PRIMARY KEY,
+            project_id TEXT,
+            source_file TEXT,
+            wing TEXT NOT NULL,
+            room TEXT,
+            normalize_version INTEGER NOT NULL DEFAULT 1,
+            deleted_at TEXT
+        );
+        PRAGMA user_version = {schema_version};
+        "#
+    ))
+    .expect("create v16 schema");
+
+    apply_fork_ext_migrations_to(&conn, 17).expect("first v17 migration");
+    apply_fork_ext_migrations_to(&conn, 17).expect("second v17 migration");
+
+    let source_root = table_columns(&conn, "drawers")
+        .into_iter()
+        .find(|(name, _)| name == "source_root")
+        .expect("source_root column exists");
+    assert_eq!(source_root.1, "TEXT");
+    let not_null: i64 = conn
+        .query_row(
+            "SELECT \"notnull\" FROM pragma_table_info('drawers') WHERE name = 'source_root'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read source_root notnull");
+    assert_eq!(not_null, 0);
+    let index_exists: i64 = conn
+        .query_row(
+            r#"
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND name = 'idx_drawers_reindex_source_identity_active'
+            "#,
+            [],
+            |row| row.get(0),
+        )
+        .expect("read index");
+    assert_eq!(index_exists, 1);
+    assert_eq!(read_fork_ext_version(&conn).expect("read version"), 17);
+    let user_version = conn
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .expect("read user_version");
+    assert_eq!(user_version, schema_version);
+    assert_eq!(schema_version, current_schema_version());
+}
+
+#[test]
 fn test_fork_ext_meta_table_exists_after_init() {
     let (_tmp, _db_path, db) = new_test_db();
 

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -4,7 +4,7 @@ use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::ingest::lock::{acquire_source_lock, source_key};
 use mempal::ingest::normalize::CURRENT_NORMALIZE_VERSION;
 use mempal::ingest::reindex::{ReindexError, ReindexMode, ReindexOptions, reindex_sources};
-use mempal::ingest::{IngestOptions, ingest_file_with_options};
+use mempal::ingest::{IngestOptions, ingest_dir_with_options, ingest_file_with_options};
 use mempal::mcp::MempalMcpServer;
 use rusqlite::Connection;
 use std::collections::BTreeMap;
@@ -172,6 +172,18 @@ fn insert_versioned_drawer(
     content: &str,
     normalize_version: u32,
 ) {
+    insert_versioned_drawer_with_scope(db, id, source_file, content, normalize_version, None, None);
+}
+
+fn insert_versioned_drawer_with_scope(
+    db: &Database,
+    id: &str,
+    source_file: &str,
+    content: &str,
+    normalize_version: u32,
+    project_id: Option<&str>,
+    source_root: Option<&str>,
+) {
     let mut drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: id.to_string(),
         content: content.to_string(),
@@ -184,7 +196,8 @@ fn insert_versioned_drawer(
         importance: 0,
     });
     drawer.normalize_version = normalize_version;
-    db.insert_drawer(&drawer).expect("insert versioned drawer");
+    db.insert_drawer_with_project_validity(&drawer, project_id, source_root, None, None)
+        .expect("insert versioned drawer");
 }
 
 fn active_drawer_versions(db: &Database) -> Vec<u32> {
@@ -269,14 +282,37 @@ fn active_vector_project_ids_for_source(
         .expect("collect vector project rows")
 }
 
-fn assert_project_source_reindex_unsupported(error: ReindexError) {
+fn active_source_roots_for_source(db: &Database, source_file: &str) -> Vec<Option<String>> {
+    let mut statement = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT source_root
+            FROM drawers
+            WHERE deleted_at IS NULL AND source_file = ?1
+            ORDER BY project_id, id
+            "#,
+        )
+        .expect("prepare source roots");
+    statement
+        .query_map([source_file], |row| row.get::<_, Option<String>>(0))
+        .expect("query source roots")
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .expect("collect source roots")
+}
+
+fn assert_project_source_reindex_unsupported(
+    error: ReindexError,
+    expected_drawers: u64,
+    expected_sources: u64,
+) {
     match error {
         ReindexError::ProjectScopedSourceReindexUnsupported {
             candidate_drawers,
             candidate_sources,
         } => {
-            assert_eq!(candidate_drawers, 2);
-            assert_eq!(candidate_sources, 1);
+            assert_eq!(candidate_drawers, expected_drawers);
+            assert_eq!(candidate_sources, expected_sources);
         }
         other => panic!("unexpected reindex error: {other:?}"),
     }
@@ -367,6 +403,52 @@ async fn test_new_ingest_writes_current_normalize_version() {
 
     let versions = distinct_versions_for_source(&db, "doc.md");
     assert_eq!(versions, vec![CURRENT_NORMALIZE_VERSION]);
+}
+
+#[tokio::test]
+async fn test_directory_ingest_persists_canonical_source_root() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    let root = tmp.path().join("source-root");
+    let nested = root.join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested source dir");
+    std::fs::write(nested.join("doc.md"), "directory source root content").expect("write source");
+
+    ingest_dir_with_options(
+        &db,
+        &StubEmbedder,
+        &root,
+        "mempal",
+        IngestOptions {
+            room: Some("normalize"),
+            source_root: Some(&root),
+            dry_run: false,
+            source_file_override: None,
+            replace_existing_source: false,
+            no_strip_noise: false,
+            ..IngestOptions::default()
+        },
+    )
+    .await
+    .expect("ingest directory");
+
+    let (source_file, source_root) = db
+        .conn()
+        .query_row(
+            r#"
+            SELECT source_file, source_root
+            FROM drawers
+            WHERE deleted_at IS NULL
+            "#,
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read source identity");
+    let canonical_root = root.canonicalize().expect("canonical root");
+
+    assert_eq!(source_file, "nested/doc.md");
+    assert_eq!(source_root, canonical_root.to_string_lossy());
 }
 
 fn distinct_versions_for_source(db: &Database, source_file: &str) -> Vec<u32> {
@@ -514,7 +596,7 @@ async fn test_reindex_force_reprocesses_all() {
 }
 
 #[tokio::test]
-async fn test_project_scoped_source_reindex_rejects_stale_and_force_without_mutation() {
+async fn test_project_source_reindex_two_projects_same_relative_file() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
     let project_a = tmp.path().join("project-a");
@@ -559,17 +641,81 @@ async fn test_project_scoped_source_reindex_rejects_stale_and_force_without_muta
     std::fs::write(&source_a, "project a replacement").expect("rewrite project-a source");
     std::fs::write(&source_b, "project b replacement").expect("rewrite project-b source");
 
-    let before_drawers = active_drawer_rows_for_source(&db, "note.md");
-    assert_eq!(before_drawers.len(), 2);
+    let report = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect("project-scoped source reindex with provenance");
+
+    assert_eq!(report.candidate_drawers, 2);
+    assert_eq!(report.candidate_sources, 2);
+    assert_eq!(report.processed_sources, 2);
+    let active_drawers = active_drawer_rows_for_source(&db, "note.md");
     assert_eq!(
-        before_drawers
+        active_drawers
             .iter()
-            .map(|(_, _, project_id)| project_id.as_deref())
+            .map(|(_, content, project_id)| (content.as_str(), project_id.as_deref()))
             .collect::<Vec<_>>(),
-        vec![Some("project-a"), Some("project-b")]
+        vec![
+            ("project a replacement", Some("project-a")),
+            ("project b replacement", Some("project-b")),
+        ]
     );
-    let before_vectors = active_vector_project_ids_for_source(&db, "note.md");
-    assert_eq!(before_vectors.len(), 2);
+    let root_a = project_a
+        .canonicalize()
+        .expect("canonical project-a")
+        .to_string_lossy()
+        .to_string();
+    let root_b = project_b
+        .canonicalize()
+        .expect("canonical project-b")
+        .to_string_lossy()
+        .to_string();
+    assert_eq!(
+        active_source_roots_for_source(&db, "note.md"),
+        vec![Some(root_a), Some(root_b)]
+    );
+    let mut vector_project_ids = active_vector_project_ids_for_source(&db, "note.md")
+        .into_values()
+        .collect::<Vec<_>>();
+    vector_project_ids.sort();
+    assert_eq!(
+        vector_project_ids,
+        vec![Some("project-a".to_string()), Some("project-b".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn test_legacy_project_source_reindex_null_root_fails_fast_without_mutation() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("legacy.md");
+    std::fs::write(&source, "legacy replacement").expect("write legacy source");
+    let source_file = source.to_string_lossy().to_string();
+    insert_versioned_drawer_with_scope(
+        &db,
+        "legacy_project_drawer",
+        &source_file,
+        "legacy original",
+        0,
+        Some("legacy-project"),
+        None,
+    );
+    db.insert_vector_with_project(
+        "legacy_project_drawer",
+        &[0.1, 0.2, 0.3],
+        Some("legacy-project"),
+    )
+    .expect("insert legacy vector");
+
+    let before_drawers = active_drawer_rows_for_source(&db, &source_file);
+    let before_vectors = active_vector_project_ids_for_source(&db, &source_file);
+    let before_roots = active_source_roots_for_source(&db, &source_file);
 
     let stale_error = reindex_sources(
         &db,
@@ -580,15 +726,19 @@ async fn test_project_scoped_source_reindex_rejects_stale_and_force_without_muta
         },
     )
     .await
-    .expect_err("project-scoped stale reindex must fail fast");
-    assert_project_source_reindex_unsupported(stale_error);
+    .expect_err("legacy project-scoped stale reindex must fail fast");
+    assert_project_source_reindex_unsupported(stale_error, 1, 1);
     assert_eq!(
-        active_drawer_rows_for_source(&db, "note.md"),
+        active_drawer_rows_for_source(&db, &source_file),
         before_drawers
     );
     assert_eq!(
-        active_vector_project_ids_for_source(&db, "note.md"),
+        active_vector_project_ids_for_source(&db, &source_file),
         before_vectors
+    );
+    assert_eq!(
+        active_source_roots_for_source(&db, &source_file),
+        before_roots
     );
 
     let force_error = reindex_sources(
@@ -600,22 +750,70 @@ async fn test_project_scoped_source_reindex_rejects_stale_and_force_without_muta
         },
     )
     .await
-    .expect_err("project-scoped force reindex must fail fast");
-    assert_project_source_reindex_unsupported(force_error);
+    .expect_err("legacy project-scoped force reindex must fail fast");
+    assert_project_source_reindex_unsupported(force_error, 1, 1);
     assert_eq!(
-        active_drawer_rows_for_source(&db, "note.md"),
+        active_drawer_rows_for_source(&db, &source_file),
         before_drawers
     );
     assert_eq!(
-        active_vector_project_ids_for_source(&db, "note.md"),
+        active_vector_project_ids_for_source(&db, &source_file),
         before_vectors
     );
+    assert_eq!(
+        active_source_roots_for_source(&db, &source_file),
+        before_roots
+    );
+}
 
-    let drawer_project_ids: BTreeMap<_, _> = before_drawers
-        .iter()
-        .map(|(id, _, project_id)| (id.clone(), project_id.clone()))
-        .collect();
-    assert_eq!(before_vectors, drawer_project_ids);
+#[tokio::test]
+async fn test_global_source_reindex_null_root_unchanged() {
+    let tmp = tempfile::Builder::new()
+        .prefix("mempal-global-reindex-")
+        .tempdir_in(std::env::current_dir().expect("current dir"))
+        .expect("tempdir in current dir");
+    let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+    let source = tmp.path().join("global.md");
+    std::fs::write(&source, "global replacement").expect("write global source");
+    let cwd = std::env::current_dir().expect("current dir");
+    let source_file = source
+        .strip_prefix(&cwd)
+        .expect("source under cwd")
+        .to_string_lossy()
+        .replace('\\', "/");
+    insert_versioned_drawer(
+        &db,
+        "global_legacy_drawer",
+        &source_file,
+        "global original",
+        0,
+    );
+
+    let report = reindex_sources(
+        &db,
+        &StubEmbedder,
+        ReindexOptions {
+            mode: ReindexMode::Stale,
+            dry_run: false,
+        },
+    )
+    .await
+    .expect("global null-root source reindex");
+
+    assert_eq!(report.candidate_drawers, 1);
+    assert_eq!(report.candidate_sources, 1);
+    assert_eq!(report.processed_sources, 1);
+    assert_eq!(
+        active_drawer_rows_for_source(&db, &source_file)
+            .into_iter()
+            .map(|(_, content, project_id)| (content, project_id))
+            .collect::<Vec<_>>(),
+        vec![("global replacement".to_string(), None)]
+    );
+    assert_eq!(
+        active_source_roots_for_source(&db, &source_file),
+        vec![None]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #283. Re-enables **project-scoped source reindex** (`mempal reindex
--stale/--force`) safely by persisting the source ROOT. #278 had to make it
fail-fast: `source_file` is stored RELATIVE to the ingested root with `project_id`
tracked separately, so two projects can share `note.md` under one `(wing, room)`
and, without the original root, source reindex could re-read the WRONG project's
file. This is Option 1 of the #278 HYBRID debate.

Per a tier-4 design debate (`VERDICT: Option A`): source identity already lives
denormalized on `drawers` and the reindex/replace paths operate directly on
`drawers`, so a nullable column is the minimal, join-free, low-migration choice — a
`drawer_sources` table would add FK/backfill/joins without solving legacy NULL
provenance.

## Changes

- **Schema — fork_ext v17.** Nullable `drawers.source_root TEXT` via the guarded
  `ensure_nullable_column` helper, plus partial index
  `idx_drawers_reindex_source_identity_active(project_id, source_root, source_file,
  wing, room, normalize_version) WHERE deleted_at IS NULL`.
  `CURRENT_FORK_EXT_VERSION` 16→17; `PRAGMA user_version` /
  `CURRENT_SCHEMA_VERSION` / `drawer_vectors` untouched; no `drawer_sources`.
- **Ingest.** `ingest_file_with_options` canonicalizes `options.source_root` to an
  absolute string and persists it per drawer; single-file ingest stores NULL.
  `normalize_source_file` still uses the original root, so relative `source_file`
  is unchanged.
- **Reindex.** `ReindexSource` gains `source_root` + `project_id`; candidate
  selection groups by full identity `(project_id, source_root, source_file, wing,
  room)`; the read path is `source_root/source_file` when a root exists (else the
  prior cwd-relative path); reingest threads `project_id`, `source_root`,
  `source_file_override`, `replace_existing_source=true`.
- **Replace (extends #278).** `replace_active_source_drawers` now also filters by
  `source_root` (NULL-safe) in the SELECT + drawer DELETE, keeping the #278
  project filter; the vector DELETE stays keyed by drawer id/project via an
  `EXISTS` guard against the scoped drawer row. This prevents same-relative-path
  collisions across projects AND within one project across two roots.
- **Fail-fast.** The unsupported predicate becomes
  `project_id IS NOT NULL AND source_root IS NULL`: newly provenanced project rows
  are allowed; legacy NULL-root project rows still return
  `ProjectScopedSourceReindexUnsupported` and are left unmodified.
- **Global / vectors.** Global (`project_id IS NULL`) rows still reindex without
  provenance (no backfill). Vectors keep `project_id` on reingest (#274 /
  fork-ext v5); the #278 delete race fix is preserved (delete is project- and now
  source-root-scoped).

## GitNexus impact (run before editing)

- `insert_drawer_with_project_validity` — CRITICAL, 54 impacted, 5 direct callers.
  Global/API/MCP/stdin callers preserved by passing `source_root=None`; directory
  ingest passes the canonical root. (Ripples to `src/api/handlers.rs`,
  `src/mcp/server.rs`, `src/search/mod.rs`, `src/core/types.rs` for the new field.)
- `replace_active_source_drawers` — CRITICAL, 50 impacted, 3 direct callers.
  Existing project filter preserved; NULL-safe root scope added.
- `gitnexus detect-changes`: 11 files / 55 symbols / 36 flows, critical as expected.

## Tests

`test_fork_ext_v16_to_v17_adds_drawers_source_root_idempotently`,
`test_directory_ingest_persists_canonical_source_root`,
`test_project_source_reindex_two_projects_same_relative_file`,
`test_legacy_project_source_reindex_null_root_fails_fast_without_mutation`,
`test_global_source_reindex_null_root_unchanged`,
`test_replace_active_source_drawers_scopes_source_root`.

fork_ext_schema_axis 10/10, normalize_version 14/14, replace_active_source_drawers
3/3, clippy 0 warnings; full suite + clippy + fmt green at the pre-commit lefthook
gate.

## Migration note

This ships a **live fork_ext schema migration** (v17) that applies to
`~/.mempal/palace.db` on the next binary run — additive and idempotent (nullable
column + `IF NOT EXISTS` index); legacy NULL rows remain valid.

## Review

Tier-4 (`csa review`, gemini→codex failover) reviewed `main...HEAD` — **clean PASS,
one iteration, zero findings**. Confirmed: v17 is additive/idempotent and leaves
`PRAGMA user_version`/`CURRENT_SCHEMA_VERSION` untouched; ingest persists canonical
roots while `source_file` normalization is unchanged; reindex groups by
`(project_id, source_root, source_file, wing, room)`, reads rooted paths, and
threads the reingest options; legacy NULL-root project rows still fail fast before
any mutation; `replace_active_source_drawers` keeps the #278 project filter and adds
NULL-safe `source_root` scoping to drawer + vector deletion; the insert-signature
change is absorbed by all callers (API/MCP/CLI-stdin/search/db tests); scope guard
held (no `drawer_sources`, no `source_root` on `drawer_vectors`, no
embedder/scoring/AAAK/CLI drift); no new unwrap/expect/unsafe/panic; project
isolation + security clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
