### PR TITLE
feat(mcp): receipt-based async mempal_ingest — non-blocking MCP writes (PR-A, #320)

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 18;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 19;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -57,6 +57,20 @@ CREATE INDEX IF NOT EXISTS idx_drawers_reindex_source_identity_active
 pub const FORK_EXT_V18_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_ctv_embedder_metadata
     ON conversation_turn_vectors(embedder_fingerprint, dim, index_version);
+"#;
+
+pub const FORK_EXT_V19_SCHEMA_SQL: &str = r#"
+ALTER TABLE pending_messages ADD COLUMN result_drawer_id TEXT;
+ALTER TABLE pending_messages ADD COLUMN op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed'));
+ALTER TABLE pending_messages ADD COLUMN rejected_reason TEXT;
+ALTER TABLE pending_messages ADD COLUMN failure_detail TEXT;
+ALTER TABLE pending_messages ADD COLUMN result_json TEXT;
+
+ALTER TABLE pending_message_completions ADD COLUMN result_drawer_id TEXT;
+ALTER TABLE pending_message_completions ADD COLUMN op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed'));
+ALTER TABLE pending_message_completions ADD COLUMN rejected_reason TEXT;
+ALTER TABLE pending_message_completions ADD COLUMN failure_detail TEXT;
+ALTER TABLE pending_message_completions ADD COLUMN result_json TEXT;
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -373,6 +387,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 18,
             up: apply_v18,
         },
+        Migration {
+            version: 19,
+            up: apply_v19,
+        },
     ]
 }
 
@@ -501,6 +519,56 @@ fn apply_v18(conn: &Connection) -> rusqlite::Result<()> {
     ensure_nullable_column(conn, "conversation_turn_vectors", "dim", "INTEGER")?;
     ensure_nullable_column(conn, "conversation_turn_vectors", "index_version", "TEXT")?;
     conn.execute_batch(FORK_EXT_V18_SCHEMA_SQL)
+}
+
+fn apply_v19(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = FORK_EXT_V19_SCHEMA_SQL;
+
+    if !table_has_column(conn, "pending_messages", "result_drawer_id")? {
+        conn.execute_batch("ALTER TABLE pending_messages ADD COLUMN result_drawer_id TEXT;")?;
+    }
+    if !table_has_column(conn, "pending_messages", "op_state")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_messages ADD COLUMN op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed'));",
+        )?;
+    }
+    if !table_has_column(conn, "pending_messages", "rejected_reason")? {
+        conn.execute_batch("ALTER TABLE pending_messages ADD COLUMN rejected_reason TEXT;")?;
+    }
+    if !table_has_column(conn, "pending_messages", "failure_detail")? {
+        conn.execute_batch("ALTER TABLE pending_messages ADD COLUMN failure_detail TEXT;")?;
+    }
+    if !table_has_column(conn, "pending_messages", "result_json")? {
+        conn.execute_batch("ALTER TABLE pending_messages ADD COLUMN result_json TEXT;")?;
+    }
+
+    if !table_has_column(conn, "pending_message_completions", "result_drawer_id")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_message_completions ADD COLUMN result_drawer_id TEXT;",
+        )?;
+    }
+    if !table_has_column(conn, "pending_message_completions", "op_state")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_message_completions ADD COLUMN op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed'));",
+        )?;
+    }
+    if !table_has_column(conn, "pending_message_completions", "rejected_reason")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_message_completions ADD COLUMN rejected_reason TEXT;",
+        )?;
+    }
+    if !table_has_column(conn, "pending_message_completions", "failure_detail")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_message_completions ADD COLUMN failure_detail TEXT;",
+        )?;
+    }
+    if !table_has_column(conn, "pending_message_completions", "result_json")? {
+        conn.execute_batch(
+            "ALTER TABLE pending_message_completions ADD COLUMN result_json TEXT;",
+        )?;
+    }
+
+    Ok(())
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -33,6 +33,22 @@ pub struct ClaimedMessage {
     pub retry_count: u32,
     pub claim_token: String,
     pub source_hash: String,
+    pub created_at: i64,
+    pub claimed_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingOperationRecord {
+    pub id: String,
+    pub kind: String,
+    pub created_at: i64,
+    pub claimed_at: Option<i64>,
+    pub completed_at: Option<i64>,
+    pub op_state: String,
+    pub result_drawer_id: Option<String>,
+    pub rejected_reason: Option<String>,
+    pub failure_detail: Option<String>,
+    pub result_json: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -85,6 +101,13 @@ impl PendingMessageStore {
         Self::with_config(path, QueueConfig::default())
     }
 
+    pub fn new_without_reclaim(path: impl AsRef<Path>) -> Self {
+        Self {
+            db_path: path.as_ref().to_path_buf(),
+            config: QueueConfig::default(),
+        }
+    }
+
     pub fn with_config(path: impl AsRef<Path>, config: QueueConfig) -> Result<Self> {
         let store = Self {
             db_path: path.as_ref().to_path_buf(),
@@ -132,7 +155,7 @@ impl PendingMessageStore {
         let row = tx
             .query_row(
                 r#"
-                SELECT id, kind, payload, retry_count, source_hash
+                SELECT id, kind, payload, retry_count, source_hash, created_at
                 FROM pending_messages
                 WHERE status = 'pending' AND next_attempt_at <= ?1
                   AND kind != 'llm_task'
@@ -147,12 +170,13 @@ impl PendingMessageStore {
                         row.get::<_, String>(2)?,
                         row.get::<_, i64>(3)?,
                         row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
                     ))
                 },
             )
             .optional()?;
 
-        let Some((id, kind, payload, retry_count_i64, source_hash)) = row else {
+        let Some((id, kind, payload, retry_count_i64, source_hash, created_at)) = row else {
             tx.commit()?;
             return Ok(None);
         };
@@ -165,7 +189,11 @@ impl PendingMessageStore {
             SET status = 'claimed',
                 claim_token = ?2,
                 claimed_at = ?3,
-                heartbeat_at = ?3
+                heartbeat_at = ?3,
+                op_state = CASE
+                    WHEN kind = 'ingest_async' THEN 'running'
+                    ELSE op_state
+                END
             WHERE id = ?1 AND status = 'pending'
             "#,
             params![id, claim_token, now],
@@ -183,6 +211,8 @@ impl PendingMessageStore {
             retry_count,
             claim_token,
             source_hash,
+            created_at,
+            claimed_at: now,
         }))
     }
 
@@ -200,7 +230,7 @@ impl PendingMessageStore {
         let row = tx
             .query_row(
                 r#"
-                SELECT id, kind, payload, retry_count, source_hash
+                SELECT id, kind, payload, retry_count, source_hash, created_at
                 FROM pending_messages
                 WHERE status = 'pending' AND next_attempt_at <= ?1 AND kind = ?2
                 ORDER BY next_attempt_at ASC, id ASC
@@ -214,12 +244,13 @@ impl PendingMessageStore {
                         row.get::<_, String>(2)?,
                         row.get::<_, i64>(3)?,
                         row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
                     ))
                 },
             )
             .optional()?;
 
-        let Some((id, kind, payload, retry_count_i64, source_hash)) = row else {
+        let Some((id, kind, payload, retry_count_i64, source_hash, created_at)) = row else {
             tx.commit()?;
             return Ok(None);
         };
@@ -232,7 +263,11 @@ impl PendingMessageStore {
             SET status = 'claimed',
                 claim_token = ?2,
                 claimed_at = ?3,
-                heartbeat_at = ?3
+                heartbeat_at = ?3,
+                op_state = CASE
+                    WHEN kind = 'ingest_async' THEN 'running'
+                    ELSE op_state
+                END
             WHERE id = ?1 AND status = 'pending'
             "#,
             params![id, claim_token, now],
@@ -250,67 +285,60 @@ impl PendingMessageStore {
             retry_count,
             claim_token,
             source_hash,
+            created_at,
+            claimed_at: now,
         }))
     }
 
     pub fn confirm(&self, id: &str) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let row = tx
