### PR TITLE
fix(325): finalize reindex_progress rows + reconcile orphan 'running' rows

### DIFF
--- a/src/core/reindex.rs
+++ b/src/core/reindex.rs
@@ -100,42 +100,43 @@ impl ReindexProgressStore {
     ) -> Result<usize> {
         let now = now_secs();
         let conn = self.open_connection()?;
+        // Aggregate each source once, then join the summary back to running rows.
         let updated = conn.execute(
             r#"
+            WITH source_summary AS (
+                SELECT
+                    COALESCE(d.source_file, d.id) AS source_path,
+                    COUNT(*) AS drawer_count,
+                    MAX(COALESCE(d.chunk_index, 0)) AS last_processed_chunk_id,
+                    SUM(
+                        CASE
+                            WHEN v.id IS NULL
+                              OR COALESCE(idx.value, legacy_idx.value, '') != ?1
+                              OR COALESCE(fp.value, '') != ?2
+                            THEN 1
+                            ELSE 0
+                        END
+                    ) AS stale_drawer_count
+                FROM drawers AS d
+                LEFT JOIN drawer_vectors AS v ON v.id = d.id
+                LEFT JOIN fork_ext_meta AS idx
+                  ON idx.key = 'reindex:' || d.id || ':index_version'
+                LEFT JOIN fork_ext_meta AS legacy_idx
+                  ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
+                LEFT JOIN fork_ext_meta AS fp
+                  ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
+                WHERE d.deleted_at IS NULL
+                GROUP BY COALESCE(d.source_file, d.id)
+            )
             UPDATE reindex_progress
-            SET last_processed_chunk_id = (
-                    SELECT COALESCE(MAX(COALESCE(d.chunk_index, 0)), 0)
-                    FROM drawers AS d
-                    WHERE d.deleted_at IS NULL
-                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
-                ),
+            SET last_processed_chunk_id = source_summary.last_processed_chunk_id,
                 updated_at = ?3,
                 status = 'done'
-            WHERE status = 'running'
-              AND EXISTS (
-                    SELECT 1
-                    FROM drawers AS d
-                    WHERE d.deleted_at IS NULL
-                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
-                )
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM drawers AS d
-                    LEFT JOIN drawer_vectors AS v ON v.id = d.id
-                    LEFT JOIN fork_ext_meta AS idx
-                      ON idx.key = 'reindex:' || d.id || ':index_version'
-                    LEFT JOIN fork_ext_meta AS legacy_idx
-                      ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
-                    LEFT JOIN fork_ext_meta AS fp
-                      ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
-                    WHERE d.deleted_at IS NULL
-                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
-                      AND (
-                            v.id IS NULL
-                         OR COALESCE(idx.value, legacy_idx.value, '') != ?1
-                         OR COALESCE(fp.value, '') != ?2
-                      )
-                )
+            FROM source_summary
+            WHERE reindex_progress.status = 'running'
+              AND reindex_progress.source_path = source_summary.source_path
+              AND source_summary.drawer_count > 0
+              AND source_summary.stale_drawer_count = 0
             "#,
             params![current_index_version, target_fingerprint, now],
         )?;

--- a/src/core/reindex.rs
+++ b/src/core/reindex.rs
@@ -73,6 +73,75 @@ impl ReindexProgressStore {
         self.upsert(source_path, last_processed_chunk_id, embedder_name, "done")
     }
 
