### PR TITLE
feat(320): waitable ingest receipts + per-stage timing + MCP/CLI write guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,16 @@ api_model = "nomic-embed-text"
 
 > **Heads-up — two different `xurl`s.** `mempal xurl` is a mempal subcommand: an `ingest` / `search` / `timeline` / `stats` / `reindex` / `backfill` pipeline over agent session transcripts. It is **not** the standalone `xurl` CLI (Xuanwo's "Resolve and read code-agent threads", invoked as `xurl …` with `agents://` URIs). The two are independent projects that happen to share a name — neither is an alias for the other.
 
-## MCP Server (10 tools)
+## MCP Server (11 tools)
 
 `mempal serve --mcp` exposes these tools via Model Context Protocol:
 
 | Tool | Purpose |
 |------|---------|
 | `mempal_status` | State + protocol + AAAK spec (teaches agent on first call) |
+| `mempal_operation_status` | Poll a receipt-backed ingest op; returns drawer_id / rejection / failure and timing breakdowns when available |
 | `mempal_search` | Hybrid search with tunnel hints, citations, and AAAK-derived structured signals |
-| `mempal_ingest` | Store memories with optional importance (0-5) and dry_run; reports `lock_wait_ms` when concurrent ingest was observed |
+| `mempal_ingest` | Store memories with optional importance (0-5), dry_run, and receipt-based `wait` / `wait_timeout_secs`; reports `lock_wait_ms` when concurrent ingest was observed and can be polled via `mempal_operation_status` |
 | `mempal_delete` | Soft-delete with audit trail |
 | `mempal_taxonomy` | List or edit routing keywords |
 | `mempal_kg` | Knowledge graph: add/query/invalidate/timeline/stats |
@@ -115,6 +116,13 @@ api_model = "nomic-embed-text"
 | `mempal_fact_check` | Offline contradiction detection vs KG triples + known entities (similar-name, relation mismatch, stale facts) |
 
 The server embeds MEMORY_PROTOCOL (11 behavioral rules) in the MCP `initialize.instructions` field. Any MCP client learns the workflow automatically.
+
+## Write Guidance
+
+- Passive or low-risk diary writes: use `mempal_ingest` with the default fire-and-forget receipt path, or `mempal ingest --stdin` without `--wait`.
+- Load-bearing decisions: use `mempal_ingest` with `wait=true` or CLI `mempal ingest --stdin --wait [--wait-timeout-secs N]` so you block until the write is terminal.
+- User-facing capture: always surface rejected or failed reasons instead of only returning a queued receipt.
+- Receipt polling: use `mempal_operation_status` or CLI `mempal operation status <operation_id>`; both include `timings` when the ingest has completed.
 
 ## Memory Protocol
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3323,6 +3323,45 @@ fn exact_duplicate_drawer_id(
         .map(|summary| summary.id))
 }
 