-            .query_row(
-                r#"
-                SELECT kind, created_at, claimed_at
-                FROM pending_messages
-                WHERE id = ?1
-                "#,
-                [id],
-                |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, i64>(1)?,
-                        row.get::<_, Option<i64>>(2)?,
-                    ))
-                },
-            )
-            .optional()?
-            .ok_or_else(|| QueueError::MessageNotFound(id.to_string()))?;
-        let completed_at = now_millis();
-        let processing_ms = row
-            .2
-            .map(|claimed_at| completed_at.saturating_sub(claimed_at.saturating_mul(1_000)));
+        confirm_in_tx(&tx, id)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn complete_operation(
+        &self,
+        id: &str,
+        op_state: &str,
+        result_drawer_id: Option<&str>,
+        rejected_reason: Option<&str>,
+        failure_detail: Option<&str>,
+        result_json: Option<&str>,
+    ) -> Result<()> {
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         tx.execute(
             r#"
-            INSERT INTO pending_message_completions (
-                message_id,
-                kind,
-                created_at,
-                claimed_at,
-                completed_at,
-                processing_ms
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-            ON CONFLICT(message_id) DO UPDATE SET
-                kind = excluded.kind,
-                created_at = excluded.created_at,
-                claimed_at = excluded.claimed_at,
-                completed_at = excluded.completed_at,
-                processing_ms = excluded.processing_ms
+            UPDATE pending_messages
+            SET op_state = ?2,
+                result_drawer_id = ?3,
+                rejected_reason = ?4,
+                failure_detail = ?5,
+                result_json = ?6
+            WHERE id = ?1 AND status = 'claimed'
             "#,
             params![
                 id,
-                row.0,
-                row.1.saturating_mul(1_000),
-                row.2.map(|s| s.saturating_mul(1_000)),
-                completed_at,
-                processing_ms
+                op_state,
+                result_drawer_id,
+                rejected_reason,
+                failure_detail,
+                result_json
             ],
         )?;
-        let updated = tx.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
-        if updated == 0 {
-            return Err(QueueError::MessageNotFound(id.to_string()));
-        }
+        confirm_in_tx(&tx, id)?;
         tx.commit()?;
         Ok(())
+    }
+
+    pub fn operation_status(&self, id: &str) -> Result<Option<PendingOperationRecord>> {
+        let conn = self.open_connection()?;
+        if let Some(record) = operation_status_from_pending(&conn, id)? {
+            return Ok(Some(record));
+        }
+        operation_status_from_completion(&conn, id)
     }
 
     pub fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
@@ -401,7 +429,27 @@ impl PendingMessageStore {
                 claim_token = NULL,
                 claimed_at = NULL,
                 heartbeat_at = NULL,
-                last_error = NULL
+                last_error = NULL,
+                op_state = CASE
+                    WHEN kind = 'ingest_async' THEN 'queued'
+                    ELSE op_state
+                END,
+                result_drawer_id = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE result_drawer_id
+                END,
+                rejected_reason = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE rejected_reason
+                END,
+                failure_detail = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE failure_detail
+                END,
+                result_json = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE result_json
+                END
             WHERE status = 'failed'
               AND kind != 'llm_task'
             "#,
@@ -422,7 +470,27 @@ impl PendingMessageStore {
             SET status = 'pending',
                 claim_token = NULL,
                 claimed_at = NULL,
-                heartbeat_at = NULL
+                heartbeat_at = NULL,
+                op_state = CASE
+                    WHEN kind = 'ingest_async' THEN 'queued'
+                    ELSE op_state
+                END,
+                result_drawer_id = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE result_drawer_id
+                END,
+                rejected_reason = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE rejected_reason
+                END,
+                failure_detail = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE failure_detail
+                END,
+                result_json = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE result_json
+                END
             WHERE id = ?1 AND status = 'claimed'
             "#,
             [id],
@@ -479,6 +547,167 @@ impl PendingMessageStore {
             .saturating_mul(multiplier)
             .min(self.config.max_delay_ms)
     }
+}
+
+fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str) -> Result<()> {
+    let row = tx
+        .query_row(
+            r#"
+            SELECT kind,
+                   created_at,
+                   claimed_at,
+                   op_state,
+                   result_drawer_id,
+                   rejected_reason,
+                   failure_detail,
+                   result_json
+            FROM pending_messages
+            WHERE id = ?1
+            "#,
+            [id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or_else(|| QueueError::MessageNotFound(id.to_string()))?;
+    let completed_at = now_millis();
+    let processing_ms = row
+        .2
+        .map(|claimed_at| completed_at.saturating_sub(claimed_at.saturating_mul(1_000)));
+    tx.execute(
+        r#"
+        INSERT INTO pending_message_completions (
+            message_id,
+            kind,
+            created_at,
+            claimed_at,
+            completed_at,
+            processing_ms,
+            result_drawer_id,
+            op_state,
+            rejected_reason,
+            failure_detail,
+            result_json
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+        ON CONFLICT(message_id) DO UPDATE SET
+            kind = excluded.kind,
+            created_at = excluded.created_at,
+            claimed_at = excluded.claimed_at,
+            completed_at = excluded.completed_at,
+            processing_ms = excluded.processing_ms,
+            result_drawer_id = excluded.result_drawer_id,
+            op_state = excluded.op_state,
+            rejected_reason = excluded.rejected_reason,
+            failure_detail = excluded.failure_detail,
+            result_json = excluded.result_json
+        "#,
+        params![
+            id,
+            row.0,
+            row.1.saturating_mul(1_000),
+            row.2.map(|s| s.saturating_mul(1_000)),
+            completed_at,
+            processing_ms,
+            row.4,
+            row.3,
+            row.5,
+            row.6,
+            row.7
+        ],
+    )?;
+    let updated = tx.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
+    if updated == 0 {
+        return Err(QueueError::MessageNotFound(id.to_string()));
+    }
+    Ok(())
+}
+
+fn operation_status_from_pending(
+    conn: &Connection,
+    id: &str,
+) -> Result<Option<PendingOperationRecord>> {
+    conn.query_row(
+        r#"
+            SELECT id,
+                   kind,
+                   created_at,
+                   claimed_at,
+                   op_state,
+                   result_drawer_id,
+                   rejected_reason,
+                   failure_detail,
+                   result_json
+            FROM pending_messages
+            WHERE id = ?1
+            "#,
+        [id],
+        |row| {
+            Ok(PendingOperationRecord {
+                id: row.get(0)?,
+                kind: row.get(1)?,
+                created_at: row.get(2)?,
+                claimed_at: row.get(3)?,
+                completed_at: None,
+                op_state: row.get(4)?,
+                result_drawer_id: row.get(5)?,
+                rejected_reason: row.get(6)?,
+                failure_detail: row.get(7)?,
+                result_json: row.get(8)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(QueueError::from)
+}
+
+fn operation_status_from_completion(
+    conn: &Connection,
+    id: &str,
+) -> Result<Option<PendingOperationRecord>> {
+    conn.query_row(
+        r#"
+            SELECT message_id,
+                   kind,
+                   created_at,
+                   claimed_at,
+                   completed_at,
+                   op_state,
+                   result_drawer_id,
+                   rejected_reason,
+                   failure_detail,
+                   result_json
+            FROM pending_message_completions
+            WHERE message_id = ?1
+            "#,
+        [id],
+        |row| {
+            Ok(PendingOperationRecord {
+                id: row.get(0)?,
+                kind: row.get(1)?,
+                created_at: row.get(2)?,
+                claimed_at: row.get(3)?,
+                completed_at: row.get(4)?,
+                op_state: row.get(5)?,
+                result_drawer_id: row.get(6)?,
+                rejected_reason: row.get(7)?,
+                failure_detail: row.get(8)?,
+                result_json: row.get(9)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(QueueError::from)
 }
 
 /// Open a WAL-mode-compatible read-only connection and return queue statistics.
@@ -575,7 +804,27 @@ fn reclaim_stale_tx(conn: &rusqlite::Transaction<'_>, stale_cutoff: i64) -> rusq
         SET status = 'pending',
             claim_token = NULL,
             claimed_at = NULL,
-            heartbeat_at = NULL
+            heartbeat_at = NULL,
+            op_state = CASE
+                WHEN kind = 'ingest_async' THEN 'queued'
+                ELSE op_state
+            END,
+            result_drawer_id = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_drawer_id
+            END,
+            rejected_reason = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE rejected_reason
+            END,
+            failure_detail = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE failure_detail
+            END,
+            result_json = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_json
+            END
         WHERE status = 'claimed'
           AND (heartbeat_at IS NULL OR heartbeat_at < ?1)
         "#,
@@ -591,7 +840,27 @@ fn reclaim_stale_conn(conn: &Connection, stale_cutoff: i64) -> rusqlite::Result<
         SET status = 'pending',
             claim_token = NULL,
             claimed_at = NULL,
-            heartbeat_at = NULL
+            heartbeat_at = NULL,
+            op_state = CASE
+                WHEN kind = 'ingest_async' THEN 'queued'
+                ELSE op_state
+            END,
+            result_drawer_id = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_drawer_id
+            END,
+            rejected_reason = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE rejected_reason
+            END,
+            failure_detail = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE failure_detail
+            END,
+            result_json = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_json
+            END
         WHERE status = 'claimed'
           AND (heartbeat_at IS NULL OR heartbeat_at < ?1)
         "#,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1409,6 +1409,8 @@ mod tests {
             retry_count: 0,
             claim_token: "worker:claim".to_string(),
             source_hash: "hash".to_string(),
+            created_at: 0,
+            claimed_at: 0,
         }
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,9 +8,9 @@ mod tools;
 pub use server::MempalMcpServer;
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
-    IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
-    PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
-    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
-    RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest, SearchResponse,
-    SearchResultDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
+    IngestOperationState, IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT,
+    MAX_READ_DRAWERS_REQUEST_IDS, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
+    PinnedFactsResponse, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
+    ReadDrawersResponse, RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest,
+    SearchResponse, SearchResultDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
 };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -198,8 +198,41 @@ impl MempalMcpServer {
 
         let worker = self.clone();
         handle.spawn(async move {
-            worker.run_ingest_drain_worker().await;
+            let _started_guard =
+                IngestDrainWorkerStartedGuard::new(Arc::clone(&worker.ingest_worker_started));
+            worker.supervise_ingest_drain_worker().await;
         });
+    }
+
+    async fn supervise_ingest_drain_worker(self) {
+        let mut restart_backoff_ms = INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS;
+        loop {
+            let worker = self.clone();
+            let join_handle = tokio::spawn(async move {
+                worker.run_ingest_drain_worker().await;
+            });
+
+            match join_handle.await {
+                Ok(()) => {
+                    tracing::error!(
+                        db_path = %self.db_path.display(),
+                        "async ingest worker exited unexpectedly; restarting"
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        db_path = %self.db_path.display(),
+                        error = %error,
+                        "async ingest worker stopped unexpectedly; restarting"
+                    );
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(restart_backoff_ms)).await;
+            restart_backoff_ms = restart_backoff_ms
+                .saturating_mul(2)
+                .min(INGEST_DRAIN_RESTART_BACKOFF_MAX_MS);
+        }
     }
 
     async fn run_ingest_drain_worker(self) {
@@ -915,6 +948,24 @@ const INGEST_ASYNC_KIND: &str = "ingest_async";
 const INGEST_CLAIM_TTL_SECS: i64 = 300;
 const INGEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const INGEST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS: u64 = 250;
+const INGEST_DRAIN_RESTART_BACKOFF_MAX_MS: u64 = 5_000;
+
+struct IngestDrainWorkerStartedGuard {
+    started: Arc<AtomicBool>,
+}
+
+impl IngestDrainWorkerStartedGuard {
+    fn new(started: Arc<AtomicBool>) -> Self {
+        Self { started }
+    }
+}
+
+impl Drop for IngestDrainWorkerStartedGuard {
+    fn drop(&mut self) {
+        self.started.store(false, Ordering::Release);
+    }
+}
 
 fn validate_temporal_param(name: &str, value: Option<&str>) -> std::result::Result<(), ErrorData> {
     if let Some(raw) = value
@@ -2733,9 +2784,12 @@ impl MempalMcpServer {
                 project_id.as_deref(),
             )
             .map_err(replacement_db_error)?;
+        let mut request = request.clone();
+        request.content = scrubbed_content.clone();
+        request.replace_text = scrubbed_replace_text;
 
         Ok(PreparedIngestOperation {
-            request: request.clone(),
+            request,
             project_id,
             scrubbed_content,
             source_type,
@@ -9634,6 +9688,78 @@ mod tests {
             .expect("ingest completion");
         assert_eq!(completed.state, Some(IngestOperationState::Completed));
         assert!(!completed.drawer_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_async_ingest_queue_payload_is_scrubbed() {
+        let config_home = tempfile::tempdir().expect("config tempdir");
+        let config_db_path = config_home.path().join("palace.db");
+        let _config_guard = ConfigOverrideGuard::install(&format!(
+            r#"
+db_path = "{}"
+
+[privacy]
+enabled = true
+"#,
+            config_db_path.display()
+        ));
+
+        let (_tempdir, db_path, server) = setup_server();
+        let raw_secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD";
+        let raw_content = format!("queued content {raw_secret}");
+        let raw_replace_text = format!("replace target {raw_secret}");
+        let expected_content = ConfigHandle::scrub_content(&raw_content);
+        let expected_replace_text = ConfigHandle::scrub_content(&raw_replace_text);
+
+        insert_drawer(
+            &db_path,
+            "drawer_async_scrub_replace_target",
+            &expected_replace_text,
+            "mcp",
+            Some("scrub"),
+            "/tmp/mcp-async-scrub.md",
+            1,
+        );
+
+        let request = IngestRequest {
+            content: raw_content,
+            wing: "mcp".to_string(),
+            room: Some("scrub".to_string()),
+            replace_text: Some(raw_replace_text),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let db = server.open_db().expect("open db");
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                &db,
+                project_id,
+            )
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let decoded: PreparedIngestOperation =
+            serde_json::from_str(&payload).expect("decode prepared ingest payload");
+
+        assert_eq!(decoded.request.content, expected_content);
+        assert_eq!(
+            decoded.request.replace_text.as_deref(),
+            Some(expected_replace_text.as_str())
+        );
+        assert_eq!(decoded.scrubbed_content, expected_content);
+        assert_eq!(decoded.request.content, decoded.scrubbed_content);
+        assert!(
+            !payload.contains(raw_secret),
+            "raw secret leaked into payload"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
@@ -78,6 +79,7 @@ use rmcp::{
     service::Peer,
     tool, tool_handler, tool_router,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::timeline::{TimelineRequest, TimelineResponse};
@@ -90,16 +92,17 @@ use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DoctorMcpDto,
     DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning, EmbedStatusDto,
     EndpointHealthDto, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
-    FieldTaxonomyResponse, IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest,
-    KgResponse, KgStatsDto, KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest,
-    KnowledgeCardsResponse, KnowledgeDemoteRequest, KnowledgeDemoteResponse,
-    KnowledgeDistillRequest, KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse,
-    KnowledgePolicyResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
-    KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest,
-    LeaseResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
-    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
-    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    FieldTaxonomyResponse, IngestOperationState, IngestRequest, IngestResponse,
+    IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
+    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
+    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
+    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
+    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
+    LeaseInfoDto, LeaseRequest, LeaseResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
+    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PeekMessageDto, PeekPartnerRequest,
+    PeekPartnerResponse, Phase3GateDto, Phase3Request, Phase3Response, PinnedFactDto,
+    PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse, QueueStatsDto,
+    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
     ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
     RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
     SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
@@ -122,6 +125,7 @@ pub struct MempalMcpServer {
     /// Per-session drawer IDs that were returned by `mempal_search`.
     /// Flushed and boosted on the next `mempal_ingest` call (P13).
     session_hit_drawers: Arc<Mutex<HashSet<String>>>,
+    ingest_worker_started: Arc<AtomicBool>,
 }
 
 impl MempalMcpServer {
@@ -155,6 +159,7 @@ impl MempalMcpServer {
             client_project_id: Arc::new(Mutex::new(None)),
             client_peer: Arc::new(Mutex::new(None)),
             session_hit_drawers: Arc::new(Mutex::new(HashSet::new())),
+            ingest_worker_started: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -166,6 +171,7 @@ impl MempalMcpServer {
         self.gating_runtime
             .validate_config_shape()
             .context("failed to validate ingest gating config")?;
+        self.spawn_ingest_drain_worker();
         let _gating_init_task =
             self.gating_runtime
                 .spawn_initialize_from_config(Duration::from_secs(
@@ -178,6 +184,148 @@ impl MempalMcpServer {
         self.serve(rmcp::transport::stdio())
             .await
             .context("failed to initialize MCP stdio transport")
+    }
+
+    fn spawn_ingest_drain_worker(&self) {
+        if self.ingest_worker_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            self.ingest_worker_started.store(false, Ordering::Release);
+            return;
+        };
+
+        let worker = self.clone();
+        handle.spawn(async move {
+            worker.run_ingest_drain_worker().await;
+        });
+    }
+
+    async fn run_ingest_drain_worker(self) {
+        let worker_id = format!(
+            "mcp-ingest-worker-{:x}-{:x}",
+            std::process::id(),
+            Arc::as_ptr(&self.ingest_worker_started) as usize
+        );
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&self.db_path);
+
+        loop {
+            match queue.claim_next_by_kind(&worker_id, INGEST_CLAIM_TTL_SECS, INGEST_ASYNC_KIND) {
+                Ok(Some(claim)) => {
+                    if let Err(error) = self.process_ingest_claim(&queue, &worker_id, claim).await {
+                        tracing::warn!(error = %error, "async ingest worker failed to process op");
+                    }
+                }
+                Ok(None) => tokio::time::sleep(INGEST_POLL_INTERVAL).await,
+                Err(error) => {
+                    tracing::warn!(error = %error, "async ingest worker claim failed");
+                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                }
+            }
+        }
+    }
+
+    async fn process_ingest_claim(
+        &self,
+        queue: &crate::core::queue::PendingMessageStore,
+        worker_id: &str,
+        claim: crate::core::queue::ClaimedMessage,
+    ) -> anyhow::Result<()> {
+        let prepared: PreparedIngestOperation = serde_json::from_str(&claim.payload)
+            .with_context(|| format!("failed to decode ingest operation {}", claim.id))?;
+
+        let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let heartbeat_queue = queue.clone();
+        let heartbeat_id = claim.id.clone();
+        let heartbeat_worker_id = worker_id.to_string();
+        let heartbeat = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(INGEST_HEARTBEAT_INTERVAL);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        if let Err(error) = heartbeat_queue.refresh_heartbeat(&heartbeat_id, &heartbeat_worker_id) {
+                            tracing::warn!(error = %error, claim_id = %heartbeat_id, "failed to refresh async ingest heartbeat");
+                            break;
+                        }
+                    }
+                    _ = &mut stop_rx => break,
+                }
+            }
+        });
+
+        let outcome = self
+            .mempal_ingest_sync(Parameters(prepared.request.clone()))
+            .await;
+
+        let _ = stop_tx.send(());
+        let _ = heartbeat.await;
+
+        match outcome {
+            Ok(Json(response)) => {
+                let rejected_reason = response
+                    .gating_decision
+                    .as_ref()
+                    .and_then(|decision| decision.drop_reason().map(ToOwned::to_owned));
+                let state = if response.dropped && rejected_reason.is_some() {
+                    IngestOperationState::Rejected
+                } else {
+                    IngestOperationState::Completed
+                };
+                let finalized = finalize_ingest_response(
+                    claim.id.clone(),
+                    claim.created_at,
+                    response,
+                    state,
+                    rejected_reason.clone(),
+                    None,
+                );
+                let result_json = serde_json::to_string(&finalized)
+                    .context("failed to serialize completed ingest response")?;
+                let result_drawer_id = if finalized.drawer_id.is_empty() {
+                    None
+                } else {
+                    Some(finalized.drawer_id.as_str())
+                };
+                queue
+                    .complete_operation(
+                        &claim.id,
+                        state.as_str(),
+                        result_drawer_id,
+                        rejected_reason.as_deref(),
+                        None,
+                        Some(&result_json),
+                    )
+                    .map_err(|error| {
+                        anyhow::anyhow!("failed to store async ingest result: {error}")
+                    })?;
+            }
+            Err(error) => {
+                let detail = error.to_string();
+                let finalized = finalize_failed_ingest_response(
+                    claim.id.clone(),
+                    claim.created_at,
+                    detail.clone(),
+                );
+                let result_json = serde_json::to_string(&finalized)
+                    .context("failed to serialize failed ingest response")?;
+                queue
+                    .complete_operation(
+                        &claim.id,
+                        IngestOperationState::Failed.as_str(),
+                        None,
+                        None,
+                        Some(&detail),
+                        Some(&result_json),
+                    )
+                    .map_err(|error| {
+                        anyhow::anyhow!("failed to store async ingest failure: {error}")
+                    })?;
+            }
+        }
+
+        Ok(())
     }
 
     pub(super) fn open_db(&self) -> std::result::Result<Database, ErrorData> {
@@ -232,9 +380,49 @@ impl MempalMcpServer {
     ) -> std::result::Result<IngestResponse, ErrorData> {
         let request = serde_json::from_value(value)
             .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
-        self.mempal_ingest(Parameters(request))
+        let response = self
+            .mempal_ingest(Parameters(request))
             .await
-            .map(|response| response.0)
+            .map(|response| response.0)?;
+        match response.operation_id.as_deref() {
+            Some(operation_id) => self.wait_for_operation_completion(operation_id).await,
+            None => Ok(response),
+        }
+    }
+
+    pub async fn operation_status_json_for_test(
+        &self,
+        operation_id: &str,
+    ) -> std::result::Result<IngestResponse, ErrorData> {
+        self.mempal_operation_status(Parameters(OperationStatusRequest {
+            operation_id: operation_id.to_string(),
+        }))
+        .await
+        .map(|response| response.0)
+    }
+
+    pub async fn wait_for_operation_completion(
+        &self,
+        operation_id: &str,
+    ) -> std::result::Result<IngestResponse, ErrorData> {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let response = self.operation_status_json_for_test(operation_id).await?;
+            if response
+                .state
+                .map(IngestOperationState::is_terminal)
+                .unwrap_or(false)
+            {
+                return Ok(response);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ErrorData::internal_error(
+                    format!("timed out waiting for ingest operation {operation_id}"),
+                    None,
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
     }
 
     pub async fn search_json_for_test(
@@ -348,6 +536,32 @@ impl MempalMcpServer {
         request: StatusRequest,
     ) -> std::result::Result<Json<StatusResponse>, ErrorData> {
         self.mempal_status_tool(Parameters(request)).await
+    }
+
+    #[tool(
+        name = "mempal_operation_status",
+        description = "Return the current status of an asynchronous ingest operation, including the queue state and any stored drawer_id, rejection reason, or failure detail. Use this to confirm a receipt-based write landed."
+    )]
+    pub async fn mempal_operation_status(
+        &self,
+        Parameters(request): Parameters<OperationStatusRequest>,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let store = crate::core::queue::PendingMessageStore::new_without_reclaim(db.path());
+        let system_warnings = system_warnings_with_stale_index(&db);
+        let record = store
+            .operation_status(&request.operation_id)
+            .map_err(|error| {
+                ErrorData::internal_error(format!("queue lookup failed: {error}"), None)
+            })?
+            .ok_or_else(|| {
+                ErrorData::invalid_params(
+                    format!("operation not found: {}", request.operation_id),
+                    None,
+                )
+            })?;
+
+        Ok(Json(operation_record_to_response(record, system_warnings)))
     }
 
     pub async fn pinned_facts_json_for_test(
@@ -502,7 +716,7 @@ impl MempalMcpServer {
 // =========================================================================
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ValidatedIngestMetadata {
     memory_kind: MemoryKind,
     domain: MemoryDomain,
@@ -683,6 +897,24 @@ fn validate_ingest_request(
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PreparedIngestOperation {
+    request: IngestRequest,
+    project_id: Option<String>,
+    scrubbed_content: String,
+    source_type: SourceType,
+    confidence: f64,
+    metadata: ValidatedIngestMetadata,
+    superseded_drawer_id: Option<String>,
+    raw_turn: bool,
+    drawer_importance: i32,
+}
+
+const INGEST_ASYNC_KIND: &str = "ingest_async";
+const INGEST_CLAIM_TTL_SECS: i64 = 300;
+const INGEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const INGEST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 
 fn validate_temporal_param(name: &str, value: Option<&str>) -> std::result::Result<(), ErrorData> {
     if let Some(raw) = value
@@ -2386,6 +2618,139 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        self.spawn_ingest_drain_worker();
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let room = request.room.as_deref();
+        let db = self.open_db()?;
+        // Snapshot the request-wide warnings once so every early-return path reports a
+        // consistent set from a single `sqlite_master` read. A mid-request embed transition
+        // to degraded is not lost: the synchronous degraded-write guard below
+        // (`should_block_writes`) re-reads fresh status via `degraded_write_error()` and
+        // rejects before any success response that would carry this snapshot is built.
+        let request_system_warnings = system_warnings_with_stale_index(&db);
+        let dry_run = request.dry_run.unwrap_or(false);
+        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
+        if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+            return Ok(Json(IngestResponse {
+                operation_id: None,
+                accepted_at: None,
+                state: None,
+                drawer_id: String::new(),
+                drawer_ids: Vec::new(),
+                chunk_count: 0,
+                dropped: false,
+                gating_decision: None,
+                novelty_action: None,
+                near_drawer_id: None,
+                duplicate_warning: None,
+                lock_wait_ms: None,
+                superseded_drawer_id: None,
+                rejected_reason: None,
+                failure_detail: None,
+                fact_check_warnings: Vec::new(),
+                system_warnings: request_system_warnings,
+            }));
+        }
+        if dry_run {
+            return self.mempal_ingest_sync(Parameters(request)).await;
+        }
+        if global_embed_status().should_block_writes() {
+            return Err(degraded_write_error());
+        }
+        let project_id = self
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await?;
+        let prepared = self.prepare_async_ingest_operation(
+            &request,
+            config.as_ref(),
+            compiled_privacy.as_ref(),
+            &db,
+            project_id,
+        )?;
+        let payload = serde_json::to_string(&prepared).map_err(|error| {
+            ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
+        })?;
+        let queue = crate::core::queue::PendingMessageStore::new(db.path()).map_err(|error| {
+            ErrorData::internal_error(format!("failed to open ingest queue: {error}"), None)
+        })?;
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .map_err(|error| {
+                ErrorData::internal_error(
+                    format!("failed to enqueue ingest operation: {error}"),
+                    None,
+                )
+            })?;
+
+        Ok(Json(IngestResponse {
+            operation_id: Some(operation_id),
+            accepted_at: Some(crate::core::utils::iso_timestamp()),
+            state: Some(IngestOperationState::Queued),
+            drawer_id: String::new(),
+            drawer_ids: Vec::new(),
+            chunk_count: 0,
+            dropped: false,
+            gating_decision: None,
+            novelty_action: None,
+            near_drawer_id: None,
+            duplicate_warning: None,
+            lock_wait_ms: None,
+            superseded_drawer_id: None,
+            rejected_reason: None,
+            failure_detail: None,
+            fact_check_warnings: Vec::new(),
+            system_warnings: request_system_warnings,
+        }))
+    }
+
+    fn prepare_async_ingest_operation(
+        &self,
+        request: &IngestRequest,
+        config: &crate::core::config::Config,
+        compiled_privacy: &crate::core::config::CompiledPrivacyConfig,
+        db: &Database,
+        project_id: Option<String>,
+    ) -> std::result::Result<PreparedIngestOperation, ErrorData> {
+        let scrubbed_content =
+            config.scrub_content_with_compiled(&request.content, compiled_privacy);
+        let room = request.room.as_deref();
+        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
+        let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
+            .unwrap_or_else(|| request.importance.unwrap_or(0));
+        let source_type = parse_source_type_param(request.source_type.as_deref())?;
+        let confidence = resolve_confidence_param(source_type, request.confidence)?;
+        let metadata = validate_ingest_request(request, &source_type)?;
+        let scrubbed_replace_text = request
+            .replace_text
+            .as_deref()
+            .map(|text| config.scrub_content_with_compiled(text, compiled_privacy));
+        let replacement_target = db
+            .resolve_replacement_target(
+                request.supersedes.as_deref(),
+                scrubbed_replace_text.as_deref(),
+                &request.wing,
+                room,
+                project_id.as_deref(),
+            )
+            .map_err(replacement_db_error)?;
+
+        Ok(PreparedIngestOperation {
+            request: request.clone(),
+            project_id,
+            scrubbed_content,
+            source_type,
+            confidence,
+            metadata,
+            superseded_drawer_id: replacement_target.map(|summary| summary.id),
+            raw_turn,
+            drawer_importance,
+        })
+    }
+
+    async fn mempal_ingest_sync(
+        &self,
+        Parameters(request): Parameters<IngestRequest>,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
@@ -2404,6 +2769,9 @@ impl MempalMcpServer {
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
+                operation_id: None,
+                accepted_at: None,
+                state: None,
                 drawer_id: String::new(),
                 drawer_ids: Vec::new(),
                 chunk_count: 0,
@@ -2414,6 +2782,8 @@ impl MempalMcpServer {
                 duplicate_warning: None,
                 lock_wait_ms: None,
                 superseded_drawer_id: None,
+                rejected_reason: None,
+                failure_detail: None,
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings,
             }));
@@ -2509,6 +2879,7 @@ impl MempalMcpServer {
                 superseded_drawer_id,
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings.clone(),
+                ..Default::default()
             }));
         }
 
@@ -2540,6 +2911,7 @@ impl MempalMcpServer {
                 superseded_drawer_id: superseded_response_id,
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings.clone(),
+                ..Default::default()
             }));
         }
 
@@ -2573,6 +2945,7 @@ impl MempalMcpServer {
                 superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings.clone(),
+                ..Default::default()
             }));
         }
 
@@ -2676,6 +3049,7 @@ impl MempalMcpServer {
                 superseded_drawer_id: None,
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings.clone(),
+                ..Default::default()
             }));
         }
         if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
@@ -2720,6 +3094,7 @@ impl MempalMcpServer {
                     superseded_drawer_id: None,
                     fact_check_warnings,
                     system_warnings: request_system_warnings.clone(),
+                    ..Default::default()
                 }));
             }
         }
@@ -3177,6 +3552,7 @@ impl MempalMcpServer {
             superseded_drawer_id: superseded_response_id,
             fact_check_warnings,
             system_warnings: request_system_warnings,
+            ..Default::default()
         }))
     }
 
@@ -6126,6 +6502,113 @@ fn system_warnings_with_stale_index(db: &Database) -> Vec<SystemWarning> {
     warnings
 }
 
+fn operation_record_accepted_at_secs(record: &crate::core::queue::PendingOperationRecord) -> i64 {
+    if record.completed_at.is_some() {
+        record.created_at.div_euclid(1_000)
+    } else {
+        record.created_at
+    }
+}
+
+fn rfc3339_from_secs(secs: i64) -> String {
+    crate::cowork::peek::format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs.max(0) as u64))
+}
+
+fn finalize_ingest_response(
+    operation_id: String,
+    accepted_at_secs: i64,
+    mut response: IngestResponse,
+    state: IngestOperationState,
+    rejected_reason: Option<String>,
+    failure_detail: Option<String>,
+) -> IngestResponse {
+    response.operation_id = Some(operation_id);
+    response.accepted_at = Some(rfc3339_from_secs(accepted_at_secs));
+    response.state = Some(state);
+    response.rejected_reason = rejected_reason;
+    response.failure_detail = failure_detail;
+    response
+}
+
+fn finalize_failed_ingest_response(
+    operation_id: String,
+    accepted_at_secs: i64,
+    failure_detail: String,
+) -> IngestResponse {
+    finalize_ingest_response(
+        operation_id,
+        accepted_at_secs,
+        IngestResponse {
+            operation_id: None,
+            accepted_at: None,
+            state: None,
+            drawer_id: String::new(),
+            drawer_ids: Vec::new(),
+            chunk_count: 0,
+            dropped: false,
+            gating_decision: None,
+            novelty_action: None,
+            near_drawer_id: None,
+            duplicate_warning: None,
+            lock_wait_ms: None,
+            superseded_drawer_id: None,
+            rejected_reason: None,
+            failure_detail: None,
+            fact_check_warnings: Vec::new(),
+            system_warnings: current_system_warnings(),
+        },
+        IngestOperationState::Failed,
+        None,
+        Some(failure_detail),
+    )
+}
+
+fn operation_record_to_response(
+    record: crate::core::queue::PendingOperationRecord,
+    system_warnings: Vec<SystemWarning>,
+) -> IngestResponse {
+    let accepted_at = Some(rfc3339_from_secs(operation_record_accepted_at_secs(
+        &record,
+    )));
+    let state = record
+        .op_state
+        .parse::<IngestOperationState>()
+        .unwrap_or(IngestOperationState::Failed);
+
+    if let Some(result_json) = record.result_json.as_deref()
+        && let Ok(mut response) = serde_json::from_str::<IngestResponse>(result_json)
+    {
+        response.operation_id = Some(record.id);
+        response.accepted_at = accepted_at;
+        response.state = Some(state);
+        response.dropped = matches!(state, IngestOperationState::Rejected);
+        response.rejected_reason = record.rejected_reason.or(response.rejected_reason);
+        response.failure_detail = record.failure_detail.or(response.failure_detail);
+        response.system_warnings = system_warnings;
+        return response;
+    }
+
+    IngestResponse {
+        operation_id: Some(record.id),
+        accepted_at,
+        state: Some(state),
+        drawer_id: record.result_drawer_id.unwrap_or_default(),
+        drawer_ids: Vec::new(),
+        chunk_count: 0,
+        dropped: matches!(state, IngestOperationState::Rejected),
+        gating_decision: None,
+        novelty_action: None,
+        near_drawer_id: None,
+        duplicate_warning: None,
+        lock_wait_ms: None,
+        superseded_drawer_id: None,
+        rejected_reason: record.rejected_reason,
+        failure_detail: record.failure_detail,
+        fact_check_warnings: Vec::new(),
+        system_warnings,
+    }
+}
+
 fn intelligence_llm_state(config: &crate::core::config::Config, reachable: bool) -> String {
     if !config.memory_intelligence.mode.uses_llm() {
         return "disabled".to_string();
@@ -6276,10 +6759,12 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
     use rusqlite::params;
     use tempfile::TempDir;
+    use tokio::sync::Notify;
 
     use super::*;
     use crate::core::db::read_fork_ext_version;
@@ -6294,6 +6779,19 @@ mod tests {
 
     struct StubEmbedder {
         vector: Vec<f32>,
+    }
+
+    #[derive(Clone)]
+    struct BlockingEmbedderFactory {
+        vector: Vec<f32>,
+        call_count: Arc<AtomicUsize>,
+        gate: Arc<Notify>,
+    }
+
+    struct BlockingEmbedder {
+        vector: Vec<f32>,
+        call_count: Arc<AtomicUsize>,
+        gate: Arc<Notify>,
     }
 
     #[derive(Default)]
@@ -6332,6 +6830,34 @@ mod tests {
 
         fn name(&self) -> &str {
             "stub"
+        }
+    }
+
+    #[async_trait]
+    impl crate::embed::EmbedderFactory for BlockingEmbedderFactory {
+        async fn build(&self) -> crate::embed::Result<Box<dyn Embedder>> {
+            Ok(Box::new(BlockingEmbedder {
+                vector: self.vector.clone(),
+                call_count: Arc::clone(&self.call_count),
+                gate: Arc::clone(&self.gate),
+            }))
+        }
+    }
+
+    #[async_trait]
+    impl Embedder for BlockingEmbedder {
+        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            self.gate.notified().await;
+            Ok(texts.iter().map(|_| self.vector.clone()).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            self.vector.len()
+        }
+
+        fn name(&self) -> &str {
+            "blocking-stub"
         }
     }
 
@@ -8731,19 +9257,19 @@ mod tests {
         supersedes: Option<&str>,
         replace_text: Option<&str>,
     ) -> IngestResponse {
+        let request = IngestRequest {
+            content: content.to_string(),
+            wing: "mempal".to_string(),
+            room: Some("replace".to_string()),
+            project_id: project_id.map(ToOwned::to_owned),
+            supersedes: supersedes.map(ToOwned::to_owned),
+            replace_text: replace_text.map(ToOwned::to_owned),
+            ..IngestRequest::default()
+        };
         server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: content.to_string(),
-                wing: "mempal".to_string(),
-                room: Some("replace".to_string()),
-                project_id: project_id.map(ToOwned::to_owned),
-                supersedes: supersedes.map(ToOwned::to_owned),
-                replace_text: replace_text.map(ToOwned::to_owned),
-                ..IngestRequest::default()
-            }))
+            .ingest_json_for_test(serde_json::to_value(request).expect("serialize ingest request"))
             .await
             .expect("ingest should succeed")
-            .0
     }
 
     #[tokio::test]
@@ -8781,16 +9307,18 @@ mod tests {
     async fn test_mcp_ingest_valid_until_is_respected_by_search_include_expired() {
         let (_tempdir, _db_path, server) = setup_server();
         let ingested = server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: "temporal expired fact".to_string(),
-                wing: "mempal".to_string(),
-                room: Some("temporal".to_string()),
-                valid_until: Some("1".to_string()),
-                ..IngestRequest::default()
-            }))
+            .ingest_json_for_test(
+                serde_json::to_value(IngestRequest {
+                    content: "temporal expired fact".to_string(),
+                    wing: "mempal".to_string(),
+                    room: Some("temporal".to_string()),
+                    valid_until: Some("1".to_string()),
+                    ..IngestRequest::default()
+                })
+                .expect("serialize ingest request"),
+            )
             .await
-            .expect("ingest should succeed")
-            .0;
+            .expect("ingest should succeed");
 
         let hidden = run_search(
             &server,
@@ -8867,21 +9395,28 @@ mod tests {
         let (_tempdir, db_path, server) = setup_server();
         let old = ingest_manual(&server, "empty replacement old fact", None, None, None).await;
 
-        let error = match server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: "   \n\t  ".to_string(),
-                wing: "mempal".to_string(),
-                room: Some("replace".to_string()),
-                supersedes: Some(old.drawer_id.clone()),
-                ..IngestRequest::default()
-            }))
+        let response = server
+            .ingest_json_for_test(
+                serde_json::to_value(IngestRequest {
+                    content: "   \n\t  ".to_string(),
+                    wing: "mempal".to_string(),
+                    room: Some("replace".to_string()),
+                    supersedes: Some(old.drawer_id.clone()),
+                    ..IngestRequest::default()
+                })
+                .expect("serialize ingest request"),
+            )
             .await
-        {
-            Ok(_) => panic!("empty replacement should fail"),
-            Err(error) => error,
-        };
+            .expect("ingest should complete");
 
-        assert!(error.to_string().contains("content produced no chunks"));
+        assert_eq!(response.state, Some(IngestOperationState::Failed));
+        assert!(
+            response
+                .failure_detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains("content produced no chunks")
+        );
         let db = Database::open(&db_path).expect("open db");
         assert!(db.get_drawer(&old.drawer_id).expect("old lookup").is_some());
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
@@ -9043,47 +9578,197 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_ingest_returns_receipt_before_embedder_runs() {
+        let db_path = PathBuf::from("/tmp/mempal-async-receipt.db");
+        Database::open(&db_path).expect("open db");
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Notify::new());
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(BlockingEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+                call_count: Arc::clone(&call_count),
+                gate: Arc::clone(&gate),
+            }),
+        );
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(2),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "receipt path should be non-blocking".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("receipt".to_string()),
+                project_id: Some("project-async".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("receipt timeout")
+        .expect("receipt response")
+        .0;
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.clone().expect("operation id");
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "embedder must not be called before the receipt is returned"
+        );
+
+        let db = server.open_db().expect("open db");
+        let op_state: String = db
+            .conn()
+            .query_row(
+                "SELECT op_state FROM pending_messages WHERE id = ?1",
+                [&operation_id],
+                |row| row.get(0),
+            )
+            .expect("read queued op_state");
+        assert_eq!(op_state, "queued");
+
+        gate.notify_one();
+        let completed = server
+            .wait_for_operation_completion(&operation_id)
+            .await
+            .expect("ingest completion");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(!completed.drawer_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_operation_status_tracks_reclaim_and_completion() {
+        let db_path = PathBuf::from("/tmp/mempal-async-status.db");
+        Database::open(&db_path).expect("open db");
+
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.4, 0.5, 0.6],
+            }),
+        );
+        let db = server.open_db().expect("open db");
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "status tool async ingest".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("status".to_string()),
+            project_id: Some("project-async".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                &db,
+                project_id,
+            )
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async ingest");
+
+        let queued = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("queued status");
+        assert_eq!(queued.state, Some(IngestOperationState::Queued));
+        assert!(queued.drawer_id.is_empty());
+
+        let claim = queue
+            .claim_next_by_kind("worker-a", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        db.conn()
+            .execute(
+                "UPDATE pending_messages SET claimed_at = ?2, heartbeat_at = ?2 WHERE id = ?1",
+                params![claim.id, 1_i64],
+            )
+            .expect("stale heartbeat");
+        assert_eq!(queue.reclaim_stale(60).expect("reclaim stale"), 1);
+
+        let reclaimed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("reclaimed status");
+        assert_eq!(reclaimed.state, Some(IngestOperationState::Queued));
+
+        let reclaimed_claim = queue
+            .claim_next_by_kind("worker-b", 60, INGEST_ASYNC_KIND)
+            .expect("reclaim claim")
+            .expect("reclaimed queued op");
+        server
+            .process_ingest_claim(&queue, "worker-b", reclaimed_claim)
+            .await
+            .expect("process reclaimed op");
+
+        let completed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(!completed.drawer_id.is_empty());
+
+        let final_status = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("final status");
+        assert_eq!(final_status.state, Some(IngestOperationState::Completed));
+        assert_eq!(final_status.drawer_id, completed.drawer_id);
+    }
+
+    #[tokio::test]
     async fn test_mcp_ingest_response_exposes_lock_wait() {
         let (_tempdir, _db_path, server) = setup_server();
 
         let response = server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: "same content for lock contention".to_string(),
-                wing: "mempal".to_string(),
-                room: Some("review".to_string()),
-                source: None,
-                source_type: None,
-                confidence: None,
-                importance: None,
-                dry_run: None,
-                diary_rollup: None,
-                supersedes: None,
-                replace_text: None,
-                valid_from: None,
-                valid_until: None,
-                memory_kind: None,
-                domain: None,
-                field: None,
-                is_pinned: None,
-                provenance: None,
-                statement: None,
-                tier: None,
-                status: None,
-                supporting_refs: None,
-                counterexample_refs: None,
-                teaching_refs: None,
-                verification_refs: None,
-                scope_constraints: None,
-                trigger_hints: None,
-                anchor_kind: None,
-                anchor_id: None,
-                parent_anchor_id: None,
-                cwd: None,
-                project_id: None,
-            }))
+            .ingest_json_for_test(
+                serde_json::to_value(IngestRequest {
+                    content: "same content for lock contention".to_string(),
+                    wing: "mempal".to_string(),
+                    room: Some("review".to_string()),
+                    source: None,
+                    source_type: None,
+                    confidence: None,
+                    importance: None,
+                    dry_run: None,
+                    diary_rollup: None,
+                    supersedes: None,
+                    replace_text: None,
+                    valid_from: None,
+                    valid_until: None,
+                    memory_kind: None,
+                    domain: None,
+                    field: None,
+                    is_pinned: None,
+                    provenance: None,
+                    statement: None,
+                    tier: None,
+                    status: None,
+                    supporting_refs: None,
+                    counterexample_refs: None,
+                    teaching_refs: None,
+                    verification_refs: None,
+                    scope_constraints: None,
+                    trigger_hints: None,
+                    anchor_kind: None,
+                    anchor_id: None,
+                    parent_anchor_id: None,
+                    cwd: None,
+                    project_id: None,
+                })
+                .expect("serialize ingest request"),
+            )
             .await
