### PR TITLE
perf(reindex): O(n) stale work-list snapshot to stop pread64 read storm (#311)

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -43,6 +43,14 @@ use crate::ingest::novelty::NoveltyAction;
 pub const CURRENT_SCHEMA_VERSION: u32 = 17;
 pub const CURRENT_VECTOR_INDEX_VERSION: &str = "v2";
 pub const VECTOR_DISTANCE_METRIC: &str = "cosine";
+/// SQLite page cache budget for issue #311's large-DB stale reindex path.
+///
+/// Negative `PRAGMA cache_size` values are KiB, so `-262144` is 256 MiB.
+/// That is enough to avoid the default 2 MiB cache thrash on ~10 GiB stores,
+/// while staying far below the 4 GiB peak-memory cap. The reindex speedup is
+/// still the O(n) snapshot work-list; do not replace it with multi-GiB cache or
+/// `mmap_size`.
+pub(crate) const SQLITE_CACHE_SIZE_KIB_256_MIB: i64 = -262_144;
 const GATING_DROP_TOTAL_KEY: &str = "gating.dropped.total";
 const AUDIT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 
@@ -340,6 +348,7 @@ impl Database {
             OpenMode::ReadWrite => Connection::open(path)?,
         };
         conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_256_MIB)?;
         register_math_functions(&conn)?;
         if mode.allows_write() {
             conn.pragma_update(None, "journal_mode", "WAL")?;
@@ -6207,6 +6216,24 @@ mod tests {
     fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
         db.insert_drawer_with_project(&test_drawer(id, content), project_id)
             .expect("insert drawer");
+    }
+
+    #[test]
+    fn database_connection_uses_256mib_cache_without_mmap() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+
+        let cache_size = db
+            .conn()
+            .query_row("PRAGMA cache_size", [], |row| row.get::<_, i64>(0))
+            .expect("query cache_size");
+        let mmap_size = db
+            .conn()
+            .query_row("PRAGMA mmap_size", [], |row| row.get::<_, i64>(0))
+            .expect("query mmap_size");
+
+        assert_eq!(cache_size, SQLITE_CACHE_SIZE_KIB_256_MIB);
+        assert_eq!(mmap_size, 0, "issue #311 must not add multi-GiB mmap");
     }
 
     fn insert_test_source_drawer_with_vector(

--- a/src/core/reindex.rs
+++ b/src/core/reindex.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rusqlite::{Connection, OptionalExtension, params};
 use thiserror::Error;
 
+use super::db::SQLITE_CACHE_SIZE_KIB_256_MIB;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReindexProgressRow {
     pub source_path: String,
@@ -142,7 +144,9 @@ impl ReindexProgressStore {
     }
 
     fn open_connection(&self) -> Result<Connection> {
-        Ok(Connection::open(&self.db_path)?)
+        let conn = Connection::open(&self.db_path)?;
+        conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_256_MIB)?;
+        Ok(conn)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5525,20 +5525,14 @@ async fn reindex_stale_batches(
     db.conn()
         .execute_batch(&format!("DELETE FROM {REINDEX_SKIPPED_TABLE};"))
         .context("failed to reset reindex skip table")?;
+    build_reindex_stale_pending_rows(db, target_fingerprint, &target)
+        .context("failed to snapshot stale reindex work list")?;
     let mut batch_index = 0usize;
-    let mut remaining = target.limit;
     loop {
-        let effective_batch_size = remaining.map_or(batch_size, |value| value.min(batch_size));
-        if effective_batch_size == 0 {
-            break;
-        }
-        let rows = reindex_stale_batch_rows(db, target_fingerprint, effective_batch_size, &target)
+        let rows = pull_reindex_pending_batch(db, batch_size)
             .context("failed to load stale reindex batch")?;
         if rows.is_empty() {
             break;
-        }
-        if let Some(value) = remaining.as_mut() {
-            *value = value.saturating_sub(rows.len());
         }
         batch_index += 1;
         let texts = rows
@@ -5567,11 +5561,16 @@ async fn reindex_stale_batches(
                 let failed_ids: Vec<String> = rows.iter().map(|row| row.id.clone()).collect();
                 stage_reindex_skipped_ids(db, &failed_ids)
                     .context("failed to record skipped drawer ids")?;
+                delete_reindex_pending_ids(db, &failed_ids)
+                    .context("failed to delete skipped stale reindex work")?;
                 continue;
             }
         };
         let stats = write_reindex_vector_batch(db, &rows, &vectors, target_fingerprint)
             .context("failed to write stale reindex batch")?;
+        let pulled_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+        delete_reindex_pending_ids(db, &pulled_ids)
+            .context("failed to delete completed stale reindex work")?;
         processed += stats.reindexed;
         skipped_concurrent_update += stats.skipped_concurrent_update;
         if stats.skipped_concurrent_update == 0 {
@@ -9647,6 +9646,7 @@ fn append_reindex_target_filters(
 /// on the reindex loop's connection, so it persists across iterations and is
 /// auto-dropped when the connection closes.
 const REINDEX_SKIPPED_TABLE: &str = "tmp_reindex_skipped";
+const REINDEX_PENDING_TABLE: &str = "tmp_reindex_pending";
 
 /// Create the reindex skip TEMP table if absent. Idempotent, so any staging or
 /// query call may invoke it without coordinating with the loop.
@@ -9697,33 +9697,56 @@ fn stage_reindex_skipped_ids(db: &Database, ids: &[String]) -> Result<()> {
     }
 }
 
-fn reindex_stale_batch_rows(
-    db: &Database,
-    target_fingerprint: &str,
-    batch_size: usize,
-    target: &ReindexVectorTarget,
-) -> Result<Vec<ReindexRow>> {
-    let limit = i64::try_from(batch_size).context("batch size is too large")?;
-    // The skip-exclusion subquery below references this connection-local TEMP
-    // table; create it lazily so the query never fails with "no such table"
-    // even when no batch has been skipped yet (issue #304).
-    ensure_reindex_skipped_table(db)?;
-    let vectors_exist = db
-        .conn()
+fn ensure_reindex_pending_table(db: &Database) -> Result<()> {
+    db.conn()
+        .execute_batch(&format!(
+            "CREATE TEMP TABLE IF NOT EXISTS {REINDEX_PENDING_TABLE} (
+                id TEXT,
+                source_path TEXT,
+                chunk_index INTEGER
+            );"
+        ))
+        .context("failed to create reindex pending table")?;
+    Ok(())
+}
+
+fn reindex_vectors_exist(db: &Database) -> Result<bool> {
+    db.conn()
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
             [],
             |row| row.get::<_, bool>(0),
         )
-        .context("failed to query vector table presence")?;
-    let rows = if vectors_exist {
-        let mut sql = r#"
+        .context("failed to query vector table presence")
+}
+
+fn build_reindex_stale_pending_rows(
+    db: &Database,
+    target_fingerprint: &str,
+    target: &ReindexVectorTarget,
+) -> Result<usize> {
+    // The skip-exclusion subquery below references this connection-local TEMP
+    // table; create it lazily so the query never fails with "no such table"
+    // even when no batch has been skipped yet (issue #304).
+    ensure_reindex_skipped_table(db)?;
+    ensure_reindex_pending_table(db)?;
+    db.conn()
+        .execute_batch(&format!("DELETE FROM {REINDEX_PENDING_TABLE};"))
+        .context("failed to reset reindex pending table")?;
+
+    let vectors_exist = reindex_vectors_exist(db)?;
+    let mut values = Vec::new();
+    let mut sql = if vectors_exist {
+        values.push(rusqlite::types::Value::Text(
+            CURRENT_VECTOR_INDEX_VERSION.to_string(),
+        ));
+        values.push(rusqlite::types::Value::Text(target_fingerprint.to_string()));
+        format!(
+            r#"
+                INSERT INTO {REINDEX_PENDING_TABLE} (id, source_path, chunk_index)
                 SELECT d.id,
-                       d.content,
-                       d.content_hash,
                        COALESCE(d.source_file, d.id) AS source_path,
-                       COALESCE(d.chunk_index, 0) AS chunk_index,
-                       d.project_id
+                       COALESCE(d.chunk_index, 0) AS chunk_index
                 FROM drawers d
                 LEFT JOIN drawer_vectors v ON v.id = d.id
                 LEFT JOIN fork_ext_meta idx
@@ -9739,82 +9762,154 @@ fn reindex_stale_batch_rows(
                       OR COALESCE(fp.value, '') != ?
                   )
                 "#
-        .to_string();
-        let mut values = vec![
-            rusqlite::types::Value::Text(CURRENT_VECTOR_INDEX_VERSION.to_string()),
-            rusqlite::types::Value::Text(target_fingerprint.to_string()),
-        ];
-        append_reindex_target_filters(&mut sql, &mut values, target, "d");
-        sql.push_str(&format!(
-            " AND d.id NOT IN (SELECT id FROM {REINDEX_SKIPPED_TABLE})"
-        ));
-        sql.push_str(
-            r#"
-                ORDER BY source_path ASC, chunk_index ASC, d.id ASC
-                LIMIT ?
-                "#,
-        );
-        values.push(rusqlite::types::Value::Integer(limit));
-        let mut stmt = db
-            .conn()
-            .prepare(&sql)
-            .context("failed to prepare stale vector batch query")?;
-        stmt.query_map(rusqlite::params_from_iter(values.iter()), |row| {
-            Ok(ReindexRow {
-                id: row.get(0)?,
-                content: row.get(1)?,
-                content_hash: row.get(2)?,
-                source_path: row.get(3)?,
-                chunk_index: row.get(4)?,
-                project_id: row.get(5)?,
-            })
-        })
-        .context("failed to query stale vector batch")?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context("failed to collect stale vector batch")?
+        )
     } else {
-        let mut sql = r#"
-                SELECT id,
-                       content,
-                       content_hash,
-                       COALESCE(source_file, id) AS source_path,
-                       COALESCE(chunk_index, 0) AS chunk_index,
-                       project_id
-                FROM drawers
-                WHERE deleted_at IS NULL
-                "#
-        .to_string();
-        let mut values = Vec::new();
-        append_reindex_target_filters(&mut sql, &mut values, target, "");
-        sql.push_str(&format!(
-            " AND id NOT IN (SELECT id FROM {REINDEX_SKIPPED_TABLE})"
-        ));
-        sql.push_str(
+        format!(
             r#"
-                ORDER BY source_path ASC, chunk_index ASC, id ASC
-                LIMIT ?
-                "#,
-        );
-        values.push(rusqlite::types::Value::Integer(limit));
-        let mut stmt = db
-            .conn()
-            .prepare(&sql)
-            .context("failed to prepare missing-vector batch query")?;
-        stmt.query_map(rusqlite::params_from_iter(values.iter()), |row| {
-            Ok(ReindexRow {
-                id: row.get(0)?,
-                content: row.get(1)?,
-                content_hash: row.get(2)?,
-                source_path: row.get(3)?,
-                chunk_index: row.get(4)?,
-                project_id: row.get(5)?,
-            })
-        })
-        .context("failed to query missing-vector batch")?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .context("failed to collect missing-vector batch")?
+                INSERT INTO {REINDEX_PENDING_TABLE} (id, source_path, chunk_index)
+                SELECT d.id,
+                       COALESCE(d.source_file, d.id) AS source_path,
+                       COALESCE(d.chunk_index, 0) AS chunk_index
+                FROM drawers d
+                WHERE d.deleted_at IS NULL
+                "#
+        )
     };
-    Ok(rows)
+    append_reindex_target_filters(&mut sql, &mut values, target, "d");
+    sql.push_str(&format!(
+        " AND d.id NOT IN (SELECT id FROM {REINDEX_SKIPPED_TABLE})"
+    ));
+    sql.push_str(" ORDER BY 2 ASC, 3 ASC, 1 ASC");
+    if let Some(limit) = target.limit {
+        let limit = i64::try_from(limit).context("target limit is too large")?;
+        sql.push_str(" LIMIT ?");
+        values.push(rusqlite::types::Value::Integer(limit));
+    }
+    db.conn()
+        .execute(&sql, rusqlite::params_from_iter(values.iter()))
+        .context("failed to build stale reindex pending rows")
+}
+
+fn pull_reindex_pending_batch(db: &Database, batch_size: usize) -> Result<Vec<ReindexRow>> {
+    let limit = i64::try_from(batch_size).context("batch size is too large")?;
+    ensure_reindex_pending_table(db)?;
+    let mut stmt = db
+        .conn()
+        .prepare(&format!(
+            r#"
+                SELECT p.id,
+                       d.content,
+                       d.content_hash,
+                       p.source_path,
+                       p.chunk_index,
+                       d.project_id
+                FROM {REINDEX_PENDING_TABLE} p
+                JOIN drawers d ON d.id = p.id
+                LIMIT ?
+                "#
+        ))
+        .context("failed to prepare stale reindex pending batch query")?;
+    stmt.query_map([limit], |row| {
+        Ok(ReindexRow {
+            id: row.get(0)?,
+            content: row.get(1)?,
+            content_hash: row.get(2)?,
+            source_path: row.get(3)?,
+            chunk_index: row.get(4)?,
+            project_id: row.get(5)?,
+        })
+    })
+    .context("failed to query stale reindex pending batch")?
+    .collect::<std::result::Result<Vec<_>, _>>()
+    .context("failed to collect stale reindex pending batch")
+}
+
+fn delete_reindex_pending_ids(db: &Database, ids: &[String]) -> Result<usize> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    ensure_reindex_pending_table(db)?;
+    let placeholders = std::iter::repeat_n("?", ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!("DELETE FROM {REINDEX_PENDING_TABLE} WHERE id IN ({placeholders})");
+    let values = ids
+        .iter()
+        .cloned()
+        .map(rusqlite::types::Value::Text)
+        .collect::<Vec<_>>();
+    db.conn()
+        .execute(&sql, rusqlite::params_from_iter(values.iter()))
+        .context("failed to delete stale reindex pending ids")
+}
+
+#[cfg(test)]
+fn reindex_pending_count(db: &Database) -> Result<i64> {
+    ensure_reindex_pending_table(db)?;
+    db.conn()
+        .query_row(
+            &format!("SELECT COUNT(*) FROM {REINDEX_PENDING_TABLE}"),
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to count stale reindex pending rows")
+}
+
+#[cfg(test)]
+fn reindex_skipped_count(db: &Database) -> Result<i64> {
+    ensure_reindex_skipped_table(db)?;
+    db.conn()
+        .query_row(
+            &format!("SELECT COUNT(*) FROM {REINDEX_SKIPPED_TABLE}"),
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to count skipped stale reindex rows")
+}
+
+#[cfg(test)]
+fn reindex_pending_ids(db: &Database) -> Result<Vec<String>> {
+    ensure_reindex_pending_table(db)?;
+    let mut stmt = db
+        .conn()
+        .prepare(&format!(
+            "SELECT id FROM {REINDEX_PENDING_TABLE} ORDER BY rowid ASC"
+        ))
+        .context("failed to prepare stale reindex pending ids query")?;
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .context("failed to query stale reindex pending ids")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect stale reindex pending ids")
+}
+
+#[cfg(test)]
+fn reindex_skipped_ids(db: &Database) -> Result<Vec<String>> {
+    ensure_reindex_skipped_table(db)?;
+    let mut stmt = db
+        .conn()
+        .prepare(&format!(
+            "SELECT id FROM {REINDEX_SKIPPED_TABLE} ORDER BY id ASC"
+        ))
+        .context("failed to prepare stale reindex skipped ids query")?;
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .context("failed to query stale reindex skipped ids")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect stale reindex skipped ids")
+}
+
+#[cfg(test)]
+fn reindex_vector_ids(db: &Database) -> Result<Vec<String>> {
+    if !reindex_vectors_exist(db)? {
+        return Ok(Vec::new());
+    }
+    let mut stmt = db
+        .conn()
+        .prepare("SELECT id FROM drawer_vectors ORDER BY id ASC")
+        .context("failed to prepare vector ids query")?;
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .context("failed to query vector ids")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to collect vector ids")
 }
 
 fn write_reindex_vector_batch(
@@ -11228,6 +11323,116 @@ fn phase3_adoption_wrap_command(db: &Database, opts: WrapCommandOpts) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    const TEST_TARGET_FINGERPRINT: &str = "test-embedder:8:target";
+
+    #[derive(Default)]
+    struct RecordingEmbedder {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingEmbedder {
+        fn seen_texts(&self) -> Vec<String> {
+            self.seen
+                .lock()
+                .expect("recording embedder mutex poisoned")
+                .clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for RecordingEmbedder {
+        async fn embed(
+            &self,
+            texts: &[&str],
+        ) -> std::result::Result<Vec<Vec<f32>>, mempal::embed::EmbedError> {
+            self.seen
+                .lock()
+                .expect("recording embedder mutex poisoned")
+                .extend(texts.iter().map(|text| (*text).to_string()));
+            Ok(texts.iter().map(|text| test_vector(text)).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        fn name(&self) -> &str {
+            "recording-test"
+        }
+    }
+
+    #[derive(Default)]
+    struct FailFirstBatchEmbedder {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for FailFirstBatchEmbedder {
+        async fn embed(
+            &self,
+            texts: &[&str],
+        ) -> std::result::Result<Vec<Vec<f32>>, mempal::embed::EmbedError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Err(mempal::embed::EmbedError::Runtime(
+                    "forced test batch failure".to_string(),
+                ));
+            }
+            Ok(texts.iter().map(|text| test_vector(text)).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        fn name(&self) -> &str {
+            "fail-first-test"
+        }
+    }
+
+    fn test_vector(text: &str) -> Vec<f32> {
+        vec![text.len() as f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    }
+
+    fn empty_reindex_target(limit: Option<usize>) -> ReindexVectorTarget {
+        ReindexVectorTarget {
+            drawer_ids: Vec::new(),
+            project_id: None,
+            wing: None,
+            room: None,
+            limit,
+        }
+    }
+
+    fn insert_reindex_test_drawer(
+        db: &Database,
+        id: &str,
+        content: &str,
+        source_file: &str,
+        chunk_index: i64,
+    ) {
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: id.to_string(),
+                content: content.to_string(),
+                wing: "test".to_string(),
+                room: Some("reindex".to_string()),
+                source_file: Some(source_file.to_string()),
+                source_type: SourceType::AgentInference,
+                added_at: format!("171300000{chunk_index}"),
+                chunk_index: Some(chunk_index),
+                ..Drawer::default()
+            },
+            Some("default"),
+        )
+        .expect("insert reindex test drawer");
+    }
 
     /// Regression for issue #249: `mempal xurl timeline` aborted with
     /// "byte index 300 is not a char boundary" when a turn's content had a
@@ -11258,6 +11463,197 @@ mod tests {
         assert_eq!(char_safe_preview(content, 300), content);
     }
 
+    #[tokio::test]
+    async fn reindex_stale_batches_processes_snapshot_once_and_drains_pending() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        db.recreate_vectors_table(8).expect("create vector table");
+        for i in 0i64..5 {
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
+        }
+
+        let embedder = RecordingEmbedder::default();
+        reindex_stale_batches(
+            &db,
+            &embedder,
+            "recording-test",
+            TEST_TARGET_FINGERPRINT,
+            2,
+            empty_reindex_target(None),
+            BatchRetryPolicy {
+                interval: std::time::Duration::from_millis(0),
+                max_retries: 0,
+            },
+        )
+        .await
+        .expect("stale reindex batches");
+
+        let seen = embedder.seen_texts();
+        let unique_seen = seen.iter().cloned().collect::<BTreeSet<_>>();
+        assert_eq!(seen.len(), 5, "all stale drawers are embedded once");
+        assert_eq!(unique_seen.len(), 5, "no stale drawer is embedded twice");
+        assert_eq!(
+            reindex_pending_count(&db).expect("pending count"),
+            0,
+            "pending work list is drained"
+        );
+        assert_eq!(
+            db.vector_row_count().expect("vector count"),
+            5,
+            "all stale drawers receive vectors"
+        );
+        for i in 0..5 {
+            assert_eq!(
+                load_reindex_metadata(&db, &format!("d-{i}"), "embedder_fingerprint")
+                    .expect("load fingerprint")
+                    .as_deref(),
+                Some(TEST_TARGET_FINGERPRINT)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn reindex_stale_batches_skips_failed_batch_and_finishes_later_batches() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        db.recreate_vectors_table(8).expect("create vector table");
+        for i in 0i64..4 {
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
+        }
+
+        let embedder = FailFirstBatchEmbedder::default();
+        reindex_stale_batches(
+            &db,
+            &embedder,
+            "fail-first-test",
+            TEST_TARGET_FINGERPRINT,
+            2,
+            empty_reindex_target(None),
+            BatchRetryPolicy {
+                interval: std::time::Duration::from_millis(0),
+                max_retries: 0,
+            },
+        )
+        .await
+        .expect("stale reindex with skipped first batch");
+
+        assert_eq!(
+            embedder.calls.load(Ordering::SeqCst),
+            2,
+            "failed batch is not retried when max_retries is zero"
+        );
+        assert_eq!(
+            reindex_pending_count(&db).expect("pending count"),
+            0,
+            "failed and successful batches are both removed from pending"
+        );
+        assert_eq!(
+            reindex_skipped_count(&db).expect("skipped count"),
+            2,
+            "failed batch ids are reported through the skip table"
+        );
+        assert_eq!(
+            reindex_skipped_ids(&db).expect("skipped ids"),
+            vec!["d-0".to_string(), "d-1".to_string()]
+        );
+        assert_eq!(
+            reindex_vector_ids(&db).expect("vector ids"),
+            vec!["d-2".to_string(), "d-3".to_string()],
+            "later batches still complete"
+        );
+    }
+
+    #[test]
+    fn reindex_stale_pending_snapshot_excludes_current_fingerprint() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        insert_reindex_test_drawer(&db, "fresh", "fresh content", "fixtures/source.txt", 0);
+        insert_reindex_test_drawer(&db, "stale", "stale content", "fixtures/source.txt", 1);
+        db.insert_vector_with_project("fresh", &[0.1_f32; 8], Some("default"))
+            .expect("insert fresh vector");
+        record_reindex_metadata(
+            &db,
+            "fresh",
+            CURRENT_VECTOR_INDEX_VERSION,
+            TEST_TARGET_FINGERPRINT,
+        )
+        .expect("record fresh metadata");
+
+        let inserted = build_reindex_stale_pending_rows(
+            &db,
+            TEST_TARGET_FINGERPRINT,
+            &empty_reindex_target(None),
+        )
+        .expect("build stale pending rows");
+
+        assert_eq!(inserted, 1);
+        assert_eq!(
+            reindex_pending_ids(&db).expect("pending ids"),
+            vec!["stale".to_string()],
+            "drawer with current fingerprint is excluded"
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_stale_batches_limit_caps_snapshot() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        db.recreate_vectors_table(8).expect("create vector table");
+        for i in 0i64..5 {
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
+        }
+
+        let embedder = RecordingEmbedder::default();
+        reindex_stale_batches(
+            &db,
+            &embedder,
+            "recording-test",
+            TEST_TARGET_FINGERPRINT,
+            2,
+            empty_reindex_target(Some(3)),
+            BatchRetryPolicy {
+                interval: std::time::Duration::from_millis(0),
+                max_retries: 0,
+            },
+        )
+        .await
+        .expect("limited stale reindex");
+
+        assert_eq!(
+            embedder.seen_texts().len(),
+            3,
+            "--limit caps the snapshot size"
+        );
+        assert_eq!(
+            db.vector_row_count().expect("vector count"),
+            3,
+            "only the limited snapshot is re-embedded"
+        );
+        assert_eq!(
+            reindex_pending_count(&db).expect("pending count"),
+            0,
+            "limited pending work list is drained"
+        );
+    }
+
     /// Issue #304: failed-batch drawer IDs were expanded into
     /// `NOT IN (?, ?, ...)` placeholders, so a `reindex --stale` run that
     /// skipped more than SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32766) drawers'
@@ -11274,21 +11670,7 @@ mod tests {
         // A live drawer that already has a vector but no reindex metadata, so it
         // is stale for any target fingerprint and must be re-selected after the
         // skipped IDs are excluded.
-        db.insert_drawer_with_project(
-            &Drawer {
-                id: "live-1".to_string(),
-                content: "keep me".to_string(),
-                wing: "test".to_string(),
-                room: Some("reindex".to_string()),
-                source_file: Some("fixtures/source.txt".to_string()),
-                source_type: SourceType::AgentInference,
-                added_at: "1713000000".to_string(),
-                chunk_index: Some(0),
-                ..Drawer::default()
-            },
-            Some("default"),
-        )
-        .expect("insert live drawer");
+        insert_reindex_test_drawer(&db, "live-1", "keep me", "fixtures/source.txt", 0);
         db.insert_vector_with_project("live-1", &[0.1_f32; 8], Some("default"))
             .expect("insert live vector");
 
@@ -11301,18 +11683,16 @@ mod tests {
         let skipped: Vec<String> = (0..over_limit).map(|i| format!("skip-{i}")).collect();
         stage_reindex_skipped_ids(&db, &skipped).expect("stage skipped ids");
 
-        let target = ReindexVectorTarget {
-            drawer_ids: Vec::new(),
-            project_id: None,
-            wing: None,
-            room: None,
-            limit: None,
-        };
-
         // Must NOT error with "too many SQL variables".
-        let rows = reindex_stale_batch_rows(&db, "target-fingerprint", 512, &target)
-            .expect("stale batch query must not hit the SQLite variable limit");
+        let inserted = build_reindex_stale_pending_rows(
+            &db,
+            "target-fingerprint",
+            &empty_reindex_target(None),
+        )
+        .expect("stale snapshot must not hit the SQLite variable limit");
+        let rows = pull_reindex_pending_batch(&db, 512).expect("pull stale pending batch");
 
+        assert_eq!(inserted, 1, "only the live stale drawer is snapshotted");
         assert!(
             rows.iter().any(|row| row.id == "live-1"),
             "the live stale drawer must still be selected"
@@ -11327,38 +11707,28 @@ mod tests {
     /// drawer — the #304 TEMP-table exclusion must not change clean-run output.
     /// This drives the no-vectors branch of the stale selection.
     #[test]
-    fn reindex_stale_batch_rows_returns_all_when_nothing_skipped() {
+    fn reindex_stale_pending_snapshot_returns_all_when_nothing_skipped() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
         for i in 0i64..3 {
-            db.insert_drawer_with_project(
-                &Drawer {
-                    id: format!("d-{i}"),
-                    content: format!("content {i}"),
-                    wing: "test".to_string(),
-                    room: Some("reindex".to_string()),
-                    source_file: Some("fixtures/source.txt".to_string()),
-                    source_type: SourceType::AgentInference,
-                    added_at: format!("171300000{i}"),
-                    chunk_index: Some(i),
-                    ..Drawer::default()
-                },
-                Some("default"),
-            )
-            .expect("insert drawer");
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
         }
 
-        let target = ReindexVectorTarget {
-            drawer_ids: Vec::new(),
-            project_id: None,
-            wing: None,
-            room: None,
-            limit: None,
-        };
+        let inserted = build_reindex_stale_pending_rows(
+            &db,
+            "target-fingerprint",
+            &empty_reindex_target(None),
+        )
+        .expect("clean stale snapshot");
+        let rows = pull_reindex_pending_batch(&db, 512).expect("pull clean stale pending rows");
 
-        let rows = reindex_stale_batch_rows(&db, "target-fingerprint", 512, &target)
-            .expect("clean stale batch query");
-
+        assert_eq!(inserted, 3);
         assert_eq!(
             rows.len(),
             3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9701,7 +9701,7 @@ fn ensure_reindex_pending_table(db: &Database) -> Result<()> {
     db.conn()
         .execute_batch(&format!(
             "CREATE TEMP TABLE IF NOT EXISTS {REINDEX_PENDING_TABLE} (
-                id TEXT,
+                id TEXT PRIMARY KEY,
                 source_path TEXT,
                 chunk_index INTEGER
             );"
@@ -9805,6 +9805,7 @@ fn pull_reindex_pending_batch(db: &Database, batch_size: usize) -> Result<Vec<Re
                        d.project_id
                 FROM {REINDEX_PENDING_TABLE} p
                 JOIN drawers d ON d.id = p.id
+                ORDER BY p.rowid ASC
                 LIMIT ?
                 "#
         ))
@@ -9829,18 +9830,23 @@ fn delete_reindex_pending_ids(db: &Database, ids: &[String]) -> Result<usize> {
         return Ok(0);
     }
     ensure_reindex_pending_table(db)?;
-    let placeholders = std::iter::repeat_n("?", ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let sql = format!("DELETE FROM {REINDEX_PENDING_TABLE} WHERE id IN ({placeholders})");
-    let values = ids
-        .iter()
-        .cloned()
-        .map(rusqlite::types::Value::Text)
-        .collect::<Vec<_>>();
-    db.conn()
-        .execute(&sql, rusqlite::params_from_iter(values.iter()))
-        .context("failed to delete stale reindex pending ids")
+    let mut deleted = 0usize;
+    for chunk in ids.chunks(999) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("DELETE FROM {REINDEX_PENDING_TABLE} WHERE id IN ({placeholders})");
+        let values = chunk
+            .iter()
+            .cloned()
+            .map(rusqlite::types::Value::Text)
+            .collect::<Vec<_>>();
+        deleted += db
+            .conn()
+            .execute(&sql, rusqlite::params_from_iter(values.iter()))
+            .context("failed to delete stale reindex pending ids")?;
+    }
+    Ok(deleted)
 }
 
 #[cfg(test)]
@@ -11700,6 +11706,71 @@ mod tests {
         assert!(
             rows.iter().all(|row| !row.id.starts_with("skip-")),
             "skipped drawers must remain excluded for the rest of the run"
+        );
+    }
+
+    #[test]
+    fn reindex_pending_delete_chunks_more_than_999_ids() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        for i in 0i64..1_500 {
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i:04}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
+        }
+
+        let inserted = build_reindex_stale_pending_rows(
+            &db,
+            "target-fingerprint",
+            &empty_reindex_target(None),
+        )
+        .expect("build stale pending rows");
+        let ids = reindex_pending_ids(&db).expect("pending ids");
+        let deleted = delete_reindex_pending_ids(&db, &ids)
+            .expect("chunked delete must not hit SQLite variable limit");
+
+        assert_eq!(inserted, 1_500);
+        assert_eq!(ids.len(), 1_500);
+        assert_eq!(deleted, 1_500);
+        assert_eq!(
+            reindex_pending_count(&db).expect("pending count"),
+            0,
+            "chunked delete removes every pending row"
+        );
+    }
+
+    #[test]
+    fn reindex_pending_pull_preserves_snapshot_order() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        insert_reindex_test_drawer(&db, "b-0", "b content", "fixtures/b.txt", 0);
+        insert_reindex_test_drawer(&db, "a-2", "a2 content", "fixtures/a.txt", 2);
+        insert_reindex_test_drawer(&db, "a-1b", "a1b content", "fixtures/a.txt", 1);
+        insert_reindex_test_drawer(&db, "a-1a", "a1a content", "fixtures/a.txt", 1);
+
+        let inserted = build_reindex_stale_pending_rows(
+            &db,
+            "target-fingerprint",
+            &empty_reindex_target(None),
+        )
+        .expect("build stale pending rows");
+        let rows = pull_reindex_pending_batch(&db, 10).expect("pull pending rows");
+        let ids = rows.into_iter().map(|row| row.id).collect::<Vec<_>>();
+
+        assert_eq!(inserted, 4);
+        assert_eq!(
+            ids,
+            vec![
+                "a-1a".to_string(),
+                "a-1b".to_string(),
+                "a-2".to_string(),
+                "b-0".to_string()
+            ],
+            "pull order follows the source_path, chunk_index, id snapshot order"
         );
     }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "7e83c771cb234123d55ab4c15d4f31340fb3532e"
+commit = "a4933d0e5bb12b402d52d2f682c8b38623c0740b"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "c6cc924647912809f0aeeefe9549fcfa33639708"
+commit = "7e83c771cb234123d55ab4c15d4f31340fb3532e"
 source_kind = "git"


### PR DESCRIPTION
## Summary

`mempal reindex --from-config --stale` on a 9.96 GB `palace.db` (~516k drawers) was crawling at ~0.66 drawer/sec with the embedding GPU **idle**. The bottleneck was a local SQLite `pread64` read storm (~91k/s, kernel-mode 81%) — not embedding, not the network. This PR fixes the root cause and makes reindex embedder-bound, within a strict ≤4 GB peak-memory budget.

## Root cause — O(n²) stale reselection

`reindex_stale_batches` re-ran `reindex_stale_batch_rows` **once per batch**, and that query re-scanned + re-sorted the **entire remaining stale set every iteration**:
- three correlated `LEFT JOIN fork_ext_meta` on string-concat keys (`'reindex:' || d.id || ':index_version'`, `:normalize_version`, `:embedder_fingerprint`),
- `ORDER BY source_path` where `source_path = COALESCE(d.source_file, d.id)` is a **computed** column (no usable index → full materialize + sort),
- staleness `WHERE` (`v.id IS NULL OR idx/fp mismatch`).

As each batch re-embedded drawers (making them non-stale), the next batch still re-scanned everything not-yet-done from the start → **O(n²)**, ~1000 batches × full re-scan/re-sort, all served from disk through SQLite's default 2 MB page cache → the `pread64` storm.

## Fix — O(n) snapshot work-list (algorithmic, memory-light)

Peak memory must stay **≤4 GB**, which rules out the "throw memory at it" option (a multi-GB `mmap_size` covering the ~8.5 GB hot region would push RSS well past 4 GB). So the fix is algorithmic:

- At the start of the run, build the stale-id work-list **once** into a connection-local TEMP table `tmp_reindex_pending(id, source_path, chunk_index)`, sorted a single time (`ORDER BY source_path, chunk_index, id`).
- Loop: pull `LIMIT batch_size` rows from pending **with no re-sort** (rows come out source-grouped from the sorted insert), JOIN `drawers` for fresh `content`/`project_id`, embed, write, then `DELETE` the processed ids from pending. On embed failure past retries, stage into `tmp_reindex_skipped` and DELETE from pending.
- Every pulled id is removed each iteration → **guaranteed termination** + **O(n)** single pass. Each DB page is now read ~once, so reindex becomes embedder-bound (GPU busy).

Secondary: `cache_size = -262144` (256 MB) at both connection-open sites (`src/core/db.rs` `open_with_mode`, `src/core/reindex.rs` `open_connection`). **No `mmap_size`** and no multi-GB cache — the 4 GB budget forbids it; the O(n) pass is what removes the read amplification, not a big cache.

## Review hardening (commit `6a681ec`)

Tier-4 cross-family review of the snapshot commit caught three defects, all fixed:

- **CRITICAL** — `tmp_reindex_pending.id` had no index, so the per-batch `DELETE … WHERE id IN (…)` full-scanned the temp table every batch, **reintroducing O(n²)** (the bottleneck merely moved from the SELECT to the DELETE). Fixed by `id TEXT PRIMARY KEY` (index-backed deletes, O(b log n); the implicit rowid still preserves insertion order).
- **HIGH** — the pull query had no `ORDER BY`, letting the planner drive the join from the `drawers` index and scramble file-sequential order. Fixed with `ORDER BY p.rowid ASC` (sequential temp-table traversal in insertion order).
- **HIGH** — `delete_reindex_pending_ids` bound one variable per id, so a `--batch-size` above `SQLITE_MAX_VARIABLE_NUMBER` (32766) crashed after the first batch. Fixed by chunking deletes at 999 ids.

Regression tests added for the chunked delete (>999 ids) and the deterministic pull order.

## Preserved invariants

- #301 skip-continue (bounded retry → skip), #304 bounded-skip (`tmp_reindex_skipped`, no giant `NOT IN`), #302 recreate-atomicity (`finalize_reindex_atomicity`) — all unchanged.
- Concurrently-updated rows stay stale and are picked up by a later `--stale` run (unchanged "must terminate" contract).

## Validation

- New tests: all-stale-processed-once, fail→skip→terminates (no infinite loop), non-stale-excluded, `--limit` cap, pragma asserts `cache_size=-262144` **and** `mmap_size=0` (guards the memory budget).
- `just fmt` / `just clippy -D warnings` / `just test` green (lefthook pre-commit gate).
- tier-4 cross-family review.

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
