### PR TITLE
fix(reindex): retry transient batch embed failures + skip-continue on persistent failure (#301)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -488,6 +488,11 @@ enum Commands {
         /// With --embedder/--from-config --stale: stop after this many candidate drawers.
         #[arg(long)]
         limit: Option<usize>,
+        /// With --embedder/--from-config --stale: max retries for a single batch's
+        /// embed call before the batch is skipped (it stays stale for a later
+        /// `--stale` re-run) and the run continues. Default: 15.
+        #[arg(long)]
+        max_batch_retries: Option<usize>,
         /// Return failed embed-queue messages to pending for daemon retry.
         #[arg(long, default_value_t = false)]
         failed: bool,
@@ -2547,6 +2552,7 @@ fn run() -> Result<()> {
             wing,
             room,
             limit,
+            max_batch_retries,
             failed,
             recompute_importance,
             only_zero,
@@ -2576,6 +2582,7 @@ fn run() -> Result<()> {
                     || force
                     || dry_run
                     || batch_size.is_some()
+                    || max_batch_retries.is_some()
                     || !vector_target.is_empty()
                     || recompute_importance
                     || only_zero
@@ -2613,6 +2620,9 @@ fn run() -> Result<()> {
                         "--drawer-id/--project/--wing/--room/--limit require --embedder or --from-config with --stale"
                     );
                 }
+                if max_batch_retries.is_some() && !stale {
+                    bail!("--max-batch-retries requires --stale");
+                }
                 if !vector_target.is_empty() && resume {
                     bail!("--resume cannot be combined with targeted stale reindex filters");
                 }
@@ -2630,13 +2640,17 @@ fn run() -> Result<()> {
                     &backend,
                     resume,
                     stale,
-                    batch_size.unwrap_or(1000),
+                    StaleBatchTuning {
+                        batch_size: batch_size.unwrap_or(1000),
+                        max_batch_retries: max_batch_retries.unwrap_or(DEFAULT_MAX_BATCH_RETRIES),
+                    },
                     vector_target,
                 ))
             } else {
-                if batch_size.is_some() || !vector_target.is_empty() {
+                if batch_size.is_some() || max_batch_retries.is_some() || !vector_target.is_empty()
+                {
                     bail!(
-                        "--batch-size/--drawer-id/--project/--wing/--room/--limit require --embedder or --from-config with --stale"
+                        "--batch-size/--max-batch-retries/--drawer-id/--project/--wing/--room/--limit require --embedder or --from-config with --stale"
                     );
                 }
                 block_on_result(reindex_command_sources(
@@ -5157,7 +5171,7 @@ async fn reindex_command_by_embedder(
     embedder_name: &str,
     resume: bool,
     stale_only: bool,
-    batch_size: usize,
+    batch: StaleBatchTuning,
     target: ReindexVectorTarget,
 ) -> Result<()> {
     let embedder = build_specific_embedder(config, embedder_name).await?;
@@ -5223,13 +5237,18 @@ async fn reindex_command_by_embedder(
         println!("resume checkpoint found; preserving existing drawer_vectors table");
     }
     if stale_only && resume_checkpoint.is_none() {
+        let policy = BatchRetryPolicy {
+            interval: std::time::Duration::from_secs(config.embed.retry.interval_secs),
+            max_retries: batch.max_batch_retries,
+        };
         return reindex_stale_batches(
             db,
             embedder.as_ref(),
             embedder_name,
             &target_fingerprint,
-            batch_size,
+            batch.batch_size,
             target,
+            policy,
         )
         .await;
     }
@@ -5327,6 +5346,74 @@ fn reindex_target_narrows_store(db: &Database, target: &ReindexVectorTarget) -> 
     Ok(limit < active_drawer_count)
 }
 
+/// Default number of retries for a single stale-reindex batch's embed call
+/// before the batch is skipped. With the default `[embed.retry].interval_secs`
+/// of 2s this absorbs blips up to ~30s while still bounding the run.
+const DEFAULT_MAX_BATCH_RETRIES: usize = 15;
+
+/// Bounded retry policy for stale-batch reindex embed calls.
+///
+/// The ingest path retries embeds *indefinitely* so NEW data is never lost.
+/// Reindex is different: it rebuilds an index over data already stored raw, so
+/// it MUST terminate. A batch that keeps failing is therefore retried a bounded
+/// number of times, then skipped (its drawers stay stale and are picked up by a
+/// later `mempal reindex --stale` re-run) rather than blocking the whole run.
+#[derive(Debug, Clone, Copy)]
+struct BatchRetryPolicy {
+    /// Fixed delay between attempts; mirrors `[embed.retry].interval_secs`
+    /// (no backoff), matching the ingest path's retry cadence.
+    interval: std::time::Duration,
+    /// Retries after the first attempt before a batch is skipped.
+    max_retries: usize,
+}
+
+/// CLI-supplied tuning for the stale-batch reindex loop (`reindex --stale`).
+/// Bundled so the embedder reindex entry point stays within a sane arity.
+#[derive(Debug, Clone, Copy)]
+struct StaleBatchTuning {
+    /// Drawers re-embedded per batch (`--batch-size`, default 1000).
+    batch_size: usize,
+    /// Max retries for a batch's embed call before it is skipped
+    /// (`--max-batch-retries`, default `DEFAULT_MAX_BATCH_RETRIES`).
+    max_batch_retries: usize,
+}
+
+/// Embed one stale batch, retrying at the policy's fixed interval (no backoff,
+/// mirroring the ingest path) up to `policy.max_retries` before giving up.
+///
+/// Retries on ANY error — including ones `EmbedError::is_retryable` classifies
+/// as terminal (e.g. a read timeout surfacing as `DecodeResponse`, the #301
+/// failure) — because a reindex batch must survive blips regardless of error
+/// class; a genuinely persistent failure is bounded by the cap and skipped by
+/// the caller. A vector-count mismatch is treated the same way (retry, then
+/// skip). Returns the embedded vectors, or the last error once the cap is
+/// exhausted so the caller can skip-and-continue.
+async fn embed_stale_batch_with_retry(
+    embedder: &dyn Embedder,
+    texts: &[&str],
+    expected_len: usize,
+    policy: BatchRetryPolicy,
+) -> Result<Vec<Vec<f32>>> {
+    let mut attempt = 0usize;
+    loop {
+        let retry_error = match embedder.embed(texts).await {
+            Ok(vectors) if vectors.len() == expected_len => return Ok(vectors),
+            Ok(vectors) => anyhow::anyhow!(
+                "embedder returned {} vectors for {expected_len} stale drawers",
+                vectors.len()
+            ),
+            Err(error) => {
+                anyhow::Error::new(error).context("embedding failed during stale batch reindex")
+            }
+        };
+        if attempt >= policy.max_retries {
+            return Err(retry_error);
+        }
+        attempt += 1;
+        tokio::time::sleep(policy.interval).await;
+    }
+}
+
 async fn reindex_stale_batches(
     db: &Database,
     embedder: &dyn Embedder,
@@ -5334,6 +5421,7 @@ async fn reindex_stale_batches(
     target_fingerprint: &str,
     batch_size: usize,
     target: ReindexVectorTarget,
+    policy: BatchRetryPolicy,
 ) -> Result<()> {
     if batch_size == 0 {
         bail!("--batch-size must be greater than 0");
@@ -5359,6 +5447,13 @@ async fn reindex_stale_batches(
     }
     let mut processed = 0usize;
     let mut skipped_concurrent_update = 0usize;
+    let mut skipped_failed_batches = 0usize;
+    let mut skipped_failed_drawers = 0usize;
+    // Drawers from batches that failed past the retry cap. They keep no fresh
+    // vector (stay stale), so they MUST be excluded from later batch queries:
+    // the stale selection re-runs every iteration, and without exclusion it
+    // would keep re-selecting them and the loop would never terminate.
+    let mut skipped_ids: Vec<String> = Vec::new();
     let mut batch_index = 0usize;
     let mut remaining = target.limit;
     loop {
@@ -5366,32 +5461,50 @@ async fn reindex_stale_batches(
         if effective_batch_size == 0 {
             break;
         }
-        let rows = reindex_stale_batch_rows(db, target_fingerprint, effective_batch_size, &target)
-            .context("failed to load stale reindex batch")?;
+        let rows = reindex_stale_batch_rows(
+            db,
+            target_fingerprint,
+            effective_batch_size,
+            &target,
+            &skipped_ids,
+        )
+        .context("failed to load stale reindex batch")?;
         if rows.is_empty() {
             break;
         }
         if let Some(value) = remaining.as_mut() {
             *value = value.saturating_sub(rows.len());
         }
+        batch_index += 1;
         let texts = rows
             .iter()
             .map(|row| row.content.as_str())
             .collect::<Vec<_>>();
-        let vectors = embedder
-            .embed(&texts)
-            .await
-            .context("embedding failed during stale batch reindex")?;
-        if vectors.len() != rows.len() {
-            bail!(
-                "embedder returned {} vectors for {} stale drawers",
-                vectors.len(),
-                rows.len()
-            );
-        }
+        let vectors = match embed_stale_batch_with_retry(embedder, &texts, rows.len(), policy).await
+        {
+            Ok(vectors) => vectors,
+            Err(error) => {
+                // Skip-and-continue: a batch still failing after the bounded
+                // retry is logged and skipped so the run can finish every other
+                // batch. Unlike ingest (which blocks forever to never lose NEW
+                // data), reindex rebuilds an index over data already stored raw,
+                // so it must terminate; the skipped drawers stay stale and a
+                // later `mempal reindex --stale` re-run retries them.
+                eprintln!(
+                    "warning: batch {batch_index}: embed failed after {} attempt(s); \
+                     skipping {} drawer(s) (they stay stale — re-run \
+                     `mempal reindex --stale` to retry): {error:#}",
+                    policy.max_retries + 1,
+                    rows.len()
+                );
+                skipped_failed_batches += 1;
+                skipped_failed_drawers += rows.len();
+                skipped_ids.extend(rows.iter().map(|row| row.id.clone()));
+                continue;
+            }
+        };
         let stats = write_reindex_vector_batch(db, &rows, &vectors, target_fingerprint)
             .context("failed to write stale reindex batch")?;
-        batch_index += 1;
         processed += stats.reindexed;
         skipped_concurrent_update += stats.skipped_concurrent_update;
         if stats.skipped_concurrent_update == 0 {
@@ -5419,6 +5532,12 @@ async fn reindex_stale_batches(
             "stale reindex complete: {processed} drawers ({skipped_concurrent_update} skipped due to concurrent updates)"
         );
     }
+    // Surface failed-batch skips (mirrors the #297 `skipped_stale_content`
+    // counter): always reported so an operator can see them. Skips are NOT
+    // fatal — the run still exits 0 on completion because the skipped drawers
+    // remain stale and are picked up by a later `mempal reindex --stale`.
+    println!("skipped failed batches: {skipped_failed_batches}");
+    println!("skipped failed drawers: {skipped_failed_drawers}");
     Ok(())
 }
 
@@ -9435,11 +9554,41 @@ fn append_reindex_target_filters(
     }
 }
 
+/// Append an `AND <alias>id NOT IN (...)` clause excluding `exclude_ids`.
+/// Used to drop drawers whose batch already failed past the retry cap this run,
+/// so the stale selection does not re-select them on every iteration.
+fn append_exclude_ids(
+    sql: &mut String,
+    values: &mut Vec<rusqlite::types::Value>,
+    exclude_ids: &[String],
+    alias: &str,
+) {
+    if exclude_ids.is_empty() {
+        return;
+    }
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+    let placeholders = std::iter::repeat_n("?", exclude_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    sql.push_str(&format!(" AND {prefix}id NOT IN ({placeholders})"));
+    values.extend(
+        exclude_ids
+            .iter()
+            .cloned()
+            .map(rusqlite::types::Value::Text),
+    );
+}
+
 fn reindex_stale_batch_rows(
     db: &Database,
     target_fingerprint: &str,
     batch_size: usize,
     target: &ReindexVectorTarget,
+    exclude_ids: &[String],
 ) -> Result<Vec<ReindexRow>> {
     let limit = i64::try_from(batch_size).context("batch size is too large")?;
     let vectors_exist = db
@@ -9479,6 +9628,7 @@ fn reindex_stale_batch_rows(
             rusqlite::types::Value::Text(target_fingerprint.to_string()),
         ];
         append_reindex_target_filters(&mut sql, &mut values, target, "d");
+        append_exclude_ids(&mut sql, &mut values, exclude_ids, "d");
         sql.push_str(
             r#"
                 ORDER BY source_path ASC, chunk_index ASC, d.id ASC
@@ -9517,6 +9667,7 @@ fn reindex_stale_batch_rows(
         .to_string();
         let mut values = Vec::new();
         append_reindex_target_filters(&mut sql, &mut values, target, "");
+        append_exclude_ids(&mut sql, &mut values, exclude_ids, "");
         sql.push_str(
             r#"
                 ORDER BY source_path ASC, chunk_index ASC, id ASC

--- a/tests/common/harness/embed_mock.rs
+++ b/tests/common/harness/embed_mock.rs
@@ -20,6 +20,13 @@ pub enum FailMode {
     Timeout,
     Http500,
     RateLimit429,
+    /// 200 OK whose body cannot be decoded as the OpenAI embeddings
+    /// response, producing a non-retryable `EmbedError::DecodeResponse`
+    /// on the client. Mirrors the issue #301 failure (a timeout surfacing
+    /// as "failed to decode embedding response"), which is classified
+    /// non-retryable — so it exercises the reindex bounded retry's
+    /// error-class-agnostic behavior.
+    MalformedBody,
 }
 
 struct Inner {
@@ -27,6 +34,14 @@ struct Inner {
     paused: AtomicBool,
     pause_notify: Notify,
     fail_mode: Mutex<FailMode>,
+    /// When armed, the first `fail_first_n` requests fail (with `fail_mode`)
+    /// and the counter decrements; once it reaches 0 the server recovers.
+    /// Models a transient blip that resolves on retry.
+    fail_first_n: AtomicU32,
+    fail_first_n_armed: AtomicBool,
+    /// When set, only requests whose input contains this marker fail (with
+    /// `fail_mode`). Models one persistently-failing batch among healthy ones.
+    fail_if_contains: Mutex<Option<String>>,
     per_item_dims: Mutex<Option<Vec<u32>>>,
     request_count: AtomicU32,
     request_times: Mutex<Vec<Duration>>,
@@ -57,6 +72,20 @@ impl MockEmbedHandle {
         *self.inner.fail_mode.lock().await = mode;
     }
 
+    /// Fail the next `n` requests (using the configured `fail_mode`), then
+    /// recover. Used to model a transient batch failure absorbed by retry.
+    pub fn set_fail_first_n(&self, n: u32) {
+        self.inner.fail_first_n.store(n, Ordering::SeqCst);
+        self.inner.fail_first_n_armed.store(true, Ordering::SeqCst);
+    }
+
+    /// Fail every request whose input array contains `marker` (using the
+    /// configured `fail_mode`). Used to model one persistently-failing batch
+    /// while the rest succeed. Pass `None` to clear.
+    pub async fn set_fail_if_input_contains(&self, marker: Option<String>) {
+        *self.inner.fail_if_contains.lock().await = marker;
+    }
+
     pub fn request_count(&self) -> u32 {
         self.inner.request_count.load(Ordering::SeqCst)
     }
@@ -82,6 +111,9 @@ pub async fn start(port: u16) -> Result<(SocketAddr, MockEmbedHandle)> {
         paused: AtomicBool::new(false),
         pause_notify: Notify::new(),
         fail_mode: Mutex::new(FailMode::Ok),
+        fail_first_n: AtomicU32::new(0),
+        fail_first_n_armed: AtomicBool::new(false),
+        fail_if_contains: Mutex::new(None),
         per_item_dims: Mutex::new(None),
         request_count: AtomicU32::new(0),
         request_times: Mutex::new(Vec::new()),
@@ -142,33 +174,72 @@ async fn handle_request(
         inner.pause_notify.notified().await;
     }
 
-    match *inner.fail_mode.lock().await {
-        FailMode::Ok => {}
-        FailMode::Timeout => {
-            std::future::pending::<()>().await;
-            unreachable!();
-        }
-        FailMode::Http500 => {
-            return Ok(response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                json!({"error": "mock 500"}),
-            ));
-        }
-        FailMode::RateLimit429 => {
-            return Ok(response(
-                StatusCode::TOO_MANY_REQUESTS,
-                json!({"error": "mock 429"}),
-            ));
-        }
-    }
-
+    // Read the request body once: it is needed both for content-scoped
+    // failure injection and for echoing the right number of vectors.
     let body = to_bytes(request.into_body()).await.unwrap_or_default();
     let payload: Value = serde_json::from_slice(&body).unwrap_or_else(|_| json!({}));
+    let inputs: Vec<String> = match payload.get("input") {
+        Some(Value::Array(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect(),
+        Some(Value::String(text)) => vec![text.clone()],
+        _ => Vec::new(),
+    };
     let count = match payload.get("input") {
         Some(Value::Array(values)) => values.len(),
         Some(_) => 1,
         None => 1,
     };
+
+    // Failure decision: content marker takes precedence over the first-N
+    // counter, which takes precedence over the legacy global fail mode.
+    let mode = *inner.fail_mode.lock().await;
+    if mode != FailMode::Ok {
+        let triggered = if let Some(marker) = inner.fail_if_contains.lock().await.as_deref() {
+            inputs.iter().any(|text| text.contains(marker))
+        } else if inner.fail_first_n_armed.load(Ordering::SeqCst) {
+            let remaining = inner.fail_first_n.load(Ordering::SeqCst);
+            if remaining > 0 {
+                inner.fail_first_n.store(remaining - 1, Ordering::SeqCst);
+                true
+            } else {
+                false
+            }
+        } else {
+            true
+        };
+        if triggered {
+            match mode {
+                FailMode::Ok => {}
+                FailMode::Timeout => {
+                    std::future::pending::<()>().await;
+                    unreachable!();
+                }
+                FailMode::Http500 => {
+                    return Ok(response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        json!({"error": "mock 500"}),
+                    ));
+                }
+                FailMode::RateLimit429 => {
+                    return Ok(response(
+                        StatusCode::TOO_MANY_REQUESTS,
+                        json!({"error": "mock 429"}),
+                    ));
+                }
+                FailMode::MalformedBody => {
+                    // 200 OK, but the body has no `data` field, so the client
+                    // cannot decode it -> non-retryable DecodeResponse.
+                    return Ok(response(
+                        StatusCode::OK,
+                        json!({"error": "mock malformed embedding response"}),
+                    ));
+                }
+            }
+        }
+    }
+
     let default_dim = inner.dim.load(Ordering::SeqCst) as usize;
     let per_item_dims = inner.per_item_dims.lock().await.clone();
     let data = (0..count)

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common::harness::FailMode;
 use common::harness::start as start_mock;
 use mempal::core::config::{Config, ConfigHandle, DEFAULT_MODEL2VEC_FINGERPRINT_MODEL};
 use mempal::core::db::{Database, VECTOR_DISTANCE_METRIC};
@@ -449,6 +450,246 @@ async fn test_reindex_stale_only() {
         "stdout: {}",
         String::from_utf8_lossy(&second.stdout)
     );
+
+    handle.shutdown().await;
+}
+
+/// #301: a transient batch embed failure must be absorbed by a bounded retry
+/// instead of aborting the entire stale reindex. The mock returns an
+/// undecodable body for the first two embed attempts of the stale batch, then
+/// recovers. Because that failure class (`DecodeResponse`) is non-retryable,
+/// this also proves the reindex retry is error-class-agnostic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retry_absorbs_transient_batch_failure() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-retry-transient.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        false,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, false),
+    );
+    seed_drawers(&env.db_path, 4, 2);
+
+    // Full reindex builds dim-4 vectors plus per-drawer fingerprint metadata.
+    let full = run_reindex(&env.home, &["--from-config"], &[]);
+    assert!(
+        full.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&full.stderr)
+    );
+    assert_eq!(handle.request_count(), 4);
+
+    // Mark two drawers stale so the stale path embeds them in a single batch.
+    let db = Database::open(&env.db_path).expect("open db");
+    for id in ["drawer-01", "drawer-02"] {
+        db.conn()
+            .execute(
+                "UPDATE fork_ext_meta SET value = 'old' WHERE key = ?1",
+                [format!("reindex:{id}:index_version")],
+            )
+            .expect("mark index stale");
+    }
+
+    // The first two embed attempts of the stale batch fail with an undecodable
+    // body; the server then recovers. The bounded retry must absorb the blip.
+    handle.set_fail_mode(FailMode::MalformedBody).await;
+    handle.set_fail_first_n(2);
+
+    let stale = run_reindex(&env.home, &["--from-config", "--stale"], &[]);
+    assert!(
+        stale.status.success(),
+        "transient blip must not abort reindex; stdout={} stderr={}",
+        String::from_utf8_lossy(&stale.stdout),
+        String::from_utf8_lossy(&stale.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&stale.stdout);
+    assert!(
+        stdout.contains("skipped failed batches: 0"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("skipped failed drawers: 0"),
+        "stdout: {stdout}"
+    );
+
+    // 4 full + 2 failed retries + 1 success = 7 embed requests.
+    assert_eq!(
+        handle.request_count(),
+        7,
+        "expected two retries followed by success"
+    );
+
+    // Both previously-stale drawers are now freshly embedded.
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
+    for id in ["drawer-01", "drawer-02"] {
+        let details = db.drawer_vector_details(id).expect("vector details");
+        assert!(!details.stale, "{id} should be re-embedded: {details:?}");
+    }
+
+    handle.shutdown().await;
+}
+
+/// #301: a batch that fails persistently (past the retry cap) must be logged,
+/// skipped, and the run must continue and finish every other batch. The
+/// skipped drawer stays stale so a later `mempal reindex --stale` retries it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn persistent_batch_failure_skips_and_continues() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-persistent-skip.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        false,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, false),
+    );
+    seed_drawers(&env.db_path, 4, 2);
+
+    let full = run_reindex(&env.home, &["--from-config"], &[]);
+    assert!(
+        full.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&full.stderr)
+    );
+
+    // Mark all four drawers stale; batch-size 1 makes each its own batch.
+    let db = Database::open(&env.db_path).expect("open db");
+    for index in 0..4 {
+        db.conn()
+            .execute(
+                "UPDATE fork_ext_meta SET value = 'old' WHERE key = ?1",
+                [format!("reindex:drawer-{index:02}:index_version")],
+            )
+            .expect("mark index stale");
+    }
+
+    // drawer-02's batch always fails; the other three succeed.
+    handle.set_fail_mode(FailMode::MalformedBody).await;
+    handle
+        .set_fail_if_input_contains(Some("drawer content 2".to_string()))
+        .await;
+
+    let stale = run_reindex(
+        &env.home,
+        &[
+            "--from-config",
+            "--stale",
+            "--batch-size",
+            "1",
+            "--max-batch-retries",
+            "1",
+        ],
+        &[],
+    );
+    assert!(
+        stale.status.success(),
+        "persistent failure must skip-and-continue with exit 0; stdout={} stderr={}",
+        String::from_utf8_lossy(&stale.stdout),
+        String::from_utf8_lossy(&stale.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&stale.stdout);
+    assert!(
+        stdout.contains("skipped failed batches: 1"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("skipped failed drawers: 1"),
+        "stdout: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&stale.stderr);
+    assert!(
+        stderr.contains("skipping") && stderr.contains("drawer"),
+        "expected a skip warning on stderr: {stderr}",
+    );
+
+    // The three healthy drawers are freshly embedded; the poisoned one stays
+    // stale so a later `--stale` re-run will select it again.
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
+    for index in [0, 1, 3] {
+        let id = format!("drawer-{index:02}");
+        let details = db.drawer_vector_details(&id).expect("vector details");
+        assert!(!details.stale, "{id} should be embedded: {details:?}");
+    }
+    let poisoned = db
+        .drawer_vector_details("drawer-02")
+        .expect("vector details");
+    assert!(
+        poisoned.stale,
+        "drawer-02 must remain stale for a later re-run: {poisoned:?}"
+    );
+
+    handle.shutdown().await;
+}
+
+/// #301 regression: with no failures, reindex behaves exactly as before and
+/// reports zero skips.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn clean_reindex_no_skips_regression() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-clean-noskip.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        false,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, false),
+    );
+    seed_drawers(&env.db_path, 4, 2);
+
+    let full = run_reindex(&env.home, &["--from-config"], &[]);
+    assert!(
+        full.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&full.stderr)
+    );
+
+    let db = Database::open(&env.db_path).expect("open db");
+    for id in ["drawer-01", "drawer-02"] {
+        db.conn()
+            .execute(
+                "UPDATE fork_ext_meta SET value = 'old' WHERE key = ?1",
+                [format!("reindex:{id}:index_version")],
+            )
+            .expect("mark index stale");
+    }
+
+    let stale = run_reindex(&env.home, &["--from-config", "--stale"], &[]);
+    assert!(
+        stale.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&stale.stdout);
+    assert!(
+        stdout.contains("batch 1: re-embedded 2 stale/new drawers"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("skipped failed batches: 0"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("skipped failed drawers: 0"),
+        "stdout: {stdout}"
+    );
+    assert_eq!(handle.request_count(), 5, "4 full + 1 stale batch");
+
+    ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
+    for id in ["drawer-01", "drawer-02"] {
+        let details = db.drawer_vector_details(id).expect("vector details");
+        assert!(!details.stale, "{id} should be embedded: {details:?}");
+    }
 
     handle.shutdown().await;
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "0cb7f79f947c0c611addcaf241438b1d8637ee4f"
+commit = "d75447df4df4e45a038e348d9058c68c083c3dd6"
 source_kind = "git"


### PR DESCRIPTION
## Summary
`mempal reindex --from-config --stale` aborted the entire run on a single batch embed failure, contradicting the documented "fixed 2s retry; ingest blocks to preserve data" embedder design that ingest honors but reindex did not.

## Changes
- Retry a failed batch embed at a fixed interval (reuses `[embed.retry].interval_secs`, default 2s), bounded by `--max-batch-retries` (default `MAX_BATCH_RETRIES`) so the run still terminates.
- On persistent failure after exhausting retries: log a warning (batch index + drawer count), increment `skipped_failed_batches` / `skipped_failed_drawers`, and continue to the next batch instead of aborting. Skipped drawers stay stale so a later `reindex --stale` re-run picks them up.
- Surface both counters in reindex output; exit 0 when completed (skips reported, not fatal). Reindex rebuilds already-stored data so it must terminate — graceful skip-continue, unlike the infinite block used by ingest.

## Tests
`tests/embedder_reindex_scenarios.rs` (+ fail-on-cue mock in `tests/common/harness/embed_mock.rs`): `retry_absorbs_transient_batch_failure`, `persistent_batch_failure_skips_and_continues`, `clean_reindex_no_skips_regression`.

## Review
tier-4 `csa review` (codex): PASS, no findings. Non-blocking advisory tracked separately: `skipped_ids` expanded into `NOT IN (...)` could grow unbounded on a pathological many-failures large store; future hardening (temp table / keyset cursor).

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)