-            .expect("ingest should succeed")
-            .0;
+            .expect("ingest should succeed");
 
         assert!(
             response.lock_wait_ms.is_some(),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1572,7 +1572,7 @@ pub struct PinnedFactDto {
     pub supersedes: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 pub struct IngestRequest {
     pub content: String,
     pub wing: String,
@@ -1633,6 +1633,11 @@ pub struct IngestRequest {
     pub anchor_id: Option<String>,
     pub parent_anchor_id: Option<String>,
     pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct OperationStatusRequest {
+    pub operation_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -1732,18 +1737,72 @@ pub struct LeaseResponse {
     pub system_warnings: Vec<SystemWarning>,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestOperationState {
+    Queued,
+    Running,
+    Completed,
+    Rejected,
+    Failed,
+}
+
+impl IngestOperationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Rejected => "rejected",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Rejected | Self::Failed)
+    }
+}
+
+impl std::str::FromStr for IngestOperationState {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "running" => Ok(Self::Running),
+            "completed" => Ok(Self::Completed),
+            "rejected" => Ok(Self::Rejected),
+            "failed" => Ok(Self::Failed),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 pub struct IngestResponse {
-    /// ID of the first (or only) drawer created. For backward compatibility,
-    /// callers that only read `drawer_id` continue to work unchanged.
+    /// Operation receipt/result ID. Present for queued and finalized
+    /// non-dry-run ingests; omitted for dry-run previews.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    /// RFC3339 timestamp when the ingest was accepted into the queue.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accepted_at: Option<String>,
+    /// Current operation state. Present for queued and finalized non-dry-run
+    /// ingests; omitted for dry-run previews.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<IngestOperationState>,
+    /// ID of the first (or only) drawer created once the ingest completes.
+    /// Empty while queued/running and for rejection/failure outcomes without
+    /// stored drawers.
     pub drawer_id: String,
     /// All drawer IDs created by this ingest (one per chunk). When content
     /// fits in a single chunk, this contains exactly one element matching
-    /// `drawer_id`. Empty when `dropped` is true.
+    /// `drawer_id`. Empty while queued/running and when `dropped` is true.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub drawer_ids: Vec<String>,
     /// Number of chunks the content was split into. Always >= 1 for
-    /// successful ingests; 0 when `dropped` is true.
+    /// successful ingests; 0 while queued/running, during dry-run previews,
+    /// and when `dropped` is true.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub chunk_count: usize,
     #[serde(default)]
@@ -1763,6 +1822,10 @@ pub struct IngestResponse {
     pub lock_wait_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub superseded_drawer_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rejected_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_detail: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fact_check_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1773,7 +1836,7 @@ fn is_zero(v: &usize) -> bool {
     *v == 0
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct DuplicateWarning {
     pub similar_drawer_id: String,
     pub similarity: f32,

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -16,7 +16,6 @@ use mempal::core::db::{CURRENT_FORK_EXT_VERSION, Database};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::ingest::gating::{IngestCandidate, evaluate_tier1};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 #[cfg(feature = "integration")]
 use rmcp::{model::CallToolRequestParams, serve_client};
 use tempfile::TempDir;
@@ -266,15 +265,17 @@ enabled = false"#
 
 async fn ingest(server: &MempalMcpServer, content: &str) -> String {
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: "mempal".to_string(),
-            room: Some("config-hot-reload".to_string()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: "mempal".to_string(),
+                room: Some("config-hot-reload".to_string()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("ingest should succeed")
-        .0;
+        .expect("ingest should succeed");
     response.drawer_id
 }
 
@@ -360,15 +361,17 @@ async fn test_ingest_gating_hot_reload_applies_without_server_restart() {
     wait_for_version_change(&previous);
 
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "tiny".to_string(),
-            wing: "mempal".to_string(),
-            room: Some("config-hot-reload".to_string()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "tiny".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("config-hot-reload".to_string()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("ingest should return structured reject")
-        .0;
+        .expect("ingest should return structured reject");
 
     let decision = response.gating_decision.expect("tier-1 decision");
     assert_eq!(decision.decision, "rejected");

--- a/tests/embedder_dim_mismatch.rs
+++ b/tests/embedder_dim_mismatch.rs
@@ -6,7 +6,6 @@ use mempal::core::types::{Drawer, SourceType};
 use mempal::embed::global_embed_status;
 use mempal::mcp::{IngestRequest, MempalMcpServer};
 use mockito::{Matcher, Server};
-use rmcp::handler::server::wrapper::Parameters;
 use tempfile::TempDir;
 
 async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
@@ -68,21 +67,25 @@ request_timeout_secs = 5
     global_embed_status().reset_for_tests();
 
     let service = MempalMcpServer::new(db_path, config);
-    let error = match service
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "new drawer".to_string(),
-            wing: "test".to_string(),
-            room: Some("room".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+    let response = service
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "new drawer".to_string(),
+                wing: "test".to_string(),
+                room: Some("room".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-    {
-        Ok(_) => panic!("ingest should fail on dim mismatch"),
-        Err(error) => error,
-    };
+        .expect("ingest should complete");
 
-    let rendered = format!("{error:?}");
+    assert_eq!(
+        response.state,
+        Some(mempal::mcp::IngestOperationState::Failed)
+    );
+    let rendered = format!("{response:?}");
     assert!(rendered.contains("dimension mismatch"));
     assert!(rendered.contains("mempal reindex"));
     global_embed_status().reset_for_tests();

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, OnceLock};
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::embed::global_embed_status;
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 use tempfile::TempDir;
 
 async fn test_guard() -> tokio::sync::OwnedMutexGuard<()> {
@@ -68,16 +67,18 @@ async fn test_embedder_fallback_to_model2vec_when_lan_unreachable() {
 
     let server = MempalMcpServer::new(db_path, config);
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "fallback path should still embed".to_string(),
-            wing: "test".to_string(),
-            room: Some("fallback".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "fallback path should still embed".to_string(),
+                wing: "test".to_string(),
+                room: Some("fallback".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("fallback ingest should succeed")
-        .0;
+        .expect("fallback ingest should succeed");
 
     assert!(
         response

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -337,16 +337,18 @@ async fn test_search_and_ingest_during_partial_reindex() {
     assert!(!search.results.is_empty());
 
     let ingest = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "ingest during partial reindex".to_string(),
-            wing: "test".to_string(),
-            room: Some("reindex".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "ingest during partial reindex".to_string(),
+                wing: "test".to_string(),
+                room: Some("reindex".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("ingest during reindex")
-        .0;
+        .expect("ingest during reindex");
     assert!(!ingest.drawer_id.is_empty());
 
     handle.resume();
@@ -1210,26 +1212,41 @@ async fn test_embed_degraded_allows_writes_when_not_configured() {
     status.record_failure(&"synthetic 1");
     status.record_failure(&"synthetic 2");
 
-    let task = tokio::spawn(async move {
-        let server = MempalMcpServer::new(env.db_path.clone(), config);
-        server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: "allowed after recovery".to_string(),
-                wing: "test".to_string(),
-                room: Some("room".to_string()),
-                dry_run: Some(false),
-                ..IngestRequest::default()
-            }))
-            .await
-    });
-    tokio::task::yield_now().await;
-    assert!(
-        !task.is_finished(),
-        "ingest should block while embedder is paused"
+    let server = MempalMcpServer::new(env.db_path.clone(), config.clone());
+    let response = tokio::time::timeout(
+        Duration::from_secs(2),
+        server.mempal_ingest(Parameters(IngestRequest {
+            content: "allowed after recovery".to_string(),
+            wing: "test".to_string(),
+            room: Some("room".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        })),
+    )
+    .await
+    .expect("receipt timeout")
+    .expect("ingest response")
+    .0;
+    assert!(response.operation_id.is_some());
+    assert_eq!(
+        response.state,
+        Some(mempal::mcp::IngestOperationState::Queued)
     );
+
     handle.resume();
-    let response = task.await.expect("join task").expect("ingest response").0;
-    assert!(!response.drawer_id.is_empty());
+    let operation_id = response
+        .operation_id
+        .clone()
+        .expect("queued ingest should carry an operation id");
+    let completed = server
+        .wait_for_operation_completion(&operation_id)
+        .await
+        .expect("ingest completion");
+    assert_eq!(
+        completed.state,
+        Some(mempal::mcp::IngestOperationState::Completed)
+    );
+    assert!(!completed.drawer_id.is_empty());
     handle.shutdown().await;
 }
 

--- a/tests/embedder_reload.rs
+++ b/tests/embedder_reload.rs
@@ -16,7 +16,6 @@ use mempal::embed::openai_compat::OpenAiCompatibleEmbedder;
 use mempal::embed::retry::retry_embed_operation;
 use mempal::embed::{EmbedError, Embedder, global_embed_status};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 use tempfile::TempDir;
 use tracing_subscriber::layer::SubscriberExt;
 
@@ -458,21 +457,29 @@ async fn test_dim_mismatch_fail_fast() {
     let config = Config::parse(&config_text(&db_path, &format!("http://{addr}/v1"), ""))
         .expect("parse config");
     let server = MempalMcpServer::new(db_path, config);
-    let error = match server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "new drawer".to_string(),
-            wing: "test".to_string(),
-            room: Some("room".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+    let response = server
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "new drawer".to_string(),
+                wing: "test".to_string(),
+                room: Some("room".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-    {
-        Ok(_) => panic!("dim mismatch should fail"),
-        Err(error) => error,
-    };
+        .expect("ingest should complete");
 
-    let rendered = error.message.to_string();
+    assert_eq!(
+        response.state,
+        Some(mempal::mcp::IngestOperationState::Failed)
+    );
+    let rendered = response
+        .failure_detail
+        .as_deref()
+        .unwrap_or_default()
+        .to_string();
     assert!(rendered.contains("dimension mismatch"));
     assert!(rendered.contains("mempal reindex"));
 }

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -249,7 +249,7 @@ async fn ingest_with_config(db_path: PathBuf, config: Config) -> Result<serde_js
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn test_ingest_blocks_but_not_rejected_when_block_writes_false() {
+async fn test_ingest_returns_receipt_when_block_writes_false() {
     let _guard = test_guard().await;
     let (addr, handle) = start_mock(0).await.expect("start embed mock");
     handle.pause();
@@ -269,19 +269,34 @@ async fn test_ingest_blocks_but_not_rejected_when_block_writes_false() {
     status.record_failure(&"synthetic failure 1");
     status.record_failure(&"synthetic failure 2");
 
-    let task = tokio::spawn(ingest_with_config(env.db_path.clone(), config));
-    tokio::task::yield_now().await;
-    assert!(
-        !task.is_finished(),
-        "ingest should block while embedder is paused"
+    let payload = tokio::time::timeout(
+        Duration::from_secs(2),
+        ingest_with_config(env.db_path.clone(), config.clone()),
+    )
+    .await
+    .expect("receipt timeout")
+    .expect("ingest succeeds");
+    assert!(payload.get("operation_id").is_some());
+    assert_eq!(
+        payload.get("state").and_then(|value| value.as_str()),
+        Some("queued")
     );
 
     handle.resume();
-    let payload = task
+    let operation_id = payload
+        .get("operation_id")
+        .and_then(|value| value.as_str())
+        .expect("operation id");
+    let status_server = MempalMcpServer::new(env.db_path.clone(), config);
+    let completed = status_server
+        .wait_for_operation_completion(operation_id)
         .await
-        .expect("join ingest task")
-        .expect("ingest succeeds");
-    assert!(payload.get("drawer_id").is_some());
+        .expect("ingest completion");
+    assert_eq!(
+        completed.state,
+        Some(mempal::mcp::IngestOperationState::Completed)
+    );
+    assert!(!completed.drawer_id.is_empty());
 
     handle.shutdown().await;
 }

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -192,6 +192,94 @@ fn test_fork_ext_v17_to_v18_adds_xurl_vector_metadata_idempotently() {
 }
 
 #[test]
+fn test_new_database_has_async_ingest_columns_after_v19() {
+    let (_tmp, _db_path, db) = new_test_db();
+
+    let pending_columns = table_columns(db.conn(), "pending_messages");
+    assert!(has_column(&pending_columns, "result_drawer_id", "TEXT"));
+    assert!(has_column(&pending_columns, "op_state", "TEXT"));
+    assert!(has_column(&pending_columns, "rejected_reason", "TEXT"));
+    assert!(has_column(&pending_columns, "failure_detail", "TEXT"));
+    assert!(has_column(&pending_columns, "result_json", "TEXT"));
+
+    let completion_columns = table_columns(db.conn(), "pending_message_completions");
+    assert!(has_column(&completion_columns, "result_drawer_id", "TEXT"));
+    assert!(has_column(&completion_columns, "op_state", "TEXT"));
+    assert!(has_column(&completion_columns, "rejected_reason", "TEXT"));
+    assert!(has_column(&completion_columns, "failure_detail", "TEXT"));
+    assert!(has_column(&completion_columns, "result_json", "TEXT"));
+
+    let version = read_fork_ext_version(db.conn()).expect("read fork-ext version");
+    assert_eq!(version, CURRENT_FORK_EXT_VERSION);
+}
+
+#[test]
+fn test_fork_ext_v18_to_v19_adds_async_ingest_columns_idempotently() {
+    let conn = Connection::open_in_memory().expect("open sqlite connection");
+    let schema_version = current_schema_version();
+    conn.execute_batch(&format!(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '18');
+
+        CREATE TABLE pending_messages (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            claim_token TEXT,
+            claimed_at INTEGER,
+            heartbeat_at INTEGER,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            retry_backoff_ms INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL CHECK(status IN ('pending', 'claimed', 'done', 'failed')),
+            payload TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            last_error TEXT
+        );
+
+        CREATE TABLE pending_message_completions (
+            message_id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            claimed_at INTEGER,
+            completed_at INTEGER NOT NULL,
+            processing_ms INTEGER
+        );
+
+        PRAGMA user_version = {schema_version};
+        "#
+    ))
+    .expect("create v18 schema");
+
+    apply_fork_ext_migrations_to(&conn, 19).expect("first v19 migration");
+    apply_fork_ext_migrations_to(&conn, 19).expect("second v19 migration");
+
+    let pending_columns = table_columns(&conn, "pending_messages");
+    assert!(has_column(&pending_columns, "result_drawer_id", "TEXT"));
+    assert!(has_column(&pending_columns, "op_state", "TEXT"));
+    assert!(has_column(&pending_columns, "rejected_reason", "TEXT"));
+    assert!(has_column(&pending_columns, "failure_detail", "TEXT"));
+    assert!(has_column(&pending_columns, "result_json", "TEXT"));
+
+    let completion_columns = table_columns(&conn, "pending_message_completions");
+    assert!(has_column(&completion_columns, "result_drawer_id", "TEXT"));
+    assert!(has_column(&completion_columns, "op_state", "TEXT"));
+    assert!(has_column(&completion_columns, "rejected_reason", "TEXT"));
+    assert!(has_column(&completion_columns, "failure_detail", "TEXT"));
+    assert!(has_column(&completion_columns, "result_json", "TEXT"));
+
+    assert_eq!(read_fork_ext_version(&conn).expect("read version"), 19);
+    let user_version = conn
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .expect("read user_version");
+    assert_eq!(user_version, schema_version);
+}
+
+#[test]
 fn test_fork_ext_meta_table_exists_after_init() {
     let (_tmp, _db_path, db) = new_test_db();
 

--- a/tests/hermes_integration.rs
+++ b/tests/hermes_integration.rs
@@ -318,18 +318,20 @@ async fn ingest(
     project_id: Option<&str>,
 ) -> mempal::mcp::IngestResponse {
     server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: "hermes".to_string(),
-            room: Some("facts".to_string()),
-            source: Some("tests://hermes/ingest".to_string()),
-            project_id: project_id.map(str::to_string),
-            importance: Some(3),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: "hermes".to_string(),
+                room: Some("facts".to_string()),
+                source: Some("tests://hermes/ingest".to_string()),
+                project_id: project_id.map(str::to_string),
+                importance: Some(3),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
         .expect("ingest")
-        .0
 }
 
 async fn search_ids(server: &MempalMcpServer, query: &str) -> Vec<String> {
@@ -370,17 +372,19 @@ async fn test_replace_supersedes_old() {
     let old = ingest(&server, "Hermes old provider fact", None).await;
 
     let new = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "Hermes new provider fact".to_string(),
-            wing: "hermes".to_string(),
-            room: Some("facts".to_string()),
-            supersedes: Some(old.drawer_id.clone()),
-            importance: Some(4),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "Hermes new provider fact".to_string(),
+                wing: "hermes".to_string(),
+                room: Some("facts".to_string()),
+                supersedes: Some(old.drawer_id.clone()),
+                importance: Some(4),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("superseding ingest")
-        .0;
+        .expect("superseding ingest");
 
     assert_eq!(
         new.superseded_drawer_id.as_deref(),
@@ -638,16 +642,18 @@ async fn test_supersession_chain_end_to_end() {
     let server = env.server();
     let old = ingest(&server, "Hermes supersession chain old", None).await;
     let new = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "Hermes supersession chain new".to_string(),
-            wing: "hermes".to_string(),
-            room: Some("facts".to_string()),
-            supersedes: Some(old.drawer_id.clone()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "Hermes supersession chain new".to_string(),
+                wing: "hermes".to_string(),
+                room: Some("facts".to_string()),
+                supersedes: Some(old.drawer_id.clone()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("superseding ingest")
-        .0;
+        .expect("superseding ingest");
 
     let ids = search_ids(&server, "Hermes supersession chain").await;
 

--- a/tests/ingest_chunker.rs
+++ b/tests/ingest_chunker.rs
@@ -163,16 +163,18 @@ async fn test_mcp_ingest_short_content_single_chunk() {
 
     let content = make_content(10);
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content,
-            wing: "test".to_string(),
-            room: Some("chunker".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content,
+                wing: "test".to_string(),
+                room: Some("chunker".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("mcp ingest")
-        .0;
+        .expect("mcp ingest");
 
     assert!(!response.dropped, "should not be dropped");
     assert_eq!(response.chunk_count, 1, "short content = 1 chunk");
@@ -198,16 +200,18 @@ async fn test_mcp_ingest_large_content_multi_chunk() {
 
     let content = make_content(100);
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.clone(),
-            wing: "test".to_string(),
-            room: Some("chunker".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.clone(),
+                wing: "test".to_string(),
+                room: Some("chunker".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("mcp ingest")
-        .0;
+        .expect("mcp ingest");
 
     assert!(!response.dropped, "should not be dropped");
     assert!(

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -27,7 +27,6 @@ use mempal::ingest::gating::{
 use mempal::llm::client::LlmClient;
 use mempal::llm::status::LlmStatus;
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
@@ -329,16 +328,18 @@ fn run_mempal(home: &Path, args: &[&str]) -> std::process::Output {
 
 async fn ingest_mcp(server: &MempalMcpServer, content: &str) -> mempal::mcp::IngestResponse {
     server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: "code-memory".to_string(),
-            room: Some("gating".to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: "code-memory".to_string(),
+                room: Some("gating".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
         .expect("mcp ingest")
-        .0
 }
 
 fn gating_rows(db: &Database) -> Vec<GatingAuditRow> {

--- a/tests/memory_strata.rs
+++ b/tests/memory_strata.rs
@@ -112,16 +112,18 @@ async fn ingest(
     importance: i32,
 ) -> mempal::mcp::IngestResponse {
     server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: wing.to_string(),
-            room: Some(room.to_string()),
-            importance: Some(importance),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: wing.to_string(),
+                room: Some(room.to_string()),
+                importance: Some(importance),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
         .expect("ingest")
-        .0
 }
 
 #[tokio::test]

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -14,7 +14,6 @@ use mempal::core::db::{
 use mempal::core::types::{Drawer, SourceType, Triple};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::mcp::{IngestRequest, IngestResponse, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 use rusqlite::{Connection, OptionalExtension, params};
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
@@ -230,17 +229,19 @@ async fn ingest(
     project_id: Option<&str>,
 ) -> IngestResponse {
     server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: wing.to_string(),
-            room: Some(room.to_string()),
-            project_id: project_id.map(ToOwned::to_owned),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: wing.to_string(),
+                room: Some(room.to_string()),
+                project_id: project_id.map(ToOwned::to_owned),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
         .expect("ingest response")
-        .0
 }
 
 fn novelty_rows(db_path: &Path) -> Vec<NoveltyAuditRow> {

--- a/tests/pattern_induction.rs
+++ b/tests/pattern_induction.rs
@@ -25,7 +25,6 @@ use mempal::core::patterns::{
 use mempal::core::types::{Drawer, SourceType};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -220,13 +219,16 @@ impl TestEnv {
 
 async fn do_ingest(server: &MempalMcpServer, content: &str, source: &str) {
     server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: content.to_string(),
-            wing: "test".to_string(),
-            source: Some(source.to_string()),
-            dry_run: Some(false),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: content.to_string(),
+                wing: "test".to_string(),
+                source: Some(source.to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
         .expect("ingest");
 }

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -610,21 +610,23 @@ async fn test_linked_drawer_ids_rejects_manual_hooks_raw_with_external_source() 
 
     let ingested = env
         .server()
-        .mempal_ingest(Parameters(IngestRequest {
-            content: serde_json::json!({
-                "event": HookEvent::PostToolUse.display_name(),
-                "preview": "tool=Bash"
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: serde_json::json!({
+                    "event": HookEvent::PostToolUse.display_name(),
+                    "preview": "tool=Bash"
+                })
+                .to_string(),
+                wing: "hooks-raw".to_string(),
+                room: Some("Bash".to_string()),
+                source: Some(forged_path.display().to_string()),
+                project_id: Some("project-alpha".to_string()),
+                ..IngestRequest::default()
             })
-            .to_string(),
-            wing: "hooks-raw".to_string(),
-            room: Some("Bash".to_string()),
-            source: Some(forged_path.display().to_string()),
-            project_id: Some("project-alpha".to_string()),
-            ..IngestRequest::default()
-        }))
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("manual hooks-raw ingest")
-        .0;
+        .expect("manual hooks-raw ingest");
 
     let assistant = format!(
         "{} Manual hooks-raw drawers must not be trusted as same-session evidence.",
@@ -665,21 +667,23 @@ async fn test_linked_drawer_ids_does_not_read_external_filesystem() {
 
     let ingested = env
         .server()
-        .mempal_ingest(Parameters(IngestRequest {
-            content: serde_json::json!({
-                "event": HookEvent::PostToolUse.display_name(),
-                "preview": "tool=Bash"
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: serde_json::json!({
+                    "event": HookEvent::PostToolUse.display_name(),
+                    "preview": "tool=Bash"
+                })
+                .to_string(),
+                wing: "hooks-raw".to_string(),
+                room: Some("Bash".to_string()),
+                source: Some(missing_path.display().to_string()),
+                project_id: Some("project-alpha".to_string()),
+                ..IngestRequest::default()
             })
-            .to_string(),
-            wing: "hooks-raw".to_string(),
-            room: Some("Bash".to_string()),
-            source: Some(missing_path.display().to_string()),
-            project_id: Some("project-alpha".to_string()),
-            ..IngestRequest::default()
-        }))
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("manual hooks-raw ingest")
-        .0;
+        .expect("manual hooks-raw ingest");
 
     let assistant = format!(
         "{} Validation must not open attacker-chosen external files.",

--- a/tests/typed_ingest_pinned.rs
+++ b/tests/typed_ingest_pinned.rs
@@ -155,20 +155,22 @@ async fn test_typed_ingest_preserves_kind() {
     let server = env.server();
 
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "Prefer CLI dashboards over web dashboards.".to_string(),
-            wing: "profile".to_string(),
-            room: Some("facts".to_string()),
-            source: Some("typed-test".to_string()),
-            memory_kind: Some("profile_fact".to_string()),
-            domain: Some("user".to_string()),
-            field: Some("preferences".to_string()),
-            is_pinned: Some(true),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "Prefer CLI dashboards over web dashboards.".to_string(),
+                wing: "profile".to_string(),
+                room: Some("facts".to_string()),
+                source: Some("typed-test".to_string()),
+                memory_kind: Some("profile_fact".to_string()),
+                domain: Some("user".to_string()),
+                field: Some("preferences".to_string()),
+                is_pinned: Some(true),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("typed ingest")
-        .0;
+        .expect("typed ingest");
 
     let db = env.db();
     let drawer = db
@@ -244,29 +246,33 @@ async fn test_supersedes_chain() {
     let env = TestEnv::new();
     let server = env.server();
     let old = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "Old canonical fact.".to_string(),
-            wing: "profile".to_string(),
-            room: Some("facts".to_string()),
-            source: Some("typed-test-old".to_string()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "Old canonical fact.".to_string(),
+                wing: "profile".to_string(),
+                room: Some("facts".to_string()),
+                source: Some("typed-test-old".to_string()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("old ingest")
-        .0;
+        .expect("old ingest");
 
     let new = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "New canonical fact.".to_string(),
-            wing: "profile".to_string(),
-            room: Some("facts".to_string()),
-            source: Some("typed-test-new".to_string()),
-            supersedes: Some(old.drawer_id.clone()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "New canonical fact.".to_string(),
+                wing: "profile".to_string(),
+                room: Some("facts".to_string()),
+                source: Some("typed-test-new".to_string()),
+                supersedes: Some(old.drawer_id.clone()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("new ingest")
-        .0;
+        .expect("new ingest");
 
     let db = env.db();
     let new_drawer = db
@@ -295,16 +301,18 @@ async fn test_default_ingest_unchanged() {
     let server = env.server();
 
     let response = server
-        .mempal_ingest(Parameters(IngestRequest {
-            content: "Plain evidence still uses old defaults.".to_string(),
-            wing: "project".to_string(),
-            room: Some("notes".to_string()),
-            source: Some("typed-test-default".to_string()),
-            ..IngestRequest::default()
-        }))
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: "Plain evidence still uses old defaults.".to_string(),
+                wing: "project".to_string(),
+                room: Some("notes".to_string()),
+                source: Some("typed-test-default".to_string()),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
         .await
-        .expect("default ingest")
-        .0;
+        .expect("default ingest");
 
     let db = env.db();
     let drawer = db


### PR DESCRIPTION
## Summary

PR-A (core) of the #320 keystone: make agent-facing MCP writes **non-blocking** so `mempal_ingest` can never hang an agent on a saturated embedder.

`mempal_ingest` now returns a **durable receipt** (`operation_id`, `accepted_at`, `state: "queued"`) immediately, then performs the embed/store work asynchronously via the existing crash-safe `pending_messages` queue. A drain worker is spawned in the MCP server bootstrap and reuses the existing ingest pipeline. A new `mempal_operation_status` tool lets agents poll the outcome (`result_drawer_id` on success, `rejected_reason` / `failure_detail` on failure). Crash-safety is inherited from the queue's heartbeat + reclaim path.

This eliminates the synchronous 120s-timeout failure mode reported across the symptom cluster.

## Changes
- **fork_ext schema → v19**: async-ingest op columns on `pending_messages` (`kind='ingest_async'`, `result_drawer_id`, `op_state`, `rejected_reason`, `failure_detail`); idempotent migration.
- **Async enqueue + receipt**: `mempal_ingest` enqueues and returns `{operation_id, accepted_at, state:"queued"}` — no synchronous embed on the MCP call path.
- **Drain worker**: spawned in MCP server bootstrap; reuses the existing ingest pipeline; no `?`-bail that would kill the loop.
- **`mempal_operation_status` tool**: poll an operation's terminal state.
- **Crash-safety**: via the existing queue reclaim/heartbeat path (no new mechanism).
- Test suite migrated from the synchronous contract to the async receipt contract.

## Scope / follow-up (PR-B)
Deferred to PR-B: MCP `wait=true` option (D5), CLI `mempal ingest --wait` / `operation wait` (D6), per-stage timing breakdown (D8, closes #319), docs (D9).

## Issues
- Advances #320 (design keystone).
- Resolves the synchronous-blocking 120s-timeout symptom — Closes #321, Closes #322, Closes #324.
- #319 (92s blocking + timing-breakdown ask): the blocking is eliminated here; the diagnostic timing breakdown lands in PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
