### PR TITLE
feat(mcp): warn on a stale drawer_vectors distance metric across search/status/ingest (#295)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1029,6 +1029,18 @@ impl Database {
         }
     }
 
+    /// True when the `drawer_vectors` table exists but declares the legacy `l2`
+    /// distance metric instead of `cosine`. In that state broad sqlite-vec KNN
+    /// ranks in the wrong metric space and semantic recall is silently degraded
+    /// until `mempal reindex --from-config --stale` rebuilds the table. False
+    /// when the table is absent (empty store) or already `cosine`.
+    pub fn vector_index_is_stale(&self) -> Result<bool, DbError> {
+        Ok(matches!(
+            self.vector_table_distance_metric()?.as_deref(),
+            Some("l2")
+        ))
+    }
+
     pub fn current_vector_embedder_fingerprint(dim: usize) -> String {
         let config = super::config::ConfigHandle::current();
         config.embed.current_vector_embedder_fingerprint(dim)
@@ -6024,6 +6036,64 @@ mod tests {
             .expect("insert drawer");
         db.insert_vector_with_project(id, &[1.0_f32, 0.0, 0.0], project_id)
             .expect("insert vector");
+    }
+
+    fn recreate_vectors_with_metric(db: &Database, metric_fragment: &str) {
+        db.conn()
+            .execute_batch(&format!(
+                r#"
+                DROP TABLE IF EXISTS drawer_vectors;
+                CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+                    id TEXT PRIMARY KEY,
+                    embedding FLOAT[3] {metric_fragment}
+                );
+                "#
+            ))
+            .expect("recreate vector table");
+    }
+
+    #[test]
+    fn vector_index_is_stale_detects_l2_metric_tables() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+
+        recreate_vectors_with_metric(&db, "distance_metric=l2");
+
+        assert!(
+            db.vector_index_is_stale()
+                .expect("detect stale vector index")
+        );
+    }
+
+    #[test]
+    fn vector_index_is_stale_ignores_cosine_metric_tables() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+
+        recreate_vectors_with_metric(&db, "distance_metric=cosine");
+
+        assert!(
+            !db.vector_index_is_stale()
+                .expect("detect fresh vector index")
+        );
+    }
+
+    #[test]
+    fn vector_index_is_stale_ignores_missing_vector_table() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+
+        db.conn()
+            .execute_batch("DROP TABLE IF EXISTS drawer_vectors;")
+            .expect("drop vector table");
+
+        assert!(
+            !db.vector_index_is_stale()
+                .expect("detect missing vector index")
+        );
     }
 
     fn active_drawer_project_id(db: &Database, id: &str) -> Option<Option<String>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8530,6 +8530,11 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         .context("failed to query daemon heartbeat")?;
     println!("schema_version: {schema_version}");
     println!("fork_ext_version: {fork_ext_version}");
+    println!(
+        "vector_index_stale: {}",
+        db.vector_index_is_stale()
+            .context("failed to check vector index metric")?
+    );
     println!("search_decay_mode: {}", config.search.decay.mode);
     println!("drawer_count: {drawer_count}");
     match project_breakdown {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1327,6 +1327,8 @@ impl MempalMcpServer {
         let stale_drawer_count = db
             .stale_drawer_count(CURRENT_NORMALIZE_VERSION)
             .map_err(db_error)? as u64;
+        // This sqlite_master read is once per request so external reindex clears the warning immediately.
+        let vector_index_stale = db.vector_index_is_stale().unwrap_or(false);
         let drawer_count = db.drawer_count().map_err(db_error)?;
         let consolidation_stats = db.consolidation_stats().map_err(db_error)?;
         let pending_card_count = db
@@ -1374,6 +1376,9 @@ impl MempalMcpServer {
                 source: "project_isolation".to_string(),
             });
         }
