### PR TITLE
fix(search): effective_importance=0.0 buries fresh drawers in recall (#309)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -3915,11 +3915,19 @@ impl Database {
     /// `stale_penalty_applied` survives `recompute_all_effective_importance`.
     ///
     /// The `effective_importance` update derives the pre-penalty value from
-    /// `NULLIF(effective_importance, 0.0)` falling back to base importance, so a
-    /// legacy row stuck at the 0.0 sentinel (GitHub #309) persists a non-zero
-    /// `importance * penalty` instead of `0.0 * penalty = 0.0` — which would
-    /// otherwise bypass the stale down-rank and surface outdated memory at full
-    /// importance via the read fallback.
+    /// `NULLIF(effective_importance, 0.0)` falling back to
+    /// `importance * COALESCE(stale_penalty_applied, 1.0)` — the same cumulative
+    /// expression the read fallback uses. So a legacy row stuck at the 0.0
+    /// sentinel (GitHub #309) re-penalizes coherently: a row already carrying
+    /// `stale_penalty_applied = 0.5` composes to `importance * 0.5 * new_penalty`
+    /// rather than dropping the prior penalty and yielding `importance *
+    /// new_penalty`. SQLite resolves every `SET` right-hand side against the
+    /// row's pre-UPDATE values, so the `stale_penalty_applied` read here is the
+    /// OLD multiplier, not the newly-assigned one on the line above. This keeps
+    /// the cumulative stale penalty order-independent and persists a non-zero
+    /// value instead of `0.0 * penalty = 0.0` — which would otherwise bypass the
+    /// stale down-rank and surface outdated memory at full importance via the
+    /// read fallback.
     pub fn apply_stale_penalty_to_drawer(
         &self,
         drawer_id: &str,
@@ -3928,7 +3936,7 @@ impl Database {
         self.conn.execute(
             r#"UPDATE drawers SET
                 stale_penalty_applied = COALESCE(stale_penalty_applied, 1.0) * ?1,
-                effective_importance = COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) * ?1
+                effective_importance = COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0)) * ?1
             WHERE id = ?2 AND deleted_at IS NULL"#,
             rusqlite::params![stale_penalty, drawer_id],
         )?;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -100,9 +100,13 @@ const DRAWER_SELECT_COLUMNS: &str = r#"
     -- COALESCE alone substitutes only on NULL, but ingest can land a literal 0.0
     -- that would otherwise sink the drawer below every ei>0 row in the importance
     -- rerank, making it unrecallable (GitHub #309). NULLIF(...,0.0) maps the 0.0
-    -- sentinel to NULL so the fallback fires. A drawer that legitimately decays to
-    -- exactly 0.0 also falls back to importance here — an acceptable safe floor.
-    COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) as effective_importance,
+    -- sentinel to NULL so the fallback fires. The fallback term carries the persisted
+    -- stale penalty (COALESCE(stale_penalty_applied, 1.0); default 1.0 for a
+    -- never-penalized row) so a legacy 0.0 row that fact-check down-ranked still ranks
+    -- at importance*penalty, not full importance — preserving the P13 stale-fact
+    -- contract without re-burying never-penalized rows. A drawer that legitimately
+    -- decays to exactly 0.0 also falls back here — an acceptable safe floor.
+    COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0)) as effective_importance,
     compacted_into
 "#;
 