+    pub fn mark_failed(
+        &self,
+        source_path: &str,
+        last_processed_chunk_id: Option<i64>,
+        embedder_name: &str,
+    ) -> Result<()> {
+        self.upsert(
+            source_path,
+            last_processed_chunk_id,
+            embedder_name,
+            "failed",
+        )
+    }
+
+    /// Finalize orphan `running` rows whose source drawers are already fully
+    /// current for the active vector index.
+    ///
+    /// This is intentionally conservative: only sources with at least one
+    /// drawer and zero stale drawers are promoted to `done`, so a partially
+    /// reindexed source remains resumable.
+    pub fn finalize_completed_running_rows(
+        &self,
+        current_index_version: &str,
+        target_fingerprint: &str,
+    ) -> Result<usize> {
+        let now = now_secs();
+        let conn = self.open_connection()?;
+        let updated = conn.execute(
+            r#"
+            UPDATE reindex_progress
+            SET last_processed_chunk_id = (
+                    SELECT COALESCE(MAX(COALESCE(d.chunk_index, 0)), 0)
+                    FROM drawers AS d
+                    WHERE d.deleted_at IS NULL
+                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
+                ),
+                updated_at = ?3,
+                status = 'done'
+            WHERE status = 'running'
+              AND EXISTS (
+                    SELECT 1
+                    FROM drawers AS d
+                    WHERE d.deleted_at IS NULL
+                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
+                )
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM drawers AS d
+                    LEFT JOIN drawer_vectors AS v ON v.id = d.id
+                    LEFT JOIN fork_ext_meta AS idx
+                      ON idx.key = 'reindex:' || d.id || ':index_version'
+                    LEFT JOIN fork_ext_meta AS legacy_idx
+                      ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
+                    LEFT JOIN fork_ext_meta AS fp
+                      ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
+                    WHERE d.deleted_at IS NULL
+                      AND COALESCE(d.source_file, d.id) = reindex_progress.source_path
+                      AND (
+                            v.id IS NULL
+                         OR COALESCE(idx.value, legacy_idx.value, '') != ?1
+                         OR COALESCE(fp.value, '') != ?2
+                      )
+                )
+            "#,
+            params![current_index_version, target_fingerprint, now],
+        )?;
+        Ok(updated)
+    }
+
     pub fn latest_resumable(
         &self,
         embedder_name: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5977,6 +5977,9 @@ async fn reindex_stale_batches(
     let mut skipped_concurrent_update = 0usize;
     let mut skipped_failed_batches = 0usize;
     let mut skipped_failed_drawers = 0usize;
+    let progress_store = ReindexProgressStore::new(db.path());
+    let mut active_source: Option<String> = None;
+    let mut last_processed: Option<(String, i64)> = None;
     // Drawers from batches that failed past the retry cap. They keep no fresh
     // vector (stay stale), so they MUST be excluded from later batch queries:
     // the stale selection re-runs every iteration, and without exclusion it
@@ -6048,12 +6051,35 @@ async fn reindex_stale_batches(
                 stats.reindexed, stats.skipped_concurrent_update
             );
         }
-        let progress_store = ReindexProgressStore::new(db.path());
-        if let Some(last) = rows.last() {
+        let mut row_index = 0usize;
+        while row_index < rows.len() {
+            let source_path = rows[row_index].source_path.clone();
+            let mut last_chunk = rows[row_index].chunk_index;
+            row_index += 1;
+            while row_index < rows.len() && rows[row_index].source_path == source_path {
+                last_chunk = rows[row_index].chunk_index;
+                row_index += 1;
+            }
+
+            if active_source.as_deref() != Some(source_path.as_str()) {
+                if let Some((previous_source, previous_chunk)) = last_processed.as_ref() {
+                    progress_store
+                        .mark_done(previous_source, Some(*previous_chunk), embedder_name)
+                        .context("failed to finalize completed reindex source")?;
+                }
+                active_source = Some(source_path.clone());
+            }
+
             progress_store
-                .upsert_running(&last.source_path, Some(last.chunk_index), embedder_name)
+                .upsert_running(&source_path, Some(last_chunk), embedder_name)
                 .context("failed to persist reindex checkpoint")?;
+            last_processed = Some((source_path, last_chunk));
         }
+    }
+    if let Some((source_path, chunk_index)) = last_processed.as_ref() {
+        progress_store
+            .mark_done(source_path, Some(*chunk_index), embedder_name)
+            .context("failed to finalize reindex checkpoint")?;
     }
     if skipped_concurrent_update == 0 {
         println!("stale reindex complete: {processed} drawers");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5978,8 +5978,7 @@ async fn reindex_stale_batches(
     let mut skipped_failed_batches = 0usize;
     let mut skipped_failed_drawers = 0usize;
     let progress_store = ReindexProgressStore::new(db.path());
-    let mut active_source: Option<String> = None;
-    let mut last_processed: Option<(String, i64)> = None;
+    let mut failed_sources = std::collections::HashSet::new();
     // Drawers from batches that failed past the retry cap. They keep no fresh
     // vector (stay stale), so they MUST be excluded from later batch queries:
     // the stale selection re-runs every iteration, and without exclusion it
@@ -6030,6 +6029,12 @@ async fn reindex_stale_batches(
                     .context("failed to record skipped drawer ids")?;
                 delete_reindex_pending_ids(db, &failed_ids)
                     .context("failed to delete skipped stale reindex work")?;
+                for (source_path, chunk_index) in reindex_source_checkpoints(&rows) {
+                    progress_store
+                        .mark_failed(&source_path, Some(chunk_index), embedder_name)
+                        .context("failed to record failed reindex checkpoint")?;
+                    failed_sources.insert(source_path);
+                }
                 continue;
             }
         };
@@ -6051,36 +6056,18 @@ async fn reindex_stale_batches(
                 stats.reindexed, stats.skipped_concurrent_update
             );
         }
-        let mut row_index = 0usize;
-        while row_index < rows.len() {
-            let source_path = rows[row_index].source_path.clone();
-            let mut last_chunk = rows[row_index].chunk_index;
-            row_index += 1;
-            while row_index < rows.len() && rows[row_index].source_path == source_path {
-                last_chunk = rows[row_index].chunk_index;
-                row_index += 1;
-            }
-
-            if active_source.as_deref() != Some(source_path.as_str()) {
-                if let Some((previous_source, previous_chunk)) = last_processed.as_ref() {
-                    progress_store
-                        .mark_done(previous_source, Some(*previous_chunk), embedder_name)
-                        .context("failed to finalize completed reindex source")?;
-                }
-                active_source = Some(source_path.clone());
-            }
-
-            progress_store
-                .upsert_running(&source_path, Some(last_chunk), embedder_name)
-                .context("failed to persist reindex checkpoint")?;
-            last_processed = Some((source_path, last_chunk));
+        for (source_path, chunk_index) in reindex_source_checkpoints(&rows) {
+            let checkpoint = if failed_sources.contains(source_path.as_str()) {
+                progress_store.mark_failed(&source_path, Some(chunk_index), embedder_name)
+            } else {
+                progress_store.upsert_running(&source_path, Some(chunk_index), embedder_name)
+            };
+            checkpoint.context("failed to persist reindex checkpoint")?;
         }
     }
-    if let Some((source_path, chunk_index)) = last_processed.as_ref() {
-        progress_store
-            .mark_done(source_path, Some(*chunk_index), embedder_name)
-            .context("failed to finalize reindex checkpoint")?;
-    }
+    progress_store
+        .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, target_fingerprint)
+        .context("failed to finalize completed reindex sources")?;
     if skipped_concurrent_update == 0 {
         println!("stale reindex complete: {processed} drawers");
     } else {
@@ -10337,6 +10324,22 @@ fn delete_reindex_pending_ids(db: &Database, ids: &[String]) -> Result<usize> {
             .context("failed to delete stale reindex pending ids")?;
     }
     Ok(deleted)
+}
+
+fn reindex_source_checkpoints(rows: &[ReindexRow]) -> Vec<(String, i64)> {
+    let mut checkpoints = Vec::new();
+    let mut row_index = 0usize;
+    while row_index < rows.len() {
+        let source_path = rows[row_index].source_path.clone();
+        let mut last_chunk = rows[row_index].chunk_index;
+        row_index += 1;
+        while row_index < rows.len() && rows[row_index].source_path == source_path {
+            last_chunk = rows[row_index].chunk_index;
+            row_index += 1;
+        }
+        checkpoints.push((source_path, last_chunk));
+    }
+    checkpoints
 }
 
 #[cfg(test)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,7 +10,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     anchor::{self, DerivedAnchor},
     config::ConfigHandle,
