### PR TITLE
feat(xurl): add embedder-fingerprint staleness metadata + `xurl reindex --stale/--force` (#297)

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 17;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 18;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -52,6 +52,11 @@ pub const FORK_EXT_V17_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_drawers_reindex_source_identity_active
     ON drawers(project_id, source_root, source_file, wing, room, normalize_version)
     WHERE deleted_at IS NULL;
+"#;
+
+pub const FORK_EXT_V18_SCHEMA_SQL: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_ctv_embedder_metadata
+    ON conversation_turn_vectors(embedder_fingerprint, dim, index_version);
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -364,6 +369,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 17,
             up: apply_v17,
         },
+        Migration {
+            version: 18,
+            up: apply_v18,
+        },
     ]
 }
 
@@ -480,6 +489,18 @@ fn apply_v16(conn: &Connection) -> rusqlite::Result<()> {
 fn apply_v17(conn: &Connection) -> rusqlite::Result<()> {
     ensure_nullable_column(conn, "drawers", "source_root", "TEXT")?;
     conn.execute_batch(FORK_EXT_V17_SCHEMA_SQL)
+}
+
+fn apply_v18(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_nullable_column(
+        conn,
+        "conversation_turn_vectors",
+        "embedder_fingerprint",
+        "TEXT",
+    )?;
+    ensure_nullable_column(conn, "conversation_turn_vectors", "dim", "INTEGER")?;
+    ensure_nullable_column(conn, "conversation_turn_vectors", "index_version", "TEXT")?;
+    conn.execute_batch(FORK_EXT_V18_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1150,6 +1150,12 @@ enum XurlCommands {
     },
     /// Embed all turns that still lack a vector (drains the historical backlog).
     Reindex {
+        /// Re-embed only turns whose vector metadata is missing or stale.
+        #[arg(long)]
+        stale: bool,
+        /// Rebuild vectors for all turns.
+        #[arg(long)]
+        force: bool,
         /// Show how many threads/turns would be embedded without writing vectors.
         #[arg(long)]
         dry_run: bool,
@@ -8940,6 +8946,9 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             json,
         } => {
             let embedder = build_embedder(config).await?;
+            let vector_fingerprint = config
+                .embed
+                .current_vector_embedder_fingerprint(embedder.dimensions());
             let parse_cb = |name: &str, turns: usize| {
                 if json {
                     eprintln!(
@@ -8963,23 +8972,27 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             let stats = if let Some(p) = path {
                 let t =
                     tool.ok_or_else(|| anyhow::anyhow!("--tool is required when --path is given"))?;
-                mempal::xurl::ingest::ingest_file(
+                mempal::xurl::ingest::ingest_file_with_vector_fingerprint(
                     db,
                     embedder.as_ref(),
                     &p,
                     t.into(),
                     session_id.as_deref(),
-                    Some(&parse_cb),
-                    Some(&embed_cb),
+                    &vector_fingerprint,
+                    mempal::xurl::ingest::IngestCallbacks {
+                        on_file_parsed: Some(&parse_cb),
+                        on_embed_progress: Some(&embed_cb),
+                    },
                 )
                 .await
                 .context("xurl ingest failed")?
             } else {
                 let cfg = mempal::xurl::ingest::AutoScanConfig::default();
-                mempal::xurl::ingest::ingest_all(
+                mempal::xurl::ingest::ingest_all_with_vector_fingerprint(
                     db,
                     embedder.as_ref(),
                     &cfg,
+                    &vector_fingerprint,
                     Some(&parse_cb),
                     Some(&embed_cb),
                 )
@@ -9163,21 +9176,56 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             Ok(())
         }
 
-        XurlCommands::Reindex { dry_run, json } => {
+        XurlCommands::Reindex {
+            stale,
+            force,
+            dry_run,
+            json,
+        } => {
+            if stale && force {
+                bail!("--stale and --force are mutually exclusive");
+            }
             if dry_run {
-                let summary = mempal::xurl::store::summarize_unindexed_turns(db.conn())
-                    .context("xurl reindex dry-run query failed")?;
+                let (mode, summary) = if force {
+                    (
+                        "force",
+                        mempal::xurl::embed::summarize_all_turns(db.conn())
+                            .context("xurl force reindex dry-run query failed")?,
+                    )
+                } else if stale {
+                    let embedder = build_embedder(config).await?;
+                    let vector_fingerprint = config
+                        .embed
+                        .current_vector_embedder_fingerprint(embedder.dimensions());
+                    (
+                        "stale",
+                        mempal::xurl::embed::summarize_stale_turns(
+                            db.conn(),
+                            &vector_fingerprint,
+                            embedder.dimensions(),
+                        )
+                        .context("xurl stale reindex dry-run query failed")?,
+                    )
+                } else {
+                    (
+                        "missing",
+                        mempal::xurl::store::summarize_unindexed_turns(db.conn())
+                            .context("xurl reindex dry-run query failed")?,
+                    )
+                };
                 if json {
                     println!(
                         "{}",
                         serde_json::json!({
                             "dry_run": true,
+                            "mode": mode,
                             "threads_would_process": summary.threads,
                             "turns_would_process": summary.turns,
                         })
                     );
                 } else {
                     println!("dry-run: true");
+                    println!("mode: {mode}");
                     println!("threads would process: {}", summary.threads);
                     println!("turns would process:   {}", summary.turns);
                     println!("vectors written:       0");
@@ -9185,6 +9233,9 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 return Ok(());
             }
             let embedder = build_embedder(config).await?;
+            let vector_fingerprint = config
+                .embed
+                .current_vector_embedder_fingerprint(embedder.dimensions());
             let embed_cb = |done: usize, total: usize| {
                 if json {
                     eprintln!(
@@ -9195,23 +9246,60 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                     eprintln!("[embed] {done}/{total} turns vectorized");
                 }
             };
-            let stats =
-                mempal::xurl::embed::embed_unindexed_turns(db, embedder.as_ref(), Some(&embed_cb))
+            let (mode, stats) = if force {
+                (
+                    "force",
+                    mempal::xurl::embed::embed_all_turns(
+                        db,
+                        embedder.as_ref(),
+                        &vector_fingerprint,
+                        Some(&embed_cb),
+                    )
                     .await
-                    .context("xurl reindex failed")?;
+                    .context("xurl force reindex failed")?,
+                )
+            } else if stale {
+                (
+                    "stale",
+                    mempal::xurl::embed::embed_stale_turns(
+                        db,
+                        embedder.as_ref(),
+                        &vector_fingerprint,
+                        Some(&embed_cb),
+                    )
+                    .await
+                    .context("xurl stale reindex failed")?,
+                )
+            } else {
+                (
+                    "missing",
+                    mempal::xurl::embed::embed_unindexed_turns_with_fingerprint(
+                        db,
+                        embedder.as_ref(),
+                        &vector_fingerprint,
+                        Some(&embed_cb),
+                    )
+                    .await
+                    .context("xurl reindex failed")?,
+                )
+            };
             if json {
                 println!(
                     "{}",
                     serde_json::json!({
+                        "mode": mode,
                         "turns_processed": stats.turns_processed,
                         "chunks_total": stats.chunks_total,
                         "vectors_created": stats.embedded,
+                        "skipped_stale_content": stats.skipped_stale_content,
                     })
                 );
             } else {
+                println!("mode: {mode}");
                 println!("turns processed: {}", stats.turns_processed);
                 println!("chunks total:    {}", stats.chunks_total);
                 println!("vectors created: {}", stats.embedded);
+                println!("skipped stale content: {}", stats.skipped_stale_content);
             }
             Ok(())
         }

--- a/src/xurl/embed.rs
+++ b/src/xurl/embed.rs
@@ -1,9 +1,12 @@
-use rusqlite::{Connection, params};
+use std::collections::{HashMap, HashSet};
+
+use rusqlite::{Connection, OptionalExtension, Params, Statement, params};
 
 use crate::core::config::ChunkerConfig;
-use crate::core::db::Database;
+use crate::core::db::{CURRENT_VECTOR_INDEX_VERSION, Database};
 use crate::embed::Embedder;
 use crate::ingest::chunk::chunk_text_token_aware;
+use crate::xurl::store::UnindexedTurnSummary;
 use crate::xurl::{XurlError, XurlResult};
 
 /// Number of turns collected per outer window before issuing the embed pass.
@@ -26,15 +29,46 @@ pub struct EmbedStats {
     pub turns_processed: usize,
     pub embedded: usize,
     pub chunks_total: usize,
+    pub skipped_stale_content: usize,
 }
 
 /// Which unindexed turns an embed pass should cover.
 enum EmbedScope<'a> {
     /// Every turn in the table that still lacks a vector (bulk / backlog drain).
-    All,
+    MissingAll { fingerprint: Option<&'a str> },
     /// Only turns whose id is in this set and that still lack a vector
     /// (e.g. the turns from a single freshly-ingested file).
-    TurnIds(&'a [String]),
+    MissingTurnIds {
+        ids: &'a [String],
+        fingerprint: Option<&'a str>,
+    },
+    /// Every turn whose vector metadata does not match the current embedder.
+    StaleAll { fingerprint: &'a str },
+    /// Every turn, regardless of existing vector state.
+    ForceAll { fingerprint: &'a str },
+}
+
+#[derive(Clone, Copy)]
+enum WriteMode {
+    InsertMissing,
+    ReplaceExisting,
+}
+
+#[derive(Clone, Copy)]
+struct VectorMetadata<'a> {
+    fingerprint: Option<&'a str>,
+    dim: Option<usize>,
+    index_version: Option<&'a str>,
+}
+
+struct TurnCandidate {
+    id: String,
+    content: String,
+}
+
+#[derive(Debug, Default)]
+struct VectorWriteStats {
+    skipped_stale_content: usize,
 }
 
 /// Serialize a float vector as little-endian bytes for BLOB storage.
@@ -57,7 +91,31 @@ pub async fn embed_unindexed_turns<E: Embedder + ?Sized>(
     embedder: &E,
     progress_fn: Option<&dyn Fn(usize, usize)>,
 ) -> XurlResult<EmbedStats> {
-    embed_turns(db, embedder, EmbedScope::All, progress_fn).await
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::MissingAll { fingerprint: None },
+        progress_fn,
+    )
+    .await
+}
+
+/// Embed every turn that lacks a vector and stamp current vector metadata.
+pub async fn embed_unindexed_turns_with_fingerprint<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    fingerprint: &str,
+    progress_fn: Option<&dyn Fn(usize, usize)>,
+) -> XurlResult<EmbedStats> {
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::MissingAll {
+            fingerprint: Some(fingerprint),
+        },
+        progress_fn,
+    )
+    .await
 }
 
 /// Embed only the turns in `turn_ids` that still lack a vector.
@@ -71,7 +129,69 @@ pub async fn embed_unindexed_turns_scoped<E: Embedder + ?Sized>(
     turn_ids: &[String],
     progress_fn: Option<&dyn Fn(usize, usize)>,
 ) -> XurlResult<EmbedStats> {
-    embed_turns(db, embedder, EmbedScope::TurnIds(turn_ids), progress_fn).await
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::MissingTurnIds {
+            ids: turn_ids,
+            fingerprint: None,
+        },
+        progress_fn,
+    )
+    .await
+}
+
+/// Embed only the scoped turns lacking vectors and stamp current vector metadata.
+pub async fn embed_unindexed_turns_scoped_with_fingerprint<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    turn_ids: &[String],
+    fingerprint: &str,
+    progress_fn: Option<&dyn Fn(usize, usize)>,
+) -> XurlResult<EmbedStats> {
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::MissingTurnIds {
+            ids: turn_ids,
+            fingerprint: Some(fingerprint),
+        },
+        progress_fn,
+    )
+    .await
+}
+
+/// Re-embed turns whose stored vector metadata does not match `fingerprint`,
+/// the embedder dimension, and the current xurl vector index version.
+pub async fn embed_stale_turns<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    fingerprint: &str,
+    progress_fn: Option<&dyn Fn(usize, usize)>,
+) -> XurlResult<EmbedStats> {
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::StaleAll { fingerprint },
+        progress_fn,
+    )
+    .await
+}
+
+/// Rebuild vectors for every stored turn.
+pub async fn embed_all_turns<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    fingerprint: &str,
+    progress_fn: Option<&dyn Fn(usize, usize)>,
+) -> XurlResult<EmbedStats> {
+    embed_turns(
+        db,
+        embedder,
+        EmbedScope::ForceAll { fingerprint },
+        progress_fn,
+    )
+    .await
 }
 
 /// Shared embed driver: collect the unindexed turns in `scope`, then embed and
@@ -87,42 +207,75 @@ async fn embed_turns<E: Embedder + ?Sized>(
     conn.execute_batch("PRAGMA busy_timeout = 5000;")
         .map_err(XurlError::Database)?;
 
-    let unindexed = match scope {
-        EmbedScope::All => collect_unindexed_all(conn)?,
-        EmbedScope::TurnIds(ids) => collect_unindexed_scoped(conn, ids)?,
+    let dim = embedder.dimensions();
+    let candidates = match scope {
+        EmbedScope::MissingAll { .. } => collect_unindexed_all(conn)?,
+        EmbedScope::MissingTurnIds { ids, .. } => collect_unindexed_scoped(conn, ids)?,
+        EmbedScope::StaleAll { fingerprint } => collect_stale_all(conn, fingerprint, dim)?,
+        EmbedScope::ForceAll { .. } => collect_all_turns(conn)?,
     };
 
-    if unindexed.is_empty() {
+    if candidates.is_empty() {
         return Ok(EmbedStats::default());
     }
 
-    let total = unindexed.len();
+    let total = candidates.len();
     let config = ChunkerConfig::default();
     let mut stats = EmbedStats::default();
+    let metadata = match scope {
+        EmbedScope::MissingAll { fingerprint } | EmbedScope::MissingTurnIds { fingerprint, .. } => {
+            match fingerprint {
+                Some(fingerprint) => VectorMetadata {
+                    fingerprint: Some(fingerprint),
+                    dim: Some(dim),
+                    index_version: Some(CURRENT_VECTOR_INDEX_VERSION),
+                },
+                None => VectorMetadata {
+                    fingerprint: None,
+                    dim: None,
+                    index_version: None,
+                },
+            }
+        }
+        EmbedScope::StaleAll { fingerprint } | EmbedScope::ForceAll { fingerprint } => {
+            VectorMetadata {
+                fingerprint: Some(fingerprint),
+                dim: Some(dim),
+                index_version: Some(CURRENT_VECTOR_INDEX_VERSION),
+            }
+        }
+    };
+    let write_mode = match scope {
+        EmbedScope::MissingAll { .. } | EmbedScope::MissingTurnIds { .. } => {
+            WriteMode::InsertMissing
+        }
+        EmbedScope::StaleAll { .. } | EmbedScope::ForceAll { .. } => WriteMode::ReplaceExisting,
+    };
 
-    for batch in unindexed.chunks(EMBED_BATCH_SIZE) {
+    for batch in candidates.chunks(EMBED_BATCH_SIZE) {
         // Phase 1: embed the whole window with no write transaction open.
         let rows = embed_batch_turns(embedder, batch, &config, &mut stats).await?;
 
         // Phase 2: bulk-insert all collected vectors under a single short transaction.
-        conn.execute_batch("BEGIN").map_err(XurlError::Database)?;
-        let insert_result = (|| -> XurlResult<()> {
-            for (turn_id, chunk_index, blob) in &rows {
-                conn.execute(
-                    "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) \
-                     VALUES (?1, ?2, ?3) \
-                     ON CONFLICT(turn_id, chunk_index) DO NOTHING",
-                    params![turn_id, *chunk_index as i64, blob],
-                )
-                .map_err(XurlError::Database)?;
-            }
+        // BEGIN IMMEDIATE pairs the content recheck with vector replacement under SQLite's
+        // write lock. If ingest commits first, the re-SELECT below sees new content and skips
+        // the old vector; if this commit wins first, the later ingest update deletes it and
+        // the missing-vector embed path rebuilds from fresh content.
+        conn.execute_batch("BEGIN IMMEDIATE")
+            .map_err(XurlError::Database)?;
+        let insert_result = (|| -> XurlResult<VectorWriteStats> {
+            let write_stats = write_vector_rows(conn, batch, &rows, write_mode, metadata)?;
             conn.execute_batch("COMMIT").map_err(XurlError::Database)?;
-            Ok(())
+            Ok(write_stats)
         })();
-        if let Err(e) = insert_result {
-            let _ = conn.execute_batch("ROLLBACK");
-            return Err(e);
-        }
+        let write_stats = match insert_result {
+            Ok(write_stats) => write_stats,
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                return Err(e);
+            }
+        };
+        stats.skipped_stale_content += write_stats.skipped_stale_content;
 
         if let Some(f) = progress_fn {
             f(stats.turns_processed, total);
@@ -132,8 +285,44 @@ async fn embed_turns<E: Embedder + ?Sized>(
     Ok(stats)
 }
 
+pub fn summarize_stale_turns(
+    conn: &Connection,
+    fingerprint: &str,
+    dim: usize,
+) -> XurlResult<UnindexedTurnSummary> {
+    let dim = dim as i64;
+    summarize_candidates(
+        conn,
+        stale_where_clause(),
+        &[&dim, &fingerprint, &CURRENT_VECTOR_INDEX_VERSION],
+    )
+}
+
+pub fn summarize_all_turns(conn: &Connection) -> XurlResult<UnindexedTurnSummary> {
+    summarize_candidates(conn, "1 = 1", &[])
+}
+
+fn summarize_candidates(
+    conn: &Connection,
+    where_clause: &str,
+    params: &[&dyn rusqlite::ToSql],
+) -> XurlResult<UnindexedTurnSummary> {
+    let sql = format!(
+        "SELECT COUNT(DISTINCT ct.session_id), COUNT(*) \
+         FROM conversation_turns ct \
+         WHERE {where_clause}"
+    );
+    conn.query_row(&sql, params, |row| {
+        Ok(UnindexedTurnSummary {
+            threads: row.get(0)?,
+            turns: row.get(1)?,
+        })
+    })
+    .map_err(XurlError::Database)
+}
+
 /// Collect `(id, content)` for every turn lacking a vector.
-fn collect_unindexed_all(conn: &Connection) -> XurlResult<Vec<(String, String)>> {
+fn collect_unindexed_all(conn: &Connection) -> XurlResult<Vec<TurnCandidate>> {
     let mut stmt = conn
         .prepare(
             "SELECT ct.id, ct.content \
@@ -145,7 +334,10 @@ fn collect_unindexed_all(conn: &Connection) -> XurlResult<Vec<(String, String)>>
 
     let rows = stmt
         .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            Ok(TurnCandidate {
+                id: row.get(0)?,
+                content: row.get(1)?,
+            })
         })
         .map_err(XurlError::Database)?;
 
@@ -156,6 +348,165 @@ fn collect_unindexed_all(conn: &Connection) -> XurlResult<Vec<(String, String)>>
     Ok(out)
 }
 
+fn collect_all_turns(conn: &Connection) -> XurlResult<Vec<TurnCandidate>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT ct.id, ct.content \
+             FROM conversation_turns ct \
+             ORDER BY ct.timestamp_epoch ASC, ct.id ASC",
+        )
+        .map_err(XurlError::Database)?;
+
+    collect_turn_rows(&mut stmt, [])
+}
+
+fn collect_stale_all(
+    conn: &Connection,
+    fingerprint: &str,
+    dim: usize,
+) -> XurlResult<Vec<TurnCandidate>> {
+    let sql = format!(
+        "SELECT ct.id, ct.content \
+         FROM conversation_turns ct \
+         WHERE {} \
+         ORDER BY ct.timestamp_epoch ASC, ct.id ASC",
+        stale_where_clause()
+    );
+    let mut stmt = conn.prepare(&sql).map_err(XurlError::Database)?;
+    collect_turn_rows(
+        &mut stmt,
+        params![dim as i64, fingerprint, CURRENT_VECTOR_INDEX_VERSION],
+    )
+}
+
+fn stale_where_clause() -> &'static str {
+    "NOT EXISTS ( \
+         SELECT 1 FROM conversation_turn_vectors ctv_any \
+         WHERE ctv_any.turn_id = ct.id \
+     ) \
+     OR EXISTS ( \
+         SELECT 1 FROM conversation_turn_vectors ctv_stale \
+         WHERE ctv_stale.turn_id = ct.id \
+           AND ( \
+               ctv_stale.dim IS NULL \
+               OR ctv_stale.dim != ?1 \
+               OR ctv_stale.embedder_fingerprint IS NULL \
+               OR ctv_stale.embedder_fingerprint != ?2 \
+               OR ctv_stale.index_version IS NULL \
+               OR ctv_stale.index_version != ?3 \
+           ) \
+     )"
+}
+
+fn collect_turn_rows<P>(stmt: &mut Statement<'_>, params: P) -> XurlResult<Vec<TurnCandidate>>
+where
+    P: Params,
+{
+    let rows = stmt
+        .query_map(params, |row| {
+            Ok(TurnCandidate {
+                id: row.get(0)?,
+                content: row.get(1)?,
+            })
+        })
+        .map_err(XurlError::Database)?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(XurlError::Database)?);
+    }
+    Ok(out)
+}
+
+fn write_vector_rows(
+    conn: &Connection,
+    candidates: &[TurnCandidate],
+    rows: &[(String, usize, Vec<u8>)],
+    mode: WriteMode,
+    metadata: VectorMetadata<'_>,
+) -> XurlResult<VectorWriteStats> {
+    let expected_content_by_turn: HashMap<&str, &str> = candidates
+        .iter()
+        .map(|candidate| (candidate.id.as_str(), candidate.content.as_str()))
+        .collect();
+    let mut verified_turns = HashSet::new();
+    let mut skipped_turns = HashSet::new();
+    let mut stats = VectorWriteStats::default();
+    for (turn_id, chunk_index, blob) in rows {
+        if skipped_turns.contains(turn_id) {
+            continue;
+        }
+        if verified_turns.insert(turn_id.clone()) {
+            let Some(expected_content) = expected_content_by_turn.get(turn_id.as_str()) else {
+                return Err(XurlError::Parse(format!(
+                    "missing collected content token for turn {turn_id}"
+                )));
+            };
+            if !turn_content_is_current(conn, turn_id, expected_content)? {
+                skipped_turns.insert(turn_id.clone());
+                stats.skipped_stale_content += 1;
+                continue;
+            }
+            if matches!(mode, WriteMode::ReplaceExisting) {
+                conn.execute(
+                    "DELETE FROM conversation_turn_vectors WHERE turn_id = ?1",
+                    params![turn_id],
+                )
+                .map_err(XurlError::Database)?;
+            }
+        }
+
+        let dim = metadata.dim.map(|value| value as i64);
+        let sql = match mode {
+            WriteMode::InsertMissing => {
+                "INSERT INTO conversation_turn_vectors \
+                 (turn_id, chunk_index, vector, embedder_fingerprint, dim, index_version) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT(turn_id, chunk_index) DO NOTHING"
+            }
+            WriteMode::ReplaceExisting => {
+                "INSERT INTO conversation_turn_vectors \
+                 (turn_id, chunk_index, vector, embedder_fingerprint, dim, index_version) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT(turn_id, chunk_index) DO UPDATE SET \
+                    vector = excluded.vector, \
+                    embedder_fingerprint = excluded.embedder_fingerprint, \
+                    dim = excluded.dim, \
+                    index_version = excluded.index_version"
+            }
+        };
+        conn.execute(
+            sql,
+            params![
+                turn_id,
+                *chunk_index as i64,
+                blob,
+                metadata.fingerprint,
+                dim,
+                metadata.index_version
+            ],
+        )
+        .map_err(XurlError::Database)?;
+    }
+    Ok(stats)
+}
+
+fn turn_content_is_current(
+    conn: &Connection,
+    turn_id: &str,
+    expected_content: &str,
+) -> XurlResult<bool> {
+    let current = conn
+        .query_row(
+            "SELECT content FROM conversation_turns WHERE id = ?1",
+            params![turn_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(XurlError::Database)?;
+    Ok(current.as_deref() == Some(expected_content))
+}
+
 /// Collect `(id, content)` for the turns in `turn_ids` that lack a vector.
 ///
 /// IDs are bound in batches of `SCOPE_ID_BATCH` to stay under SQLite's
@@ -163,7 +514,7 @@ fn collect_unindexed_all(conn: &Connection) -> XurlResult<Vec<(String, String)>>
 fn collect_unindexed_scoped(
     conn: &Connection,
     turn_ids: &[String],
-) -> XurlResult<Vec<(String, String)>> {
+) -> XurlResult<Vec<TurnCandidate>> {
     let mut out = Vec::new();
     for id_batch in turn_ids.chunks(SCOPE_ID_BATCH) {
         let placeholders = vec!["?"; id_batch.len()].join(",");
@@ -178,7 +529,10 @@ fn collect_unindexed_scoped(
             id_batch.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
         let rows = stmt
             .query_map(param_refs.as_slice(), |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                Ok(TurnCandidate {
+                    id: row.get(0)?,
+                    content: row.get(1)?,
+                })
             })
             .map_err(XurlError::Database)?;
         for row in rows {
@@ -198,7 +552,7 @@ fn collect_unindexed_scoped(
 /// used here; the caller writes the returned rows inside a transaction.
 async fn embed_batch_turns<E: Embedder + ?Sized>(
     embedder: &E,
-    batch: &[(String, String)],
+    batch: &[TurnCandidate],
     config: &ChunkerConfig,
     stats: &mut EmbedStats,
 ) -> XurlResult<Vec<(String, usize, Vec<u8>)>> {
@@ -207,12 +561,13 @@ async fn embed_batch_turns<E: Embedder + ?Sized>(
     let mut all_chunks: Vec<String> = Vec::new();
     let mut chunk_map: Vec<(String, usize)> = Vec::new();
 
-    for (turn_id, content) in batch {
-        let chunks = chunk_text_token_aware(content, config, embedder, Some(turn_id));
+    for candidate in batch {
+        let chunks =
+            chunk_text_token_aware(&candidate.content, config, embedder, Some(&candidate.id));
         stats.chunks_total += chunks.len();
         stats.turns_processed += 1;
         for (chunk_index, chunk) in chunks.into_iter().enumerate() {
-            chunk_map.push((turn_id.clone(), chunk_index));
+            chunk_map.push((candidate.id.clone(), chunk_index));
             all_chunks.push(chunk);
         }
     }

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -16,6 +16,11 @@ type ParsedCb<'a> = Option<&'a dyn Fn(&str, usize)>;
 /// Callback invoked after each embed batch: `(done, total)`.
 type EmbedCb<'a> = Option<&'a dyn Fn(usize, usize)>;
 
+pub struct IngestCallbacks<'a> {
+    pub on_file_parsed: ParsedCb<'a>,
+    pub on_embed_progress: EmbedCb<'a>,
+}
+
 #[derive(Debug, Default, Serialize)]
 pub struct IngestStats {
     pub turns_parsed: usize,
@@ -122,15 +127,79 @@ pub async fn ingest_file<E: Embedder + ?Sized>(
     on_file_parsed: ParsedCb<'_>,
     on_embed_progress: EmbedCb<'_>,
 ) -> XurlResult<IngestStats> {
+    ingest_file_inner(
+        db,
+        embedder,
+        path,
+        tool,
+        session_id_override,
+        None,
+        IngestCallbacks {
+            on_file_parsed,
+            on_embed_progress,
+        },
+    )
+    .await
+}
+
+pub async fn ingest_file_with_vector_fingerprint<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    path: &Path,
+    tool: Tool,
+    session_id_override: Option<&str>,
+    vector_fingerprint: &str,
+    callbacks: IngestCallbacks<'_>,
+) -> XurlResult<IngestStats> {
+    ingest_file_inner(
+        db,
+        embedder,
+        path,
+        tool,
+        session_id_override,
+        Some(vector_fingerprint),
+        callbacks,
+    )
+    .await
+}
+
+async fn ingest_file_inner<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    path: &Path,
+    tool: Tool,
+    session_id_override: Option<&str>,
+    vector_fingerprint: Option<&str>,
+    callbacks: IngestCallbacks<'_>,
+) -> XurlResult<IngestStats> {
     let (filename, turns_parsed, insert_stats, turn_ids) =
         parse_and_store_file(db, path, tool, session_id_override)?;
-    if let Some(f) = on_file_parsed {
+    if let Some(f) = callbacks.on_file_parsed {
         f(&filename, turns_parsed);
     }
     // Scope the embed pass to just this file's turns so a single-file ingest
     // returns promptly instead of draining the entire historical backlog.
-    let embed_stats =
-        embed::embed_unindexed_turns_scoped(db, embedder, &turn_ids, on_embed_progress).await?;
+    let embed_stats = match vector_fingerprint {
+        Some(fingerprint) => {
+            embed::embed_unindexed_turns_scoped_with_fingerprint(
+                db,
+                embedder,
+                &turn_ids,
+                fingerprint,
+                callbacks.on_embed_progress,
+            )
+            .await?
+        }
+        None => {
+            embed::embed_unindexed_turns_scoped(
+                db,
+                embedder,
+                &turn_ids,
+                callbacks.on_embed_progress,
+            )
+            .await?
+        }
+    };
 
     Ok(IngestStats {
         turns_parsed,
@@ -153,6 +222,36 @@ pub async fn ingest_all<E: Embedder + ?Sized>(
     db: &Database,
     embedder: &E,
     cfg: &AutoScanConfig,
+    on_file_parsed: ParsedCb<'_>,
+    on_embed_progress: EmbedCb<'_>,
+) -> XurlResult<IngestStats> {
+    ingest_all_inner(db, embedder, cfg, None, on_file_parsed, on_embed_progress).await
+}
+
+pub async fn ingest_all_with_vector_fingerprint<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    cfg: &AutoScanConfig,
+    vector_fingerprint: &str,
+    on_file_parsed: ParsedCb<'_>,
+    on_embed_progress: EmbedCb<'_>,
+) -> XurlResult<IngestStats> {
+    ingest_all_inner(
+        db,
+        embedder,
+        cfg,
+        Some(vector_fingerprint),
+        on_file_parsed,
+        on_embed_progress,
+    )
+    .await
+}
+
+async fn ingest_all_inner<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    cfg: &AutoScanConfig,
+    vector_fingerprint: Option<&str>,
     on_file_parsed: ParsedCb<'_>,
     on_embed_progress: EmbedCb<'_>,
 ) -> XurlResult<IngestStats> {
@@ -208,7 +307,18 @@ pub async fn ingest_all<E: Embedder + ?Sized>(
     }
 
     // Phase 2: embed all unindexed turns in one batched pass.
-    let embed_stats = embed::embed_unindexed_turns(db, embedder, on_embed_progress).await?;
+    let embed_stats = match vector_fingerprint {
+        Some(fingerprint) => {
+            embed::embed_unindexed_turns_with_fingerprint(
+                db,
+                embedder,
+                fingerprint,
+                on_embed_progress,
+            )
+            .await?
+        }
+        None => embed::embed_unindexed_turns(db, embedder, on_embed_progress).await?,
+    };
     total.vectors_created += embed_stats.embedded;
 
     Ok(total)

--- a/src/xurl/store.rs
+++ b/src/xurl/store.rs
@@ -197,68 +197,86 @@ fn parse_provenance(s: &str) -> Provenance {
 pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertStats> {
     let mut stats = InsertStats::default();
 
-    for turn in turns {
-        let tool = turn.tool.as_str();
-        let existing: Option<(String, String)> = conn
-            .query_row(
-                "SELECT id, content FROM conversation_turns \
-                 WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
-                params![&turn.session_id, tool, turn.turn_index],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-            )
-            .optional()
-            .map_err(XurlError::Database)?;
+    conn.execute_batch("SAVEPOINT xurl_insert_turns")
+        .map_err(XurlError::Database)?;
+    let insert_result = (|| -> XurlResult<()> {
+        for turn in turns {
+            let tool = turn.tool.as_str();
+            let existing: Option<(String, String)> = conn
+                .query_row(
+                    "SELECT id, content FROM conversation_turns \
+                     WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
+                    params![&turn.session_id, tool, turn.turn_index],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(XurlError::Database)?;
 
-        match existing {
-            None => {
-                let id = generate_turn_id(&turn.session_id, tool, turn.turn_index);
-                conn.execute(
-                    "INSERT INTO conversation_turns \
-                     (id, session_id, tool, turn_index, role, content, timestamp_epoch, \
-                      token_count, project_path, git_branch, is_csa_delegated, provenance) \
-                     VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
-                    params![
-                        id,
-                        &turn.session_id,
-                        tool,
-                        turn.turn_index,
-                        turn.role.as_str(),
-                        &turn.content,
-                        turn.timestamp_epoch,
-                        Option::<i64>::None,
-                        &turn.project_path,
-                        &turn.git_branch,
-                        turn.is_csa_delegated as i64,
-                        turn.provenance.as_str(),
-                    ],
-                )
-                .map_err(XurlError::Database)?;
-                stats.inserted += 1;
-            }
-            Some((_, ref existing_content)) if existing_content == &turn.content => {
-                stats.skipped += 1;
-            }
-            Some((existing_id, _)) => {
-                conn.execute(
-                    "UPDATE conversation_turns SET \
-                     content=?2, timestamp_epoch=?3, token_count=?4, \
-                     project_path=?5, git_branch=?6, is_csa_delegated=?7, provenance=?8 \
-                     WHERE id=?1",
-                    params![
-                        existing_id,
-                        &turn.content,
-                        turn.timestamp_epoch,
-                        Option::<i64>::None,
-                        &turn.project_path,
-                        &turn.git_branch,
-                        turn.is_csa_delegated as i64,
-                        turn.provenance.as_str(),
-                    ],
-                )
-                .map_err(XurlError::Database)?;
-                stats.updated += 1;
+            match existing {
+                None => {
+                    let id = generate_turn_id(&turn.session_id, tool, turn.turn_index);
+                    conn.execute(
+                        "INSERT INTO conversation_turns \
+                         (id, session_id, tool, turn_index, role, content, timestamp_epoch, \
+                          token_count, project_path, git_branch, is_csa_delegated, provenance) \
+                         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+                        params![
+                            id,
+                            &turn.session_id,
+                            tool,
+                            turn.turn_index,
+                            turn.role.as_str(),
+                            &turn.content,
+                            turn.timestamp_epoch,
+                            Option::<i64>::None,
+                            &turn.project_path,
+                            &turn.git_branch,
+                            turn.is_csa_delegated as i64,
+                            turn.provenance.as_str(),
+                        ],
+                    )
+                    .map_err(XurlError::Database)?;
+                    stats.inserted += 1;
+                }
+                Some((_, ref existing_content)) if existing_content == &turn.content => {
+                    stats.skipped += 1;
+                }
+                Some((existing_id, _)) => {
+                    conn.execute(
+                        "UPDATE conversation_turns SET \
+                         content=?2, timestamp_epoch=?3, token_count=?4, \
+                         project_path=?5, git_branch=?6, is_csa_delegated=?7, provenance=?8 \
+                         WHERE id=?1",
+                        params![
+                            existing_id,
+                            &turn.content,
+                            turn.timestamp_epoch,
+                            Option::<i64>::None,
+                            &turn.project_path,
+                            &turn.git_branch,
+                            turn.is_csa_delegated as i64,
+                            turn.provenance.as_str(),
+                        ],
+                    )
+                    .map_err(XurlError::Database)?;
+                    conn.execute(
+                        "DELETE FROM conversation_turn_vectors WHERE turn_id = ?1",
+                        params![existing_id],
+                    )
+                    .map_err(XurlError::Database)?;
+                    stats.updated += 1;
+                }
             }
         }
+
+        conn.execute_batch("RELEASE xurl_insert_turns")
+            .map_err(XurlError::Database)?;
+        Ok(())
+    })();
+
+    if let Err(err) = insert_result {
+        let _ = conn.execute_batch("ROLLBACK TO xurl_insert_turns; RELEASE xurl_insert_turns;");
+        return Err(err);
     }
 
     Ok(stats)

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -141,6 +141,57 @@ fn test_fork_ext_v16_to_v17_adds_drawers_source_root_idempotently() {
 }
 
 #[test]
+fn test_fork_ext_v17_to_v18_adds_xurl_vector_metadata_idempotently() {
+    let conn = Connection::open_in_memory().expect("open sqlite connection");
+    let schema_version = current_schema_version();
+    conn.execute_batch(&format!(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '17');
+        CREATE TABLE conversation_turns (
+            id TEXT PRIMARY KEY
+        );
+        CREATE TABLE conversation_turn_vectors (
+            turn_id     TEXT NOT NULL REFERENCES conversation_turns(id),
+            chunk_index INTEGER NOT NULL DEFAULT 0,
+            vector      BLOB NOT NULL,
+            PRIMARY KEY (turn_id, chunk_index)
+        );
+        PRAGMA user_version = {schema_version};
+        "#
+    ))
+    .expect("create v17 xurl vector schema");
+
+    apply_fork_ext_migrations_to(&conn, 18).expect("first v18 migration");
+    apply_fork_ext_migrations_to(&conn, 18).expect("second v18 migration");
+
+    let columns = table_columns(&conn, "conversation_turn_vectors");
+    assert!(has_column(&columns, "embedder_fingerprint", "TEXT"));
+    assert!(has_column(&columns, "dim", "INTEGER"));
+    assert!(has_column(&columns, "index_version", "TEXT"));
+    assert_eq!(
+        columns
+            .iter()
+            .filter(|(name, _)| name == "embedder_fingerprint")
+            .count(),
+        1
+    );
+    assert_eq!(columns.iter().filter(|(name, _)| name == "dim").count(), 1);
+    assert_eq!(
+        columns
+            .iter()
+            .filter(|(name, _)| name == "index_version")
+            .count(),
+        1
+    );
+    let version = read_fork_ext_version(&conn).expect("read fork-ext version");
+    assert_eq!(version, 18);
+}
+
+#[test]
 fn test_fork_ext_meta_table_exists_after_init() {
     let (_tmp, _db_path, db) = new_test_db();
 

--- a/tests/xurl_embed.rs
+++ b/tests/xurl_embed.rs
@@ -1,14 +1,19 @@
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_VECTOR_INDEX_VERSION, Database};
 use mempal::embed::Embedder;
 use mempal::xurl::embed;
-use rusqlite::params;
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::store;
+use rusqlite::{OptionalExtension, params};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Command, Output};
 use tempfile::TempDir;
 
 struct TestDb {
     _dir: TempDir,
+    path: PathBuf,
     inner: Database,
 }
 
@@ -24,6 +29,7 @@ fn open_temp_db_at_fork_ext(_version: u32) -> TestDb {
     let db = Database::open(&path).expect("open db");
     TestDb {
         _dir: dir,
+        path,
         inner: db,
     }
 }
@@ -127,6 +133,102 @@ impl Embedder for CountingEmbedder {
     }
 }
 
+struct ValueEmbedder {
+    dim: usize,
+    value: f32,
+    total_inputs: std::sync::atomic::AtomicUsize,
+}
+
+struct UpdatingEmbedder {
+    dim: usize,
+    old_value: f32,
+    unchanged_value: f32,
+    db_path: PathBuf,
+    updated_turn: RawTurn,
+    updated: std::sync::atomic::AtomicBool,
+}
+
+impl UpdatingEmbedder {
+    fn new(
+        dim: usize,
+        old_value: f32,
+        unchanged_value: f32,
+        db_path: PathBuf,
+        updated_turn: RawTurn,
+    ) -> Self {
+        Self {
+            dim,
+            old_value,
+            unchanged_value,
+            db_path,
+            updated_turn,
+            updated: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for UpdatingEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        if !self.updated.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            let db = Database::open(&self.db_path).expect("open db during embed");
+            store::insert_turns(db.conn(), std::slice::from_ref(&self.updated_turn))
+                .expect("simulate concurrent content update");
+        }
+
+        Ok(texts
+            .iter()
+            .map(|text| {
+                let value = if *text == "old content" {
+                    self.old_value
+                } else {
+                    self.unchanged_value
+                };
+                vec![value; self.dim]
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        "updating"
+    }
+}
+
+impl ValueEmbedder {
+    fn new(dim: usize, value: f32) -> Self {
+        Self {
+            dim,
+            value,
+            total_inputs: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn total_inputs(&self) -> usize {
+        self.total_inputs.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for ValueEmbedder {
+    async fn embed(&self, texts: &[&str]) -> mempal::embed::Result<Vec<Vec<f32>>> {
+        self.total_inputs
+            .fetch_add(texts.len(), std::sync::atomic::Ordering::Relaxed);
+        Ok(texts.iter().map(|_| vec![self.value; self.dim]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+
+    fn name(&self) -> &str {
+        "value"
+    }
+}
+
 /// Minimal description of a turn row for test fixtures.
 struct TurnRow<'a> {
     id: &'a str,
@@ -167,6 +269,92 @@ fn vector_count(conn: &rusqlite::Connection) -> i64 {
         |row| row.get(0),
     )
     .expect("count vectors")
+}
+
+fn vector_blob(values: &[f32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn seed_vector(
+    conn: &rusqlite::Connection,
+    turn_id: &str,
+    values: &[f32],
+    fingerprint: &str,
+    index_version: &str,
+) {
+    conn.execute(
+        "INSERT INTO conversation_turn_vectors \
+         (turn_id, chunk_index, vector, embedder_fingerprint, dim, index_version) \
+         VALUES (?1, 0, ?2, ?3, ?4, ?5)",
+        params![
+            turn_id,
+            vector_blob(values),
+            fingerprint,
+            values.len() as i64,
+            index_version
+        ],
+    )
+    .expect("seed vector");
+}
+
+fn make_raw_turn(session_id: &str, turn_index: u32, content: &str) -> RawTurn {
+    RawTurn {
+        session_id: session_id.to_string(),
+        tool: Tool::Cc,
+        role: Role::User,
+        content: content.to_string(),
+        timestamp_epoch: 1_000.0 + f64::from(turn_index),
+        project_path: None,
+        git_branch: None,
+        is_csa_delegated: false,
+        provenance: Provenance::Human,
+        turn_index,
+    }
+}
+
+fn vector_metadata(conn: &rusqlite::Connection) -> HashMap<String, (String, i64, String)> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT turn_id, embedder_fingerprint, dim, index_version \
+             FROM conversation_turn_vectors \
+             ORDER BY turn_id",
+        )
+        .expect("prepare metadata query");
+    stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            (
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+            ),
+        ))
+    })
+    .expect("query metadata")
+    .collect::<Result<HashMap<_, _>, _>>()
+    .expect("collect metadata")
+}
+
+fn vector_bytes(conn: &rusqlite::Connection, turn_id: &str) -> Vec<u8> {
+    conn.query_row(
+        "SELECT vector FROM conversation_turn_vectors WHERE turn_id = ?1 AND chunk_index = 0",
+        params![turn_id],
+        |row| row.get(0),
+    )
+    .expect("read vector bytes")
+}
+
+fn maybe_vector_bytes(conn: &rusqlite::Connection, turn_id: &str) -> Option<Vec<u8>> {
+    conn.query_row(
+        "SELECT vector FROM conversation_turn_vectors WHERE turn_id = ?1 AND chunk_index = 0",
+        params![turn_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .expect("read optional vector bytes")
 }
 
 #[tokio::test]
@@ -529,6 +717,327 @@ async fn test_reindex_path_drains_all_unindexed() {
 
     let after = mempal::xurl::store::count_unindexed_turns(db.conn()).unwrap();
     assert_eq!(after, 0, "reindex must drain the entire backlog");
+}
+
+#[tokio::test]
+async fn test_xurl_reindex_stale_reembeds_only_stale_fingerprint_turns() {
+    let db = open_temp_db_at_fork_ext(18);
+    for (idx, turn_id) in ["turn-a1", "turn-a2", "turn-b1"].iter().enumerate() {
+        insert_raw_turn_row(
+            db.conn(),
+            TurnRow {
+                id: turn_id,
+                session: "sess-stale",
+                tool: "cc",
+                turn_index: idx as i64,
+                role: "user",
+                content: &format!("stale switch turn {idx}"),
+                timestamp: idx as f64,
+                token_count: None,
+            },
+        );
+    }
+    seed_vector(
+        db.conn(),
+        "turn-a1",
+        &[1.0, 1.0],
+        "fp-a",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    seed_vector(
+        db.conn(),
+        "turn-a2",
+        &[1.0, 1.0],
+        "fp-a",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    seed_vector(
+        db.conn(),
+        "turn-b1",
+        &[9.0, 9.0, 9.0],
+        "fp-b",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    let before_b = vector_bytes(db.conn(), "turn-b1");
+
+    let embedder = ValueEmbedder::new(3, 2.0);
+    let stats = embed::embed_stale_turns(&db.inner, &embedder, "fp-b", None)
+        .await
+        .expect("stale reindex should succeed");
+
+    assert_eq!(stats.turns_processed, 2);
+    assert_eq!(stats.embedded, 2);
+    assert_eq!(
+        embedder.total_inputs(),
+        2,
+        "only the stale A-fingerprint turns should be embedded"
+    );
+    let metadata = vector_metadata(db.conn());
+    assert_eq!(
+        metadata.get("turn-a1"),
+        Some(&(
+            "fp-b".to_string(),
+            3,
+            CURRENT_VECTOR_INDEX_VERSION.to_string()
+        ))
+    );
+    assert_eq!(
+        metadata.get("turn-a2"),
+        Some(&(
+            "fp-b".to_string(),
+            3,
+            CURRENT_VECTOR_INDEX_VERSION.to_string()
+        ))
+    );
+    assert_eq!(
+        metadata.get("turn-b1"),
+        Some(&(
+            "fp-b".to_string(),
+            3,
+            CURRENT_VECTOR_INDEX_VERSION.to_string()
+        ))
+    );
+    assert_eq!(
+        vector_bytes(db.conn(), "turn-b1"),
+        before_b,
+        "fresh B-fingerprint vector must not be rewritten by --stale"
+    );
+}
+
+#[tokio::test]
+async fn test_xurl_reindex_force_rebuilds_all_turn_vectors() {
+    let db = open_temp_db_at_fork_ext(18);
+    for (idx, turn_id) in ["turn-force-a", "turn-force-b", "turn-force-c"]
+        .iter()
+        .enumerate()
+    {
+        insert_raw_turn_row(
+            db.conn(),
+            TurnRow {
+                id: turn_id,
+                session: "sess-force",
+                tool: "cc",
+                turn_index: idx as i64,
+                role: "user",
+                content: &format!("force turn {idx}"),
+                timestamp: idx as f64,
+                token_count: None,
+            },
+        );
+    }
+    seed_vector(
+        db.conn(),
+        "turn-force-a",
+        &[1.0, 1.0],
+        "fp-a",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    seed_vector(
+        db.conn(),
+        "turn-force-b",
+        &[9.0, 9.0, 9.0],
+        "fp-b",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+
+    let embedder = ValueEmbedder::new(3, 4.0);
+    let stats = embed::embed_all_turns(&db.inner, &embedder, "fp-b", None)
+        .await
+        .expect("force reindex should succeed");
+
+    assert_eq!(stats.turns_processed, 3);
+    assert_eq!(stats.embedded, 3);
+    assert_eq!(stats.skipped_stale_content, 0);
+    assert_eq!(embedder.total_inputs(), 3);
+    let metadata = vector_metadata(db.conn());
+    for turn_id in ["turn-force-a", "turn-force-b", "turn-force-c"] {
+        assert_eq!(
+            metadata.get(turn_id),
+            Some(&(
+                "fp-b".to_string(),
+                3,
+                CURRENT_VECTOR_INDEX_VERSION.to_string()
+            ))
+        );
+        assert_eq!(
+            vector_bytes(db.conn(), turn_id),
+            vector_blob(&[4.0, 4.0, 4.0])
+        );
+    }
+}
+
+#[tokio::test]
+async fn force_reindex_skips_vector_write_when_content_changes_after_collection() {
+    let db = open_temp_db_at_fork_ext(18);
+    let changed = make_raw_turn("sess-race", 0, "old content");
+    let changed_id = store::turn_id_for(&changed);
+    let unchanged = make_raw_turn("sess-race", 1, "unchanged content");
+    let unchanged_id = store::turn_id_for(&unchanged);
+    store::insert_turns(db.conn(), &[changed, unchanged]).expect("seed turns");
+    seed_vector(
+        db.conn(),
+        &changed_id,
+        &[0.5, 0.5, 0.5],
+        "fp-current",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    seed_vector(
+        db.conn(),
+        &unchanged_id,
+        &[0.5, 0.5, 0.5],
+        "fp-current",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+
+    let updated = make_raw_turn("sess-race", 0, "new content");
+    let embedder = UpdatingEmbedder::new(3, 1.0, 2.0, db.path.clone(), updated);
+    let stats = embed::embed_all_turns(&db.inner, &embedder, "fp-current", None)
+        .await
+        .expect("force reindex should succeed");
+
+    assert_eq!(stats.turns_processed, 2);
+    assert_eq!(stats.skipped_stale_content, 1);
+    assert_eq!(
+        maybe_vector_bytes(db.conn(), &changed_id),
+        None,
+        "old-content vector write must be skipped after the turn content changes"
+    );
+    assert_eq!(
+        vector_bytes(db.conn(), &unchanged_id),
+        vector_blob(&[2.0, 2.0, 2.0]),
+        "unchanged peer turn must still be rewritten normally"
+    );
+}
+
+#[tokio::test]
+async fn test_xurl_reindex_stale_noops_for_current_embedder_metadata() {
+    let db = open_temp_db_at_fork_ext(18);
+    insert_raw_turn_row(
+        db.conn(),
+        TurnRow {
+            id: "turn-current",
+            session: "sess-current",
+            tool: "cc",
+            turn_index: 0,
+            role: "user",
+            content: "already current",
+            timestamp: 1.0,
+            token_count: None,
+        },
+    );
+    seed_vector(
+        db.conn(),
+        "turn-current",
+        &[7.0, 7.0, 7.0],
+        "fp-current",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+
+    let embedder = ValueEmbedder::new(3, 8.0);
+    let stats = embed::embed_stale_turns(&db.inner, &embedder, "fp-current", None)
+        .await
+        .expect("stale reindex should succeed");
+
+    assert_eq!(stats.turns_processed, 0);
+    assert_eq!(stats.embedded, 0);
+    assert_eq!(embedder.total_inputs(), 0);
+    assert_eq!(
+        vector_bytes(db.conn(), "turn-current"),
+        vector_blob(&[7.0, 7.0, 7.0])
+    );
+}
+
+#[tokio::test]
+async fn content_update_invalidates_vectors_for_scoped_missing_embed() {
+    let db = open_temp_db_at_fork_ext(18);
+    let original = make_raw_turn("sess-update", 0, "old content");
+    let turn_id = store::turn_id_for(&original);
+    let insert_stats = store::insert_turns(db.conn(), std::slice::from_ref(&original))
+        .expect("insert original turn");
+    assert_eq!(insert_stats.inserted, 1);
+
+    seed_vector(
+        db.conn(),
+        &turn_id,
+        &[1.0, 1.0, 1.0],
+        "fp-current",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    let old_vector = vector_bytes(db.conn(), &turn_id);
+
+    let updated = make_raw_turn("sess-update", 0, "new content");
+    let update_stats =
+        store::insert_turns(db.conn(), &[updated]).expect("update changed turn content");
+    assert_eq!(update_stats.updated, 1);
+
+    let embedder = ValueEmbedder::new(3, 2.0);
+    let embed_stats = embed::embed_unindexed_turns_scoped_with_fingerprint(
+        &db.inner,
+        &embedder,
+        std::slice::from_ref(&turn_id),
+        "fp-current",
+        None,
+    )
+    .await
+    .expect("scoped missing embed should rebuild invalidated vector");
+
+    assert_eq!(embed_stats.turns_processed, 1);
+    assert_eq!(embed_stats.embedded, 1);
+    assert_eq!(embedder.total_inputs(), 1);
+    assert_ne!(
+        vector_bytes(db.conn(), &turn_id),
+        old_vector,
+        "changed content must not retain the old-content vector"
+    );
+    assert_eq!(
+        vector_bytes(db.conn(), &turn_id),
+        vector_blob(&[2.0, 2.0, 2.0])
+    );
+
+    let stale_stats = embed::embed_stale_turns(&db.inner, &embedder, "fp-current", None)
+        .await
+        .expect("stale reindex should see the rebuilt vector as current");
+    assert_eq!(stale_stats.turns_processed, 0);
+}
+
+#[tokio::test]
+async fn identical_reingest_keeps_existing_vector_without_churn() {
+    let db = open_temp_db_at_fork_ext(18);
+    let turn = make_raw_turn("sess-no-churn", 0, "same content");
+    let turn_id = store::turn_id_for(&turn);
+    store::insert_turns(db.conn(), std::slice::from_ref(&turn)).expect("insert original turn");
+    seed_vector(
+        db.conn(),
+        &turn_id,
+        &[3.0, 3.0, 3.0],
+        "fp-current",
+        CURRENT_VECTOR_INDEX_VERSION,
+    );
+    let before = vector_bytes(db.conn(), &turn_id);
+
+    let reingest_stats =
+        store::insert_turns(db.conn(), std::slice::from_ref(&turn)).expect("reingest same turn");
+    assert_eq!(reingest_stats.skipped, 1);
+
+    let embedder = ValueEmbedder::new(3, 4.0);
+    let embed_stats = embed::embed_unindexed_turns_scoped_with_fingerprint(
+        &db.inner,
+        &embedder,
+        std::slice::from_ref(&turn_id),
+        "fp-current",
+        None,
+    )
+    .await
+    .expect("scoped missing embed should skip unchanged vector");
+
+    assert_eq!(embed_stats.turns_processed, 0);
+    assert_eq!(embed_stats.embedded, 0);
+    assert_eq!(embedder.total_inputs(), 0);
+    assert_eq!(
+        vector_bytes(db.conn(), &turn_id),
+        before,
+        "identical reingest must not delete or rebuild vectors"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #297. xurl turn vectors (`conversation_turn_vectors`) had **no embedder
fingerprint / dim / index_version metadata** and `mempal xurl reindex` only filled
**MISSING** vectors — a latent staleness risk and the xurl analogue of #287's main-store
l2→cosine gap. A future embedder switch (model change, or a *same-dim different-model*
change) would silently leave existing xurl vectors in the old embedding space, so xurl
semantic search would return cross-space (wrong) results with **no detection and no
rebuild path**. Harmless today (all ~10017 xurl vectors are current-embedder 4096d), but
the gap is now closed.

## Change (mirrors #287 for the xurl subsystem)

- **`core/db_fork_ext.rs`** — fork-ext **v18** migration adds nullable
  `embedder_fingerprint TEXT`, `dim INTEGER`, `index_version TEXT` to
  `conversation_turn_vectors` + a metadata index; idempotent. **Schema axis verified from
  the migration code**: the table is created under fork-ext v16, so this is a
  `fork_ext_version` bump, NOT the upstream `PRAGMA user_version` axis.
- **`xurl/embed.rs` + `xurl/ingest.rs` + `main.rs`**:
  - `xurl reindex --stale` — re-embeds turns that are missing a vector **OR** dim-mismatched
    **OR** fingerprint-mismatched **OR** have a missing/old `index_version` (the same stale
    predicate as #287's per-vector staleness).
  - `xurl reindex --force` — deletes and rebuilds **all** xurl vectors.
  - default `xurl reindex` — still only fills missing, now also stamping metadata.
  - new ingests stamp the fingerprint going forward.
- Fingerprint reuses the existing accessor
  `Config.embed.current_vector_embedder_fingerprint(embedder.dimensions())`
  (`EmbedConfig::vector_embedder_fingerprint`, `core/config.rs`) — **no new fingerprint
  scheme**.

### Sibling content-staleness fix (surfaced in tier-4 review)

On re-ingest, `xurl/store.rs` `insert_turns` UPSERT updated `conversation_turns.content`
for an existing `(session_id, tool, turn_index)` turn but left its **old-content vector**
in place — the missing-only embed and the new embedder-staleness predicate both skip a turn
that already has a current-metadata vector, so xurl search could rank **updated content with
an old-content embedding**, with no visible stale signal. Fix (reviewer's option a, no new
column): `insert_turns` is SAVEPOINT-wrapped, UPDATEs only when content actually differs,
and on a genuine content change deletes that turn's `conversation_turn_vectors` in the same
transaction so the missing-only embed re-creates them from the new content. An **identical
re-ingest stays a no-op (no vector churn)**. Centralized in `insert_turns`, so it covers
**both** single-file and scan-all ingest (both route through it).

### Concurrency race the content-invalidation fix exposes (also surfaced in tier-4 review)

`xurl reindex --stale/--force` embeds a turn's content **outside** the vector write, so a
concurrent `xurl ingest` that updates the same turn (and deletes its vectors, via the fix
above) **between collect and write** could let reindex re-insert a vector for the **old**
content stamped with the **current** fingerprint — which the new stale predicate then can't
detect. The vector write path (`embed_turns` → `write_vector_rows`, shared by **all four**
reindex scopes: `MissingAll` / `MissingTurnIds` / `StaleAll` / `ForceAll`) now runs under
`BEGIN IMMEDIATE` and **re-reads `conversation_turns.content` for each turn inside that
transaction**, skipping the write when the content no longer matches what was embedded
(counted in `EmbedStats.skipped_stale_content`, surfaced in `xurl reindex` output). Both
commit orders converge — ingest-first → reindex re-SELECT sees new content → skip;
reindex-first → ingest deletes the just-written vector and the missing-only embed rebuilds
it from new content — so **no current-stamped old-content vector survives**. The embedded
text is carried in-memory on the collected candidate (`TurnCandidate { id, content }`); no
new column.

## Design decisions

- **No backfill (deliberate).** The migration layer cannot prove the current
  embedder/config at schema time, so existing rows keep `NULL` metadata and read as stale.
  A dim-based backfill (stamp current fingerprint when stored dim == current dim) was
  **rejected** because same-dim ≠ same-model — the issue explicitly lists *same-dim
  different-model* as a staleness case, so a dim heuristic would mask the very staleness
  this PR detects.
  - **Operational consequence (note for the real store):** the **first**
    `mempal xurl reindex --stale` on an existing store re-embeds the whole backlog once
    (re-stamping the current fingerprint on all ~10017 turns); every subsequent run is a
    no-op. This is a one-time, user-initiated cost and produces identical vectors (same
    embedder) — correctness, not waste.
- **`xurl stats` / `mempal status` surfacing deferred.** Computing the current
  fingerprint/dim there would force embedder initialization on the stats path (not cheap);
  tracked as the issue's optional follow-up.

## Tests

Red-first, test-store-based (never the real ~10K store):
- fork-ext **v17→v18** idempotent-migration test (`tests/fork_ext_schema_axis.rs`).
- `xurl reindex --stale` / `--force` / unchanged-embedder-no-op acceptance across an
  embedder-A→B fingerprint switch (`tests/xurl_embed.rs`).
- content-update vector-invalidation + identical-reingest no-churn regression
  (`tests/xurl_embed.rs`).
- collect→embed→concurrent-content-update→write **interleaving** regression
  (`force_reindex_skips_vector_write_when_content_changes_after_collection`, `tests/xurl_embed.rs`)
  — red against pre-fix code (wrote back the old-content vector), green after, and verifies
  the unchanged peer turn is still rewritten normally.

Green: `xurl_embed` 15, `fork_ext_schema_axis` 11, `xurl_schema` 2, `xurl_search` 13,
`xurl_ingest` 4, `xurl_store` 6; `cargo fmt --check` + `cargo clippy --all-targets -- -D
warnings` clean. Full lefthook gate (clippy + full test suite) passed at commit/amend time.

## Review

Three tier-4 single-codex rounds (gemini OAuth quota-dead, no API key → single `--tool codex
--build-jobs 2`, avoiding the dead consensus slot + its concurrent-scope memory spike),
fixed to zero in-commit before push:

- **Round 1** (on the base impl) — found a **content-staleness** hole: re-ingest UPSERT
  updated `conversation_turns.content` for an existing turn but left its old-content vector,
  which the missing-only embed and the new stale predicate both skip. Fixed:
  delete-on-genuine-content-change in `store::insert_turns` (the "Sibling content-staleness
  fix" above).
- **Round 2** (session `01KT86G7HCG3H2MAEV50JXFQQT`, on the round-1 fix) — found a **TOCTOU
  race** (P2/correctness, conf 0.86): `xurl reindex` embeds outside the vector write, so a
  concurrent `xurl ingest` between collect and write could leave a current-stamped
  old-content vector that `--stale` can't detect; flagged as a Rust-017 concurrent-writer
  violation, contrasted against the main-drawer path's existing `content_hash` recheck.
  Fixed: `BEGIN IMMEDIATE` + in-transaction `conversation_turns.content` recheck before the
  write, skip on mismatch, across all four reindex scopes (the "Concurrency race" section
  above).
- **Round 3** (session `01KT882KV0H3BNMY599NKP28P0`, on the round-2 fix) — **PASS, findings:
  none.** The reviewer re-verified the `BEGIN IMMEDIATE` content recheck and the
  content-update invalidation, ran a security/adversarial pass over the SQLite writes +
  vector replacement + concurrent ingest/reindex behavior, confirmed the prior finding does
  not reproduce, and found no AGENTS.md violations. Overall risk: **low**.

Full lefthook gate (clippy `-D warnings` + full test suite, incl. the new interleaving
regression) passed at amend time for the reviewed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
