### PR TITLE
fix(embed-queue): retry transient failures instead of first-blip dead-letter; surface failed count; add reindex --failed (#288)

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -50,13 +50,15 @@ pub struct QueueStats {
 pub struct QueueConfig {
     pub base_delay_ms: i64,
     pub max_delay_ms: i64,
+    /// Legacy compatibility knob. Terminal dead-lettering is controlled by
+    /// `QueueFailureDisposition::Terminal`, not by retryable attempt count.
     pub max_retries: u32,
 }
 
 /// Controls whether a processing failure is retried or dead-lettered immediately.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueueFailureDisposition {
-    /// Retry with bounded queue backoff until `QueueConfig::max_retries` is exhausted.
+    /// Retry with queue backoff without converting the item to a terminal dead-letter.
     Retryable,
     /// Move directly to the failed/dead-letter state without another attempt.
     Terminal,
@@ -336,8 +338,7 @@ impl PendingMessageStore {
         let next_retry = current_retry.saturating_add(1);
         let next_retry_u32 = u32::try_from(next_retry)
             .map_err(|_| QueueError::RetryCountOverflow { id: id.to_string() })?;
-        let terminal = disposition == QueueFailureDisposition::Terminal
-            || next_retry_u32 > self.config.max_retries;
+        let terminal = disposition == QueueFailureDisposition::Terminal;
         let backoff_ms = if terminal {
             0
         } else {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6460,7 +6460,13 @@ mod tests {
             .claim_next("status-worker", 60)
             .expect("claim failed fixture")
             .expect("failed fixture row");
-        store.mark_failed(&failed.id, "boom").expect("mark failed");
+        store
+            .mark_failed_with_disposition(
+                &failed.id,
+                "boom",
+                crate::core::queue::QueueFailureDisposition::Terminal,
+            )
+            .expect("mark terminal failed");
 
         let status = server.mempal_status().await.expect("status").0;
         let json = serde_json::to_value(&status).expect("serialize compact status");

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use blake3::Hasher;
 use mempal::core::db::{CURRENT_VECTOR_INDEX_VERSION, Database};
 use mempal::core::project::ProjectSearchScope;
-use mempal::core::queue::PendingMessageStore;
+use mempal::core::queue::{PendingMessageStore, QueueFailureDisposition};
 use mempal::core::types::{Drawer, SourceType};
 use mempal::ingest::gating::GatingDecision;
 use mempal::ingest::novelty::NoveltyAction;
@@ -180,7 +180,9 @@ fn seed_queue_rows(db_path: &Path) {
         .claim_next("dashboard-test", 120)
         .expect("claim next")
         .expect("claimed message");
-    store.mark_failed(&failed, "boom").expect("mark failed");
+    store
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
 }
 
 fn write_config_atomic(path: &Path, contents: &str) {

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -13,7 +13,7 @@ use common::harness::McpStdio;
 use mempal::core::compaction::merge_cluster;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
-use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use mempal::core::queue::{PendingMessageStore, QueueConfig, QueueFailureDisposition};
 use mempal::core::types::{BootstrapEvidenceArgs, CompactionStrategy, Drawer, SourceType};
 use mempal::mcp::MempalMcpServer;
 #[cfg(feature = "integration")]
@@ -162,7 +162,9 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
         .claim_next("worker-failed", 60)
         .expect("claim")
         .expect("failed row");
-    store.mark_failed(&failed.id, "boom").expect("mark failed");
+    store
+        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
 
     let server = MempalMcpServer::new(db_path, config);
     let response = server.mempal_status().await.expect("status").0;

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -185,7 +185,7 @@ fn test_terminal_failure_dead_letters_immediately() {
 }
 
 #[test]
-fn test_max_retries_marks_failed_permanently() {
+fn test_retryable_failure_stays_retryable_past_max_retries() {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     Database::open(&db_path).expect("open db");
@@ -210,20 +210,20 @@ fn test_max_retries_marks_failed_permanently() {
     }
 
     let conn = Connection::open(&db_path).expect("open sqlite");
-    let status = conn
+    let (status, retry_count): (String, i64) = conn
         .query_row(
-            "SELECT status FROM pending_messages WHERE id = ?1",
+            "SELECT status, retry_count FROM pending_messages WHERE id = ?1",
             [&id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .expect("query status");
-    assert_eq!(status, "failed");
-    assert!(
-        store
-            .claim_next("worker-z", 60)
-            .expect("claim after failed")
-            .is_none()
-    );
+    assert_eq!(status, "pending");
+    assert_eq!(retry_count, 4);
+    let retry = store
+        .claim_next("worker-z", 60)
+        .expect("claim after retryable failures")
+        .expect("retryable message");
+    assert_eq!(retry.id, id);
 }
 
 #[test]
@@ -279,6 +279,13 @@ fn test_retry_failed_embed_messages_requeues_only_failed_embed_items() {
         assert_eq!(retry_count, expected_retry_count, "{id}");
         assert_eq!(last_error.as_deref(), expected_error, "{id}");
     }
+    drop(conn);
+
+    let recovered = store
+        .claim_next("retry-worker", 60)
+        .expect("claim requeued failed embed")
+        .expect("requeued failed embed item");
+    assert_eq!(recovered.id, failed_embed);
 }
 
 /// Verifies concurrent enqueue doesn't deadlock or starve.

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -10,7 +10,7 @@ use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mempal::core::db::{Database, apply_fork_ext_migrations_to};
-use mempal::core::queue::{PendingMessageStore, QueueConfig};
+use mempal::core::queue::{PendingMessageStore, QueueConfig, QueueFailureDisposition};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use rusqlite::{Connection, params};
 use tempfile::TempDir;
@@ -221,7 +221,9 @@ fn test_queue_stats_reflects_current_state() {
         .expect("claim")
         .expect("failed row");
     assert_eq!(failed.id, failed_id);
-    store.mark_failed(&failed.id, "boom").expect("mark failed");
+    store
+        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
 
     let stats = store.stats().expect("stats");
     assert_eq!(stats.pending, 1);
@@ -303,7 +305,9 @@ fn test_status_command_shows_queue_stats() {
         .expect("claim")
         .expect("failed");
     assert_eq!(failed.id, failed_id);
-    store.mark_failed(&failed.id, "boom").expect("mark failed");
+    store
+        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
 
     let output = Command::new(mempal_bin())
         .arg("status")

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "68a82e502d3d7f6050ad15b60db040c1dad5288a"
+commit = "fe45e1c30c76a133ae343538c3c6379de250921f"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #288. Transient embed-endpoint failures were permanently **dead-lettered
with no retry** — orphaning 566 queue items while the `status` headline reported
`embed_fail_count:0` / `failure_count:0`. Each orphan is a drawer with no
current-space vector, feeding the recall degradation in #287. This PR makes
transient failures retry (data is never lost on a blip), surfaces the real failed
count, and adds a targeted recovery path.

## Problem (issue #288)

`mempal audit embed` showed every failure was a **transport** error,
`consecutive=1` (connection blips — endpoint reachable, returns a 4096-dim vector
on direct curl), yet a single blip permanently orphaned the item. The headline
counter masked the 566-item backlog, and the only recovery was the all-or-nothing
512K `reindex --stale`.

## Changes

**State machine (`src/core/queue.rs`):**
- `QueueFailureDisposition::Retryable` — increments `retry_count`, records a
  redacted/truncated `last_error`, clears claim + heartbeat, returns the item to
  `pending`, schedules backoff, and **never terminal-dead-letters by retry
  count**. Honors the project invariant *"transient failures retry, data is never
  lost"* — a single connection blip can no longer orphan an item.
- `QueueFailureDisposition::Terminal` — durable `last_error`, moves to `failed`;
  reserved for genuinely permanent errors.

**Recovery + visibility:**
- `mempal reindex --failed` (`retry_failed_embed_messages`) requeues only
  `status='failed'` non-`llm_task` items (resets retry/backoff/error; leaves
  pending/claimed/LLM rows untouched), so the existing 566 orphans recover without
  the 512K pass. This is the targeted re-embed #287 item (d) reuses.
- The `status` headline (CLI `status` + MCP `mempal_status`,
  `failure_headline_count`) now surfaces the queue's real `failed` count, in both
  compact and full modes (does not regress #289's compact-default test).

No schema change; `fork_ext_version` unchanged.

## Verification

- TDD red-first: `test_retryable_failure_stays_retryable_past_max_retries` failed
  pre-impl (`left: "failed"`, `right: "pending"`).
- `cargo test` (`queue_claim_confirm`, `queue_stats`, `mcp_status_queue_stats`,
  `cli_dashboard`), `cargo clippy --all-targets -- -D warnings`, `cargo fmt
  --check` — all green (`CARGO_BUILD_JOBS=1`). lefthook full-suite gate on commit.

## GitNexus impact

detect-changes: 7 files, 12 symbols, **0 affected processes, risk LOW**.
`retry_failed_embed_messages` is HIGH only as a *new* CLI-path symbol (caller
`reindex_failed_queue_command`); `confirm` (HIGH, daemon + LLM worker) was **not**
modified.

## Residual / follow-up

- The minor 7-day failure-log retention forensics item (#288 point 4) is deferred.
- Draining the existing 566 orphans is a **user-owned** step: run
  `mempal reindex --failed` when ready (targeted; does not touch the 512K store).

## Review

Tier-4 (`csa review --single`, gemini-cli) reviewed `main...HEAD` — **clean PASS**.
Confirmed the critical invariant: the `Retryable` disposition is now unbounded
(true infinite retry — eliminates dropping queue items under prolonged outage /
transient unavailability, respecting "never lose data"); `Terminal` dead-lettering
is strictly caller-controlled and maps to deterministic failures (e.g. malformed
payloads), not transient blips. `max_retries` is intentionally retained in
`QueueConfig` as a documented legacy knob (config back-compat). Tests validate the
new invariant; "mechanically sound and logically complete."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