@@ -3909,6 +3913,13 @@ impl Database {
     /// Apply stale penalty: persist the multiplier in `stale_penalty_applied` and
     /// immediately reduce `effective_importance` for a specific drawer.
     /// `stale_penalty_applied` survives `recompute_all_effective_importance`.
+    ///
+    /// The `effective_importance` update derives the pre-penalty value from
+    /// `NULLIF(effective_importance, 0.0)` falling back to base importance, so a
+    /// legacy row stuck at the 0.0 sentinel (GitHub #309) persists a non-zero
+    /// `importance * penalty` instead of `0.0 * penalty = 0.0` — which would
+    /// otherwise bypass the stale down-rank and surface outdated memory at full
+    /// importance via the read fallback.
     pub fn apply_stale_penalty_to_drawer(
         &self,
         drawer_id: &str,
@@ -3917,7 +3928,7 @@ impl Database {
         self.conn.execute(
             r#"UPDATE drawers SET
                 stale_penalty_applied = COALESCE(stale_penalty_applied, 1.0) * ?1,
-                effective_importance = effective_importance * ?1
+                effective_importance = COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) * ?1
             WHERE id = ?2 AND deleted_at IS NULL"#,
             rusqlite::params![stale_penalty, drawer_id],
         )?;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -96,7 +96,13 @@ const DRAWER_SELECT_COLUMNS: &str = r#"
     COALESCE(is_pinned, 0) as is_pinned,
     pin_order,
     supersedes,
-    COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) as effective_importance,
+    -- Treat a persisted 0.0 as "not computed" and fall back to base importance.
+    -- COALESCE alone substitutes only on NULL, but ingest can land a literal 0.0
+    -- that would otherwise sink the drawer below every ei>0 row in the importance
+    -- rerank, making it unrecallable (GitHub #309). NULLIF(...,0.0) maps the 0.0
+    -- sentinel to NULL so the fallback fires. A drawer that legitimately decays to
+    -- exactly 0.0 also falls back to importance here — an acceptable safe floor.
+    COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) as effective_importance,
     compacted_into
 "#;
 
@@ -377,6 +383,17 @@ impl Database {
         anchor::validate_anchor_domain(&drawer.domain, &drawer.anchor_kind)
             .map_err(|message| DbError::InvalidDrawerMetadata(message.to_string()))?;
 
+        // Persist effective_importance explicitly so a new drawer is never
+        // stranded at the column DEFAULT 0.0 — a literal 0.0 sinks below every
+        // ei>0 row in the importance rerank and is effectively unrecallable
+        // (GitHub #309). Seed from base importance when the constructor left the
+        // field at the 0.0 sentinel, mirroring the read-time NULLIF(...,0.0) guard.
+        let seeded_effective_importance = if drawer.effective_importance == 0.0 {
+            f64::from(drawer.importance)
+        } else {
+            drawer.effective_importance
+        };
+
         self.conn.execute(
             r#"
             INSERT OR IGNORE INTO drawers (
@@ -414,9 +431,10 @@ impl Database {
                 pin_order,
                 supersedes,
                 valid_from,
-                valid_until
+                valid_until,
+                effective_importance
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32, ?33, ?34, ?35, ?36)
             "#,
             params![
                 drawer.id.as_str(),
@@ -454,6 +472,7 @@ impl Database {
                 drawer.supersedes.as_deref(),
                 valid_from.unwrap_or(drawer.added_at.as_str()),
                 valid_until,
+                seeded_effective_importance,
             ],
         )?;
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2514,6 +2514,65 @@ mod tests {
         );
     }
 
+    /// Regression for the #309 round-3 finding (cumulative stale-penalty in the
+    /// persist path): re-penalizing a legacy row that is BOTH stuck at the
+    /// `effective_importance` 0.0 sentinel AND already carries a prior
+    /// `stale_penalty_applied` must compound the penalties, not drop the old one.
+    /// The persist-path fallback derives the pre-penalty value as
+    /// `importance * COALESCE(stale_penalty_applied, 1.0)` — SQLite resolves every
+    /// `SET` right-hand side against the row's pre-UPDATE values, so the penalty
+    /// read here is the OLD multiplier. Applying 0.5 to a row with importance=3,
+    /// stale_penalty_applied=0.5 must yield effective_importance = 3 * 0.5 * 0.5 =
+    /// 0.75 and stale_penalty_applied = 0.5 * 0.5 = 0.25 — coherent with the read
+    /// fallback. Pre-fix the fallback ignored the old penalty and persisted
+    /// 3 * 0.5 = 1.5, which (being non-zero) also disabled the read fallback,
+    /// leaving the stale row over-ranked until a later recompute.
+    #[test]
+    fn repenalizing_legacy_zero_ei_compounds_cumulative_stale_penalty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        let mut drawer = make_drawer("legacy-recompound", "alpha", "decision");
+        drawer.importance = 3;
+        db.insert_drawer_with_project_validity(&drawer, None, None, None, None)
+            .expect("insert drawer");
+        // Already-penalized legacy row: 0.0 sentinel + a prior 0.5 stale penalty.
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0, stale_penalty_applied = 0.5 \
+                 WHERE id = ?1",
+                ["legacy-recompound"],
+            )
+            .expect("force legacy stale 0.0");
+
+        // Apply the default stale penalty again (fact-check path re-penalizing).
+        db.apply_stale_penalty_to_drawer("legacy-recompound", 0.5)
+            .expect("apply stale penalty");
+
+        let fetched = db
+            .get_drawer("legacy-recompound")
+            .expect("get_drawer")
+            .expect("drawer exists");
+        assert_eq!(
+            fetched.effective_importance, 0.75,
+            "re-penalizing a legacy 0.0 row must compound the prior penalty: \
+             3 * 0.5 (old) * 0.5 (new) = 0.75, not 3 * 0.5 = 1.5"
+        );
+
+        let persisted_penalty: f64 = db
+            .conn()
+            .query_row(
+                "SELECT stale_penalty_applied FROM drawers WHERE id = ?1",
+                ["legacy-recompound"],
+                |row| row.get(0),
+            )
+            .expect("read stale_penalty_applied");
+        assert_eq!(
+            persisted_penalty, 0.25,
+            "cumulative stale penalty must compound: 0.5 (old) * 0.5 (new) = 0.25"
+        );
+    }
+
     /// Regression for the #309 follow-up (penalty-aware read fallback): a legacy
     /// row stale-penalized *before* the persistence fix is stuck at
     /// `effective_importance = 0.0` with `stale_penalty_applied < 1.0`. The read

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -576,10 +576,12 @@ fn apply_consistent_effective_importance(db: &Database, results: &mut [SearchRes
         .map(|index| format!("?{index}"))
         .collect::<Vec<_>>()
         .join(", ");
-    // Mirror `get_drawer`'s COALESCE so the snapshot value matches what the
-    // per-result hydrate would have produced absent a concurrent write.
+    // Mirror `get_drawer`'s NULLIF(...,0.0) guard so the snapshot value matches
+    // what the per-result hydrate would have produced absent a concurrent write.
+    // A persisted 0.0 is the "not computed" sentinel and must fall back to base
+    // importance, else the drawer sinks in the importance rerank (GitHub #309).
     let sql = format!(
-        "SELECT id, COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) \
+        "SELECT id, COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) \
          FROM drawers WHERE id IN ({placeholders})"
     );
     let snapshot: std::collections::HashMap<String, f64> = match db.conn().prepare(&sql) {
@@ -2381,6 +2383,95 @@ mod tests {
         assert!(
             sims[0] > sims[1] && sims[1] > sims[2],
             "similarity must strictly decrease along the ranking: {sims:?}"
+        );
+    }
+
+    /// Regression for GitHub #309: a freshly-ingested high-importance drawer must
+    /// not be buried in the importance rerank by a persisted `effective_importance`
+    /// of 0.0. Pre-fix, the INSERT omitted the column (so it took the column
+    /// DEFAULT 0.0) and the read fallback used a NULL-only `COALESCE`, so
+    /// `rerank_by_effective_importance` sorted the fresh drawer last and
+    /// `truncate(top_k)` dropped it. This drives the real BM25 rerank pipeline
+    /// (`apply_consistent_effective_importance` -> `rerank_by_effective_importance`
+    /// -> `truncate`) with no embedder; under the default `DecayMode::None` it is
+    /// fully deterministic.
+    #[test]
+    fn fresh_high_importance_drawer_not_buried_by_zero_effective_importance() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        // Fresh, high-importance drawer ingested through the real INSERT path with
+        // the constructor's 0.0 sentinel left in place. Fix (B) must seed its
+        // persisted effective_importance from `importance` (4.0); pre-fix it would
+        // land at the column DEFAULT 0.0.
+        let mut fresh = make_drawer("fresh-309", "alpha", "decision");
+        fresh.content = "needle three zero nine".to_string();
+        fresh.importance = 4;
+        db.insert_drawer_with_project_validity(&fresh, None, None, None, None)
+            .expect("insert fresh");
+
+        // Older rival with a positive effective_importance (as the v10 migration
+        // backfill would have produced). Pre-fix this outranks the 0.0 fresh drawer
+        // and, at top_k = 1, evicts it entirely.
+        let mut rival = make_drawer("rival-low", "alpha", "decision");
+        rival.content = "needle rival".to_string();
+        rival.importance = 1;
+        db.insert_drawer_with_project_validity(&rival, None, None, None, None)
+            .expect("insert rival");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 2.0 WHERE id = ?1",
+                ["rival-low"],
+            )
+            .expect("force rival effective_importance");
+
+        let results = search_bm25_only_with_options(
+            &db,
+            "needle",
+            route(),
+            &ProjectSearchScope::all_projects(),
+            SearchOptions::default(),
+            1,
+        )
+        .expect("search");
+
+        assert_eq!(
+            results.first().map(|result| result.drawer_id.as_str()),
+            Some("fresh-309"),
+            "fresh importance-4 drawer must rank #1 over the importance-2 rival, not \
+             be buried by a persisted effective_importance of 0.0 (GitHub #309)"
+        );
+    }
+
+    /// Regression for GitHub #309 (read-time guard): a row whose
+    /// `effective_importance` column holds a literal 0.0 (e.g. ingested before the
+    /// seed fix) must read back as its base `importance` via
+    /// `NULLIF(effective_importance, 0.0)`, not as 0.0. Exercises the shared
+    /// `DRAWER_SELECT_COLUMNS` fallback through `get_drawer`.
+    #[test]
+    fn persisted_zero_effective_importance_reads_back_as_importance() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        let mut drawer = make_drawer("legacy-zero", "alpha", "decision");
+        drawer.importance = 3;
+        db.insert_drawer_with_project_validity(&drawer, None, None, None, None)
+            .expect("insert drawer");
+        // Simulate a legacy row that persisted the 0.0 sentinel directly.
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0 WHERE id = ?1",
+                ["legacy-zero"],
+            )
+            .expect("force legacy 0.0");
+
+        let fetched = db
+            .get_drawer("legacy-zero")
+            .expect("get_drawer")
+            .expect("drawer exists");
+        assert_eq!(
+            fetched.effective_importance, 3.0,
+            "persisted 0.0 must fall back to base importance (3.0) via NULLIF, not stay 0.0"
         );
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -580,8 +580,10 @@ fn apply_consistent_effective_importance(db: &Database, results: &mut [SearchRes
     // what the per-result hydrate would have produced absent a concurrent write.
     // A persisted 0.0 is the "not computed" sentinel and must fall back to base
     // importance, else the drawer sinks in the importance rerank (GitHub #309).
+    // The fallback carries the persisted stale penalty (default 1.0) so a legacy
+    // 0.0 row that was fact-check down-ranked ranks at importance*penalty.
     let sql = format!(
-        "SELECT id, COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) \
+        "SELECT id, COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0)) \
          FROM drawers WHERE id IN ({placeholders})"
     );
     let snapshot: std::collections::HashMap<String, f64> = match db.conn().prepare(&sql) {
@@ -2472,6 +2474,156 @@ mod tests {
         assert_eq!(
             fetched.effective_importance, 3.0,
             "persisted 0.0 must fall back to base importance (3.0) via NULLIF, not stay 0.0"
+        );
+    }
+
+    /// Regression for the #309 follow-up (stale-penalty persistence): applying a
+    /// stale penalty to a legacy row stuck at the `effective_importance` 0.0
+    /// sentinel must persist `importance * penalty` (non-zero), not
+    /// `0.0 * penalty = 0.0`. Otherwise the row stays at 0.0 and the read fallback
+    /// would surface it at full base importance, bypassing the P13 stale down-rank.
+    #[test]
+    fn apply_stale_penalty_to_legacy_zero_ei_persists_importance_times_penalty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        let mut drawer = make_drawer("legacy-stale", "alpha", "decision");
+        drawer.importance = 3;
+        db.insert_drawer_with_project_validity(&drawer, None, None, None, None)
+            .expect("insert drawer");
+        // Force the legacy 0.0 sentinel that #309 left behind.
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0 WHERE id = ?1",
+                ["legacy-stale"],
+            )
+            .expect("force legacy 0.0");
+
+        // Default stale penalty (0.5), as the fact-check path applies it.
+        db.apply_stale_penalty_to_drawer("legacy-stale", 0.5)
+            .expect("apply stale penalty");
+
+        let fetched = db
+            .get_drawer("legacy-stale")
+            .expect("get_drawer")
+            .expect("drawer exists");
+        assert_eq!(
+            fetched.effective_importance, 1.5,
+            "stale penalty on a legacy 0.0 row must persist importance*penalty \
+             (3 * 0.5 = 1.5), not stay at 0.0 * 0.5 = 0.0"
+        );
+    }
+
+    /// Regression for the #309 follow-up (penalty-aware read fallback): a legacy
+    /// row stale-penalized *before* the persistence fix is stuck at
+    /// `effective_importance = 0.0` with `stale_penalty_applied < 1.0`. The read
+    /// fallback must rank it at `importance * penalty`, not full base importance, so
+    /// fact-check down-ranks survive (P13). A never-penalized 0.0 row (penalty
+    /// default 1.0) must still fall back to full importance — no re-burial.
+    #[test]
+    fn read_fallback_applies_stale_penalty_for_legacy_zero_ei() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        // Stale-penalized legacy row stuck at the 0.0 sentinel.
+        let mut stale = make_drawer("legacy-stale-read", "alpha", "decision");
+        stale.importance = 3;
+        db.insert_drawer_with_project_validity(&stale, None, None, None, None)
+            .expect("insert stale");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0, stale_penalty_applied = 0.5 \
+                 WHERE id = ?1",
+                ["legacy-stale-read"],
+            )
+            .expect("force legacy stale 0.0");
+
+        // Never-penalized legacy row (stale_penalty_applied defaults to 1.0).
+        let mut fresh = make_drawer("legacy-fresh-read", "alpha", "decision");
+        fresh.importance = 4;
+        db.insert_drawer_with_project_validity(&fresh, None, None, None, None)
+            .expect("insert fresh");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0 WHERE id = ?1",
+                ["legacy-fresh-read"],
+            )
+            .expect("force legacy 0.0");
+
+        let stale_fetched = db
+            .get_drawer("legacy-stale-read")
+            .expect("get_drawer")
+            .expect("stale exists");
+        assert_eq!(
+            stale_fetched.effective_importance, 1.5,
+            "stale-penalized 0.0 row must read back as importance*penalty \
+             (3 * 0.5 = 1.5) via the fallback"
+        );
+
+        let fresh_fetched = db
+            .get_drawer("legacy-fresh-read")
+            .expect("get_drawer")
+            .expect("fresh exists");
+        assert_eq!(
+            fresh_fetched.effective_importance, 4.0,
+            "never-penalized 0.0 row must read back at full importance (4.0); the \
+             penalty multiplier defaults to 1.0 and must not collapse it (no #309 re-burial)"
+        );
+    }
+
+    /// Regression for the #309 follow-up (search ranking): a stale-penalized legacy
+    /// row stuck at `effective_importance = 0.0` must be ranked by
+    /// `importance * penalty` in the search rerank, not full importance. The stale
+    /// importance-4 row (penalty 0.5 -> effective 2.0) must lose top_k=1 to an
+    /// importance-1 rival with a real effective_importance of 2.5. Pre-fix the
+    /// penalty was ignored, the stale row computed 4.0 and wrongly evicted the rival.
+    /// Exercises the consistent-snapshot fallback (`search/mod.rs`) ->
+    /// `rerank_by_effective_importance`; deterministic under `DecayMode::None`.
+    #[test]
+    fn stale_penalized_zero_ei_ranks_below_real_rival_in_search() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+
+        let mut stale = make_drawer("stale-hi", "alpha", "decision");
+        stale.content = "needle stale".to_string();
+        stale.importance = 4;
+        db.insert_drawer_with_project_validity(&stale, None, None, None, None)
+            .expect("insert stale");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0, stale_penalty_applied = 0.5 \
+                 WHERE id = ?1",
+                ["stale-hi"],
+            )
+            .expect("force stale 0.0");
+
+        let mut rival = make_drawer("rival-mid", "alpha", "decision");
+        rival.content = "needle rival".to_string();
+        rival.importance = 1;
+        db.insert_drawer_with_project_validity(&rival, None, None, None, None)
+            .expect("insert rival");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 2.5 WHERE id = ?1",
+                ["rival-mid"],
+            )
+            .expect("force rival effective_importance");
+
+        let results = search_bm25_only_with_options(
+            &db,
+            "needle",
+            route(),
+            &ProjectSearchScope::all_projects(),
+            SearchOptions::default(),
+            1,
+        )
+        .expect("search");
+
+        assert_eq!(
+            results.first().map(|result| result.drawer_id.as_str()),
+            Some("rival-mid"),
+            "stale importance-4 row (effective 4 * 0.5 = 2.0) must rank below the rival's \
+             real effective_importance 2.5; pre-fix the ignored penalty let it compute 4.0 and win"
         );
     }
 }

