### PR TITLE
fix(queue): preserve FIFO position on failed-embed retry to kill claim_next flake (#293)

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -136,7 +136,7 @@ impl PendingMessageStore {
                 FROM pending_messages
                 WHERE status = 'pending' AND next_attempt_at <= ?1
                   AND kind != 'llm_task'
-                ORDER BY next_attempt_at ASC, created_at ASC, id ASC
+                ORDER BY next_attempt_at ASC, id ASC
                 LIMIT 1
                 "#,
                 [now],
@@ -203,7 +203,7 @@ impl PendingMessageStore {
                 SELECT id, kind, payload, retry_count, source_hash
                 FROM pending_messages
                 WHERE status = 'pending' AND next_attempt_at <= ?1 AND kind = ?2
-                ORDER BY next_attempt_at ASC, created_at ASC, id ASC
+                ORDER BY next_attempt_at ASC, id ASC
                 LIMIT 1
                 "#,
                 params![now, kind_filter],
@@ -383,6 +383,9 @@ impl PendingMessageStore {
 
     /// Return dead-lettered embed-queue messages to pending for a targeted retry.
     ///
+    /// Retried messages keep their original FIFO position among immediately
+    /// available work instead of moving behind already-pending items.
+    ///
     /// LLM tasks share the same storage table but are not embed queue work, so
     /// they are intentionally left untouched.
     pub fn retry_failed_embed_messages(&self) -> Result<u64> {
@@ -394,7 +397,7 @@ impl PendingMessageStore {
             SET status = 'pending',
                 retry_count = 0,
                 retry_backoff_ms = 0,
-                next_attempt_at = ?1,
+                next_attempt_at = MIN(created_at, ?1),
                 claim_token = NULL,
                 claimed_at = NULL,
                 heartbeat_at = NULL,

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -227,6 +227,74 @@ fn test_retryable_failure_stays_retryable_past_max_retries() {
 }
 
 #[test]
+fn test_claim_next_breaks_timestamp_ties_by_id() {
+    let (_tmp, db_path, store) = new_store();
+    let first = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue first");
+    let second = store
+        .enqueue("hook_event", r#"{"n":2}"#)
+        .expect("enqueue second");
+    let tied_at = now_secs().saturating_sub(10);
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET created_at = ?3, next_attempt_at = ?3 WHERE id IN (?1, ?2)",
+        rusqlite::params![first, second, tied_at],
+    )
+    .expect("force timestamp tie");
+    drop(conn);
+
+    let claimed_first = store
+        .claim_next("worker-first", 60)
+        .expect("claim first")
+        .expect("first tied item");
+    let claimed_second = store
+        .claim_next("worker-second", 60)
+        .expect("claim second")
+        .expect("second tied item");
+
+    assert_eq!(claimed_first.id, first);
+    assert_eq!(claimed_second.id, second);
+}
+
+#[test]
+fn test_retry_failed_embed_messages_preserves_fifo_after_later_retry() {
+    let (_tmp, db_path, store) = new_store();
+    let failed_embed = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue failed embed");
+    let pending_embed = store
+        .enqueue("hook_event", r#"{"n":2}"#)
+        .expect("enqueue pending embed");
+    let base = now_secs().saturating_sub(10);
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom', created_at = ?2, next_attempt_at = ?2 WHERE id = ?1",
+        rusqlite::params![failed_embed, base],
+    )
+    .expect("mark failed embed with older queue position");
+    conn.execute(
+        "UPDATE pending_messages SET created_at = ?2, next_attempt_at = ?2 WHERE id = ?1",
+        rusqlite::params![pending_embed, base + 1],
+    )
+    .expect("place pending embed after failed embed but before retry time");
+    drop(conn);
+
+    let retried = store
+        .retry_failed_embed_messages()
+        .expect("retry failed embed messages");
+    assert_eq!(retried, 1);
+
+    let recovered = store
+        .claim_next("retry-worker", 60)
+        .expect("claim requeued failed embed")
+        .expect("requeued failed embed item");
+    assert_eq!(recovered.id, failed_embed);
+}
+
+#[test]
 fn test_retry_failed_embed_messages_requeues_only_failed_embed_items() {
     let (_tmp, db_path, store) = new_store();
     let failed_embed = store

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "32cc5123f51d1f10f6d527e46161d36fdf799eea"
+commit = "74417d58896cdbc481bf808a32836c0ccbdb35ec"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #293. Fixes the intermittent failure of
`test_retry_failed_embed_messages_requeues_only_failed_embed_items`
(`tests/queue_claim_confirm.rs`) in the full `cargo test` gate — a real flaky test
introduced by #288 (PR #292). The lefthook pre-commit gate runs the full suite, so
this flake could block any commit on a bad-timing run (it tripped the #287 fix
commit, which is how it surfaced).

## Root cause

`claim_next` orders pending rows by a **second-granularity** `next_attempt_at`
(from `now_secs()`). The branch already had an `id ASC` tie-break, so pure
equal-timestamp ties were stable. The real flaky path was
`retry_failed_embed_messages`: it **reset** `next_attempt_at` to the current second
on requeue, so when the test's execution straddled a 1-second boundary, the older
failed item sorted *after* an already-pending item and `claim_next` returned the
wrong row. Under the CPU-saturated parallel full-suite gate the straddle window
widened, raising the failure rate (passed at 9355597, failed on a later run).

## Fix (`src/core/queue.rs`)

- `retry_failed_embed_messages` (`:400`): `next_attempt_at = MIN(created_at, now)`
  on requeue (was `= now`), so a recovered failed item **keeps its original FIFO
  position** instead of jumping behind pending work — removing the straddle-
  dependent reordering that caused the flake.
- `claim_next` (`:139`) and `claim_next_by_kind` (`:206`): `ORDER BY` simplified to
  `next_attempt_at ASC, id ASC` (dropped a redundant `created_at` middle key); the
  `id ASC` tie-break keeps equal-timestamp ordering deterministic.

**Semantic decision:** FIFO-preserve, not requeue-to-back. `retry` is a targeted
recovery path and the existing test already expected the earlier failed item to be
reclaimed first; moving old failed work behind pending work was the nondeterminism
source. `drawers`/queue payloads are untouched. No schema / `fork_ext_version`
change.

## Tests (`tests/queue_claim_confirm.rs`)

- `test_claim_next_breaks_timestamp_ties_by_id` — pins the `id` tie-break without
  wall-clock dependence.
- `test_retry_failed_embed_messages_preserves_fifo_after_later_retry` — red-first
  regression. Red: `claim_next` returned the later pending item; green after the
  `MIN(created_at, now)` change.
- `cargo test --test queue_claim_confirm -- --test-threads=1`: 16 passed.
- **20× loop: 20/20 passed** (deterministic). `cargo fmt --check` + `clippy
  --all-targets -- -D warnings` green.

## GitNexus impact

- `claim_next`: LOW (1 direct test caller).
- `retry_failed_embed_messages`: HIGH upstream callers (`reindex_failed_queue_command`
  / `reindex --failed` from #288 + the queue test) — the function had to change to
  fix the confirmed flake; the FIFO-preserve refinement applies equally to
  `reindex --failed`. `detect-changes`: risk **low**, 0 affected processes.

## Review

Re-review of `main...HEAD` (tier-4-critical, direct codex, session
`01KT7VN2EZF7K79M9EBAD0HWW2`): **PASS — no blocking findings.** The reviewer
confirmed `next_id()` formats IDs as timestamp-plus-counter (so `id ASC` is a true
insertion-order tie-break), swept both claim paths and the sole production retry
caller (`reindex_failed_queue_command`), and verified claim remains transactional
(`TransactionBehavior::Immediate`) with failed retry still excluding `llm_task`.
The adversarial security pass found no exploitable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