-    db::{Database, read_fork_ext_version},
+    db::{CURRENT_VECTOR_INDEX_VERSION, Database, VECTOR_DISTANCE_METRIC, read_fork_ext_version},
     phase3::{
         EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
@@ -22,6 +22,7 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
+    reindex::ReindexProgressStore,
     strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
         AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
@@ -79,6 +80,7 @@ use rmcp::{
     service::Peer,
     tool, tool_handler, tool_router,
 };
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -171,6 +173,23 @@ impl MempalMcpServer {
         self.gating_runtime
             .validate_config_shape()
             .context("failed to validate ingest gating config")?;
+        match self.reconcile_reindex_progress() {
+            Ok(0) => {}
+            Ok(updated) => {
+                tracing::info!(
+                    db_path = %self.db_path.display(),
+                    updated,
+                    "reconciled orphan reindex progress rows on startup"
+                );
+            }
+            Err(error) => {
+                tracing::warn!(
+                    db_path = %self.db_path.display(),
+                    error = %error,
+                    "failed to reconcile orphan reindex progress rows on startup"
+                );
+            }
+        }
         self.spawn_ingest_drain_worker();
         let _gating_init_task =
             self.gating_runtime
@@ -184,6 +203,35 @@ impl MempalMcpServer {
         self.serve(rmcp::transport::stdio())
             .await
             .context("failed to initialize MCP stdio transport")
+    }
+
+    fn reconcile_reindex_progress(&self) -> anyhow::Result<usize> {
+        let db = Database::open(&self.db_path)
+            .context("failed to open database for reindex progress reconciliation")?;
+        if db.vector_table_distance_metric()?.as_deref() != Some(VECTOR_DISTANCE_METRIC) {
+            return Ok(0);
+        }
+        let Some(dim) = Self::current_vector_dim(&db)? else {
+            return Ok(0);
+        };
+        let target_fingerprint = Database::current_vector_embedder_fingerprint(dim);
+        ReindexProgressStore::new(&self.db_path)
+            .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+            .context("failed to finalize orphan reindex progress rows")
+    }
+
+    fn current_vector_dim(db: &Database) -> anyhow::Result<Option<usize>> {
+        let dim = db
+            .conn()
+            .query_row(
+                "SELECT vec_length(embedding) FROM drawer_vectors LIMIT 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .context("failed to read current vector dimension")?
+            .map(|value| value as usize);
+        Ok(dim)
     }
 
     fn spawn_ingest_drain_worker(&self) {

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -193,6 +193,16 @@ fn read_vector(db: &Database, drawer_id: &str) -> Vec<f32> {
     serde_json::from_str(&json).expect("parse vector json")
 }
 
+fn read_reindex_progress_state(db: &Database, source_path: &str) -> (i64, String) {
+    db.conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = ?1",
+            [source_path],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read reindex progress state")
+}
+
 async fn wait_for_request_count(handle: &common::harness::MockEmbedHandle, expected: u32) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
     while tokio::time::Instant::now() < deadline {
@@ -554,6 +564,19 @@ async fn persistent_batch_failure_skips_and_continues() {
         &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, false),
     );
     seed_drawers(&env.db_path, 4, 2);
+    let db = Database::open(&env.db_path).expect("open db");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET source_file = 'fixtures/a-failed.txt' WHERE id = 'drawer-00'",
+            [],
+        )
+        .expect("split failed source");
+    db.conn()
+        .execute(
+            "UPDATE drawers SET source_file = 'fixtures/b-healthy.txt' WHERE id != 'drawer-00'",
+            [],
+        )
+        .expect("split healthy source");
 
     let full = run_reindex(&env.home, &["--from-config"], &[]);
     assert!(
@@ -573,10 +596,10 @@ async fn persistent_batch_failure_skips_and_continues() {
             .expect("mark index stale");
     }
 
-    // drawer-02's batch always fails; the other three succeed.
+    // drawer-00's batch always fails; the other three succeed.
     handle.set_fail_mode(FailMode::MalformedBody).await;
     handle
-        .set_fail_if_input_contains(Some("drawer content 2".to_string()))
+        .set_fail_if_input_contains(Some("drawer content 0".to_string()))
         .await;
 
     let stale = run_reindex(
@@ -612,20 +635,94 @@ async fn persistent_batch_failure_skips_and_continues() {
         "expected a skip warning on stderr: {stderr}",
     );
 
-    // The three healthy drawers are freshly embedded; the poisoned one stays
-    // stale so a later `--stale` re-run will select it again.
+    let failed_state = read_reindex_progress_state(&db, "fixtures/a-failed.txt");
+    assert_eq!(
+        failed_state,
+        (0, "failed".to_string()),
+        "failed source must stay failed after the final reconciliation"
+    );
+
+    let healthy_state = read_reindex_progress_state(&db, "fixtures/b-healthy.txt");
+    assert_eq!(
+        healthy_state,
+        (3, "done".to_string()),
+        "healthy source should still finalize to done"
+    );
+
+    // The healthy drawers are freshly embedded; the poisoned one stays stale
+    // so a later `--stale` re-run will select it again.
     ConfigHandle::bootstrap(&env.config_path).expect("bootstrap config");
-    for index in [0, 1, 3] {
+    for index in [1, 2, 3] {
         let id = format!("drawer-{index:02}");
         let details = db.drawer_vector_details(&id).expect("vector details");
         assert!(!details.stale, "{id} should be embedded: {details:?}");
     }
     let poisoned = db
-        .drawer_vector_details("drawer-02")
+        .drawer_vector_details("drawer-00")
         .expect("vector details");
     assert!(
         poisoned.stale,
-        "drawer-02 must remain stale for a later re-run: {poisoned:?}"
+        "drawer-00 must remain stale for a later re-run: {poisoned:?}"
+    );
+
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_limit_leaves_source_running_until_all_chunks_are_reembedded() {
+    let _guard = test_guard().await;
+    let (addr, handle) = start_mock(0).await.expect("start mock");
+    let env = TestHome::new(&reindex_config(
+        Path::new("/tmp/mempal-limit-partial.db"),
+        &format!("http://{addr}/v1"),
+        4,
+        false,
+    ));
+    write_config(
+        &env.config_path,
+        &reindex_config(&env.db_path, &format!("http://{addr}/v1"), 4, false),
+    );
+    seed_drawers(&env.db_path, 5, 4);
+
+    let db = Database::open(&env.db_path).expect("open db");
+    for index in 0..5 {
+        db.conn()
+            .execute(
+                "UPDATE fork_ext_meta SET value = 'old' WHERE key = ?1",
+                [format!("reindex:drawer-{index:02}:index_version")],
+            )
+            .expect("mark index stale");
+    }
+
+    let output = run_reindex(
+        &env.home,
+        &[
+            "--from-config",
+            "--stale",
+            "--batch-size",
+            "2",
+            "--limit",
+            "3",
+        ],
+        &[],
+    );
+    assert!(
+        output.status.success(),
+        "limit reindex must finish cleanly; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        handle.request_count(),
+        2,
+        "limit should only embed three stale drawers"
+    );
+
+    let state = read_reindex_progress_state(&db, "fixtures/source.txt");
+    assert_eq!(
+        state,
+        (2, "running".to_string()),
+        "partially reembedded source must remain resumable rather than done"
     );
 
     handle.shutdown().await;

--- a/tests/reindex_progress.rs
+++ b/tests/reindex_progress.rs
@@ -7,8 +7,11 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 
+use mempal::core::db::CURRENT_VECTOR_INDEX_VERSION;
 use mempal::core::db::Database;
+use mempal::core::reindex::ReindexProgressStore;
 use mempal::core::types::{Drawer, SourceType};
+use serde_json::Value;
 use tempfile::TempDir;
 
 fn mempal_bin() -> String {
@@ -48,9 +51,25 @@ impl MockEmbeddingServer {
                     continue;
                 };
                 let mut buffer = [0_u8; 4096];
-                let _ = stream.read(&mut buffer);
+                let bytes_read = stream.read(&mut buffer).unwrap_or(0);
                 requests_clone.fetch_add(1, Ordering::SeqCst);
-                let body = r#"{"data":[{"embedding":[0.1,0.2,0.3]}]}"#;
+                let request_text = String::from_utf8_lossy(&buffer[..bytes_read]);
+                let body_start = request_text.find("\r\n\r\n").map_or(0, |index| index + 4);
+                let input_count = serde_json::from_str::<Value>(&request_text[body_start..])
+                    .ok()
+                    .and_then(|json| {
+                        json.get("input").map(|input| match input {
+                            Value::Array(items) => items.len(),
+                            Value::Null => 1,
+                            _ => 1,
+                        })
+                    })
+                    .unwrap_or(1);
+                let data = (0..input_count)
+                    .map(|_| r#"{"embedding":[0.1,0.2,0.3]}"#)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let body = format!(r#"{{"data":[{data}]}}"#);
                 let response = format!(
                     "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
                     body.len(),
@@ -137,13 +156,21 @@ fn seed_db(db_path: &Path) {
     }
 }
 
-fn run_reindex(home: &Path, stop_after: Option<usize>, resume: bool) -> std::process::Output {
+fn run_reindex(
+    home: &Path,
+    stop_after: Option<usize>,
+    resume: bool,
+    stale: bool,
+) -> std::process::Output {
     let mut command = Command::new(mempal_bin());
     command
         .env("HOME", home)
         .arg("reindex")
         .arg("--embedder")
         .arg("openai_compat");
+    if stale {
+        command.arg("--stale");
+    }
     if let Some(limit) = stop_after {
         command.env("MEMPAL_TEST_REINDEX_STOP_AFTER", limit.to_string());
     }
@@ -164,7 +191,7 @@ async fn test_reindex_resume_from_checkpoint() {
     write_config(&home, &db_path, &server.base_url);
     seed_db(&db_path);
 
-    let first = run_reindex(&home, Some(20), false);
+    let first = run_reindex(&home, Some(20), false, false);
     assert!(!first.status.success());
     assert!(String::from_utf8_lossy(&first.stderr).contains("interrupted for test"));
     assert_eq!(server.request_count(), 20);
@@ -180,7 +207,7 @@ async fn test_reindex_resume_from_checkpoint() {
         .expect("read paused checkpoint");
     assert_eq!(paused, (19, "paused".to_string()));
 
-    let second = run_reindex(&home, None, true);
+    let second = run_reindex(&home, None, true, false);
     assert!(
         second.status.success(),
         "resume stderr: {}",
@@ -206,4 +233,91 @@ async fn test_reindex_resume_from_checkpoint() {
         })
         .expect("count vectors");
     assert_eq!(vector_count, 50);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reindex_stale_finalizes_progress() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join("home");
+    let db_path = home.join(".mempal").join("palace.db");
+    let server = MockEmbeddingServer::start();
+
+    write_config(&home, &db_path, &server.base_url);
+    seed_db(&db_path);
+
+    let output = run_reindex(&home, None, false, true);
+    assert!(
+        output.status.success(),
+        "reindex stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(server.request_count(), 1);
+
+    let db = Database::open(&db_path).expect("open db after stale reindex");
+    let state = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read stale checkpoint");
+    assert_eq!(state, (49, "done".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join("home");
+    let db_path = home.join(".mempal").join("palace.db");
+    let server = MockEmbeddingServer::start();
+
+    write_config(&home, &db_path, &server.base_url);
+    seed_db(&db_path);
+
+    let output = run_reindex(&home, None, false, true);
+    assert!(
+        output.status.success(),
+        "stale reindex stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(server.request_count(), 1);
+
+    let db = Database::open(&db_path).expect("open db after stale reindex");
+    let progress = ReindexProgressStore::new(&db_path);
+    progress
+        .upsert_running("fixtures/source.txt", Some(49), "openai_compat")
+        .expect("insert orphan running row");
+
+    let running = db
+        .conn()
+        .query_row(
+            "SELECT status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read running checkpoint");
+    assert_eq!(running, "running");
+
+    let target_fingerprint = format!(
+        "openai_compat:Qwen/Qwen3-Embedding-8B:{}:{}",
+        server.base_url.trim_end_matches('/'),
+        3
+    );
+    let reconciled = progress
+        .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+        .expect("reconcile orphan running row");
+    assert_eq!(reconciled, 1);
+
+    let state = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read reconciled checkpoint");
+    assert_eq!(state, (49, "done".to_string()));
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "a1d7ab9e3e7228f4d43d64ba6011263d93f51541"
+commit = "5c64c2b1ffd842bde7e84e647c88f6a1fef32d50"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #325 — `reindex_progress` rows were INSERTed with `status='running'` and `last_processed_chunk_id=0` but **never transitioned to a terminal state**, even after the source was fully turned into drawers. On the live `~/.mempal/palace.db` this left **1009 orphan `running` rows** (0 done/failed/paused), and a clean `reindex --stale` (310006 drawers, 0 skipped) still left every row `running`.

## Root cause

The reindex path inserted a `running` checkpoint at start but the finalize-status step was missing/unreachable on the paths actually exercised — both the per-source reindex inside `serve --mcp` and the bulk `reindex --stale` path abandoned their checkpoint rows after the source's chunks were embedded.

## Fix

The reindex path keeps writing per-source `upsert_running` checkpoints during iteration, but the terminal transition no longer relies on a brittle per-batch heuristic. Instead a single shared helper finalizes by **actual vector existence**:

1. **Single-scan set-based finalize** (`src/core/reindex.rs`): `finalize_completed_running_rows` promotes a `running` row to `done` (advancing `last_processed_chunk_id`, bumping `updated_at`) **iff** the source has ≥1 drawer and zero remaining unembedded vectors — the same predicate as `build_reindex_stale_pending_rows`'s "stale" definition. It is implemented as one `UPDATE ... FROM (SELECT … GROUP BY …)` that aggregates `drawers` exactly once (O(N+M)), not a per-row correlated subquery (O(N·M)). It only ever promotes `running`→`done`; it never touches `failed` rows.
2. **Accurate per-source status** (`src/main.rs`): the CLI stale-reindex command no longer infers completion from a `source_path` change (which falsely marked `done` under `--limit` truncation or a batch failure). It records persistent batch failures via `mark_failed`, and calls `finalize_completed_running_rows` once at command end — so `--limit`-truncated and failed sources stay non-`done`/resumable.
3. **Startup reconciliation** (`src/mcp/server.rs`): `serve --mcp` startup calls the same `finalize_completed_running_rows`, idempotently clearing pre-existing orphan `running` rows (the live 1009-row backlog) without a manual SQL step — and without the O(N·M) startup stall the single-scan rewrite eliminates.
4. **Regression tests** (`tests/embedder_reindex_scenarios.rs`, `tests/reindex_progress.rs`): a fully-processed source ends `done` with `last_processed_chunk_id != 0`; a `--limit`-truncated source stays non-`done`; a batch failure marks the source `failed` (never flipped to `done`); startup reconciliation finalizes an orphan `running` row whose source has drawers.

## Review convergence (3 rounds)

- **R1 (HIGH):** CLI inner-loop `mark_done` on `source_path` change falsely completed `--limit`-truncated and failed sources → replaced with the actual-vector-existence finalize + `mark_failed`.
- **R2 (HIGH):** the finalize helper used correlated `EXISTS`/`MAX` subqueries (full `drawers` scan per `running` row) that would stall synchronous MCP startup at scale → rewritten as a single-scan set-based `UPDATE ... FROM`.
- **R3:** PASS — no blocking findings.

## Compatibility

- Resume path stays correct: stuck `running` chunk_id=0 rows no longer cause redundant re-embed or wrong skips after finalize.
- Preserves the merged #301 (retry + skip-continue) and #302 (recreate-empties atomicity) reindex behavior.
- Any schema touch uses the fork_ext axis (`fork_ext_version` + `apply_fork_ext_migrations`), not `PRAGMA user_version`.

## Acceptance

- `just fmt && just clippy && just test` green.
- A fully-processed source ends `status='done'`, `last_processed_chunk_id != 0`.
- Orphan `running` rows with existing drawers are reconciled to terminal state on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