--- a/src/search/tiered.rs
+++ b/src/search/tiered.rs
@@ -138,14 +138,16 @@ pub fn fetch_t1(db: &Database, params: T1Params<'_>) -> Result<Vec<TieredItem>, 
 
     let sql = format!(
         r#"
+        -- NULLIF(...,0.0) maps the persisted 0.0 sentinel to NULL so it falls back
+        -- to base importance instead of ranking last (GitHub #309).
         SELECT id, content, room, source_file, added_at,
-               COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL))
+               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL))
         FROM drawers
         WHERE deleted_at IS NULL
           AND room IN ('decision', 'feedback', 'rule')
           AND COALESCE(importance, 0) >= ?1
           AND {project_clause}
-        ORDER BY COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL)) DESC,
+        ORDER BY COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) DESC,
                  CAST(added_at AS INTEGER) DESC
         "#,
     );
@@ -239,8 +241,9 @@ pub fn fetch_t3(db: &Database, params: T3Params<'_>) -> Result<Vec<TieredItem>, 
 
     let sql = format!(
         r#"
+        -- NULLIF(...,0.0): persisted 0.0 sentinel falls back to importance (GitHub #309).
         SELECT id, content, room, source_file, added_at,
-               COALESCE(effective_importance, CAST(COALESCE(importance, 0) AS REAL))
+               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL))
         FROM drawers
         WHERE deleted_at IS NULL
           AND CAST(added_at AS INTEGER) >= ?1

--- a/src/search/tiered.rs
+++ b/src/search/tiered.rs
@@ -139,15 +139,17 @@ pub fn fetch_t1(db: &Database, params: T1Params<'_>) -> Result<Vec<TieredItem>, 
     let sql = format!(
         r#"
         -- NULLIF(...,0.0) maps the persisted 0.0 sentinel to NULL so it falls back
-        -- to base importance instead of ranking last (GitHub #309).
+        -- to base importance instead of ranking last (GitHub #309). The fallback
+        -- carries the persisted stale penalty (default 1.0) so a legacy 0.0 row that
+        -- fact-check down-ranked ranks at importance*penalty, not full importance.
         SELECT id, content, room, source_file, added_at,
-               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL))
+               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0))
         FROM drawers
         WHERE deleted_at IS NULL
           AND room IN ('decision', 'feedback', 'rule')
           AND COALESCE(importance, 0) >= ?1
           AND {project_clause}
-        ORDER BY COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL)) DESC,
+        ORDER BY COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0)) DESC,
                  CAST(added_at AS INTEGER) DESC
         "#,
     );