+        if let Some(warning) = stale_index_warning_from_bool(vector_index_stale) {
+            system_warnings.push(warning);
+        }
         if unresolved_project_scope && config.search.strict_project_isolation {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
@@ -1390,6 +1395,7 @@ impl MempalMcpServer {
             fork_ext_version,
             normalize_version_current: CURRENT_NORMALIZE_VERSION,
             stale_drawer_count,
+            vector_index_stale,
             search_decay_mode: config.search.decay.mode.to_string(),
             drawer_count,
             total_compacted_drawers: consolidation_stats.total_compacted_drawers,
@@ -1701,6 +1707,9 @@ impl MempalMcpServer {
 
         let mut system_warnings = current_system_warnings();
         system_warnings.extend(extra_warnings);
+        if let Some(warning) = stale_index_warning(&db) {
+            system_warnings.push(warning);
+        }
         if unresolved_scope && config.search.strict_project_isolation {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
@@ -2361,6 +2370,12 @@ impl MempalMcpServer {
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
         let db = self.open_db()?;
+        // Snapshot the request-wide warnings once so every early-return path reports a
+        // consistent set from a single `sqlite_master` read. A mid-request embed transition
+        // to degraded is not lost: the synchronous degraded-write guard below
+        // (`should_block_writes`) re-reads fresh status via `degraded_write_error()` and
+        // rejects before any success response that would carry this snapshot is built.
+        let request_system_warnings = system_warnings_with_stale_index(&db);
         let dry_run = request.dry_run.unwrap_or(false);
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
@@ -2376,7 +2391,7 @@ impl MempalMcpServer {
                 lock_wait_ms: None,
                 superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
-                system_warnings: current_system_warnings(),
+                system_warnings: request_system_warnings,
             }));
         }
         let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
@@ -2469,7 +2484,7 @@ impl MempalMcpServer {
                 lock_wait_ms: None,
                 superseded_drawer_id,
                 fact_check_warnings: Vec::new(),
-                system_warnings: current_system_warnings(),
+                system_warnings: request_system_warnings.clone(),
             }));
         }
 
@@ -2500,7 +2515,7 @@ impl MempalMcpServer {
                 lock_wait_ms: None,
                 superseded_drawer_id: superseded_response_id,
                 fact_check_warnings: Vec::new(),
-                system_warnings: current_system_warnings(),
+                system_warnings: request_system_warnings.clone(),
             }));
         }
 
@@ -2533,7 +2548,7 @@ impl MempalMcpServer {
                 lock_wait_ms: None,
                 superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
-                system_warnings: current_system_warnings(),
+                system_warnings: request_system_warnings.clone(),
             }));
         }
 
@@ -2636,7 +2651,7 @@ impl MempalMcpServer {
                 lock_wait_ms,
                 superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
-                system_warnings: current_system_warnings(),
+                system_warnings: request_system_warnings.clone(),
             }));
         }
         if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
@@ -2680,7 +2695,7 @@ impl MempalMcpServer {
                     lock_wait_ms,
                     superseded_drawer_id: None,
                     fact_check_warnings,
-                    system_warnings: current_system_warnings(),
+                    system_warnings: request_system_warnings.clone(),
                 }));
             }
         }
@@ -3137,7 +3152,7 @@ impl MempalMcpServer {
             lock_wait_ms,
             superseded_drawer_id: superseded_response_id,
             fact_check_warnings,
-            system_warnings: current_system_warnings(),
+            system_warnings: request_system_warnings,
         }))
     }
 
@@ -6066,6 +6081,26 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
     warnings
 }
 