+struct ExactDuplicateStdinIngest<'a> {
+    db: &'a Database,
+    wing: &'a str,
+    json: bool,
+    record: &'a StdinIngestRecord,
+    stats: &'a mut IngestStats,
+    drawer_id: &'a str,
+    is_pinned: bool,
+    superseded_drawer_id: Option<&'a str>,
+}
+
+fn finalize_exact_duplicate_stdin_ingest(ctx: ExactDuplicateStdinIngest<'_>) -> Result<()> {
+    let ExactDuplicateStdinIngest {
+        db,
+        wing,
+        json,
+        record,
+        stats,
+        drawer_id,
+        is_pinned,
+        superseded_drawer_id,
+    } = ctx;
+    if is_pinned {
+        db.pin_drawer(drawer_id, None)
+            .with_context(|| format!("failed to pin duplicate drawer {drawer_id}"))?;
+    }
+    stats.skipped = 1;
+    stats.drawer_ids = vec![drawer_id.to_string()];
+    if let Some(old_id) = superseded_drawer_id {
+        db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
+            .with_context(|| format!("failed to supersede drawer {old_id}"))?;
+        stats.superseded_drawer_id = Some(old_id.to_string());
+    }
+    append_ingest_stdin_audit_log(db, wing, false, record, stats)
+        .context("failed to append ingest audit log")?;
+    print_stdin_ingest_output(json, false, stats)?;
+    Ok(())
+}
+
 fn validate_temporal_bound<'a>(field: &str, value: Option<&'a str>) -> Result<Option<&'a str>> {
     if let Some(raw) = value {
         if mempal::core::decay::parse_temporal_timestamp_secs(raw).is_none() {
@@ -3504,6 +3543,23 @@ async fn ingest_stdin_command(
         return Ok(());
     }
 
+    // Exact duplicates are a local no-op. Keep `--wait` on the same
+    // terminal stats/audit path as the direct stdin ingest instead of
+    // queueing a receipt that would report different skip semantics.
+    if options.wait && exact_duplicate.is_some() {
+        finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
+            db,
+            wing,
+            json: options.json,
+            record: &record,
+            stats: &mut stats,
+            drawer_id: &drawer_id,
+            is_pinned,
+            superseded_drawer_id: superseded_drawer_id.as_deref(),
+        })?;
+        return Ok(());
+    }
+
     if options.wait {
         let wait_request = IngestRequest {
             content: content.clone(),
@@ -3559,7 +3615,7 @@ async fn ingest_stdin_command(
             );
         }
 
-        let wait_stats = ingest_stdin_wait_stats_from_response(&response);
+        let mut wait_stats = ingest_stdin_wait_stats_from_response(&response);
         match response.state {
             Some(IngestOperationState::Completed) => {
                 append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
@@ -3568,14 +3624,11 @@ async fn ingest_stdin_command(
                 return Ok(());
             }
             Some(IngestOperationState::Rejected) => {
+                wait_stats.drawer_ids.clear();
                 append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, false, &wait_stats)?;
-                bail!(
-                    "ingest operation {} was rejected: {}",
-                    response.operation_id.as_deref().unwrap_or(""),
-                    response.rejected_reason.as_deref().unwrap_or("rejected")
-                );
+                return Ok(());
             }
             Some(IngestOperationState::Failed) => {
                 print_stdin_ingest_output(options.json, false, &wait_stats)?;
@@ -3593,20 +3646,16 @@ async fn ingest_stdin_command(
     }
 
     if exact_duplicate.is_some() {
-        if is_pinned {
-            db.pin_drawer(&drawer_id, None)
-                .with_context(|| format!("failed to pin duplicate drawer {drawer_id}"))?;
-        }
-        stats.skipped = 1;
-        stats.drawer_ids.push(drawer_id.clone());
-        if let Some(old_id) = superseded_drawer_id.as_deref() {
-            db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
-                .with_context(|| format!("failed to supersede drawer {old_id}"))?;
-            stats.superseded_drawer_id = Some(old_id.to_string());
-        }
-        append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
-            .context("failed to append ingest audit log")?;
-        print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+        finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
+            db,
+            wing,
+            json: options.json,
+            record: &record,
+            stats: &mut stats,
+            drawer_id: &drawer_id,
+            is_pinned,
+            superseded_drawer_id: superseded_drawer_id.as_deref(),
+        })?;
         return Ok(());
     }
 
@@ -3645,6 +3694,7 @@ async fn ingest_stdin_command(
                 .with_context(|| format!("failed to record gating audit for {drawer_id}"))?;
             if decision.is_rejected() {
                 stats.dropped_by_gate = 1;
+                stats.drawer_ids.clear();
                 append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
@@ -3666,6 +3716,7 @@ async fn ingest_stdin_command(
             stats.fact_check_warnings.extend(outcome.warnings);
             if outcome.decision.is_rejected() {
                 stats.dropped_by_gate = 1;
+                stats.drawer_ids.clear();
                 append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, options.dry_run, &stats)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3564,13 +3564,13 @@ async fn ingest_stdin_command(
             Some(IngestOperationState::Completed) => {
                 append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
-                print_operation_response(&response)?;
+                print_stdin_ingest_output(options.json, false, &wait_stats)?;
                 return Ok(());
             }
             Some(IngestOperationState::Rejected) => {
                 append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
-                print_operation_response(&response)?;
+                print_stdin_ingest_output(options.json, false, &wait_stats)?;
                 bail!(
                     "ingest operation {} was rejected: {}",
                     response.operation_id.as_deref().unwrap_or(""),
@@ -3578,7 +3578,7 @@ async fn ingest_stdin_command(
                 );
             }
             Some(IngestOperationState::Failed) => {
-                print_operation_response(&response)?;
+                print_stdin_ingest_output(options.json, false, &wait_stats)?;
                 bail!(
                     "ingest operation {} failed: {}",
                     response.operation_id.as_deref().unwrap_or(""),

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,8 @@ use mempal::knowledge_lifecycle::{
     DemoteRequest, PromoteRequest, demote_knowledge, promote_knowledge,
 };
 use mempal::mcp::{
-    IngestOperationState, IngestRequest, IngestResponse, MempalMcpServer, OperationStatusRequest,
+    IngestControls, IngestOperationState, IngestRequest, IngestResponse, MempalMcpServer,
+    OperationStatusRequest,
 };
 use mempal::observability;
 use mempal::search::{SearchFilters, SearchOptions, search_with_all_options};
@@ -3338,7 +3339,6 @@ impl ResolvedStdinIngest {
             valid_from: self.valid_from.clone(),
             valid_until: self.valid_until.clone(),
             dry_run: Some(false),
-            no_gate: Some(self.no_gate),
             wait: Some(true),
             wait_timeout_secs: Some(wait_timeout_secs),
             diary_rollup: Some(false),
@@ -3360,7 +3360,6 @@ impl ResolvedStdinIngest {
             anchor_kind: None,
             anchor_id: None,
             parent_anchor_id: None,
-            bypass_novelty: self.bypass_novelty,
             cwd: self.cwd.as_ref().map(|path| path.display().to_string()),
         }
     }
@@ -3696,9 +3695,13 @@ async fn ingest_stdin_command(
 
     if options.wait {
         let wait_request = resolved.wait_request(options.wait_timeout_secs.unwrap_or(30));
+        let controls = IngestControls {
+            no_gate: resolved.no_gate,
+            bypass_novelty: resolved.bypass_novelty,
+        };
         let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
         let response = server
-            .mempal_ingest(rmcp::handler::server::wrapper::Parameters(wait_request))
+            .mempal_ingest_with_controls(wait_request, controls)
             .await
             .map(|response| response.0)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3510,6 +3510,7 @@ async fn ingest_stdin_command(
             wing: wing.to_string(),
             room: room.map(ToOwned::to_owned),
             source: record.source.clone(),
+            source_file: record.source_file.clone(),
             source_type: Some(source_type.to_string()),
             confidence: Some(confidence),
             project_id: project.map(ToOwned::to_owned),
@@ -3518,6 +3519,7 @@ async fn ingest_stdin_command(
             valid_from: valid_from.map(ToOwned::to_owned),
             valid_until: valid_until.map(ToOwned::to_owned),
             dry_run: Some(false),
+            no_gate: Some(options.no_gate),
             wait: Some(true),
             wait_timeout_secs: Some(options.wait_timeout_secs.unwrap_or(30)),
             diary_rollup: Some(false),
@@ -3549,16 +3551,26 @@ async fn ingest_stdin_command(
             .await
             .map(|response| response.0)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
-        print_operation_response(&response)?;
         if response.timed_out {
+            print_operation_response(&response)?;
             bail!(
                 "timed out waiting for ingest operation {}",
                 response.operation_id.as_deref().unwrap_or("")
             );
         }
+
+        let wait_stats = ingest_stdin_wait_stats_from_response(&response);
         match response.state {
-            Some(IngestOperationState::Completed) => return Ok(()),
+            Some(IngestOperationState::Completed) => {
+                append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
+                    .context("failed to append ingest audit log")?;
+                print_operation_response(&response)?;
+                return Ok(());
+            }
             Some(IngestOperationState::Rejected) => {
+                append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
+                    .context("failed to append ingest audit log")?;
+                print_operation_response(&response)?;
                 bail!(
                     "ingest operation {} was rejected: {}",
                     response.operation_id.as_deref().unwrap_or(""),
@@ -3566,13 +3578,17 @@ async fn ingest_stdin_command(
                 );
             }
             Some(IngestOperationState::Failed) => {
+                print_operation_response(&response)?;
                 bail!(
                     "ingest operation {} failed: {}",
                     response.operation_id.as_deref().unwrap_or(""),
                     response.failure_detail.as_deref().unwrap_or("failed")
                 );
             }
-            _ => return Ok(()),
+            _ => {
+                print_operation_response(&response)?;
+                return Ok(());
+            }
         }
     }
 
@@ -3832,6 +3848,27 @@ fn print_operation_response(response: &IngestResponse) -> Result<()> {
         serde_json::to_string(&response.timings).context("failed to serialize timings")?
     );
     Ok(())
+}
+
+fn ingest_stdin_wait_stats_from_response(response: &IngestResponse) -> IngestStats {
+    let mut stats = IngestStats {
+        files: 1,
+        chunks: if response.dropped {
+            0
+        } else {
+            response.chunk_count
+        },
+        dropped_by_gate: if response.dropped { 1 } else { 0 },
+        ..IngestStats::default()
+    };
+    stats.drawer_ids = if response.drawer_ids.is_empty() && !response.drawer_id.is_empty() {
+        vec![response.drawer_id.clone()]
+    } else {
+        response.drawer_ids.clone()
+    };
+    stats.fact_check_warnings = response.fact_check_warnings.clone();
+    stats.superseded_drawer_id = response.superseded_drawer_id.clone();
+    stats
 }
 
 async fn wait_for_operation_status_with_progress(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3840,7 +3840,7 @@ async fn wait_for_operation_status_with_progress(
     timeout: std::time::Duration,
     poll_interval: std::time::Duration,
 ) -> Result<Option<IngestResponse>> {
-    let deadline = std::time::Instant::now() + timeout;
+    let deadline = std::time::Instant::now() + clamp_wait_timeout(timeout);
     loop {
         let response = server
             .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
@@ -3871,6 +3871,12 @@ async fn wait_for_operation_status_with_progress(
         );
         tokio::time::sleep(poll_interval).await;
     }
+}
+
+const MAX_WAIT_TIMEOUT_SECS: u64 = 86_400;
+
+fn clamp_wait_timeout(timeout: std::time::Duration) -> std::time::Duration {
+    timeout.min(std::time::Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
 }
 
 async fn operation_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -3311,6 +3311,7 @@ struct ResolvedStdinIngest {
     raw_turn: bool,
     drawer_importance: i32,
     cwd: Option<PathBuf>,
+    bypass_novelty: bool,
 }
 
 impl ResolvedStdinIngest {
@@ -3359,6 +3360,7 @@ impl ResolvedStdinIngest {
             anchor_kind: None,
             anchor_id: None,
             parent_anchor_id: None,
+            bypass_novelty: self.bypass_novelty,
             cwd: self.cwd.as_ref().map(|path| path.display().to_string()),
         }
     }
@@ -3521,6 +3523,7 @@ fn resolve_stdin_ingest(
         raw_turn,
         drawer_importance,
         cwd,
+        bypass_novelty: true,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,9 @@ use mempal::knowledge_gate::{
 use mempal::knowledge_lifecycle::{
     DemoteRequest, PromoteRequest, demote_knowledge, promote_knowledge,
 };
-use mempal::mcp::MempalMcpServer;
+use mempal::mcp::{
+    IngestOperationState, IngestRequest, IngestResponse, MempalMcpServer, OperationStatusRequest,
+};
 use mempal::observability;
 use mempal::search::{SearchFilters, SearchOptions, search_with_all_options};
 use mempal::sleep::{
@@ -152,6 +154,8 @@ struct IngestCommandOptions<'a> {
     json: bool,
     no_strip_noise: bool,
     diary_rollup: bool,
+    wait: bool,
+    wait_timeout_secs: Option<u64>,
     source_type: Option<&'a str>,
     memory_kind: Option<&'a str>,
     domain: Option<&'a str>,
@@ -284,6 +288,10 @@ enum Commands {
         dry_run: bool,
         #[arg(long)]
         json: bool,
+        #[arg(long, default_value_t = false)]
+        wait: bool,
+        #[arg(long = "wait-timeout-secs")]
+        wait_timeout_secs: Option<u64>,
         #[arg(long)]
         no_strip_noise: bool,
         #[arg(long)]
@@ -308,6 +316,11 @@ enum Commands {
         valid_from: Option<String>,
         #[arg(long = "valid-until")]
         valid_until: Option<String>,
+    },
+    /// Inspect or wait for a receipt-backed ingest operation.
+    Operation {
+        #[command(subcommand)]
+        command: OperationCommands,
     },
     /// Index a Claude Code session JSONL transcript as searchable conversation memory.
     /// Wing is always "conversation"; room defaults to the sessionId field or filename stem.
@@ -1001,6 +1014,18 @@ enum Commands {
         query: String,
         #[arg(long, default_value = "plain")]
         format: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum OperationCommands {
+    /// Print the current status of a receipt-backed ingest operation.
+    Status { operation_id: String },
+    /// Block until a receipt-backed ingest operation reaches a terminal state.
+    Wait {
+        operation_id: String,
+        #[arg(long = "timeout-secs", default_value_t = 30)]
+        timeout_secs: u64,
     },
 }
 
@@ -2387,6 +2412,8 @@ fn run() -> Result<()> {
             no_gate,
             dry_run,
             json,
+            wait,
+            wait_timeout_secs,
             no_strip_noise,
             diary_rollup,
             source_type,
@@ -2412,6 +2439,8 @@ fn run() -> Result<()> {
                 no_gate,
                 dry_run,
                 json,
+                wait,
+                wait_timeout_secs,
                 no_strip_noise,
                 diary_rollup,
                 source_type: source_type.as_deref(),
@@ -2426,6 +2455,9 @@ fn run() -> Result<()> {
                 valid_until: valid_until.as_deref(),
             },
         )),
+        Commands::Operation { command } => {
+            block_on_result(operation_command(&db, config.as_ref(), command))
+        }
         Commands::IngestConversation { .. } => {
             eprintln!(
                 "error: `mempal ingest-conversation` was removed in P16.\n\
@@ -3472,6 +3504,78 @@ async fn ingest_stdin_command(
         return Ok(());
     }
 
+    if options.wait {
+        let wait_request = IngestRequest {
+            content: content.clone(),
+            wing: wing.to_string(),
+            room: room.map(ToOwned::to_owned),
+            source: record.source.clone(),
+            source_type: Some(source_type.to_string()),
+            confidence: Some(confidence),
+            project_id: project.map(ToOwned::to_owned),
+            supersedes: supersedes.map(ToOwned::to_owned),
+            replace_text: replace_text.map(ToOwned::to_owned),
+            valid_from: valid_from.map(ToOwned::to_owned),
+            valid_until: valid_until.map(ToOwned::to_owned),
+            dry_run: Some(false),
+            wait: Some(true),
+            wait_timeout_secs: Some(options.wait_timeout_secs.unwrap_or(30)),
+            diary_rollup: Some(false),
+            importance: Some(drawer_importance),
+            memory_kind: Some(memory_kind_slug(&memory_kind).to_string()),
+            domain: Some(domain_slug(&domain).to_string()),
+            field: Some(field.to_string()),
+            is_pinned: Some(is_pinned),
+            provenance: None,
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: None,
+            counterexample_refs: None,
+            teaching_refs: None,
+            verification_refs: None,
+            scope_constraints: None,
+            trigger_hints: None,
+            anchor_kind: None,
+            anchor_id: None,
+            parent_anchor_id: None,
+            cwd: env::current_dir()
+                .ok()
+                .map(|path| path.display().to_string()),
+        };
+        let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
+        let response = server
+            .mempal_ingest(rmcp::handler::server::wrapper::Parameters(wait_request))
+            .await
+            .map(|response| response.0)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        print_operation_response(&response)?;
+        if response.timed_out {
+            bail!(
+                "timed out waiting for ingest operation {}",
+                response.operation_id.as_deref().unwrap_or("")
+            );
+        }
+        match response.state {
+            Some(IngestOperationState::Completed) => return Ok(()),
+            Some(IngestOperationState::Rejected) => {
+                bail!(
+                    "ingest operation {} was rejected: {}",
+                    response.operation_id.as_deref().unwrap_or(""),
+                    response.rejected_reason.as_deref().unwrap_or("rejected")
+                );
+            }
+            Some(IngestOperationState::Failed) => {
+                bail!(
+                    "ingest operation {} failed: {}",
+                    response.operation_id.as_deref().unwrap_or(""),
+                    response.failure_detail.as_deref().unwrap_or("failed")
+                );
+            }
+            _ => return Ok(()),
+        }
+    }
+
     if exact_duplicate.is_some() {
         if is_pinned {
             db.pin_drawer(&drawer_id, None)
@@ -3695,6 +3799,143 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
 fn print_fact_check_warnings(warnings: &[String]) {
     for warning in warnings {
         eprintln!("{warning}");
+    }
+}
+
+fn print_operation_response(response: &IngestResponse) -> Result<()> {
+    println!(
+        "operation_id={}",
+        response.operation_id.as_deref().unwrap_or("")
+    );
+    println!(
+        "state={}",
+        response.state.map(|state| state.as_str()).unwrap_or("")
+    );
+    println!("timed_out={}", response.timed_out);
+    println!("drawer_id={}", response.drawer_id);
+    if !response.drawer_ids.is_empty() {
+        println!("drawer_ids={}", response.drawer_ids.join(","));
+    }
+    println!("chunk_count={}", response.chunk_count);
+    println!("dropped={}", response.dropped);
+    if let Some(accepted_at) = response.accepted_at.as_deref() {
+        println!("accepted_at={accepted_at}");
+    }
+    if let Some(rejected_reason) = response.rejected_reason.as_deref() {
+        println!("rejected_reason={rejected_reason}");
+    }
+    if let Some(failure_detail) = response.failure_detail.as_deref() {
+        println!("failure_detail={failure_detail}");
+    }
+    println!(
+        "timings={}",
+        serde_json::to_string(&response.timings).context("failed to serialize timings")?
+    );
+    Ok(())
+}
+
+async fn wait_for_operation_status_with_progress(
+    server: &MempalMcpServer,
+    operation_id: &str,
+    timeout: std::time::Duration,
+    poll_interval: std::time::Duration,
+) -> Result<Option<IngestResponse>> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let response = server
+            .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
+                OperationStatusRequest {
+                    operation_id: operation_id.to_string(),
+                },
+            ))
+            .await
+            .context("failed to load operation status")?
+            .0;
+        if response
+            .state
+            .map(IngestOperationState::is_terminal)
+            .unwrap_or(false)
+        {
+            return Ok(Some(response));
+        }
+        if timeout.is_zero() || std::time::Instant::now() >= deadline {
+            return Ok(None);
+        }
+        eprintln!(
+            "waiting operation_id={} state={}",
+            operation_id,
+            response
+                .state
+                .map(|state| state.as_str())
+                .unwrap_or("unknown")
+        );
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+async fn operation_command(
+    db: &Database,
+    config: &Config,
+    command: OperationCommands,
+) -> Result<()> {
+    let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
+    match command {
+        OperationCommands::Status { operation_id } => {
+            let response = server
+                .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
+                    OperationStatusRequest { operation_id },
+                ))
+                .await
+                .context("failed to load operation status")?
+                .0;
+            print_operation_response(&response)?;
+            Ok(())
+        }
+        OperationCommands::Wait {
+            operation_id,
+            timeout_secs,
+        } => {
+            eprintln!(
+                "waiting for operation_id={} timeout_secs={timeout_secs}",
+                operation_id
+            );
+            match wait_for_operation_status_with_progress(
+                &server,
+                &operation_id,
+                std::time::Duration::from_secs(timeout_secs),
+                std::time::Duration::from_millis(150),
+            )
+            .await?
+            {
+                Some(response) => {
+                    print_operation_response(&response)?;
+                    match response.state {
+                        Some(IngestOperationState::Completed) => Ok(()),
+                        Some(IngestOperationState::Rejected) => {
+                            bail!("operation {operation_id} was rejected")
+                        }
+                        Some(IngestOperationState::Failed) => {
+                            bail!("operation {operation_id} failed")
+                        }
+                        _ => Ok(()),
+                    }
+                }
+                None => {
+                    let mut response = server
+                        .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
+                            OperationStatusRequest {
+                                operation_id: operation_id.clone(),
+                            },
+                        ))
+                        .await
+                        .context("failed to load timed-out operation status")?
+                        .0;
+                    response.timed_out = true;
+                    print_operation_response(&response)?;
+                    bail!("timed out waiting for operation {operation_id}")
+                }
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3289,6 +3289,81 @@ struct StdinIngestRecord {
 
 const MAX_STDIN_INGEST_BYTES: usize = 10 * 1024 * 1024;
 
+#[derive(Debug)]
+struct ResolvedStdinIngest {
+    content: String,
+    wing: String,
+    room: Option<String>,
+    source: Option<String>,
+    source_file: Option<String>,
+    project_id: Option<String>,
+    source_type: SourceType,
+    confidence: f64,
+    supersedes: Option<String>,
+    replace_text: Option<String>,
+    valid_from: Option<String>,
+    valid_until: Option<String>,
+    memory_kind: MemoryKind,
+    domain: MemoryDomain,
+    field: String,
+    is_pinned: bool,
+    no_gate: bool,
+    raw_turn: bool,
+    drawer_importance: i32,
+    cwd: Option<PathBuf>,
+}
+
+impl ResolvedStdinIngest {
+    fn source_hint(&self) -> Option<&str> {
+        self.source_file.as_deref().or(self.source.as_deref())
+    }
+
+    fn source_file_for_drawer(drawer_id: &str, source_hint: Option<&str>) -> String {
+        source_file_or_synthetic(drawer_id, source_hint)
+    }
+
+    fn wait_request(&self, wait_timeout_secs: u64) -> IngestRequest {
+        IngestRequest {
+            content: self.content.clone(),
+            wing: self.wing.clone(),
+            room: self.room.clone(),
+            source: self.source.clone(),
+            source_file: self.source_file.clone(),
+            source_type: Some(self.source_type.to_string()),
+            confidence: Some(self.confidence),
+            project_id: self.project_id.clone(),
+            supersedes: self.supersedes.clone(),
+            replace_text: self.replace_text.clone(),
+            valid_from: self.valid_from.clone(),
+            valid_until: self.valid_until.clone(),
+            dry_run: Some(false),
+            no_gate: Some(self.no_gate),
+            wait: Some(true),
+            wait_timeout_secs: Some(wait_timeout_secs),
+            diary_rollup: Some(false),
+            importance: Some(self.drawer_importance),
+            memory_kind: Some(memory_kind_slug(&self.memory_kind).to_string()),
+            domain: Some(domain_slug(&self.domain).to_string()),
+            field: Some(self.field.clone()),
+            is_pinned: Some(self.is_pinned),
+            provenance: None,
+            statement: None,
+            tier: None,
+            status: None,
+            supporting_refs: None,
+            counterexample_refs: None,
+            teaching_refs: None,
+            verification_refs: None,
+            scope_constraints: None,
+            trigger_hints: None,
+            anchor_kind: None,
+            anchor_id: None,
+            parent_anchor_id: None,
+            cwd: self.cwd.as_ref().map(|path| path.display().to_string()),
+        }
+    }
+}
+
 #[derive(Serialize)]
 struct StdinIngestJsonOutput<'a> {
     drawer_ids: &'a [String],
@@ -3360,6 +3435,93 @@ fn finalize_exact_duplicate_stdin_ingest(ctx: ExactDuplicateStdinIngest<'_>) -> 
         .context("failed to append ingest audit log")?;
     print_stdin_ingest_output(json, false, stats)?;
     Ok(())
+}
+
+fn resolve_stdin_ingest(
+    config: &Config,
+    options: &IngestCommandOptions<'_>,
+    record: &StdinIngestRecord,
+    content: String,
+    wing: String,
+    room: Option<String>,
+) -> Result<ResolvedStdinIngest> {
+    let source = record.source.clone();
+    let source_file = record.source_file.clone();
+    let project = options.project.or(record.project.as_deref());
+    let supersedes = options
+        .supersedes
+        .or(record.supersedes.as_deref())
+        .map(ToOwned::to_owned);
+    let replace_text = options
+        .replace_text
+        .or(record.replace_text.as_deref())
+        .map(ToOwned::to_owned);
+    let source_type = parse_source_type_bound(
+        "source_type",
+        options.source_type.or(record.source_type.as_deref()),
+    )?
+    .unwrap_or(SourceType::AgentInference);
+    let memory_kind = parse_memory_kind_bound(
+        "memory_kind",
+        options.memory_kind.or(record.memory_kind.as_deref()),
+    )?
+    .unwrap_or(MemoryKind::Evidence);
+    let domain = options
+        .domain
+        .or(record.domain.as_deref())
+        .map(parse_domain)
+        .transpose()
+        .context("failed to parse stdin ingest domain")?
+        .unwrap_or(MemoryDomain::Project);
+    let field = options
+        .field
+        .or(record.field.as_deref())
+        .unwrap_or("general")
+        .to_string();
+    let is_pinned = options.is_pinned || record.is_pinned.unwrap_or(false);
+    let confidence = resolve_confidence_bound(
+        "confidence",
+        source_type,
+        options.confidence.or(record.confidence),
+    )?;
+    let valid_from = validate_temporal_bound(
+        "valid_from",
+        options.valid_from.or(record.valid_from.as_deref()),
+    )?
+    .map(ToOwned::to_owned);
+    let valid_until = validate_temporal_bound(
+        "valid_until",
+        options.valid_until.or(record.valid_until.as_deref()),
+    )?
+    .map(ToOwned::to_owned);
+    let cwd = env::current_dir().ok();
+    let project_id = resolve_project_id(project, config, cwd.as_deref())
+        .context("failed to resolve stdin ingest project id")?;
+    let raw_turn = is_raw_turn(&wing, room.as_deref(), &config.turns);
+    let drawer_importance = raw_turn_importance(&wing, room.as_deref(), &config.turns).unwrap_or(0);
+
+    Ok(ResolvedStdinIngest {
+        content,
+        wing,
+        room,
+        source,
+        source_file,
+        project_id,
+        source_type,
+        confidence,
+        supersedes,
+        replace_text,
+        valid_from,
+        valid_until,
+        memory_kind,
+        domain,
+        field,
+        is_pinned,
+        no_gate: options.no_gate,
+        raw_turn,
+        drawer_importance,
+        cwd,
+    })
 }
 
 fn validate_temporal_bound<'a>(field: &str, value: Option<&'a str>) -> Result<Option<&'a str>> {
@@ -3447,71 +3609,35 @@ async fn ingest_stdin_command(
     let wing = options
         .wing
         .or(record.wing.as_deref())
-        .context("stdin ingest requires --wing or JSON `wing`")?;
-    let room = options.room.or(record.room.as_deref());
-    let project = options.project.or(record.project.as_deref());
-    let supersedes = options.supersedes.or(record.supersedes.as_deref());
-    let replace_text = options.replace_text.or(record.replace_text.as_deref());
-    let source_type = parse_source_type_bound(
-        "source_type",
-        options.source_type.or(record.source_type.as_deref()),
-    )?
-    .unwrap_or(SourceType::AgentInference);
-    let memory_kind = parse_memory_kind_bound(
-        "memory_kind",
-        options.memory_kind.or(record.memory_kind.as_deref()),
-    )?
-    .unwrap_or(MemoryKind::Evidence);
-    let domain = options
-        .domain
-        .or(record.domain.as_deref())
-        .map(parse_domain)
-        .transpose()
-        .context("failed to parse stdin ingest domain")?
-        .unwrap_or(MemoryDomain::Project);
-    let field = options
-        .field
-        .or(record.field.as_deref())
-        .unwrap_or("general");
-    let is_pinned = options.is_pinned || record.is_pinned.unwrap_or(false);
-    let confidence = resolve_confidence_bound(
-        "confidence",
-        source_type,
-        options.confidence.or(record.confidence),
-    )?;
-    let valid_from = validate_temporal_bound(
-        "valid_from",
-        options.valid_from.or(record.valid_from.as_deref()),
-    )?;
-    let valid_until = validate_temporal_bound(
-        "valid_until",
-        options.valid_until.or(record.valid_until.as_deref()),
-    )?;
-    let raw_turn = is_raw_turn(wing, room, &config.turns);
+        .context("stdin ingest requires --wing or JSON `wing`")?
+        .to_string();
+    let room = options
+        .room
+        .or(record.room.as_deref())
+        .map(ToOwned::to_owned);
+    let resolved = resolve_stdin_ingest(config, &options, &record, content, wing, room)?;
     let mut stats = IngestStats {
         files: 1,
         ..IngestStats::default()
     };
-    if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
+    if resolved.raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
         stats.skipped = 1;
         print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
         return Ok(());
     }
-    let drawer_importance = raw_turn_importance(wing, room, &config.turns).unwrap_or(0);
     let (privacy_config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
-    let scrubbed_replace_text = replace_text
+    let scrubbed_replace_text = resolved
+        .replace_text
+        .as_deref()
         .map(|text| privacy_config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
-    let cwd = env::current_dir().ok();
-    let project_id = resolve_project_id(project, config, cwd.as_deref())
-        .context("failed to resolve stdin ingest project id")?;
 
     let replacement_target = db
         .resolve_replacement_target(
-            supersedes,
+            resolved.supersedes.as_deref(),
             scrubbed_replace_text.as_deref(),
-            wing,
-            room,
-            project_id.as_deref(),
+            &resolved.wing,
+            resolved.room.as_deref(),
+            resolved.project_id.as_deref(),
         )
         .context("failed to resolve replacement target")?;
     let superseded_drawer_id = replacement_target
@@ -3520,24 +3646,29 @@ async fn ingest_stdin_command(
     let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
     let exact_duplicate = exact_duplicate_drawer_id(
         db,
-        &content,
-        wing,
-        room,
-        project_id.as_deref(),
+        &resolved.content,
+        &resolved.wing,
+        resolved.room.as_deref(),
+        resolved.project_id.as_deref(),
         superseded_drawer_id_ref,
     )
     .context("failed to check exact duplicate")?;
     let drawer_id = if let Some(existing_id) = exact_duplicate.as_ref() {
         existing_id.clone()
     } else {
-        let preferred_id = build_bootstrap_evidence_drawer_id(wing, room, &content, &source_type);
+        let preferred_id = build_bootstrap_evidence_drawer_id(
+            &resolved.wing,
+            resolved.room.as_deref(),
+            &resolved.content,
+            &resolved.source_type,
+        );
         db.resolve_available_drawer_id(&preferred_id)
             .with_context(|| format!("failed to resolve drawer id for {preferred_id}"))?
     };
     if options.dry_run {
         stats.chunks = 1;
         stats.drawer_ids.push(drawer_id.clone());
-        append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+        append_ingest_stdin_audit_log(db, &resolved.wing, options.dry_run, &record, &stats)
             .context("failed to append ingest audit log")?;
         print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
         return Ok(());
@@ -3549,58 +3680,19 @@ async fn ingest_stdin_command(
     if options.wait && exact_duplicate.is_some() {
         finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
             db,
-            wing,
+            wing: &resolved.wing,
             json: options.json,
             record: &record,
             stats: &mut stats,
             drawer_id: &drawer_id,
-            is_pinned,
+            is_pinned: resolved.is_pinned,
             superseded_drawer_id: superseded_drawer_id.as_deref(),
         })?;
         return Ok(());
     }
 
     if options.wait {
-        let wait_request = IngestRequest {
-            content: content.clone(),
-            wing: wing.to_string(),
-            room: room.map(ToOwned::to_owned),
-            source: record.source.clone(),
-            source_file: record.source_file.clone(),
-            source_type: Some(source_type.to_string()),
-            confidence: Some(confidence),
-            project_id: project.map(ToOwned::to_owned),
-            supersedes: supersedes.map(ToOwned::to_owned),
-            replace_text: replace_text.map(ToOwned::to_owned),
-            valid_from: valid_from.map(ToOwned::to_owned),
-            valid_until: valid_until.map(ToOwned::to_owned),
-            dry_run: Some(false),
-            no_gate: Some(options.no_gate),
-            wait: Some(true),
-            wait_timeout_secs: Some(options.wait_timeout_secs.unwrap_or(30)),
-            diary_rollup: Some(false),
-            importance: Some(drawer_importance),
-            memory_kind: Some(memory_kind_slug(&memory_kind).to_string()),
-            domain: Some(domain_slug(&domain).to_string()),
-            field: Some(field.to_string()),
-            is_pinned: Some(is_pinned),
-            provenance: None,
-            statement: None,
-            tier: None,
-            status: None,
-            supporting_refs: None,
-            counterexample_refs: None,
-            teaching_refs: None,
-            verification_refs: None,
-            scope_constraints: None,
-            trigger_hints: None,
-            anchor_kind: None,
-            anchor_id: None,
-            parent_anchor_id: None,
-            cwd: env::current_dir()
-                .ok()
-                .map(|path| path.display().to_string()),
-        };
+        let wait_request = resolved.wait_request(options.wait_timeout_secs.unwrap_or(30));
         let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
         let response = server
             .mempal_ingest(rmcp::handler::server::wrapper::Parameters(wait_request))
@@ -3618,14 +3710,14 @@ async fn ingest_stdin_command(
         let mut wait_stats = ingest_stdin_wait_stats_from_response(&response);
         match response.state {
             Some(IngestOperationState::Completed) => {
-                append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
+                append_ingest_stdin_audit_log(db, &resolved.wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, false, &wait_stats)?;
                 return Ok(());
             }
             Some(IngestOperationState::Rejected) => {
                 wait_stats.drawer_ids.clear();
-                append_ingest_stdin_audit_log(db, wing, false, &record, &wait_stats)
+                append_ingest_stdin_audit_log(db, &resolved.wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, false, &wait_stats)?;
                 return Ok(());
@@ -3648,18 +3740,18 @@ async fn ingest_stdin_command(
     if exact_duplicate.is_some() {
         finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
             db,
-            wing,
+            wing: &resolved.wing,
             json: options.json,
             record: &record,
             stats: &mut stats,
             drawer_id: &drawer_id,
-            is_pinned,
+            is_pinned: resolved.is_pinned,
             superseded_drawer_id: superseded_drawer_id.as_deref(),
         })?;
         return Ok(());
     }
 
-    let prototype_classifier = if config.ingest_gating.enabled && !options.no_gate {
+    let prototype_classifier = if config.ingest_gating.enabled && !resolved.no_gate {
         compile_classifier_from_config(config)
             .await
             .map_err(|error| anyhow::anyhow!(error.to_string()))
@@ -3669,9 +3761,9 @@ async fn ingest_stdin_command(
     };
     let embedder = build_embedder(config).await?;
 
-    if !options.no_gate {
+    if !resolved.no_gate {
         let candidate = IngestCandidate {
-            content: content.clone(),
+            content: resolved.content.clone(),
             event: None,
             tool_name: None,
             exit_code: None,
@@ -3690,26 +3782,31 @@ async fn ingest_stdin_command(
             gating_decision = Some(tier2.decision);
         }
         if let Some(decision) = gating_decision.as_ref() {
-            db.record_gating_audit(&drawer_id, decision, project_id.as_deref(), Some(&content))
-                .with_context(|| format!("failed to record gating audit for {drawer_id}"))?;
+            db.record_gating_audit(
+                &drawer_id,
+                decision,
+                resolved.project_id.as_deref(),
+                Some(&resolved.content),
+            )
+            .with_context(|| format!("failed to record gating audit for {drawer_id}"))?;
             if decision.is_rejected() {
                 stats.dropped_by_gate = 1;
                 stats.drawer_ids.clear();
-                append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+                append_ingest_stdin_audit_log(db, &resolved.wing, options.dry_run, &record, &stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
                 return Ok(());
             }
         }
 
-        if !raw_turn
+        if !resolved.raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
-                &content,
+                &resolved.content,
                 db,
-                project_id.as_deref(),
+                resolved.project_id.as_deref(),
                 &config.ingest_gating.fact_check,
-                confidence,
+                resolved.confidence,
             )
             .with_context(|| format!("failed to record fact-check gate audit for {drawer_id}"))?
         {
@@ -3717,7 +3814,7 @@ async fn ingest_stdin_command(
             if outcome.decision.is_rejected() {
                 stats.dropped_by_gate = 1;
                 stats.drawer_ids.clear();
-                append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+                append_ingest_stdin_audit_log(db, &resolved.wing, options.dry_run, &record, &stats)
                     .context("failed to append ingest audit log")?;
                 print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
                 return Ok(());
@@ -3725,7 +3822,7 @@ async fn ingest_stdin_command(
         }
     }
 
-    let texts = [content.as_str()];
+    let texts = [resolved.content.as_str()];
     let vectors = embedder
         .embed(&texts)
         .await
@@ -3736,47 +3833,44 @@ async fn ingest_stdin_command(
         .context("embedder returned no vector for stdin content")?;
     let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
     let scrub = |s: &str| config.scrub_content_with_compiled(s, compiled_privacy.as_ref());
-    let source_hint = record
-        .source_file
-        .as_deref()
-        .or(record.source.as_deref())
-        .map(&scrub);
-    let source_file = source_file_or_synthetic(&drawer_id, source_hint.as_deref());
+    let source_hint = resolved.source_hint().map(&scrub);
+    let source_file =
+        ResolvedStdinIngest::source_file_for_drawer(&drawer_id, source_hint.as_deref());
 
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: drawer_id.clone(),
-        content,
-        wing: wing.to_string(),
-        room: room.map(ToOwned::to_owned),
+        content: resolved.content,
+        wing: resolved.wing.clone(),
+        room: resolved.room.clone(),
         source_file: Some(source_file),
-        source_type,
+        source_type: resolved.source_type,
         added_at: iso_timestamp(),
         chunk_index: Some(0),
-        importance: drawer_importance,
+        importance: resolved.drawer_importance,
     });
     let drawer = Drawer {
-        confidence,
+        confidence: resolved.confidence,
         normalize_version: CURRENT_NORMALIZE_VERSION,
         ..drawer
     };
     let mut drawer = drawer;
-    drawer.memory_kind = memory_kind;
-    drawer.domain = domain;
-    drawer.field = field.to_string();
-    drawer.is_pinned = is_pinned;
+    drawer.memory_kind = resolved.memory_kind;
+    drawer.domain = resolved.domain;
+    drawer.field = resolved.field;
+    drawer.is_pinned = resolved.is_pinned;
     if let Some(old_id) = superseded_drawer_id.as_deref() {
         link_superseded_drawer(&mut drawer, old_id);
     }
 
     db.insert_drawer_with_project_validity(
         &drawer,
-        project_id.as_deref(),
+        resolved.project_id.as_deref(),
         None,
-        valid_from,
-        valid_until,
+        resolved.valid_from.as_deref(),
+        resolved.valid_until.as_deref(),
     )
     .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
-    db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
+    db.insert_vector_with_project(&drawer_id, &vector, resolved.project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
 
     if let Some(old_id) = superseded_drawer_id.as_deref() {
@@ -3793,9 +3887,9 @@ async fn ingest_stdin_command(
                 db.path(),
                 &drawer_id,
                 &drawer.content,
-                wing,
-                room,
-                project_id.as_deref(),
+                &resolved.wing,
+                resolved.room.as_deref(),
+                resolved.project_id.as_deref(),
                 &config_snap.repair,
             );
         }
@@ -3803,7 +3897,7 @@ async fn ingest_stdin_command(
 
     stats.chunks = 1;
     stats.drawer_ids.push(drawer_id);
-    append_ingest_stdin_audit_log(db, wing, options.dry_run, &record, &stats)
+    append_ingest_stdin_audit_log(db, &resolved.wing, options.dry_run, &record, &stats)
         .context("failed to append ingest audit log")?;
     print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
     Ok(())

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -9,8 +9,9 @@ pub use server::MempalMcpServer;
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestOperationState, IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT,
-    MAX_READ_DRAWERS_REQUEST_IDS, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
-    PinnedFactsResponse, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
-    ReadDrawersResponse, RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest,
-    SearchResponse, SearchResultDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
+    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PinnedFactDto, PinnedFactProjectCount,
+    PinnedFactsRequest, PinnedFactsResponse, ReadDrawerRequest, ReadDrawerResponse,
+    ReadDrawersRequest, ReadDrawersResponse, RollbackRequest, RollbackResponse, RouteDecisionDto,
+    SearchRequest, SearchResponse, SearchResultDto, StatusDetail, StatusRequest, StatusResponse,
+    StatusScope,
 };

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,10 +8,10 @@ mod tools;
 pub use server::MempalMcpServer;
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
-    IngestOperationState, IngestRequest, IngestResponse, MAX_READ_DRAWERS_MAX_COUNT,
-    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PinnedFactDto, PinnedFactProjectCount,
-    PinnedFactsRequest, PinnedFactsResponse, ReadDrawerRequest, ReadDrawerResponse,
-    ReadDrawersRequest, ReadDrawersResponse, RollbackRequest, RollbackResponse, RouteDecisionDto,
-    SearchRequest, SearchResponse, SearchResultDto, StatusDetail, StatusRequest, StatusResponse,
-    StatusScope,
+    IngestControls, IngestOperationState, IngestRequest, IngestResponse,
+    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
+    PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
+    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    RollbackRequest, RollbackResponse, RouteDecisionDto, SearchRequest, SearchResponse,
+    SearchResultDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
 };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -297,7 +297,7 @@ impl MempalMcpServer {
         let _ = heartbeat.await;
 
         match outcome {
-            Ok(Json(response)) => {
+            Ok(Json(mut response)) => {
                 let rejected_reason = response
                     .gating_decision
                     .as_ref()
@@ -307,6 +307,10 @@ impl MempalMcpServer {
                 } else {
                     IngestOperationState::Completed
                 };
+                if matches!(state, IngestOperationState::Rejected) {
+                    response.drawer_id.clear();
+                    response.drawer_ids.clear();
+                }
                 let mut finalized = finalize_ingest_response(
                     claim.id.clone(),
                     claim.created_at,
@@ -320,10 +324,11 @@ impl MempalMcpServer {
                     .insert("queue_wait_ms".to_string(), queue_wait_ms);
                 let result_json = serde_json::to_string(&finalized)
                     .context("failed to serialize completed ingest response")?;
-                let result_drawer_id = if finalized.drawer_id.is_empty() {
-                    None
-                } else {
-                    Some(finalized.drawer_id.as_str())
+                let result_drawer_id = match state {
+                    IngestOperationState::Completed if !finalized.drawer_id.is_empty() => {
+                        Some(finalized.drawer_id.as_str())
+                    }
+                    _ => None,
                 };
                 queue
                     .complete_operation(
@@ -6745,6 +6750,10 @@ fn operation_record_to_response(
         response.accepted_at = accepted_at;
         response.state = Some(state);
         response.dropped = matches!(state, IngestOperationState::Rejected);
+        if !matches!(state, IngestOperationState::Completed) {
+            response.drawer_id.clear();
+            response.drawer_ids.clear();
+        }
         response.rejected_reason = record.rejected_reason.or(response.rejected_reason);
         response.failure_detail = record.failure_detail.or(response.failure_detail);
         response.system_warnings = system_warnings;
@@ -6756,7 +6765,11 @@ fn operation_record_to_response(
         accepted_at,
         state: Some(state),
         timed_out: false,
-        drawer_id: record.result_drawer_id.unwrap_or_default(),
+        drawer_id: if matches!(state, IngestOperationState::Completed) {
+            record.result_drawer_id.unwrap_or_default()
+        } else {
+            String::new()
+        },
         drawer_ids: Vec::new(),
         chunk_count: 0,
         dropped: matches!(state, IngestOperationState::Rejected),
@@ -10107,12 +10120,78 @@ enabled = true
         assert_eq!(completed.state, Some(IngestOperationState::Completed));
         assert!(!completed.drawer_id.is_empty());
 
+        let completed_record =
+            crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
+                .operation_status(&operation_id)
+                .expect("load completed operation record")
+                .expect("completed operation record exists");
+        assert_eq!(
+            completed_record.result_drawer_id.as_deref(),
+            Some(completed.drawer_id.as_str())
+        );
+        assert_eq!(completed_record.rejected_reason.as_deref(), None);
+
         let final_status = server
             .operation_status_json_for_test(&operation_id)
             .await
             .expect("final status");
         assert_eq!(final_status.state, Some(IngestOperationState::Completed));
         assert_eq!(final_status.drawer_id, completed.drawer_id);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_operation_status_rejected_has_no_result_drawer_id() {
+        let (_tempdir, db_path, server) = setup_server();
+        let _config_guard = ConfigOverrideGuard::install(&format!(
+            r#"
+db_path = "{}"
+
+[privacy]
+enabled = false
+
+[ingest_gating.fact_check]
+enabled = true
+reject_on_contradiction = true
+"#,
+            db_path.display()
+        ));
+        insert_triple(
+            &db_path,
+            "Bob",
+            "husband_of",
+            "Alice",
+            Some("1700000000"),
+            None,
+        );
+
+        let response = server
+            .ingest_json_for_test(
+                serde_json::to_value(IngestRequest {
+                    content: "Bob is Alice's brother.".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("status".to_string()),
+                    project_id: Some("project-async".to_string()),
+                    wait: Some(true),
+                    ..IngestRequest::default()
+                })
+                .expect("serialize ingest request"),
+            )
+            .await
+            .expect("rejected ingest should complete");
+
+        assert_eq!(response.state, Some(IngestOperationState::Rejected));
+        assert!(response.drawer_id.is_empty());
+        assert!(response.drawer_ids.is_empty());
+        assert!(response.rejected_reason.is_some());
+
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let rejected_record =
+            crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
+                .operation_status(operation_id)
+                .expect("load rejected operation record")
+                .expect("rejected operation record exists");
+        assert_eq!(rejected_record.result_drawer_id, None);
+        assert!(rejected_record.rejected_reason.is_some());
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -267,6 +267,7 @@ impl MempalMcpServer {
     ) -> anyhow::Result<()> {
         let prepared: PreparedIngestOperation = serde_json::from_str(&claim.payload)
             .with_context(|| format!("failed to decode ingest operation {}", claim.id))?;
+        let queue_wait_ms = queue_wait_ms(claim.created_at, claim.claimed_at);
 
         let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
         let heartbeat_queue = queue.clone();
@@ -306,7 +307,7 @@ impl MempalMcpServer {
                 } else {
                     IngestOperationState::Completed
                 };
-                let finalized = finalize_ingest_response(
+                let mut finalized = finalize_ingest_response(
                     claim.id.clone(),
                     claim.created_at,
                     response,
@@ -314,6 +315,9 @@ impl MempalMcpServer {
                     rejected_reason.clone(),
                     None,
                 );
+                finalized
+                    .timings
+                    .insert("queue_wait_ms".to_string(), queue_wait_ms);
                 let result_json = serde_json::to_string(&finalized)
                     .context("failed to serialize completed ingest response")?;
                 let result_drawer_id = if finalized.drawer_id.is_empty() {
@@ -336,11 +340,14 @@ impl MempalMcpServer {
             }
             Err(error) => {
                 let detail = error.to_string();
-                let finalized = finalize_failed_ingest_response(
+                let mut finalized = finalize_failed_ingest_response(
                     claim.id.clone(),
                     claim.created_at,
                     detail.clone(),
                 );
+                finalized
+                    .timings
+                    .insert("queue_wait_ms".to_string(), queue_wait_ms);
                 let result_json = serde_json::to_string(&finalized)
                     .context("failed to serialize failed ingest response")?;
                 queue
@@ -2896,6 +2903,7 @@ impl MempalMcpServer {
         let source_type = parse_source_type_param(request.source_type.as_deref())?;
         let confidence = resolve_confidence_param(source_type, request.confidence)?;
         let metadata = validate_ingest_request(&request, &source_type)?;
+        let mut timings = BTreeMap::new();
 
         if !dry_run && global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
@@ -3018,6 +3026,7 @@ impl MempalMcpServer {
             }));
         }
 
+        let gating_started = Instant::now();
         let candidate = IngestCandidate {
             content: scrubbed_content.clone(),
             event: None,
@@ -3202,6 +3211,12 @@ impl MempalMcpServer {
             }
         }
 
+        timings.insert(
+            "gating_ms".to_string(),
+            gating_started.elapsed().as_millis() as u64,
+        );
+
+        let embedding_started = Instant::now();
         let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
         let vectors = if first_vector.is_some() && chunks.len() == 1 {
             vec![first_vector.take().expect("checked Some")]
@@ -3235,8 +3250,13 @@ impl MempalMcpServer {
         if let Some(v) = vectors.first() {
             ensure_vector_dim_matches(&db, v.len())?;
         }
+        timings.insert(
+            "embedding_ms".to_string(),
+            embedding_started.elapsed().as_millis() as u64,
+        );
 
         let first_vector_ref = &vectors[0];
+        let novelty_started = Instant::now();
         let duplicate_warning = check_semantic_duplicate(&db, first_vector_ref, first_chunk);
         let novelty_candidate = NoveltyCandidate {
             wing: request.wing.clone(),
@@ -3256,6 +3276,10 @@ impl MempalMcpServer {
                 &config.ingest_gating.novelty,
             )
         };
+        timings.insert(
+            "novelty_ms".to_string(),
+            novelty_started.elapsed().as_millis() as u64,
+        );
         let mut response_drawer_id = drawer_id.clone();
         let (novelty_action, near_drawer_id);
 
@@ -3264,6 +3288,7 @@ impl MempalMcpServer {
         // drawers found by hash) must NOT appear here, so LLM reject cannot soft-delete them.
         let mut newly_created_drawer_ids: Vec<String> = Vec::new();
 
+        let db_write_started = Instant::now();
         match novelty.action {
             NoveltyAction::Insert => {
                 if novelty.should_audit {
@@ -3505,6 +3530,11 @@ impl MempalMcpServer {
             }
         }
 
+        timings.insert(
+            "db_write_ms".to_string(),
+            db_write_started.elapsed().as_millis() as u64,
+        );
+
         if let Some(old_id) = superseded_drawer_id.as_deref()
             && let Some(replacement_id) = inserted_drawer_ids.first()
         {
@@ -3654,6 +3684,7 @@ impl MempalMcpServer {
             lock_wait_ms,
             superseded_drawer_id: superseded_response_id,
             fact_check_warnings,
+            timings,
             system_warnings: request_system_warnings,
             ..Default::default()
         }))
@@ -6611,6 +6642,13 @@ fn operation_record_accepted_at_secs(record: &crate::core::queue::PendingOperati
     } else {
         record.created_at
     }
+}
+
+fn queue_wait_ms(created_at_secs: i64, claimed_at_secs: i64) -> u64 {
+    claimed_at_secs
+        .saturating_sub(created_at_secs)
+        .max(0)
+        .saturating_mul(1_000) as u64
 }
 
 fn rfc3339_from_secs(secs: i64) -> String {
@@ -9795,6 +9833,20 @@ mod tests {
         assert_eq!(response.state, Some(IngestOperationState::Completed));
         assert!(!response.drawer_id.is_empty());
         assert!(!response.timed_out);
+
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let completed_status = server
+            .operation_status_json_for_test(operation_id)
+            .await
+            .expect("completed status");
+        assert!(
+            completed_status.timings.contains_key("embedding_ms"),
+            "completed status must include embedding_ms timing"
+        );
+        assert!(
+            completed_status.timings.contains_key("db_write_ms"),
+            "completed status must include db_write_ms timing"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1093,7 +1093,7 @@ fn drawer_from_ingest_metadata(
         )),
         MemoryKind::Evidence | MemoryKind::ProfileFact => Some(source_file_or_synthetic(
             drawer_id,
-            request.source.as_deref(),
+            request.source_file.as_deref().or(request.source.as_deref()),
         )),
     };
 
@@ -2824,6 +2824,14 @@ impl MempalMcpServer {
     ) -> std::result::Result<PreparedIngestOperation, ErrorData> {
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy);
+        let scrubbed_source = request
+            .source
+            .as_deref()
+            .map(|value| config.scrub_content_with_compiled(value, compiled_privacy));
+        let scrubbed_source_file = request
+            .source_file
+            .as_deref()
+            .map(|value| config.scrub_content_with_compiled(value, compiled_privacy));
         let room = request.room.as_deref();
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
@@ -2846,6 +2854,8 @@ impl MempalMcpServer {
             .map_err(replacement_db_error)?;
         let mut request = request.clone();
         request.content = scrubbed_content.clone();
+        request.source = scrubbed_source;
+        request.source_file = scrubbed_source_file;
         request.replace_text = scrubbed_replace_text;
 
         Ok(PreparedIngestOperation {
@@ -2880,6 +2890,7 @@ impl MempalMcpServer {
         // rejects before any success response that would carry this snapshot is built.
         let request_system_warnings = system_warnings_with_stale_index(&db);
         let dry_run = request.dry_run.unwrap_or(false);
+        let no_gate = request.no_gate.unwrap_or(false);
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
@@ -3039,32 +3050,133 @@ impl MempalMcpServer {
             tool_name: None,
             exit_code: None,
         };
-        let mut gating_decision = evaluate_tier1(&candidate, &config.ingest_gating);
-        if let Some(decision) = gating_decision.as_ref()
-            && decision.is_rejected()
-        {
-            db.record_gating_audit(
-                &drawer_id,
-                decision,
-                project_id.as_deref(),
-                Some(&candidate.content),
-            )
-            .map_err(db_error)?;
-            return Ok(Json(IngestResponse {
-                drawer_id,
-                drawer_ids: Vec::new(),
-                chunk_count: 0,
-                dropped: true,
-                gating_decision,
-                novelty_action: None,
-                near_drawer_id: None,
-                duplicate_warning: None,
-                lock_wait_ms: None,
-                superseded_drawer_id: None,
-                fact_check_warnings: Vec::new(),
-                system_warnings: request_system_warnings.clone(),
-                ..Default::default()
-            }));
+        let mut gating_decision: Option<GatingDecision> = None;
+        let mut fact_check_warnings = Vec::new();
+        let mut should_enqueue_llm_task = false;
+        let mut first_vector = None;
+        if !no_gate {
+            let mut gating_audit_recorded = false;
+            gating_decision = evaluate_tier1(&candidate, &config.ingest_gating);
+            if let Some(decision) = gating_decision.as_ref()
+                && decision.is_rejected()
+            {
+                db.record_gating_audit(
+                    &drawer_id,
+                    decision,
+                    project_id.as_deref(),
+                    Some(&candidate.content),
+                )
+                .map_err(db_error)?;
+                return Ok(Json(IngestResponse {
+                    drawer_id,
+                    drawer_ids: Vec::new(),
+                    chunk_count: 0,
+                    dropped: true,
+                    gating_decision,
+                    novelty_action: None,
+                    near_drawer_id: None,
+                    duplicate_warning: None,
+                    lock_wait_ms: None,
+                    superseded_drawer_id: None,
+                    fact_check_warnings: Vec::new(),
+                    system_warnings: request_system_warnings.clone(),
+                    ..Default::default()
+                }));
+            }
+
+            if gating_decision.is_none() {
+                let tier2_classifier = if config.ingest_gating.enabled
+                    && config.ingest_gating.embedding_classifier.enabled
+                {
+                    self.gating_runtime
+                        .classifier()
+                        .await
+                        .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+                } else {
+                    None
+                };
+                if let Some(classifier) = tier2_classifier.as_ref() {
+                    let tier2 = evaluate_tier2(
+                        &candidate,
+                        classifier,
+                        embedder.as_ref(),
+                        config.ingest_gating.embedding_classifier.threshold,
+                    )
+                    .await;
+                    first_vector = tier2.vector;
+                    // Tier 3: intercept uncertain Tier 2 results ("prototype_below_threshold")
+                    // and route to LLM judge when enabled (fail-open: store now, judge async).
+                    let llm_judge_active = superseded_drawer_id.is_none()
+                        && config.llm.enabled
+                        && config.llm.enabled_for.contains(&"gating".to_string())
+                        && config
+                            .ingest_gating
+                            .llm_judge
+                            .as_ref()
+                            .is_some_and(|j| j.enabled);
+                    let is_unclassified = tier2.decision.gating_reason.as_deref()
+                        == Some("prototype_below_threshold");
+                    if llm_judge_active && is_unclassified {
+                        let llm_decision =
+                            GatingDecision::accepted(0, Some("llm_pending".to_string()), None);
+                        db.record_gating_audit(
+                            &drawer_id,
+                            &llm_decision,
+                            project_id.as_deref(),
+                            Some(&candidate.content),
+                        )
+                        .map_err(db_error)?;
+                        gating_audit_recorded = true;
+                        gating_decision = Some(llm_decision);
+                        should_enqueue_llm_task = true;
+                    } else {
+                        db.record_gating_audit(
+                            &drawer_id,
+                            &tier2.decision,
+                            project_id.as_deref(),
+                            Some(&candidate.content),
+                        )
+                        .map_err(db_error)?;
+                        gating_audit_recorded = true;
+                        gating_decision = Some(tier2.decision);
+                    }
+                } else if config.ingest_gating.enabled {
+                    gating_decision = Some(GatingDecision::accepted(
+                        0,
+                        Some("tier2_disabled".to_string()),
+                        None,
+                    ));
+                }
+            }
+
+            if let Some(decision) = gating_decision.as_ref()
+                && decision.is_rejected()
+            {
+                return Ok(Json(IngestResponse {
+                    drawer_id,
+                    drawer_ids: Vec::new(),
+                    chunk_count: 0,
+                    dropped: true,
+                    gating_decision,
+                    novelty_action: None,
+                    near_drawer_id: None,
+                    duplicate_warning: None,
+                    lock_wait_ms: None,
+                    superseded_drawer_id: None,
+                    fact_check_warnings: Vec::new(),
+                    system_warnings: request_system_warnings.clone(),
+                    ..Default::default()
+                }));
+            }
+            if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
+                db.record_gating_audit(
+                    &drawer_id,
+                    decision,
+                    project_id.as_deref(),
+                    Some(&candidate.content),
+                )
+                .map_err(db_error)?;
+            }
         }
 
         let mut db = db;
@@ -3083,105 +3195,8 @@ impl MempalMcpServer {
         let lock_wait_ms = Some(lock_guard.wait_duration().as_millis() as u64);
 
         let first_chunk = chunks.first().map(|c| c.as_str()).unwrap_or("");
-        let mut first_vector = None;
-        let mut gating_audit_recorded = false;
-        let mut should_enqueue_llm_task = false;
-        if gating_decision.is_none() {
-            let tier2_classifier = if config.ingest_gating.enabled
-                && config.ingest_gating.embedding_classifier.enabled
-            {
-                self.gating_runtime
-                    .classifier()
-                    .await
-                    .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
-            } else {
-                None
-            };
-            if let Some(classifier) = tier2_classifier.as_ref() {
-                let tier2 = evaluate_tier2(
-                    &candidate,
-                    classifier,
-                    embedder.as_ref(),
-                    config.ingest_gating.embedding_classifier.threshold,
-                )
-                .await;
-                first_vector = tier2.vector;
-                // Tier 3: intercept uncertain Tier 2 results ("prototype_below_threshold")
-                // and route to LLM judge when enabled (fail-open: store now, judge async).
-                let llm_judge_active = superseded_drawer_id.is_none()
-                    && config.llm.enabled
-                    && config.llm.enabled_for.contains(&"gating".to_string())
-                    && config
-                        .ingest_gating
-                        .llm_judge
-                        .as_ref()
-                        .is_some_and(|j| j.enabled);
-                let is_unclassified =
-                    tier2.decision.gating_reason.as_deref() == Some("prototype_below_threshold");
-                if llm_judge_active && is_unclassified {
-                    let llm_decision =
-                        GatingDecision::accepted(0, Some("llm_pending".to_string()), None);
-                    db.record_gating_audit(
-                        &drawer_id,
-                        &llm_decision,
-                        project_id.as_deref(),
-                        Some(&candidate.content),
-                    )
-                    .map_err(db_error)?;
-                    gating_audit_recorded = true;
-                    gating_decision = Some(llm_decision);
-                    should_enqueue_llm_task = true;
-                } else {
-                    db.record_gating_audit(
-                        &drawer_id,
-                        &tier2.decision,
-                        project_id.as_deref(),
-                        Some(&candidate.content),
-                    )
-                    .map_err(db_error)?;
-                    gating_audit_recorded = true;
-                    gating_decision = Some(tier2.decision);
-                }
-            } else if config.ingest_gating.enabled {
-                gating_decision = Some(GatingDecision::accepted(
-                    0,
-                    Some("tier2_disabled".to_string()),
-                    None,
-                ));
-            }
-        }
-        if let Some(decision) = gating_decision.as_ref()
-            && decision.is_rejected()
-        {
-            drop(lock_guard);
-            return Ok(Json(IngestResponse {
-                drawer_id,
-                drawer_ids: Vec::new(),
-                chunk_count: 0,
-                dropped: true,
-                gating_decision,
-                novelty_action: None,
-                near_drawer_id: None,
-                duplicate_warning: None,
-                lock_wait_ms,
-                superseded_drawer_id: None,
-                fact_check_warnings: Vec::new(),
-                system_warnings: request_system_warnings.clone(),
-                ..Default::default()
-            }));
-        }
-        if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
-            db.record_gating_audit(
-                &drawer_id,
-                decision,
-                project_id.as_deref(),
-                Some(&candidate.content),
-            )
-            .map_err(db_error)?;
-        }
-
-        let mut fact_check_warnings = Vec::new();
-        if !raw_turn
+        if !no_gate
+            && !raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
                 &drawer_id,
                 &candidate.content,
@@ -3216,7 +3231,6 @@ impl MempalMcpServer {
                 }));
             }
         }
-
         timings.insert(
             "gating_ms".to_string(),
             gating_started.elapsed().as_millis() as u64,
@@ -9909,8 +9923,12 @@ enabled = true
         let raw_secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD";
         let raw_content = format!("queued content {raw_secret}");
         let raw_replace_text = format!("replace target {raw_secret}");
+        let raw_source = format!("source {raw_secret}");
+        let raw_source_file = format!("source-file {raw_secret}");
         let expected_content = ConfigHandle::scrub_content(&raw_content);
         let expected_replace_text = ConfigHandle::scrub_content(&raw_replace_text);
+        let expected_source = ConfigHandle::scrub_content(&raw_source);
+        let expected_source_file = ConfigHandle::scrub_content(&raw_source_file);
 
         insert_drawer(
             &db_path,
@@ -9926,6 +9944,8 @@ enabled = true
             content: raw_content,
             wing: "mcp".to_string(),
             room: Some("scrub".to_string()),
+            source: Some(raw_source),
+            source_file: Some(raw_source_file),
             replace_text: Some(raw_replace_text),
             dry_run: Some(false),
             ..IngestRequest::default()
@@ -9954,6 +9974,14 @@ enabled = true
         assert_eq!(
             decoded.request.replace_text.as_deref(),
             Some(expected_replace_text.as_str())
+        );
+        assert_eq!(
+            decoded.request.source.as_deref(),
+            Some(expected_source.as_str())
+        );
+        assert_eq!(
+            decoded.request.source_file.as_deref(),
+            Some(expected_source_file.as_str())
         );
         assert_eq!(decoded.scrubbed_content, expected_content);
         assert_eq!(decoded.request.content, decoded.scrubbed_content);
@@ -10063,10 +10091,12 @@ enabled = true
                     wing: "mempal".to_string(),
                     room: Some("review".to_string()),
                     source: None,
+                    source_file: None,
                     source_type: None,
                     confidence: None,
                     importance: None,
                     dry_run: None,
+                    no_gate: None,
                     diary_rollup: None,
                     supersedes: None,
                     replace_text: None,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
@@ -434,11 +434,13 @@ impl MempalMcpServer {
         .map(|response| response.0)
     }
 
-    pub async fn wait_for_operation_completion(
+    pub async fn wait_for_operation_status(
         &self,
         operation_id: &str,
-    ) -> std::result::Result<IngestResponse, ErrorData> {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        timeout: Duration,
+        poll_interval: Duration,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        let deadline = Instant::now() + timeout;
         loop {
             let response = self.operation_status_json_for_test(operation_id).await?;
             if response
@@ -446,15 +448,32 @@ impl MempalMcpServer {
                 .map(IngestOperationState::is_terminal)
                 .unwrap_or(false)
             {
-                return Ok(response);
+                return Ok(Some(response));
             }
-            if tokio::time::Instant::now() >= deadline {
-                return Err(ErrorData::internal_error(
-                    format!("timed out waiting for ingest operation {operation_id}"),
-                    None,
-                ));
+            if timeout.is_zero() || Instant::now() >= deadline {
+                return Ok(None);
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    pub async fn wait_for_operation_completion(
+        &self,
+        operation_id: &str,
+    ) -> std::result::Result<IngestResponse, ErrorData> {
+        match self
+            .wait_for_operation_status(
+                operation_id,
+                Duration::from_secs(30),
+                Duration::from_millis(150),
+            )
+            .await?
+        {
+            Some(response) => Ok(response),
+            None => Err(ErrorData::internal_error(
+                format!("timed out waiting for ingest operation {operation_id}"),
+                None,
+            )),
         }
     }
 
@@ -2680,12 +2699,15 @@ impl MempalMcpServer {
         // rejects before any success response that would carry this snapshot is built.
         let request_system_warnings = system_warnings_with_stale_index(&db);
         let dry_run = request.dry_run.unwrap_or(false);
+        let wait = request.wait.unwrap_or(false);
+        let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
                 operation_id: None,
                 accepted_at: None,
                 state: None,
+                timed_out: false,
                 drawer_id: String::new(),
                 drawer_ids: Vec::new(),
                 chunk_count: 0,
@@ -2698,6 +2720,7 @@ impl MempalMcpServer {
                 superseded_drawer_id: None,
                 rejected_reason: None,
                 failure_detail: None,
+                timings: BTreeMap::new(),
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings,
             }));
@@ -2733,10 +2756,11 @@ impl MempalMcpServer {
                 )
             })?;
 
-        Ok(Json(IngestResponse {
+        let queued_response = IngestResponse {
             operation_id: Some(operation_id),
             accepted_at: Some(crate::core::utils::iso_timestamp()),
             state: Some(IngestOperationState::Queued),
+            timed_out: false,
             drawer_id: String::new(),
             drawer_ids: Vec::new(),
             chunk_count: 0,
@@ -2749,9 +2773,32 @@ impl MempalMcpServer {
             superseded_drawer_id: None,
             rejected_reason: None,
             failure_detail: None,
+            timings: BTreeMap::new(),
             fact_check_warnings: Vec::new(),
             system_warnings: request_system_warnings,
-        }))
+        };
+
+        if wait {
+            if let Some(final_response) = self
+                .wait_for_operation_status(
+                    queued_response
+                        .operation_id
+                        .as_deref()
+                        .expect("queued receipt must include operation id"),
+                    Duration::from_secs(wait_timeout_secs),
+                    Duration::from_millis(150),
+                )
+                .await?
+            {
+                return Ok(Json(final_response));
+            }
+
+            let mut timed_out_response = queued_response;
+            timed_out_response.timed_out = true;
+            return Ok(Json(timed_out_response));
+        }
+
+        Ok(Json(queued_response))
     }
 
     fn prepare_async_ingest_operation(
@@ -2826,6 +2873,7 @@ impl MempalMcpServer {
                 operation_id: None,
                 accepted_at: None,
                 state: None,
+                timed_out: false,
                 drawer_id: String::new(),
                 drawer_ids: Vec::new(),
                 chunk_count: 0,
@@ -2838,6 +2886,7 @@ impl MempalMcpServer {
                 superseded_drawer_id: None,
                 rejected_reason: None,
                 failure_detail: None,
+                timings: BTreeMap::new(),
                 fact_check_warnings: Vec::new(),
                 system_warnings: request_system_warnings,
             }));
@@ -6596,6 +6645,7 @@ fn finalize_failed_ingest_response(
             operation_id: None,
             accepted_at: None,
             state: None,
+            timed_out: false,
             drawer_id: String::new(),
             drawer_ids: Vec::new(),
             chunk_count: 0,
@@ -6608,6 +6658,7 @@ fn finalize_failed_ingest_response(
             superseded_drawer_id: None,
             rejected_reason: None,
             failure_detail: None,
+            timings: BTreeMap::new(),
             fact_check_warnings: Vec::new(),
             system_warnings: current_system_warnings(),
         },
@@ -6646,6 +6697,7 @@ fn operation_record_to_response(
         operation_id: Some(record.id),
         accepted_at,
         state: Some(state),
+        timed_out: false,
         drawer_id: record.result_drawer_id.unwrap_or_default(),
         drawer_ids: Vec::new(),
         chunk_count: 0,
@@ -6658,6 +6710,7 @@ fn operation_record_to_response(
         superseded_drawer_id: None,
         rejected_reason: record.rejected_reason,
         failure_detail: record.failure_detail,
+        timings: BTreeMap::new(),
         fact_check_warnings: Vec::new(),
         system_warnings,
     }
@@ -6814,6 +6867,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use async_trait::async_trait;
     use rusqlite::params;
@@ -9691,6 +9745,95 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mcp_ingest_wait_returns_terminal_result() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Notify::new());
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(BlockingEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+                call_count: Arc::clone(&call_count),
+                gate: Arc::clone(&gate),
+            }),
+        );
+
+        let request = IngestRequest {
+            content: "wait path should return the final ingest result".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("wait".to_string()),
+            project_id: Some("project-async".to_string()),
+            dry_run: Some(false),
+            wait: Some(true),
+            wait_timeout_secs: Some(30),
+            ..IngestRequest::default()
+        };
+        let ingest = {
+            let server = server.clone();
+            tokio::spawn(async move {
+                server
+                    .mempal_ingest(Parameters(request))
+                    .await
+                    .expect("wait ingest should succeed")
+                    .0
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while call_count.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("embedder should start before timeout");
+        gate.notify_one();
+
+        let response = ingest.await.expect("join wait ingest");
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.drawer_id.is_empty());
+        assert!(!response.timed_out);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_timeout_returns_receipt() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+
+        let gate = Arc::new(Notify::new());
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(BlockingEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+                call_count: Arc::new(AtomicUsize::new(0)),
+                gate: Arc::clone(&gate),
+            }),
+        );
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "timeout should return a receipt".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("timeout".to_string()),
+                project_id: Some("project-async".to_string()),
+                dry_run: Some(false),
+                wait: Some(true),
+                wait_timeout_secs: Some(0),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("timeout ingest response")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.operation_id.is_some());
+    }
+
+    #[tokio::test]
     async fn test_mcp_async_ingest_queue_payload_is_scrubbed() {
         let config_home = tempfile::tempdir().expect("config tempdir");
         let config_db_path = config_home.path().join("palace.db");
@@ -9890,6 +10033,8 @@ enabled = true
                     parent_anchor_id: None,
                     cwd: None,
                     project_id: None,
+                    wait: None,
+                    wait_timeout_secs: None,
                 })
                 .expect("serialize ingest request"),
             )

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -447,7 +447,7 @@ impl MempalMcpServer {
         timeout: Duration,
         poll_interval: Duration,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
-        let deadline = Instant::now() + timeout;
+        let deadline = Instant::now() + clamp_wait_timeout(timeout);
         loop {
             let response = self.operation_status_json_for_test(operation_id).await?;
             if response
@@ -818,6 +818,12 @@ impl ValidatedIngestMetadata {
             trigger_hints: self.trigger_hints.as_ref(),
         }
     }
+}
+
+const MAX_WAIT_TIMEOUT_SECS: u64 = 86_400;
+
+fn clamp_wait_timeout(timeout: Duration) -> Duration {
+    timeout.min(Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
 }
 
 #[allow(dead_code)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -597,32 +597,6 @@ impl MempalMcpServer {
         self.mempal_status_tool(Parameters(request)).await
     }
 
-    #[tool(
-        name = "mempal_operation_status",
-        description = "Return the current status of an asynchronous ingest operation, including the queue state, stored drawer_id, rejection reason, failure detail, and persisted per-stage timings. Use this to confirm a receipt-based write landed."
-    )]
-    pub async fn mempal_operation_status(
-        &self,
-        Parameters(request): Parameters<OperationStatusRequest>,
-    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
-        let db = self.open_db()?;
-        let store = crate::core::queue::PendingMessageStore::new_without_reclaim(db.path());
-        let system_warnings = system_warnings_with_stale_index(&db);
-        let record = store
-            .operation_status(&request.operation_id)
-            .map_err(|error| {
-                ErrorData::internal_error(format!("queue lookup failed: {error}"), None)
-            })?
-            .ok_or_else(|| {
-                ErrorData::invalid_params(
-                    format!("operation not found: {}", request.operation_id),
-                    None,
-                )
-            })?;
-
-        Ok(Json(operation_record_to_response(record, system_warnings)))
-    }
-
     pub async fn pinned_facts_json_for_test(
         &self,
         value: Value,
@@ -3708,6 +3682,32 @@ impl MempalMcpServer {
             system_warnings: request_system_warnings,
             ..Default::default()
         }))
+    }
+
+    #[tool(
+        name = "mempal_operation_status",
+        description = "Return the current status of an asynchronous ingest operation, including the queue state, stored drawer_id, rejection reason, failure detail, and persisted per-stage timings. Use this to confirm a receipt-based write landed."
+    )]
+    pub async fn mempal_operation_status(
+        &self,
+        Parameters(request): Parameters<OperationStatusRequest>,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        let db = self.open_db()?;
+        let store = crate::core::queue::PendingMessageStore::new_without_reclaim(db.path());
+        let system_warnings = system_warnings_with_stale_index(&db);
+        let record = store
+            .operation_status(&request.operation_id)
+            .map_err(|error| {
+                ErrorData::internal_error(format!("queue lookup failed: {error}"), None)
+            })?
+            .ok_or_else(|| {
+                ErrorData::invalid_params(
+                    format!("operation not found: {}", request.operation_id),
+                    None,
+                )
+            })?;
+
+        Ok(Json(operation_record_to_response(record, system_warnings)))
     }
 
     #[tool(
@@ -8034,6 +8034,41 @@ mod tests {
                 .unwrap_or_default()
                 .contains("dao_tian -> dao_ren -> shu -> qi")
         );
+    }
+
+    #[test]
+    fn test_mcp_tool_registry_includes_operation_status_and_ingest_wait_fields() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let tools = server.tool_router.list_all();
+
+        let operation_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_operation_status")
+            .expect("mempal_operation_status tool exists");
+        assert!(
+            operation_tool
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains("receipt-based write landed")
+        );
+
+        let ingest_tool = tools
+            .iter()
+            .find(|tool| tool.name == "mempal_ingest")
+            .expect("mempal_ingest tool exists");
+        let props = ingest_tool
+            .input_schema
+            .get("properties")
+            .and_then(|value| value.as_object())
+            .expect("mempal_ingest must have a properties object");
+
+        for field in ["wait", "wait_timeout_secs"] {
+            assert!(
+                props.get(field).is_some(),
+                "mempal_ingest must expose {field} in tools/list"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -92,7 +92,7 @@ use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DoctorMcpDto,
     DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning, EmbedStatusDto,
     EndpointHealthDto, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
-    FieldTaxonomyResponse, IngestOperationState, IngestRequest, IngestResponse,
+    FieldTaxonomyResponse, IngestControls, IngestOperationState, IngestRequest, IngestResponse,
     IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
     KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
     KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
@@ -290,7 +290,7 @@ impl MempalMcpServer {
         });
 
         let outcome = self
-            .mempal_ingest_sync(Parameters(prepared.request.clone()))
+            .mempal_ingest_sync(prepared.request.clone(), prepared.controls)
             .await;
 
         let _ = stop_tx.send(());
@@ -945,6 +945,8 @@ fn validate_ingest_request(
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PreparedIngestOperation {
     request: IngestRequest,
+    #[serde(default)]
+    controls: IngestControls,
     project_id: Option<String>,
     scrubbed_content: String,
     source_type: SourceType,
@@ -2680,6 +2682,16 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<IngestRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        self.mempal_ingest_with_controls(request, IngestControls::default())
+            .await
+    }
+
+    #[doc(hidden)]
+    pub async fn mempal_ingest_with_controls(
+        &self,
+        request: IngestRequest,
+        controls: IngestControls,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         self.spawn_ingest_drain_worker();
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let room = request.room.as_deref();
@@ -2718,7 +2730,7 @@ impl MempalMcpServer {
             }));
         }
         if dry_run {
-            return self.mempal_ingest_sync(Parameters(request)).await;
+            return self.mempal_ingest_sync(request, controls).await;
         }
         if global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
@@ -2728,6 +2740,7 @@ impl MempalMcpServer {
             .await?;
         let prepared = self.prepare_async_ingest_operation(
             &request,
+            controls,
             config.as_ref(),
             compiled_privacy.as_ref(),
             &db,
@@ -2796,6 +2809,7 @@ impl MempalMcpServer {
     fn prepare_async_ingest_operation(
         &self,
         request: &IngestRequest,
+        controls: IngestControls,
         config: &crate::core::config::Config,
         compiled_privacy: &crate::core::config::CompiledPrivacyConfig,
         db: &Database,
@@ -2839,6 +2853,7 @@ impl MempalMcpServer {
 
         Ok(PreparedIngestOperation {
             request,
+            controls,
             project_id,
             scrubbed_content,
             source_type,
@@ -2852,7 +2867,8 @@ impl MempalMcpServer {
 
     async fn mempal_ingest_sync(
         &self,
-        Parameters(request): Parameters<IngestRequest>,
+        request: IngestRequest,
+        controls: IngestControls,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let project_id = self
@@ -2869,7 +2885,8 @@ impl MempalMcpServer {
         // rejects before any success response that would carry this snapshot is built.
         let request_system_warnings = system_warnings_with_stale_index(&db);
         let dry_run = request.dry_run.unwrap_or(false);
-        let no_gate = request.no_gate.unwrap_or(false);
+        let no_gate = controls.no_gate;
+        let bypass_novelty = controls.bypass_novelty;
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
@@ -3262,7 +3279,7 @@ impl MempalMcpServer {
             room: request.room.clone(),
             project_id: project_id.clone(),
         };
-        let novelty = if superseded_drawer_id.is_some() || request.bypass_novelty {
+        let novelty = if superseded_drawer_id.is_some() || bypass_novelty {
             crate::ingest::novelty::NoveltyDecision {
                 should_audit: false,
                 ..crate::ingest::novelty::NoveltyDecision::insert()
@@ -8082,6 +8099,12 @@ mod tests {
                 "mempal_ingest must expose {field} in tools/list"
             );
         }
+        for field in ["no_gate", "bypass_novelty"] {
+            assert!(
+                props.get(field).is_none(),
+                "mempal_ingest must not expose {field} in tools/list"
+            );
+        }
     }
 
     #[tokio::test]
@@ -10008,6 +10031,7 @@ enabled = true
         let prepared = server
             .prepare_async_ingest_operation(
                 &request,
+                IngestControls::default(),
                 config.as_ref(),
                 compiled_privacy.as_ref(),
                 &db,
@@ -10033,6 +10057,7 @@ enabled = true
         );
         assert_eq!(decoded.scrubbed_content, expected_content);
         assert_eq!(decoded.request.content, decoded.scrubbed_content);
+        assert_eq!(decoded.controls, IngestControls::default());
         assert!(
             !payload.contains(raw_secret),
             "raw secret leaked into payload"
@@ -10067,6 +10092,7 @@ enabled = true
         let prepared = server
             .prepare_async_ingest_operation(
                 &request,
+                IngestControls::default(),
                 config.as_ref(),
                 compiled_privacy.as_ref(),
                 &db,
@@ -10210,7 +10236,6 @@ reject_on_contradiction = true
                     confidence: None,
                     importance: None,
                     dry_run: None,
-                    no_gate: None,
                     diary_rollup: None,
                     supersedes: None,
                     replace_text: None,
@@ -10237,7 +10262,6 @@ reject_on_contradiction = true
                     project_id: None,
                     wait: None,
                     wait_timeout_secs: None,
-                    bypass_novelty: false,
                 })
                 .expect("serialize ingest request"),
             )
@@ -10254,6 +10278,80 @@ reject_on_contradiction = true
             json.get("lock_wait_ms").is_some(),
             "JSON must expose lock_wait_ms"
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_public_handler_forces_internal_controls_off() {
+        let _tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = _tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let _config_guard = ConfigOverrideGuard::install(&format!(
+            r#"
+db_path = "{}"
+
+[privacy]
+enabled = false
+
+[ingest_gating]
+enabled = false
+"#,
+            db_path.display()
+        ));
+        let gate = Arc::new(Notify::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(BlockingEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+                call_count: Arc::clone(&call_count),
+                gate: Arc::clone(&gate),
+            }),
+        );
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "public handler control test".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("review".to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest should queue")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while call_count.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker should reach embed");
+        let db = Database::open(&db_path).expect("open db");
+        let payload: String = db
+            .conn()
+            .query_row(
+                "SELECT payload FROM pending_messages WHERE id = ?1",
+                [operation_id],
+                |row| row.get(0),
+            )
+            .expect("read queued ingest payload");
+        let decoded: PreparedIngestOperation =
+            serde_json::from_str(&payload).expect("decode queued ingest payload");
+
+        assert_eq!(decoded.controls, IngestControls::default());
+        assert!(!decoded.controls.no_gate);
+        assert!(!decoded.controls.bypass_novelty);
+
+        gate.notify_one();
+
+        let completed = server
+            .wait_for_operation_completion(operation_id)
+            .await
+            .expect("cleanup ingest completion");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
     }
 
     // =========================================================================

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3262,7 +3262,7 @@ impl MempalMcpServer {
             room: request.room.clone(),
             project_id: project_id.clone(),
         };
-        let novelty = if superseded_drawer_id.is_some() {
+        let novelty = if superseded_drawer_id.is_some() || request.bypass_novelty {
             crate::ingest::novelty::NoveltyDecision {
                 should_audit: false,
                 ..crate::ingest::novelty::NoveltyDecision::insert()
@@ -10237,6 +10237,7 @@ reject_on_contradiction = true
                     project_id: None,
                     wait: None,
                     wait_timeout_secs: None,
+                    bypass_novelty: false,
                 })
                 .expect("serialize ingest request"),
             )

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -599,7 +599,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_operation_status",
-        description = "Return the current status of an asynchronous ingest operation, including the queue state and any stored drawer_id, rejection reason, or failure detail. Use this to confirm a receipt-based write landed."
+        description = "Return the current status of an asynchronous ingest operation, including the queue state, stored drawer_id, rejection reason, failure detail, and persisted per-stage timings. Use this to confirm a receipt-based write landed."
     )]
     pub async fn mempal_operation_status(
         &self,
@@ -2689,7 +2689,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_ingest",
-        description = "Persist a decision, bug fix, design insight, profile fact, or typed knowledge/evidence drawer to project memory. Call this when a durable fact is reached in conversation and include the rationale, not just the outcome. Wing is required; room is optional. Supports typed metadata params (`memory_kind`, `domain`, `field`, `statement`, `tier`, `status`, anchors), pinned facts (`is_pinned`), supersession (`supersedes`/`replace_text`), validity windows, confidence/source_type, and dry_run preview."
+        description = "Persist a decision, bug fix, design insight, profile fact, or typed knowledge/evidence drawer to project memory. Call this when a durable fact is reached in conversation and include the rationale, not just the outcome. Wing is required; room is optional. Supports typed metadata params (`memory_kind`, `domain`, `field`, `statement`, `tier`, `status`, anchors), pinned facts (`is_pinned`), supersession (`supersedes`/`replace_text`), validity windows, confidence/source_type, dry_run preview, and receipt-based waiting via `wait`/`wait_timeout_secs` (wait=true blocks to a terminal state or returns a timed_out receipt you can poll with `mempal_operation_status`)."
     )]
     pub async fn mempal_ingest(
         &self,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1598,6 +1598,14 @@ pub struct IngestRequest {
     /// writing to the database. Use this to preview before committing.
     pub dry_run: Option<bool>,
 
+    /// If true, wait for the durable ingest operation to reach a terminal
+    /// state before returning. Defaults to false.
+    pub wait: Option<bool>,
+
+    /// Maximum number of seconds to wait for `wait=true` before returning
+    /// the queued receipt with `timed_out=true`. Defaults to 30.
+    pub wait_timeout_secs: Option<u64>,
+
     /// If true, append this entry to one agent-diary drawer for the current
     /// UTC day. Requires wing="agent-diary" and an explicit room.
     pub diary_rollup: Option<bool>,
@@ -1791,6 +1799,11 @@ pub struct IngestResponse {
     /// ingests; omitted for dry-run previews.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<IngestOperationState>,
+    /// True when `wait=true` timed out before the operation reached a
+    /// terminal state. The queued receipt remains pollable via
+    /// `mempal_operation_status`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub timed_out: bool,
     /// ID of the first (or only) drawer created once the ingest completes.
     /// Empty while queued/running and for rejection/failure outcomes without
     /// stored drawers.
@@ -1826,6 +1839,10 @@ pub struct IngestResponse {
     pub rejected_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_detail: Option<String>,
+    /// Per-stage elapsed milliseconds captured by the async ingest pipeline.
+    /// Present on completed receipt-backed writes.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub timings: BTreeMap<String, u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fact_check_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1834,6 +1851,10 @@ pub struct IngestResponse {
 
 fn is_zero(v: &usize) -> bool {
     *v == 0
+}
+
+fn is_false(v: &bool) -> bool {
+    !*v
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1599,9 +1599,6 @@ pub struct IngestRequest {
     /// If true, return the drawer_id that WOULD be created without actually
     /// writing to the database. Use this to preview before committing.
     pub dry_run: Option<bool>,
-    /// If true, bypass ingest gating and fact-checking for this request.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_gate: Option<bool>,
 
     /// If true, wait for the durable ingest operation to reach a terminal
     /// state before returning. Defaults to false.
@@ -1610,11 +1607,6 @@ pub struct IngestRequest {
     /// Maximum number of seconds to wait for `wait=true` before returning
     /// the queued receipt with `timed_out=true`. Defaults to 30.
     pub wait_timeout_secs: Option<u64>,
-
-    /// Internal override used by stdin `--wait` ingest to preserve the same
-    /// novelty behavior as the non-wait stdin path.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub bypass_novelty: bool,
 
     /// If true, append this entry to one agent-diary drawer for the current
     /// UTC day. Requires wing="agent-diary" and an explicit room.
@@ -1651,6 +1643,14 @@ pub struct IngestRequest {
     pub anchor_id: Option<String>,
     pub parent_anchor_id: Option<String>,
     pub cwd: Option<String>,
+}
+
+/// Internal ingest overrides used by trusted local callers.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct IngestControls {
+    pub no_gate: bool,
+    pub bypass_novelty: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1611,6 +1611,11 @@ pub struct IngestRequest {
     /// the queued receipt with `timed_out=true`. Defaults to 30.
     pub wait_timeout_secs: Option<u64>,
 
+    /// Internal override used by stdin `--wait` ingest to preserve the same
+    /// novelty behavior as the non-wait stdin path.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub bypass_novelty: bool,
+
     /// If true, append this entry to one agent-diary drawer for the current
     /// UTC day. Requires wing="agent-diary" and an explicit room.
     pub diary_rollup: Option<bool>,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1578,6 +1578,8 @@ pub struct IngestRequest {
     pub wing: String,
     pub room: Option<String>,
     pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
     pub source_type: Option<String>,
     pub confidence: Option<f64>,
     pub project_id: Option<String>,
@@ -1597,6 +1599,9 @@ pub struct IngestRequest {
     /// If true, return the drawer_id that WOULD be created without actually
     /// writing to the database. Use this to preview before committing.
     pub dry_run: Option<bool>,
+    /// If true, bypass ingest gating and fact-checking for this request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_gate: Option<bool>,
 
     /// If true, wait for the durable ingest operation to reach a terminal
     /// state before returning. Defaults to false.

--- a/tests/common/harness/embed_mock.rs
+++ b/tests/common/harness/embed_mock.rs
@@ -42,6 +42,7 @@ struct Inner {
     /// When set, only requests whose input contains this marker fail (with
     /// `fail_mode`). Models one persistently-failing batch among healthy ones.
     fail_if_contains: Mutex<Option<String>>,
+    embedding_fill: Mutex<f32>,
     per_item_dims: Mutex<Option<Vec<u32>>>,
     request_count: AtomicU32,
     request_times: Mutex<Vec<Duration>>,
@@ -86,6 +87,12 @@ impl MockEmbedHandle {
         *self.inner.fail_if_contains.lock().await = marker;
     }
 
+    /// Set the constant value used to populate every embedding element.
+    /// Defaults to `0.0`, which preserves the previous zero-vector mock.
+    pub async fn set_embedding_fill(&self, value: f32) {
+        *self.inner.embedding_fill.lock().await = value;
+    }
+
     pub fn request_count(&self) -> u32 {
         self.inner.request_count.load(Ordering::SeqCst)
     }
@@ -114,6 +121,7 @@ pub async fn start(port: u16) -> Result<(SocketAddr, MockEmbedHandle)> {
         fail_first_n: AtomicU32::new(0),
         fail_first_n_armed: AtomicBool::new(false),
         fail_if_contains: Mutex::new(None),
+        embedding_fill: Mutex::new(0.0),
         per_item_dims: Mutex::new(None),
         request_count: AtomicU32::new(0),
         request_times: Mutex::new(Vec::new()),
@@ -241,6 +249,7 @@ async fn handle_request(
     }
 
     let default_dim = inner.dim.load(Ordering::SeqCst) as usize;
+    let embedding_fill = *inner.embedding_fill.lock().await;
     let per_item_dims = inner.per_item_dims.lock().await.clone();
     let data = (0..count)
         .map(|index| {
@@ -248,7 +257,7 @@ async fn handle_request(
                 .as_ref()
                 .and_then(|dims| dims.get(index).copied())
                 .unwrap_or(default_dim as u32) as usize;
-            let embedding = vec![0.0_f32; dim];
+            let embedding = vec![embedding_fill; dim];
             json!({
                 "index": index,
                 "embedding": embedding,

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -346,6 +346,27 @@ fn run_mempal_in_dir(home: &Path, cwd: &Path, args: &[&str]) -> Output {
         .expect("run mempal")
 }
 
+fn run_mempal_in_dir_with_stdin(home: &Path, cwd: &Path, args: &[&str], payload: &[u8]) -> Output {
+    use std::io::Write as _;
+
+    let mut child = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload)
+        .expect("write stdin");
+    child.wait_with_output().expect("wait mempal")
+}
+
 fn expected_project_id(path: &Path) -> String {
     expected_project_id_for_path(path).expect("expected project id from path")
 }
@@ -355,6 +376,17 @@ fn expected_project_id_for_path(path: &Path) -> Option<String> {
     canonical
         .file_name()
         .map(|name| name.to_string_lossy().into_owned())
+}
+
+fn latest_drawer_project_id(db_path: &Path) -> Option<String> {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .query_row(
+            "SELECT project_id FROM drawers ORDER BY rowid DESC LIMIT 1",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .expect("read stored project id")
 }
 
 fn drawer_project_ids(conn: &Connection, table: &str) -> Vec<Option<String>> {
@@ -2251,6 +2283,96 @@ async fn test_ingest_with_project_id_persists() {
         .expect("read stored project");
     assert_eq!(stored.as_deref(), Some("foo"));
     handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_stores_project_id_from_cwd() {
+    let direct_tmp = TempDir::new().expect("tempdir");
+    let wait_tmp = TempDir::new().expect("tempdir");
+    let direct_home = install_cli_home(&direct_tmp);
+    let wait_home = install_cli_home(&wait_tmp);
+    let direct_db_path = direct_home.join(".mempal").join("palace.db");
+    let wait_db_path = wait_home.join(".mempal").join("palace.db");
+    let direct_project_dir = direct_tmp.path().join("workspace").join("delta");
+    let wait_project_dir = wait_tmp.path().join("workspace").join("delta");
+    fs::create_dir_all(&direct_project_dir).expect("create direct project dir");
+    fs::create_dir_all(&wait_project_dir).expect("create wait project dir");
+    let expected = expected_project_id(&direct_project_dir);
+    let payload = serde_json::json!({
+        "content": "ingest wait project scope",
+        "source": "csa-session",
+        "source_file": "csa://session/project-scope",
+        "source_type": "user_explicit"
+    })
+    .to_string();
+
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    for db_path in [&direct_db_path, &wait_db_path] {
+        write_config_atomic(
+            &db_path.parent().expect("db parent").join("config.toml"),
+            &cli_embed_config(db_path, &format!("http://{addr}/v1"), None),
+        );
+    }
+
+    let direct_output = run_mempal_in_dir_with_stdin(
+        &direct_home,
+        &direct_project_dir,
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "code",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+        ],
+        payload.as_bytes(),
+    );
+    let wait_timeout = u64::MAX.to_string();
+    let wait_output = run_mempal_in_dir_with_stdin(
+        &wait_home,
+        &wait_project_dir,
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "code",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+        ],
+        payload.as_bytes(),
+    );
+
+    handle.shutdown().await;
+
+    assert!(
+        direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&direct_output.stdout),
+        String::from_utf8_lossy(&direct_output.stderr)
+    );
+    assert!(
+        wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+
+    let direct_project_id = latest_drawer_project_id(&direct_db_path);
+    let wait_project_id = latest_drawer_project_id(&wait_db_path);
+    assert_eq!(
+        direct_project_id.as_deref(),
+        Some(expected.as_str()),
+        "non-wait ingest must inherit the cwd project"
+    );
+    assert_eq!(
+        wait_project_id, direct_project_id,
+        "--wait ingest must land in the same resolved project as non-wait ingest"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -11,6 +11,8 @@ use common::harness::embed_mock::start as start_embed_mock;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
+use mempal::core::types::Triple;
+use mempal::core::utils::build_triple_id;
 use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
 use serde_json::Value;
@@ -207,6 +209,60 @@ fn print_lines(output: &Output) -> (String, String) {
         String::from_utf8_lossy(&output.stdout).to_string(),
         String::from_utf8_lossy(&output.stderr).to_string(),
     )
+}
+
+fn assert_bootstrap_stderr(output: &Output) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut lines = stderr.lines();
+    let bootstrap = lines.next().expect("stderr must contain bootstrap line");
+    assert!(
+        bootstrap.starts_with("config hot-reload: bootstrapped version "),
+        "unexpected stderr bootstrap line: {stderr}"
+    );
+    for line in lines {
+        assert!(
+            line.starts_with("fact_check."),
+            "unexpected stderr noise: {stderr}"
+        );
+    }
+}
+
+fn last_audit_entry(home: &Path) -> Value {
+    let audit_path = home.join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(&audit_path).expect("read audit log");
+    serde_json::from_str(audit.lines().last().expect("audit entry")).expect("parse audit entry")
+}
+
+fn assert_stdin_audit_entry(
+    entry: &Value,
+    expected_source: &str,
+    expected_source_file: &str,
+    expected_chunks: u64,
+    expected_skipped: u64,
+    expected_dropped_by_gate: u64,
+) {
+    assert_eq!(entry["mode"], "stdin");
+    assert_eq!(entry["source"], expected_source);
+    assert_eq!(entry["source_file"], expected_source_file);
+    assert_eq!(entry["files"], 1);
+    assert_eq!(entry["chunks"], expected_chunks);
+    assert_eq!(entry["skipped"], expected_skipped);
+    assert_eq!(entry["dropped_by_gate"], expected_dropped_by_gate);
+}
+
+fn insert_fact_check_contradiction(home: &Path) {
+    let db = Database::open(&home.join(".mempal/palace.db")).expect("open db");
+    let triple = Triple {
+        id: build_triple_id("Bob", "husband_of", "Alice"),
+        subject: "Bob".to_string(),
+        predicate: "husband_of".to_string(),
+        object: "Alice".to_string(),
+        valid_from: Some("1700000000".to_string()),
+        valid_to: None,
+        confidence: 1.0,
+        source_drawer: None,
+    };
+    db.insert_triple(&triple).expect("insert triple");
 }
 
 fn assert_completed_status(output: &Output) {
@@ -505,6 +561,249 @@ async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
     assert_eq!(entry["source_file"], "csa://session/99");
     assert_eq!(entry["dry_run"], false);
     assert_eq!(entry["dropped_by_gate"], 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_exact_duplicate_matches_non_wait_plain_and_json_output() {
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+
+    for json in [false, true] {
+        let wait_home = setup_home();
+        let direct_home = setup_home();
+        let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
+        let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
+
+        let payload = serde_json::json!({
+            "content": "duplicate wait content",
+            "wing": "cli-wing",
+            "room": "duplicate-room",
+            "project": "duplicate-project",
+            "source": "csa-session",
+            "source_file": "csa://session/duplicate",
+            "source_type": "user_explicit",
+            "confidence": 0.82
+        })
+        .to_string();
+
+        let seed_args = if json {
+            vec!["ingest", "--stdin", "--no-gate", "--json"]
+        } else {
+            vec!["ingest", "--stdin", "--no-gate"]
+        };
+        let seed_wait = run_cli_with_stdin(wait_home.path(), &seed_args, payload.as_bytes());
+        let seed_direct = run_cli_with_stdin(direct_home.path(), &seed_args, payload.as_bytes());
+        assert!(
+            seed_wait.status.success() && seed_direct.status.success(),
+            "seeding duplicate fixture must succeed"
+        );
+
+        let wait_timeout = u64::MAX.to_string();
+        let mut direct_args = vec![
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+        ];
+        let mut wait_args = vec![
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+        ];
+        if json {
+            direct_args.push("--json");
+            wait_args.push("--json");
+        }
+
+        let direct_output =
+            run_cli_with_stdin(direct_home.path(), &direct_args, payload.as_bytes());
+        let wait_output = run_cli_with_stdin(wait_home.path(), &wait_args, payload.as_bytes());
+
+        assert!(
+            direct_output.status.success(),
+            "stdout={}, stderr={}",
+            String::from_utf8_lossy(&direct_output.stdout),
+            String::from_utf8_lossy(&direct_output.stderr)
+        );
+        assert!(
+            wait_output.status.success(),
+            "stdout={}, stderr={}",
+            String::from_utf8_lossy(&wait_output.stdout),
+            String::from_utf8_lossy(&wait_output.stderr)
+        );
+        assert_bootstrap_stderr(&direct_output);
+        assert_bootstrap_stderr(&wait_output);
+
+        if json {
+            let direct_json: Value =
+                serde_json::from_slice(&direct_output.stdout).expect("parse direct duplicate JSON");
+            let wait_json: Value =
+                serde_json::from_slice(&wait_output.stdout).expect("parse wait duplicate JSON");
+            assert_eq!(
+                wait_json, direct_json,
+                "wait JSON output must match direct duplicate output"
+            );
+            assert_eq!(direct_json["stats"]["files"], 1);
+            assert_eq!(direct_json["stats"]["chunks"], 0);
+            assert_eq!(direct_json["stats"]["skipped"], 1);
+            assert_eq!(direct_json["stats"]["dropped_by_gate"], 0);
+            assert_eq!(
+                direct_json["drawer_ids"]
+                    .as_array()
+                    .expect("drawer ids")
+                    .len(),
+                1
+            );
+        } else {
+            assert_eq!(
+                String::from_utf8_lossy(&wait_output.stdout),
+                String::from_utf8_lossy(&direct_output.stdout),
+                "wait plain output must match direct duplicate output"
+            );
+            let stdout = String::from_utf8_lossy(&direct_output.stdout);
+            assert!(stdout.contains("files=1"), "{stdout}");
+            assert!(stdout.contains("chunks=0"), "{stdout}");
+            assert!(stdout.contains("skipped=1"), "{stdout}");
+            assert!(stdout.contains("dropped_by_gate=0"), "{stdout}");
+        }
+
+        let direct_audit = last_audit_entry(direct_home.path());
+        let wait_audit = last_audit_entry(wait_home.path());
+        assert_eq!(direct_audit["command"], "ingest");
+        assert_eq!(wait_audit["command"], "ingest");
+        assert_stdin_audit_entry(
+            &direct_audit,
+            "csa-session",
+            "csa://session/duplicate",
+            0,
+            1,
+            0,
+        );
+        assert_stdin_audit_entry(
+            &wait_audit,
+            "csa-session",
+            "csa://session/duplicate",
+            0,
+            1,
+            0,
+        );
+        assert!(direct_audit["superseded_drawer_id"].is_null());
+        assert!(wait_audit["superseded_drawer_id"].is_null());
+    }
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_rejected_matches_non_wait_output_and_audit() {
+    let wait_home = setup_home();
+    let direct_home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
+    let direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
+    {
+        use std::io::Write as _;
+
+        for config_path in [&wait_config, &direct_config] {
+            let mut config = fs::OpenOptions::new()
+                .append(true)
+                .open(config_path)
+                .expect("open config for append");
+            writeln!(
+                config,
+                "\n[ingest_gating]\nenabled = true\n\n[ingest_gating.fact_check]\nenabled = true\nreject_on_contradiction = true"
+            )
+            .expect("append gating config");
+        }
+    }
+    insert_fact_check_contradiction(wait_home.path());
+    insert_fact_check_contradiction(direct_home.path());
+
+    let payload = serde_json::json!({
+        "content": "Bob is Alice's brother.",
+        "wing": "cli-wing",
+        "room": "reject-room",
+        "project": "reject-project",
+        "source": "csa-session",
+        "source_file": "csa://session/reject",
+        "source_type": "user_explicit",
+        "confidence": 0.8
+    })
+    .to_string();
+
+    let direct_output = run_cli_with_stdin(
+        direct_home.path(),
+        &["ingest", "--stdin", "--json"],
+        payload.as_bytes(),
+    );
+    let wait_output = run_cli_with_stdin(
+        wait_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wait",
+            "--wait-timeout-secs",
+            "30",
+            "--json",
+        ],
+        payload.as_bytes(),
+    );
+
+    assert!(
+        direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&direct_output.stdout),
+        String::from_utf8_lossy(&direct_output.stderr)
+    );
+    assert!(
+        wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+    assert_bootstrap_stderr(&direct_output);
+    assert_bootstrap_stderr(&wait_output);
+
+    let direct_json: Value = serde_json::from_slice(&direct_output.stdout).expect("direct json");
+    let wait_json: Value = serde_json::from_slice(&wait_output.stdout).expect("wait json");
+    assert_eq!(
+        wait_json, direct_json,
+        "wait rejection JSON must match direct rejection JSON"
+    );
+    assert_eq!(direct_json["stats"]["files"], 1);
+    assert_eq!(direct_json["stats"]["chunks"], 0);
+    assert_eq!(direct_json["stats"]["skipped"], 0);
+    assert_eq!(direct_json["stats"]["dropped_by_gate"], 1);
+    assert!(
+        direct_json["drawer_ids"]
+            .as_array()
+            .expect("drawer ids")
+            .is_empty(),
+        "rejected ingest must not report drawer ids"
+    );
+
+    let direct_audit = last_audit_entry(direct_home.path());
+    let wait_audit = last_audit_entry(wait_home.path());
+    assert_stdin_audit_entry(
+        &direct_audit,
+        "csa-session",
+        "csa://session/reject",
+        0,
+        0,
+        1,
+    );
+    assert_stdin_audit_entry(&wait_audit, "csa-session", "csa://session/reject", 0, 0, 1);
+    assert!(direct_audit["superseded_drawer_id"].is_null());
+    assert!(wait_audit["superseded_drawer_id"].is_null());
+
+    handle.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
@@ -254,14 +255,30 @@ fn start_worker(server: MempalMcpServer) -> tokio::task::JoinHandle<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_wait_returns_drawer_id() {
-    let home = setup_home();
+async fn test_ingest_wait_matches_non_wait_plain_output() {
+    let wait_home = setup_home();
+    let direct_home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
-    let _config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
+    let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
     let wait_timeout = u64::MAX.to_string();
+    let payload = br#"{"content":"cli wait content"}"#;
 
-    let output = run_cli_with_stdin(
-        home.path(),
+    let direct_output = run_cli_with_stdin(
+        direct_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+        ],
+        payload,
+    );
+    let wait_output = run_cli_with_stdin(
+        wait_home.path(),
         &[
             "ingest",
             "--stdin",
@@ -274,13 +291,133 @@ async fn test_ingest_wait_returns_drawer_id() {
             "--wait-timeout-secs",
             wait_timeout.as_str(),
         ],
-        br#"{"content":"cli wait content"}"#,
+        payload,
     );
     handle.shutdown().await;
 
-    assert_completed_status(&output);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("drawer_id="), "{stdout}");
+    assert!(
+        direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&direct_output.stdout),
+        String::from_utf8_lossy(&direct_output.stderr)
+    );
+    assert!(
+        wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+
+    let direct_stdout = String::from_utf8_lossy(&direct_output.stdout);
+    let wait_stdout = String::from_utf8_lossy(&wait_output.stdout);
+    assert_eq!(
+        wait_stdout, direct_stdout,
+        "wait stdout must match direct stdout"
+    );
+    assert!(wait_stdout.contains("dry_run=false"), "{wait_stdout}");
+    assert!(wait_stdout.contains("files=1"), "{wait_stdout}");
+    assert!(wait_stdout.contains("chunks=1"), "{wait_stdout}");
+    assert!(wait_stdout.contains("skipped=0"), "{wait_stdout}");
+    assert!(wait_stdout.contains("dropped_by_gate=0"), "{wait_stdout}");
+    assert!(
+        wait_stdout.contains("superseded_drawer_id="),
+        "{wait_stdout}"
+    );
+    assert!(
+        !wait_stdout
+            .lines()
+            .any(|line| line.starts_with("drawer_id=")),
+        "{wait_stdout}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_json_matches_non_wait_json_output() {
+    let wait_home = setup_home();
+    let direct_home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
+    let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
+    let wait_timeout = u64::MAX.to_string();
+    let payload = br#"{"content":"cli wait json content"}"#;
+
+    let direct_output = run_cli_with_stdin(
+        direct_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--json",
+        ],
+        payload,
+    );
+    let wait_output = run_cli_with_stdin(
+        wait_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+            "--json",
+        ],
+        payload,
+    );
+    handle.shutdown().await;
+
+    assert!(
+        direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&direct_output.stdout),
+        String::from_utf8_lossy(&direct_output.stderr)
+    );
+    assert!(
+        wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+
+    let direct_json: Value =
+        serde_json::from_slice(&direct_output.stdout).expect("parse direct ingest JSON");
+    let wait_json: Value = serde_json::from_slice(&wait_output.stdout).expect("parse wait JSON");
+    let direct_keys: BTreeSet<String> = direct_json
+        .as_object()
+        .expect("direct JSON object")
+        .keys()
+        .cloned()
+        .collect();
+    let wait_keys: BTreeSet<String> = wait_json
+        .as_object()
+        .expect("wait JSON object")
+        .keys()
+        .cloned()
+        .collect();
+    assert_eq!(
+        wait_keys, direct_keys,
+        "wait JSON keys must match direct JSON keys"
+    );
+    assert_eq!(
+        wait_json["stats"], direct_json["stats"],
+        "wait stats must match direct stats"
+    );
+    let drawer_ids = wait_json["drawer_ids"]
+        .as_array()
+        .expect("drawer_ids array");
+    assert!(!drawer_ids.is_empty(), "drawer_ids must be non-empty");
+    assert!(
+        drawer_ids.iter().all(|value| value.as_str().is_some()),
+        "drawer_ids must contain strings"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -326,17 +463,34 @@ async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
     );
     handle.shutdown().await;
 
-    assert_completed_status(&output);
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("drawer_id="), "{stdout}");
+    assert!(stdout.contains("dry_run=false"), "{stdout}");
+    assert!(stdout.contains("files=1"), "{stdout}");
+    assert!(stdout.contains("chunks=1"), "{stdout}");
+    assert!(stdout.contains("skipped=0"), "{stdout}");
+    assert!(stdout.contains("dropped_by_gate=0"), "{stdout}");
+    assert!(stdout.contains("superseded_drawer_id="), "{stdout}");
+    assert!(
+        !stdout.lines().any(|line| line.starts_with("drawer_id=")),
+        "{stdout}"
+    );
 
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
-    let drawer_id = stdout
-        .lines()
-        .find_map(|line| line.strip_prefix("drawer_id="))
-        .expect("drawer id line");
+    let drawer_id = db
+        .find_active_drawers_by_content("hi", "cli-wing", Some("audit-room"), None)
+        .expect("find drawer by content")
+        .into_iter()
+        .next()
+        .expect("drawer entry")
+        .id;
     let drawer = db
-        .get_drawer(drawer_id)
+        .get_drawer(&drawer_id)
         .expect("get drawer")
         .expect("drawer exists");
     assert_eq!(drawer.source_file.as_deref(), Some("csa://session/99"));

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -257,6 +257,7 @@ async fn test_ingest_wait_returns_drawer_id() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let _config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    let wait_timeout = u64::MAX.to_string();
 
     let output = run_cli_with_stdin(
         home.path(),
@@ -270,7 +271,7 @@ async fn test_ingest_wait_returns_drawer_id() {
             "--no-gate",
             "--wait",
             "--wait-timeout-secs",
-            "30",
+            wait_timeout.as_str(),
         ],
         br#"{"content":"cli wait content"}"#,
     );
@@ -333,11 +334,18 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
 
     let operation_id =
         enqueue_prepared_operation(&db_path, "wait cli content", "mcp", Some("wait"));
+    let wait_timeout = u64::MAX.to_string();
 
     handle.pause();
     let child = spawn_cli(
         home.path(),
-        &["operation", "wait", &operation_id, "--timeout-secs", "30"],
+        &[
+            "operation",
+            "wait",
+            &operation_id,
+            "--timeout-secs",
+            wait_timeout.as_str(),
+        ],
     );
     tokio::time::sleep(Duration::from_millis(150)).await;
 

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -12,6 +12,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
 use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
+use serde_json::Value;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -280,6 +281,76 @@ async fn test_ingest_wait_returns_drawer_id() {
     assert_completed_status(&output);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("drawer_id="), "{stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    {
+        use std::io::Write as _;
+
+        let mut config = fs::OpenOptions::new()
+            .append(true)
+            .open(&config_path)
+            .expect("open config");
+        writeln!(config, "\n[ingest_gating]\nenabled = true").expect("append gating config");
+    }
+
+    let payload = serde_json::json!({
+        "content": "hi",
+        "wing": "cli-wing",
+        "room": "audit-room",
+        "source": "csa-session",
+        "source_file": "csa://session/99",
+        "source_type": "user_explicit"
+    })
+    .to_string();
+
+    let output = run_cli_with_stdin(
+        home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            "30",
+        ],
+        payload.as_bytes(),
+    );
+    handle.shutdown().await;
+
+    assert_completed_status(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("drawer_id="), "{stdout}");
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let drawer_id = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("drawer_id="))
+        .expect("drawer id line");
+    let drawer = db
+        .get_drawer(drawer_id)
+        .expect("get drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.source_file.as_deref(), Some("csa://session/99"));
+    assert_eq!(drawer.wing, "cli-wing");
+
+    let audit_path = home.path().join(".mempal").join("audit.jsonl");
+    let audit = fs::read_to_string(&audit_path).expect("read audit log");
+    let entry: Value = serde_json::from_str(audit.lines().last().expect("audit entry"))
+        .expect("parse audit entry");
+    assert_eq!(entry["mode"], "stdin");
+    assert_eq!(entry["source"], "csa-session");
+    assert_eq!(entry["source_file"], "csa://session/99");
+    assert_eq!(entry["dry_run"], false);
+    assert_eq!(entry["dropped_by_gate"], 0);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -15,6 +15,7 @@ use mempal::core::types::Triple;
 use mempal::core::utils::build_triple_id;
 use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
+use rusqlite::Connection;
 use serde_json::Value;
 use serde_json::json;
 use tempfile::TempDir;
@@ -211,6 +212,16 @@ fn print_lines(output: &Output) -> (String, String) {
     )
 }
 
+fn novelty_audit_count(home: &Path) -> i64 {
+    let db_path = home.join(".mempal/palace.db");
+    Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row("SELECT COUNT(*) FROM novelty_audit", [], |row| {
+            row.get::<_, i64>(0)
+        })
+        .expect("count novelty audit")
+}
+
 fn assert_bootstrap_stderr(output: &Output) {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let mut lines = stderr.lines();
@@ -315,6 +326,7 @@ async fn test_ingest_wait_matches_non_wait_plain_output() {
     let wait_home = setup_home();
     let direct_home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    handle.set_embedding_fill(1.0).await;
     let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
     let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
     let wait_timeout = u64::MAX.to_string();
@@ -473,6 +485,125 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
     assert!(
         drawer_ids.iter().all(|value| value.as_str().is_some()),
         "drawer_ids must contain strings"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_matches_non_wait_when_novelty_is_enabled() {
+    let wait_home = setup_home();
+    let direct_home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
+    let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
+
+    {
+        use std::io::Write as _;
+
+        for home in [wait_home.path(), direct_home.path()] {
+            let config_path = home.join(".mempal/config.toml");
+            let mut config = fs::OpenOptions::new()
+                .append(true)
+                .open(&config_path)
+                .expect("open config");
+            writeln!(config, "\n[ingest_gating.novelty]\nenabled = true")
+                .expect("append novelty config");
+        }
+    }
+
+    let seed_payload = br#"{"content":"novelty seed content"}"#;
+    let seed_args = [
+        "ingest",
+        "--stdin",
+        "--wing",
+        "cli-wing",
+        "--source-type",
+        "user_explicit",
+        "--no-gate",
+    ];
+    let seed_wait_output = run_cli_with_stdin(wait_home.path(), &seed_args, seed_payload);
+    let seed_direct_output = run_cli_with_stdin(direct_home.path(), &seed_args, seed_payload);
+    assert!(
+        seed_wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&seed_wait_output.stdout),
+        String::from_utf8_lossy(&seed_wait_output.stderr)
+    );
+    assert!(
+        seed_direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&seed_direct_output.stdout),
+        String::from_utf8_lossy(&seed_direct_output.stderr)
+    );
+
+    let wait_timeout = u64::MAX.to_string();
+    let payload = br#"{"content":"novelty candidate content"}"#;
+
+    let direct_output = run_cli_with_stdin(
+        direct_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--json",
+        ],
+        payload,
+    );
+    let wait_output = run_cli_with_stdin(
+        wait_home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+            "--json",
+        ],
+        payload,
+    );
+    handle.shutdown().await;
+
+    assert!(
+        direct_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&direct_output.stdout),
+        String::from_utf8_lossy(&direct_output.stderr)
+    );
+    assert!(
+        wait_output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&wait_output.stdout),
+        String::from_utf8_lossy(&wait_output.stderr)
+    );
+
+    let direct_json: Value =
+        serde_json::from_slice(&direct_output.stdout).expect("parse direct ingest JSON");
+    let wait_json: Value = serde_json::from_slice(&wait_output.stdout).expect("parse wait JSON");
+    assert_eq!(
+        wait_json["stats"], direct_json["stats"],
+        "wait stats must match direct stats when novelty is enabled"
+    );
+    let drawer_ids = wait_json["drawer_ids"]
+        .as_array()
+        .expect("drawer_ids array");
+    assert!(!drawer_ids.is_empty(), "drawer_ids must be non-empty");
+    assert_eq!(
+        novelty_audit_count(wait_home.path()),
+        0,
+        "wait stdin ingest must not write novelty audits when non-wait stdin would not"
+    );
+    assert_eq!(
+        novelty_audit_count(direct_home.path()),
+        0,
+        "direct stdin ingest must not write novelty audits"
     );
 }
 

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -1,0 +1,371 @@
+mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+use common::harness::embed_mock::start as start_embed_mock;
+use mempal::core::config::{Config, ConfigHandle};
+use mempal::core::db::Database;
+use mempal::core::queue::PendingMessageStore;
+use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
+use rmcp::handler::server::wrapper::Parameters;
+use serde_json::json;
+use tempfile::TempDir;
+
+static CONFIG_LOCK: Mutex<()> = Mutex::new(());
+
+struct ConfigOverrideGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl ConfigOverrideGuard {
+    fn install(config_path: &Path) -> Self {
+        let lock = CONFIG_LOCK.lock().expect("config override lock");
+        ConfigHandle::harness_reload_from_path(config_path);
+        Self { _lock: lock }
+    }
+}
+
+impl Drop for ConfigOverrideGuard {
+    fn drop(&mut self) {
+        let tempdir = TempDir::new().expect("reset tempdir");
+        let path = tempdir.path().join("default.toml");
+        fs::write(&path, "db_path = \"~/.mempal/palace.db\"\n").expect("write default config");
+        ConfigHandle::harness_reload_from_path(&path);
+    }
+}
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    fs::create_dir_all(tmp.path().join(".mempal")).expect("create mempal home");
+    Database::open(&tmp.path().join(".mempal/palace.db")).expect("open db");
+    tmp
+}
+
+fn write_config(home: &Path, base_url: &str) -> PathBuf {
+    let db_path = home.join(".mempal/palace.db");
+    let config_path = home.join(".mempal/config.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+api_model = "test-embed"
+base_url = "{}"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+
+[privacy]
+enabled = false
+"#,
+            db_path.display(),
+            base_url,
+            base_url
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+fn run_cli(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .output()
+        .expect("run mempal")
+}
+
+fn run_cli_with_stdin(home: &Path, args: &[&str], payload: &[u8]) -> Output {
+    use std::io::Write as _;
+
+    let mut child = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal");
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(payload).expect("write stdin payload");
+    }
+    child.wait_with_output().expect("wait mempal")
+}
+
+fn spawn_cli(home: &Path, args: &[&str]) -> Child {
+    Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal")
+}
+
+fn prepared_ingest_payload(content: &str, wing: &str, room: Option<&str>) -> String {
+    serde_json::to_string(&json!({
+        "request": {
+            "content": content,
+            "wing": wing,
+            "room": room,
+            "source": "cli-test",
+            "source_type": "user_explicit",
+            "confidence": 0.9,
+            "project_id": null,
+            "supersedes": null,
+            "replace_text": null,
+            "valid_from": null,
+            "valid_until": null,
+            "dry_run": false,
+            "wait": false,
+            "wait_timeout_secs": null,
+            "diary_rollup": false,
+            "importance": 0,
+            "memory_kind": "evidence",
+            "domain": "project",
+            "field": "general",
+            "is_pinned": false,
+            "provenance": null,
+            "statement": null,
+            "tier": null,
+            "status": null,
+            "supporting_refs": null,
+            "counterexample_refs": null,
+            "teaching_refs": null,
+            "verification_refs": null,
+            "scope_constraints": null,
+            "trigger_hints": null,
+            "anchor_kind": null,
+            "anchor_id": null,
+            "parent_anchor_id": null,
+            "cwd": null
+        },
+        "project_id": null,
+        "scrubbed_content": content,
+        "source_type": "user_explicit",
+        "confidence": 0.9,
+        "metadata": {
+            "memory_kind": "evidence",
+            "domain": "project",
+            "field": "general",
+            "is_pinned": false,
+            "anchor_kind": "global",
+            "anchor_id": "general",
+            "parent_anchor_id": null,
+            "provenance": null,
+            "statement": null,
+            "tier": null,
+            "status": null,
+            "supporting_refs": [],
+            "counterexample_refs": [],
+            "teaching_refs": [],
+            "verification_refs": [],
+            "scope_constraints": null,
+            "trigger_hints": null
+        },
+        "superseded_drawer_id": null,
+        "raw_turn": false,
+        "drawer_importance": 0
+    }))
+    .expect("serialize prepared ingest payload")
+}
+
+fn enqueue_prepared_operation(
+    db_path: &Path,
+    content: &str,
+    wing: &str,
+    room: Option<&str>,
+) -> String {
+    PendingMessageStore::new(db_path)
+        .expect("queue store")
+        .enqueue(
+            "ingest_async",
+            &prepared_ingest_payload(content, wing, room),
+        )
+        .expect("enqueue prepared ingest")
+}
+
+fn print_lines(output: &Output) -> (String, String) {
+    (
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+fn assert_completed_status(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("state=completed"), "{stdout}");
+    assert!(stdout.contains("timed_out=false"), "{stdout}");
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.starts_with("drawer_id=") && line.len() > "drawer_id=".len()),
+        "{stdout}"
+    );
+    assert!(stdout.contains("timings={"), "{stdout}");
+}
+
+fn assert_queued_status(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("state=queued"), "{stdout}");
+    assert!(stdout.contains("timed_out=false"), "{stdout}");
+    assert!(stdout.contains("timings={"), "{stdout}");
+}
+
+fn start_worker(server: MempalMcpServer) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let request = IngestRequest {
+            content: "worker warmup".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("warmup".to_string()),
+            dry_run: Some(true),
+            ..IngestRequest::default()
+        };
+        let _ = server.mempal_ingest(Parameters(request)).await;
+    })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_returns_drawer_id() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+
+    let output = run_cli_with_stdin(
+        home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "cli-wing",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            "30",
+        ],
+        br#"{"content":"cli wait content"}"#,
+    );
+    handle.shutdown().await;
+
+    assert_completed_status(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("drawer_id="), "{stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_operation_status_reports_queued_then_completed() {
+    let home = setup_home();
+    let (addr, _handle) = start_embed_mock(0).await.expect("start embed mock");
+    let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    let _guard = ConfigOverrideGuard::install(&config_path);
+    let config = Config::load_from(&config_path).expect("load config");
+    let db_path = home.path().join(".mempal/palace.db");
+    let server = MempalMcpServer::new(db_path.clone(), config);
+
+    let operation_id =
+        enqueue_prepared_operation(&db_path, "status cli content", "mcp", Some("status"));
+
+    let queued_output = run_cli(home.path(), &["operation", "status", &operation_id]);
+    assert_queued_status(&queued_output);
+
+    let warmup = start_worker(server.clone());
+    let completed = server
+        .wait_for_operation_completion(&operation_id)
+        .await
+        .expect("wait for completion");
+    warmup.await.expect("warmup join");
+
+    assert_eq!(completed.state, Some(IngestOperationState::Completed));
+    assert!(
+        completed.timings.contains_key("embedding_ms"),
+        "completed timings must include embedding_ms"
+    );
+    assert!(
+        completed.timings.contains_key("db_write_ms"),
+        "completed timings must include db_write_ms"
+    );
+
+    let completed_output = run_cli(home.path(), &["operation", "status", &operation_id]);
+    assert_completed_status(&completed_output);
+    let stdout = String::from_utf8_lossy(&completed_output.stdout);
+    assert!(stdout.contains("embedding_ms"), "{stdout}");
+    assert!(stdout.contains("db_write_ms"), "{stdout}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_operation_wait_exits_zero_and_prints_progress() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    let _guard = ConfigOverrideGuard::install(&config_path);
+    let config = Config::load_from(&config_path).expect("load config");
+    let db_path = home.path().join(".mempal/palace.db");
+    let server = MempalMcpServer::new(db_path.clone(), config);
+
+    let operation_id =
+        enqueue_prepared_operation(&db_path, "wait cli content", "mcp", Some("wait"));
+
+    handle.pause();
+    let child = spawn_cli(
+        home.path(),
+        &["operation", "wait", &operation_id, "--timeout-secs", "30"],
+    );
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let warmup = start_worker(server.clone());
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    handle.resume();
+
+    let output = child.wait_with_output().expect("wait operation child");
+    warmup.await.expect("warmup join");
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let (stdout, stderr) = print_lines(&output);
+    assert!(stdout.contains("state=completed"), "{stdout}");
+    assert!(
+        stdout
+            .lines()
+            .any(|line| line.starts_with("drawer_id=") && line.len() > "drawer_id=".len()),
+        "{stdout}"
+    );
+    assert!(stderr.contains("waiting for operation_id="), "{stderr}");
+    assert!(
+        stderr.contains("state=queued") || stderr.contains("state=running"),
+        "{stderr}"
+    );
+}

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -538,8 +538,18 @@ async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
     );
 
     let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    let expected_project = mempal::core::project::infer_project_id_from_path(
+        &std::env::current_dir().expect("current dir"),
+    )
+    .expect("infer project id from cwd")
+    .expect("expected project id from cwd");
     let drawer_id = db
-        .find_active_drawers_by_content("hi", "cli-wing", Some("audit-room"), None)
+        .find_active_drawers_by_content(
+            "hi",
+            "cli-wing",
+            Some("audit-room"),
+            Some(expected_project.as_str()),
+        )
         .expect("find drawer by content")
         .into_iter()
         .next()

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -160,6 +160,10 @@ fn prepared_ingest_payload(content: &str, wing: &str, room: Option<&str>) -> Str
             "parent_anchor_id": null,
             "cwd": null
         },
+        "controls": {
+            "no_gate": false,
+            "bypass_novelty": false
+        },
         "project_id": null,
         "scrubbed_content": content,
         "source_type": "user_explicit",

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "77ccde826fbf8f895fa17d11d77eaa40b56e0289"
+commit = "a1d7ab9e3e7228f4d43d64ba6011263d93f51541"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Completes #320 (PR-B, follow-up to PR-A #327). PR-A made `mempal_ingest` non-blocking via a receipt-based async pipeline; this PR delivers the remaining #320 acceptance criteria: an explicit blocking/waitable option, per-stage timing observability, and MCP-vs-CLI write guidance.

## Changes

- **MCP `wait` option** — `mempal_ingest` gains `wait` (default false) + `wait_timeout_secs`. `wait=true` blocks up to the timeout polling the operation to a terminal state and returns the final result (drawer_id / rejected_reason / failure_detail); on timeout returns the receipt with `timed_out: true` (never errors). `wait=false` and `dry_run` behavior unchanged.
- **CLI waitable writes** — `mempal ingest --wait [--wait-timeout-secs N]`; new `mempal operation status <id>` (one-shot) and `mempal operation wait <id> [--timeout-secs N]` (block-poll with progress, in the spirit of `csa session wait`). Nonzero exit on rejected/failed.
- **Per-stage timing breakdown** — the async ingest pipeline records elapsed-ms per stage (queue_wait / embedding / gating / novelty / db_write, whichever exist) into the existing `result_json`; surfaced in `mempal_operation_status` and `mempal operation status`. Answers #319's "where did the 92s go" without a schema change.
- **Docs** — `mempal_ingest` tool description documents the wait/poll model + timings; a "When to use MCP vs CLI for writes" section maps passive/diary → fire-and-forget receipt, load-bearing → `wait=true` / `--wait`, user-facing capture → must surface rejected/failed.
- **Admission-control hardening** — internal ingest overrides (`no_gate`, `bypass_novelty`) live on a private `IngestControls` struct, NOT the public `mempal_ingest` MCP schema. The public tool always runs full gating + novelty admission control (`IngestControls::default()`); only trusted local CLI paths can request overrides, via an internal `*_with_controls` entrypoint. The controls serialize into the queued operation so authorized CLI bypasses propagate securely across the async boundary.

## Acceptance criteria (#320)

- [x] Agent-facing writes have a bounded fast-return mode (PR-A receipt + this PR's wait/timeout).
- [x] Callers can obtain a definitive final result (drawer id / rejected reason / failure) — `wait=true`, `operation status`/`wait`.
- [x] Slow work reports where time is spent — per-stage timings in `result_json` + status output.
- [x] Documentation tells agents when to use MCP vs CLI.

Closes #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