@@ -241,9 +243,10 @@ pub fn fetch_t3(db: &Database, params: T3Params<'_>) -> Result<Vec<TieredItem>, 
 
     let sql = format!(
         r#"
-        -- NULLIF(...,0.0): persisted 0.0 sentinel falls back to importance (GitHub #309).
+        -- NULLIF(...,0.0): persisted 0.0 sentinel falls back to importance*penalty
+        -- (stale_penalty_applied default 1.0) so down-ranked legacy rows stay down (GitHub #309).
         SELECT id, content, room, source_file, added_at,
-               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL))
+               COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0))
         FROM drawers
         WHERE deleted_at IS NULL
           AND CAST(added_at AS INTEGER) >= ?1

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "437bbef712f519bf14ada7086ea4ce52a5e5edcb"
+commit = "c6cc924647912809f0aeeefe9549fcfa33639708"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #309 — freshly-ingested drawers were unrecallable because they persisted `effective_importance = 0.0`, and hybrid search reranks by `effective_importance` DESC then truncates to `top_k`, burying them below every `ei > 0` drawer regardless of vector/BM25 match. This silently hid the most recent, highest-value memories (including agent decision records), defeating mempal's immediate-recall promise. **Independent of the embedder reindex** — affected drawers already carry valid cosine vectors.