+fn stale_index_warning_from_bool(is_stale: bool) -> Option<SystemWarning> {
+    is_stale.then(|| SystemWarning {
+        level: "warn".to_string(),
+        message: "drawer_vectors index is stale (metric mismatch: l2, expected cosine); vector recall is degraded; run `mempal reindex --from-config --stale` to rebuild".to_string(),
+        source: "vector_index".to_string(),
+    })
+}
+
+fn stale_index_warning(db: &Database) -> Option<SystemWarning> {
+    stale_index_warning_from_bool(db.vector_index_is_stale().unwrap_or(false))
+}
+
+fn system_warnings_with_stale_index(db: &Database) -> Vec<SystemWarning> {
+    let mut warnings = current_system_warnings();
+    if let Some(warning) = stale_index_warning(db) {
+        warnings.push(warning);
+    }
+    warnings
+}
+
 fn intelligence_llm_state(config: &crate::core::config::Config, reachable: bool) -> String {
     if !config.memory_intelligence.mode.uses_llm() {
         return "disabled".to_string();
@@ -6401,6 +6436,35 @@ mod tests {
             .expect("insert vector");
     }
 
+    fn recreate_vectors_with_metric(db_path: &Path, metric: &str) {
+        let db = Database::open(db_path).expect("open db");
+        db.conn()
+            .execute_batch(&format!(
+                r#"
+                DROP TABLE IF EXISTS drawer_vectors;
+                CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+                    id TEXT PRIMARY KEY,
+                    embedding FLOAT[3] distance_metric={metric},
+                    +project_id TEXT
+                );
+                "#
+            ))
+            .expect("recreate vector table");
+    }
+
+    fn insert_test_vector(db_path: &Path, id: &str) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_vector_with_project(id, &[0.1, 0.2, 0.3], None)
+            .expect("insert test vector");
+    }
+
+    fn has_vector_index_warning(warnings: &[SystemWarning]) -> bool {
+        warnings.iter().any(|warning| {
+            warning.source == "vector_index"
+                && warning.message.contains("reindex --from-config --stale")
+        })
+    }
+
     fn insert_drawer_with_project(
         db_path: &Path,
         id: &str,
@@ -6603,6 +6667,28 @@ mod tests {
                 .contains(&("project-b-wing".to_string(), Some("status".to_string()))),
             "detail=full defaults to the CLI --full all-scope breakdown"
         );
+    }
+
+    #[tokio::test]
+    async fn test_mempal_status_warns_when_vector_index_metric_is_stale() {
+        let (_tempdir, db_path, server) = setup_server();
+        recreate_vectors_with_metric(&db_path, "l2");
+
+        let status = server.mempal_status().await.expect("status").0;
+
+        assert!(status.vector_index_stale);
+        assert!(has_vector_index_warning(&status.system_warnings));
+    }
+
+    #[tokio::test]
+    async fn test_mempal_status_omits_vector_index_warning_when_metric_is_cosine() {
+        let (_tempdir, db_path, server) = setup_server();
+        recreate_vectors_with_metric(&db_path, "cosine");
+
+        let status = server.mempal_status().await.expect("status").0;
+
+        assert!(!status.vector_index_stale);
+        assert!(!has_vector_index_warning(&status.system_warnings));
     }
 
     fn insert_knowledge_drawer(
@@ -6879,6 +6965,45 @@ mod tests {
         let response = run_search(&server, "state", Some("other-wing"), None, 5).await;
 
         assert!(response.results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mempal_search_warns_when_vector_index_metric_is_stale() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer-1",
+            "stale vector metric search fixture",
+            "mempal",
+            Some("signals"),
+            "/tmp/stale.md",
+            4,
+        );
+        recreate_vectors_with_metric(&db_path, "l2");
+        insert_test_vector(&db_path, "drawer-1");
+
+        let response = run_search(&server, "stale vector metric", None, None, 5).await;
+
+        assert_eq!(response.search_mode, "hybrid");
+        assert!(has_vector_index_warning(&response.system_warnings));
+    }
+
+    #[tokio::test]
+    async fn test_mempal_search_omits_vector_index_warning_when_metric_is_cosine() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "drawer-1",
+            "fresh vector metric search fixture",
+            "mempal",
+            Some("signals"),
+            "/tmp/fresh.md",
+            4,
+        );
+
+        let response = run_search(&server, "fresh vector metric", None, None, 5).await;
+
+        assert!(!has_vector_index_warning(&response.system_warnings));
     }
 
     #[tokio::test]
