### PR TITLE
feat(mcp): surface fork_ext_version in compact status + lock compact-default (#289)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,7 +9,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     config::ConfigHandle,
-    db::Database,
+    db::{Database, read_fork_ext_version},
     phase3::{
         EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
@@ -1323,6 +1323,7 @@ impl MempalMcpServer {
         let embed_snapshot = global_embed_status().snapshot();
         let intelligence_snapshot = crate::intelligence::global_intelligence_status().snapshot();
         let schema_version = db.schema_version().map_err(db_error)?;
+        let fork_ext_version = read_fork_ext_version(db.conn()).map_err(db_error)?;
         let stale_drawer_count = db
             .stale_drawer_count(CURRENT_NORMALIZE_VERSION)
             .map_err(db_error)? as u64;
@@ -1386,6 +1387,7 @@ impl MempalMcpServer {
 
         Ok(Json(StatusResponse {
             schema_version,
+            fork_ext_version,
             normalize_version_current: CURRENT_NORMALIZE_VERSION,
             stale_drawer_count,
             search_decay_mode: config.search.decay.mode.to_string(),
@@ -6220,6 +6222,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::core::db::read_fork_ext_version;
     use crate::core::types::BootstrapEvidenceArgs;
     use crate::core::types::{KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole};
     use crate::embed::Embedder;
@@ -6461,10 +6464,18 @@ mod tests {
 
         let status = server.mempal_status().await.expect("status").0;
         let json = serde_json::to_value(&status).expect("serialize compact status");
+        let fork_ext_version =
+            read_fork_ext_version(Database::open(&db_path).expect("open db").conn())
+                .expect("read fork ext version");
 
         assert!(json.get("memory_protocol").is_none());
         assert!(json.get("aaak_spec").is_none());
         assert!(json.get("schema_version").and_then(Value::as_u64).is_some());
+        assert_eq!(
+            json.get("fork_ext_version").and_then(Value::as_u64),
+            Some(fork_ext_version.into())
+        );
+        assert_eq!(status.fork_ext_version, fork_ext_version);
         assert!(
             json.get("stale_drawer_count")
                 .and_then(Value::as_u64)

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1758,6 +1758,7 @@ pub struct DuplicateWarning {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct StatusResponse {
     pub schema_version: u32,
+    pub fork_ext_version: u32,
     pub normalize_version_current: u32,
     pub stale_drawer_count: u64,
     pub search_decay_mode: String,

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3b9a042dad3171a8a8e0a7b3efb0debf0ee8a1ad"
+commit = "68a82e502d3d7f6050ad15b60db040c1dad5288a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #289. Completes the MCP `mempal_status` **compact mode** by surfacing
`fork_ext_version` in the lean response and locking the compact-default behavior
with a regression test.

## Background — #289 was largely already shipped

The core of #289 (the ~15–20 KB firehose: full memory protocol + AAAK spec +
all-project `scopes[]` on every call) is **already fixed** on `main`: the MCP
`mempal_status` tool defaults to `detail=compact` (protocol + AAAK gated behind
`detail=full`) and `scope=project`.

Verified empirically against the running MCP server — a no-arg `mempal_status`
returns the lean payload: **no** memory protocol, **no** AAAK spec, project-scoped
breakdown, just the health fields. The 15–20 KB the issue measured was observed
against a binary that predated the compact-default ship.

The one genuine gap: the compact response omitted `fork_ext_version` (it carried
`schema_version` and `normalize_version` but not the fork-ext schema axis), so an
operator could not read the fork-ext version from the lean status.

## Changes

- **`src/mcp/tools.rs`** — `StatusResponse` gains `fork_ext_version: u32`.
- **`src/mcp/server.rs`** — `mempal_status_tool` populates it from
  `read_fork_ext_version(db.conn())`; new regression test asserts the default
  (compact) response omits protocol / AAAK / all-project scopes **and** keeps the
  health numbers (schema + fork_ext version, queue stats, embed status).

No schema change; no other tool touched; CLI `status` path untouched.

## Verification

- TDD: test red first (`no field fork_ext_version`), then green.
- `cargo test test_mempal_status` (3 passed), `cargo test --test mcp_status_queue_stats`
  (4 passed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` —
  all green (`CARGO_BUILD_JOBS=1`).
- Empirical: live MCP no-arg `mempal_status` payload is lean (protocol/AAAK absent).

## GitNexus impact

`mempal_status` MEDIUM (12 callers, all Tests); `mempal_status_tool` /
`StatusResponse` LOW (0 callers, 0 flows). Additive field — no signature/routing
change.

## Residual (out of scope, tracked elsewhere)

A few cross-project `scopes[]` entries remain because **142 drawers still carry
NULL `project_id`**; hard project filtering is the project-isolation effort
(`mempal project migrate` backfill / project-vector-isolation), not the
compact-mode mechanism.

## Review

Tier-4 (`csa review --single`, gemini-cli) reviewed `main...HEAD` — **clean PASS,
zero findings**. Confirmed: `fork_ext_version` is read via `read_fork_ext_version`
with standard `map_err(db_error)?` propagation and is distinct from
`schema_version` / `normalize_version`; the regression test genuinely asserts the
compact default omits protocol/AAAK/all-project scopes and matches the field
against the DB value; `weave.lock` committed alongside (rule 043); adversarial
security pass clean (no data exposure, no production lock contention). AGENTS.md
checklist all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