## Root cause

`insert_drawer_with_project_validity` **omitted** the `effective_importance` column from its INSERT, so every new drawer took the column `DEFAULT 0.0` regardless of the struct field. The read-fallback `COALESCE(effective_importance, importance)` only substitutes on `NULL`, so the persisted `0.0` passed straight through into rerank. The one-time backfill migration (`db_fork_ext.rs:518`) fixed pre-existing rows but did not cover later ingests.

## Fix (defense in depth)

- **Ingest seed (root):** `insert_drawer_with_project_validity` now persists `effective_importance`, seeded from `importance` when the constructor left the `0.0` sentinel — new drawers never carry `0.0`.
- **Penalty-aware read-time guard:** at all **5** crate-wide COALESCE read-fallback sites — `core/db.rs` (`DRAWER_SELECT_COLUMNS`), `search/mod.rs` (consistent snapshot), `search/tiered.rs` ×3 (T1 SELECT+ORDER BY, T3 SELECT) — the fallback is now `COALESCE(NULLIF(effective_importance, 0.0), CAST(COALESCE(importance, 0) AS REAL) * COALESCE(stale_penalty_applied, 1.0))`. `NULLIF` makes **existing** persisted-`0.0` rows recall at query time (no data migration); the `stale_penalty_applied` factor (a REAL multiplier column, `DEFAULT 1.0`, so never-penalized rows are unaffected) preserves P13's stale-fact down-rank for any legacy `0.0` row that `mempal_fact_check` later penalized. Penalty applies only on the `NULLIF` fallback branch; rows with `ei != 0` already embed their penalty and are not double-multiplied.
- **Persist-path fix:** `apply_stale_penalty_to_drawer` now derives the new `effective_importance` from `COALESCE(NULLIF(ei, 0.0), importance) * penalty`, so penalizing a legacy `0.0` row stores `importance*penalty` (non-zero) instead of staying stuck at `0.0` (`0.0 * 0.5 = 0.0`).
- **Regression tests** (embedder-free, deterministic): the real BM25 rerank pipeline proving a fresh importance-4 drawer out-ranks a forced-`ei` rival at `top_k=1` (fails pre-fix: buried by `0.0`); the `get_drawer` read-fallback for legacy persisted-`0.0` rows; and the penalty path — legacy `ei=0.0`/`imp=3` + penalty `0.5` persists/reads `1.5`, never-penalized `ei=0.0`/`imp=4` reads `4.0`, e2e search ranks a stale `0.0` row below a higher-effective rival.

The `rerank_by_effective_importance` design is unchanged; only the `0.0`-vs-`NULL` sentinel mismatch, the ingest seed, and the stale-penalty composition are fixed. The non-COALESCE raw read at `db.rs` `audit --stale` is deliberately left untouched (out of scope).

## Validation

- Discovered during empirical recall validation of the in-flight l2→cosine reindex: every 2026-06 `mempal`-wing drawer (16/16) had `ei = 0.0` and never surfaced; 2026-04 drawers with `ei > 0` recalled fine. The missing drawers had valid cosine vectors (present in `drawer_vectors_rowids`, reindex-stamped current) and were not expired.
- `just fmt`, `just clippy` (`-D warnings`), `just test` green (enforced by the lefthook pre-commit gate on this branch, per commit).
- tier-4 cross-family review (codex). The first round flagged that the bare `NULLIF` fallback revived stale-penalized legacy rows at full base importance (bypassing P13); the penalty-aware fallback + persist-path fix above resolve it.

Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
