### PR TITLE
fix(mcp): defer gating prototype prewarm off serve --mcp startup critical path (#315)

### DIFF
--- a/src/ingest/gating.rs
+++ b/src/ingest/gating.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::core::config::{
     AutoFactCheckConfig, Config, EmbeddingClassifierConfig, GatingRuleConfig, IngestGatingConfig,
@@ -9,7 +9,7 @@ use crate::factcheck::{self, FactIssue};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::OnceCell;
+use tokio::{sync::OnceCell, task::JoinHandle};
 
 const MIN_SIGNAL_BYTES: usize = 12;
 const MAX_PROTOTYPE_COUNT: usize = 64;
@@ -202,16 +202,66 @@ impl GatingRuntime {
         Ok(())
     }
 
+    pub fn validate_config_shape(&self) -> Result<(), GatingInitError> {
+        validate_classifier_config(&self.config.ingest_gating.embedding_classifier)
+    }
+
     pub async fn initialize_from_config(&self) -> Result<(), GatingInitError> {
-        let classifier = compile_classifier_from_config(&self.config).await?;
+        self.validate_config_shape()?;
+        if !tier2_enabled(&self.config.ingest_gating) {
+            return Ok(());
+        }
+        let embedder = self
+            .factory
+            .build()
+            .await
+            .map_err(GatingInitError::BuildEmbedder)?;
+        let classifier = compile_classifier(
+            &self.config.ingest_gating.embedding_classifier,
+            embedder.as_ref(),
+        )
+        .await?;
         let _ = self.classifier.set(classifier);
         Ok(())
+    }
+
+    pub async fn initialize_from_config_with_deadline(
+        &self,
+        deadline: Duration,
+    ) -> Result<(), GatingInitError> {
+        self.validate_config_shape()?;
+        match tokio::time::timeout(deadline, self.initialize_from_config()).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::warn!(
+                    deadline_secs = deadline.as_secs_f32(),
+                    "gating prototype initialization exceeded deadline; deferring to lazy classifier init"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    pub fn spawn_initialize_from_config(self: &Arc<Self>, deadline: Duration) -> JoinHandle<()> {
+        let runtime = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(error) = runtime.initialize_from_config_with_deadline(deadline).await {
+                tracing::warn!(
+                    error = %error,
+                    "gating prototype initialization failed; deferring to lazy classifier init"
+                );
+            }
+        })
     }
 
     pub async fn classifier(&self) -> Result<Option<PrototypeClassifier>, GatingInitError> {
         let classifier = self
             .classifier
             .get_or_try_init(|| async {
+                if !tier2_enabled(&self.config.ingest_gating) {
+                    return Ok(None);
+                }
+                self.validate_config_shape()?;
                 let embedder = self
                     .factory
                     .build()
@@ -536,6 +586,33 @@ async fn compile_classifier<E: Embedder + ?Sized>(
     Prototypes::load(config, embedder).await
 }
 
+fn validate_classifier_config(config: &EmbeddingClassifierConfig) -> Result<(), GatingInitError> {
+    if !config.enabled || config.prototypes.is_empty() {
+        return Ok(());
+    }
+
+    if config.prototypes.len() > MAX_PROTOTYPE_COUNT {
+        return Err(GatingInitError::PrototypeCountLimit {
+            actual: config.prototypes.len(),
+            limit: MAX_PROTOTYPE_COUNT,
+        });
+    }
+
+    for (index, raw_label) in config.prototypes.iter().enumerate() {
+        let label = prototype_display_label(index, raw_label);
+        let actual_bytes = raw_label.len();
+        if actual_bytes > MAX_PROTOTYPE_LEN_BYTES {
+            return Err(GatingInitError::PrototypeTooLong {
+                label,
+                actual_bytes,
+                limit_bytes: MAX_PROTOTYPE_LEN_BYTES,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 impl Prototypes {
     async fn load<E: Embedder + ?Sized>(
         config: &EmbeddingClassifierConfig,
@@ -545,47 +622,44 @@ impl Prototypes {
             return Ok(None);
         }
 
-        if config.prototypes.len() > MAX_PROTOTYPE_COUNT {
-            return Err(GatingInitError::PrototypeCountLimit {
-                actual: config.prototypes.len(),
-                limit: MAX_PROTOTYPE_COUNT,
-            });
-        }
+        validate_classifier_config(config)?;
 
+        let labels = config
+            .prototypes
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        let vectors =
+            embedder
+                .embed(&labels)
+                .await
+                .map_err(|source| GatingInitError::PrototypeEmbed {
+                    label: prototype_embed_error_label(&config.prototypes),
+                    source,
+                })?;
+        let expected = embedder.dimensions();
         let mut prototypes = Vec::with_capacity(config.prototypes.len());
         for (index, raw_label) in config.prototypes.iter().enumerate() {
             let label = prototype_display_label(index, raw_label);
-            let actual_bytes = raw_label.len();
-            if actual_bytes > MAX_PROTOTYPE_LEN_BYTES {
-                return Err(GatingInitError::PrototypeTooLong {
-                    label,
-                    actual_bytes,
-                    limit_bytes: MAX_PROTOTYPE_LEN_BYTES,
-                });
-            }
-
-            let vectors = embedder
-                .embed(&[raw_label.as_str()])
-                .await
-                .map_err(|source| GatingInitError::PrototypeEmbed {
+            let vector = vectors.get(index).cloned().ok_or_else(|| {
+                GatingInitError::PrototypeDimMismatch {
                     label: label.clone(),
-                    source,
-                })?;
-            if let Some(vector) = vectors.into_iter().next() {
-                let actual = vector.len();
-                let expected = embedder.dimensions();
-                if actual != expected {
-                    return Err(GatingInitError::PrototypeDimMismatch {
-                        label,
-                        expected,
-                        actual,
-                    });
+                    expected,
+                    actual: 0,
                 }
-                prototypes.push(EmbeddedPrototype {
-                    label: raw_label.clone(),
-                    vector,
+            })?;
+            let actual = vector.len();
+            if actual != expected {
+                return Err(GatingInitError::PrototypeDimMismatch {
+                    label,
+                    expected,
+                    actual,
                 });
             }
+            prototypes.push(EmbeddedPrototype {
+                label: raw_label.clone(),
+                vector,
+            });
         }
 
         Ok(Some(PrototypeClassifier { prototypes }))
@@ -774,4 +848,16 @@ fn prototype_display_label(index: usize, raw_label: &str) -> String {
         return trimmed.to_string();
     }
     format!("prototype#{}", index + 1)
+}
+
+fn prototype_embed_error_label(raw_labels: &[String]) -> String {
+    match raw_labels {
+        [raw_label] => prototype_display_label(0, raw_label),
+        [first, ..] => format!(
+            "{}..{}",
+            prototype_display_label(0, first),
+            raw_labels.len()
+        ),
+        [] => "prototype#0".to_string(),
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -164,9 +164,17 @@ impl MempalMcpServer {
         crate::mcp::logging::init_stdio_log_sink(ConfigHandle::current().as_ref())
             .context("failed to initialize MCP log sink")?;
         self.gating_runtime
-            .initialize_from_config()
-            .await
-            .context("failed to initialize ingest gating")?;
+            .validate_config_shape()
+            .context("failed to validate ingest gating config")?;
+        let _gating_init_task =
+            self.gating_runtime
+                .spawn_initialize_from_config(Duration::from_secs(
+                    ConfigHandle::current()
+                        .as_ref()
+                        .embed
+                        .retry
+                        .search_deadline_secs,
+                ));
         self.serve(rmcp::transport::stdio())
             .await
             .context("failed to initialize MCP stdio transport")

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -4,10 +4,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, OnceLock,
+    Arc, Mutex, OnceLock,
     atomic::{AtomicUsize, Ordering},
 };
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use common::harness::AlwaysFailMigrationHook;
@@ -81,6 +81,31 @@ struct DeterministicEmbedder {
     fail_on: Arc<Vec<String>>,
 }
 
+#[derive(Clone)]
+struct CountingEmbedderFactory {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+    build_count: Arc<AtomicUsize>,
+    call_count: Arc<AtomicUsize>,
+    batch_sizes: Arc<Mutex<Vec<usize>>>,
+    delay: Duration,
+}
+
+struct CountingEmbedder {
+    vectors: Arc<HashMap<String, Vec<f32>>>,
+    default_vector: Vec<f32>,
+    call_count: Arc<AtomicUsize>,
+    batch_sizes: Arc<Mutex<Vec<usize>>>,
+    delay: Duration,
+}
+
+type CountingFactoryWithBuildCount = (
+    Arc<CountingEmbedderFactory>,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<usize>>>,
+);
+
 #[async_trait]
 impl EmbedderFactory for DeterministicEmbedderFactory {
     async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
@@ -119,6 +144,51 @@ impl Embedder for DeterministicEmbedder {
 
     fn name(&self) -> &str {
         "deterministic"
+    }
+}
+
+#[async_trait]
+impl EmbedderFactory for CountingEmbedderFactory {
+    async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
+        self.build_count.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::new(CountingEmbedder {
+            vectors: Arc::clone(&self.vectors),
+            default_vector: self.default_vector.clone(),
+            call_count: Arc::clone(&self.call_count),
+            batch_sizes: Arc::clone(&self.batch_sizes),
+            delay: self.delay,
+        }))
+    }
+}
+
+#[async_trait]
+impl Embedder for CountingEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        self.batch_sizes
+            .lock()
+            .expect("batch sizes lock")
+            .push(texts.len());
+        if !self.delay.is_zero() {
+            tokio::time::sleep(self.delay).await;
+        }
+        Ok(texts
+            .iter()
+            .map(|text| {
+                self.vectors
+                    .get(*text)
+                    .cloned()
+                    .unwrap_or_else(|| self.default_vector.clone())
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.default_vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "counting"
     }
 }
 
@@ -208,6 +278,44 @@ fn deterministic_factory(
         default_vector,
         fail_on: Arc::new(fail_on.iter().map(|text| (*text).to_string()).collect()),
     })
+}
+
+fn counting_factory(
+    vectors: &[(&str, Vec<f32>)],
+    default_vector: Vec<f32>,
+    delay: Duration,
+) -> (
+    Arc<CountingEmbedderFactory>,
+    Arc<AtomicUsize>,
+    Arc<Mutex<Vec<usize>>>,
+) {
+    let (factory, _build_count, call_count, batch_sizes) =
+        counting_factory_with_build_count(vectors, default_vector, delay);
+    (factory, call_count, batch_sizes)
+}
+
+fn counting_factory_with_build_count(
+    vectors: &[(&str, Vec<f32>)],
+    default_vector: Vec<f32>,
+    delay: Duration,
+) -> CountingFactoryWithBuildCount {
+    let build_count = Arc::new(AtomicUsize::new(0));
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(CountingEmbedderFactory {
+        vectors: Arc::new(
+            vectors
+                .iter()
+                .map(|(text, vector)| ((*text).to_string(), vector.clone()))
+                .collect(),
+        ),
+        default_vector,
+        build_count: Arc::clone(&build_count),
+        call_count: Arc::clone(&call_count),
+        batch_sizes: Arc::clone(&batch_sizes),
+        delay,
+    });
+    (factory, build_count, call_count, batch_sizes)
 }
 
 fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
@@ -458,6 +566,143 @@ prototypes = ["valuable"]
     assert_eq!(outcome.decision.tier, 0);
     assert_eq!(outcome.decision.label.as_deref(), Some("embedder_error"));
     assert!(outcome.vector.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_prototype_init_batches_labels_once() {
+    let _guard = test_guard().await;
+    let config = Config::parse(
+        r#"
+[config_hot_reload]
+enabled = false
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable", "noise", "decision"]
+"#,
+    )
+    .expect("parse config");
+    let (factory, call_count, batch_sizes) = counting_factory(
+        &[
+            ("valuable", vec![1.0, 0.0]),
+            ("noise", vec![0.0, 1.0]),
+            ("decision", vec![0.5, 0.5]),
+        ],
+        vec![0.2, 0.2],
+        Duration::ZERO,
+    );
+    let embedder = factory.build().await.expect("build embedder");
+
+    let classifier = compile_classifier_from_embedder(embedder.as_ref(), &config.ingest_gating)
+        .await
+        .expect("compile classifier");
+
+    assert!(classifier.is_some());
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *batch_sizes.lock().expect("batch sizes lock"),
+        vec![3],
+        "prototype labels must be embedded in one batch"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gating_init_deadline_defers_slow_embedder() {
+    let _guard = test_guard().await;
+    let config = Config::parse(
+        r#"
+[config_hot_reload]
+enabled = false
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable", "noise"]
+"#,
+    )
+    .expect("parse config");
+    let (factory, call_count, batch_sizes) = counting_factory(
+        &[("valuable", vec![1.0, 0.0]), ("noise", vec![0.0, 1.0])],
+        vec![0.2, 0.2],
+        Duration::from_millis(250),
+    );
+    let runtime = GatingRuntime::new(config, factory);
+    let started = Instant::now();
+
+    runtime
+        .initialize_from_config_with_deadline(Duration::from_millis(25))
+        .await
+        .expect("deadline init should fail open");
+
+    assert!(
+        started.elapsed() < Duration::from_millis(150),
+        "deadline init blocked for {:?}",
+        started.elapsed()
+    );
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        *batch_sizes.lock().expect("batch sizes lock"),
+        vec![2],
+        "startup prewarm should still issue one batched prototype embed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gating_disabled_skips_startup_and_lazy_embedder_build() {
+    let _guard = test_guard().await;
+    let config = Config::parse(
+        r#"
+[config_hot_reload]
+enabled = false
+
+[ingest_gating]
+enabled = false
+
+[ingest_gating.embedding_classifier]
+enabled = true
+threshold = 0.4
+prototypes = ["valuable", "noise"]
+"#,
+    )
+    .expect("parse config");
+    let (factory, build_count, call_count, batch_sizes) = counting_factory_with_build_count(
+        &[("valuable", vec![1.0, 0.0]), ("noise", vec![0.0, 1.0])],
+        vec![0.2, 0.2],
+        Duration::ZERO,
+    );
+    let runtime = GatingRuntime::new(config, factory);
+
+    runtime
+        .initialize_from_config()
+        .await
+        .expect("disabled gating init should be a no-op");
+
+    assert_eq!(build_count.load(Ordering::SeqCst), 0);
+    assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    assert!(
+        batch_sizes.lock().expect("batch sizes lock").is_empty(),
+        "disabled startup init must not embed prototypes"
+    );
+
+    let classifier = runtime
+        .classifier()
+        .await
+        .expect("disabled lazy classifier should be a no-op");
+
+    assert!(classifier.is_none());
+    assert_eq!(build_count.load(Ordering::SeqCst), 0);
+    assert_eq!(call_count.load(Ordering::SeqCst), 0);
+    assert!(
+        batch_sizes.lock().expect("batch sizes lock").is_empty(),
+        "disabled lazy classifier must not embed prototypes"
+    );
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "dad8fbc8794b14c43d92375d234aff4400b2fa07"
+commit = "ea23945eb00132e5c06027556db6cb9f9f3ccc86"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #315 — new MCP sessions intermittently failed to connect because `mempal serve --mcp` blocked the client's `initialize` handshake for >30s whenever the embedder backend was busy (e.g. during a `mempal reindex`).

**Root cause:** `serve_stdio` (`src/mcp/server.rs`) awaited `gating_runtime.initialize_from_config()` *before* `self.serve(stdio())` began answering `initialize`. That init path (`src/ingest/gating.rs` `Prototypes::load`) embedded **each gating prototype label in its own sequential `.embed()` round-trip** against the configured backend (gb10 `Qwen3-Embedding-8B`). With N prototypes × the embedder's fixed-2s-retry under contention, total init time blew past the client's ~30s `initialize` deadline → silent connection failure.

## Changes

1. **Batch prototype embeds (N → 1).** `Prototypes::load` now issues a single `embedder.embed(&all_labels)` call instead of looping N single-item calls, mapping vectors back per-label while preserving per-label length / dimension / error labelling.
2. **Bound gating init with a deadline + lazy fallback.** Prototype embedding is wrapped in a timeout; on timeout it emits a tracing warning and falls back to the existing lazy `classifier()` OnceCell path (first-ingest computes prototypes) rather than hard-failing startup. Backend latency/unreachability can no longer block startup.
3. **Move gating init off the `initialize` critical path.** `serve_stdio` no longer blocks the handshake on `initialize_from_config`; the `initialize` response returns promptly regardless of embedder latency. Malformed-config still fails fast (R3 preserved) — only backend *latency* is deferred.
4. **Preserve the gating-disabled contract.** `initialize_from_config` and the lazy `classifier()` path now guard on `tier2_enabled(...)` before building the embedder, so `[ingest_gating…] enabled = false` never triggers the heavy ONNX/TCP embedder allocation (caught in review — the deferral refactor had bypassed the original config-enabled guard).

## Test

`tests/judge_gating.rs` gains a regression test injecting a slow/failing embedder test-double, asserting (a) startup/gating-init reaches the ready state within a bounded time (not blocked on the embedder) and (b) prototype embedding is a **single batched call** (counting mock asserts `call_count == 1`).

## Quality gates

- `cargo fmt --all` clean, `just clippy` zero warnings, `just test` green (incl. the new regression test).
- Reviewed via tier-4 csa review (`main...HEAD`).

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