@@ -8607,6 +8732,24 @@ mod tests {
         assert_eq!(second.drawer_ids, vec![first.drawer_id.clone()]);
         let db = Database::open(&db_path).expect("open db");
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_warns_but_succeeds_when_vector_index_metric_is_stale() {
+        let (_tempdir, db_path, server) = setup_server();
+        recreate_vectors_with_metric(&db_path, "l2");
+
+        let response = ingest_manual(
+            &server,
+            "stale metric ingest still succeeds",
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(!response.drawer_id.is_empty());
+        assert!(has_vector_index_warning(&response.system_warnings));
     }
 
     #[tokio::test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1761,6 +1761,8 @@ pub struct StatusResponse {
     pub fork_ext_version: u32,
     pub normalize_version_current: u32,
     pub stale_drawer_count: u64,
+    /// True when drawer_vectors still uses the legacy l2 metric and needs reindex.
+    pub vector_index_stale: bool,
     pub search_decay_mode: String,
     pub drawer_count: i64,
     pub total_compacted_drawers: u64,

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -69,6 +69,22 @@ fn insert_status_drawer(db_path: &Path, id: &str, source_type: SourceType) {
     db.insert_drawer(&drawer).expect("insert status drawer");
 }
 
+fn recreate_vectors_with_metric(db_path: &Path, metric: &str) {
+    let db = Database::open(db_path).expect("open db for vector table");
+    db.conn()
+        .execute_batch(&format!(
+            r#"
+            DROP TABLE IF EXISTS drawer_vectors;
+            CREATE VIRTUAL TABLE drawer_vectors USING vec0(
+                id TEXT PRIMARY KEY,
+                embedding FLOAT[3] distance_metric={metric},
+                +project_id TEXT
+            );
+            "#
+        ))
+        .expect("recreate vector table");
+}
+
 #[cfg(feature = "integration")]
 fn setup_home_with_status_endpoints(base_url: &str) -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
@@ -328,6 +344,22 @@ fn test_status_command_shows_queue_stats() {
     assert!(stdout.contains("oldest_pending_age_secs:"), "{stdout}");
     assert!(stdout.contains("Source Types:"), "{stdout}");
     assert!(stdout.contains("user_explicit: 1"), "{stdout}");
+}
+
+#[test]
+fn test_status_command_shows_vector_index_stale_flag() {
+    let (home, db_path) = setup_home();
+    recreate_vectors_with_metric(&db_path, "l2");
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal status");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(stdout.contains("vector_index_stale: true"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #295. A legacy `drawer_vectors` table that still declares the `l2` distance
metric (pre-cosine, before the #287/#274 migration) makes broad sqlite-vec KNN rank in
the wrong metric space — the candidate set is wrong, so the later `vec_distance_cosine`
re-score and RRF fusion can't recover it and semantic recall silently degrades. #287
shipped the REPAIR path (`reindex --from-config --stale`) and a one-off `view --project`
diagnostic, but the LIVE search/status path stayed silent while a table was still stale.
This surfaces the degradation on the live path (warn-only).

## Scope decision (tier-4 analysis: option A, not B)

A tier-4 codex analysis settled scope at **option A (warn-only)**; option B (small-store
exact-scan fallback) was rejected:
- The main search path (`src/search/mod.rs`) already runs an exact cosine path for
  filtered candidate sets `<= 4096`, so B would largely duplicate existing behavior while
  adding config + RRF interaction risk.
- The real store is ~516K drawers — far above any sane small-store exact-scan threshold,
  so B would never activate for it and would still leave large stores degraded.
- The goal is to stop SILENT degradation; a visible, actionable warning addresses that
  directly, whereas exact-scan would *hide* the staleness for small stores.

## Change

Detection reuses #287's table-metadata read; the warning reuses #288's degraded-state
`SystemWarning` channel.

- **`src/core/db.rs`** — `vector_index_is_stale()`: true iff `drawer_vectors` exists and
  declares `l2` (via the existing `vector_table_distance_metric()`). DB/core layer so MCP,
  CLI, and REST stay consistent. Metric mismatch alone is the live-path signal.
- **`src/mcp/server.rs`** — `stale_index_warning{,_from_bool}` / `system_warnings_with_
  stale_index` helpers emit one `SystemWarning { level: "warn", source: "vector_index" }`
  pointing at `mempal reindex --from-config --stale`, wired into `mempal_search`,
  `mempal_status`, and ALL `mempal_ingest` return paths. `search_mode` is NOT relabeled
  (the vector arm still runs; only ranking quality degrades). `mempal_ingest` WARNS but
  never rejects (refuse/error was explicitly rejected for #295).
- **`src/mcp/tools.rs`** `StatusResponse` + **`src/main.rs`** CLI `mempal status`: new
  `vector_index_stale: bool`.

**Detection is a per-request read, deliberately NOT cached.** `open_db()` opens a fresh
connection per request, so the check is one sub-ms `sqlite_master` `query_row` per
search/status/ingest — not a hot loop. A cache was avoided because it would make the
warning itself stale (keep warning after an external `reindex --from-config --stale`
already fixed the table); the once-per-request cost is negligible and the warning stays
fresh. A comment at the status call site documents this.

## Tests

- db-layer (red-first): `vector_index_is_stale_{detects_l2,ignores_cosine,ignores_
  missing}_metric_tables`.
- MCP handlers: `test_mempal_{status,search}_warns_when_vector_index_metric_is_stale` +
  the `_omits_..._when_metric_is_cosine` negatives; `test_mcp_ingest_warns_but_succeeds_
  when_vector_index_metric_is_stale` (ingest still returns a drawer_id).
- integration: `test_status_command_shows_vector_index_stale_flag`.

No schema / `fork_ext_version` change (pure detection + surfacing reuse). `cargo fmt` +
`clippy --all-targets -D warnings` green; full lefthook gate (clippy + full test suite)
passed at commit time.

## Review

Two independent tier-4-critical reviewers confirm **PASS**; the change carries no
blocking findings.

**Round 1 — tier-4 consensus** (session `01KT826K63PCRMH665155JAGZR`, range `main...HEAD`).
The 3-reviewer panel degraded to infra noise: `gemini-cli` UNAVAILABLE (OAuth
`QUOTA_EXHAUSTED`, ~10h reset, no API key → 400) and `codex` UNAVAILABLE
(earlyoom-killed mid-turn — three concurrent 16 GB reviewer scopes spiked host memory;
corroborated on cli-sub-agent#1840). The one reviewer that completed, **claude-code**, ran
a three-pass review and returned **PASS** with a single **LOW, non-blocking advisory**:
`mempal_ingest` snapshots `system_warnings` once at request start (server.rs), so a
mid-request embed→degraded transition wouldn't appear on the success response —
negligible in practice (embedding is queued; the synchronous degraded-write guard still
re-reads fresh status). The aggregate machine verdict read FAIL purely because 2/3
reviewers were down, not from any code finding (`findings = []`, synthetic).

**Advisory addressed** — added an inline comment at the snapshot site documenting the
deliberate snapshot-once design (consistent warnings across all early-returns + single
`sqlite_master` read) and the degraded-write fresh-read interaction, so the intent is
explicit and the pattern won't re-trigger. (amend → `e96fd6d`)

**Round 2 — single-codex tier-4** (session `01KT834RGNAGC80K45GTGRBB0A`, `--tool codex
--build-jobs 2` on `e96fd6d`, avoiding the dead gemini and the consensus memory spike).
Codex traced the detection call chain through all three table states (missing / l2 /
cosine), verified the `vector_index` warning surfaces on every promised response face
(status / search / successful ingest) plus the CLI flag, and checked struct-literal /
JSON-contract coverage and the dimension-stale branch interaction. **Verdict: CLEAN — "No
confirmed findings", Overall Risk: Low.** (Its internal iteration-1 candidate did not
reproduce on re-examination.)

Full lefthook gate (clippy `-D warnings` + full test suite) passed at commit time for
`e96fd6d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
