### PR TITLE
fix(317): make mempal_search BM25-fallback consistent with + observable from mempal_status

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -93,18 +93,18 @@ use super::tools::{
     CoworkBusResponse, CoworkBusSessionDto, CoworkBusTmuxPeekDto, CoworkBusTmuxProbeDto,
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DoctorMcpDto,
     DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning, EmbedStatusDto,
-    EndpointHealthDto, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
-    FieldTaxonomyResponse, IngestControls, IngestOperationState, IngestRequest, IngestResponse,
-    IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
-    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
-    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
-    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
-    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
-    LeaseInfoDto, LeaseRequest, LeaseResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
-    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PeekMessageDto, PeekPartnerRequest,
-    PeekPartnerResponse, Phase3GateDto, Phase3Request, Phase3Response, PinnedFactDto,
-    PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse, QueueStatsDto,
-    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    EmbedderCircuitDto, EndpointHealthDto, FactCheckRequest, FactCheckResponse,
+    FieldTaxonomyEntryDto, FieldTaxonomyResponse, IngestControls, IngestOperationState,
+    IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto,
+    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
+    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
+    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
+    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
+    KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest, LeaseResponse, LlmStatusDto,
+    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
+    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
+    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
     ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
     RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
     SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
@@ -1811,6 +1811,18 @@ impl MempalMcpServer {
                 last_error: embed_snapshot.last_error,
                 last_success_at_unix_ms: embed_snapshot.last_success_at_unix_ms,
             },
+            embedder_circuit: EmbedderCircuitDto {
+                open: embed_snapshot.degraded,
+                failure_count: embed_snapshot.fail_count,
+                failure_threshold: config.embed.degradation.degrade_after_n_failures,
+                bm25_fallback_enabled: config.search.bm25_fallback,
+                search_deadline_secs: config.embed.retry.search_deadline_secs,
+                vector_search_mode: if config.search.bm25_fallback && embed_snapshot.degraded {
+                    SearchMode::Bm25Only.as_str().to_string()
+                } else {
+                    SearchMode::Hybrid.as_str().to_string()
+                },
+            },
             queue_stats: QueueStatsDto {
                 pending: queue_stats.pending,
                 claimed: queue_stats.claimed,
@@ -1926,9 +1938,10 @@ impl MempalMcpServer {
         let mut extra_warnings = Vec::new();
         let mut search_mode = SearchMode::Hybrid;
         let mut response_warnings = Vec::new();
-        let results = if config.search.bm25_fallback && global_embed_status().is_degraded() {
+        let embed_snapshot = global_embed_status().snapshot();
+        let results = if config.search.bm25_fallback && embed_snapshot.degraded {
             search_mode = SearchMode::Bm25Only;
-            let warning = "embedding backend is degraded; using BM25-only search".to_string();
+            let warning = bm25_fallback_warning_degraded(embed_snapshot.fail_count);
             response_warnings.push(warning.clone());
             extra_warnings.push(SystemWarning {
                 level: "warn".to_string(),
@@ -1952,7 +1965,7 @@ impl MempalMcpServer {
                 Err(error) if config.search.bm25_fallback => {
                     search_mode = SearchMode::Bm25Only;
                     let warning = format!(
-                        "embedding unavailable; using BM25-only search: {}",
+                        "embedding unavailable; using BM25-only search: {} (retry may help)",
                         crate::core::config::scrub_sensitive_text(&error.to_string())
                     );
                     response_warnings.push(warning.clone());
@@ -1996,7 +2009,9 @@ impl MempalMcpServer {
                     }
                     Ok(Err(error)) => {
                         search_mode = SearchMode::Bm25Only;
-                        let warning = "vector unavailable, BM25 fallback".to_string();
+                        let warning = bm25_fallback_warning_embed_error(
+                            &crate::core::config::scrub_sensitive_text(&error.to_string()),
+                        );
                         response_warnings.push(warning.clone());
                         extra_warnings.push(SystemWarning {
                             level: "warn".to_string(),
@@ -2022,7 +2037,8 @@ impl MempalMcpServer {
                     }
                     Err(_) => {
                         search_mode = SearchMode::Bm25Only;
-                        let warning = "vector unavailable, BM25 fallback".to_string();
+                        let warning =
+                            bm25_fallback_warning_timeout(config.embed.retry.search_deadline_secs);
                         response_warnings.push(warning.clone());
                         extra_warnings.push(SystemWarning {
                             level: "warn".to_string(),
@@ -6704,6 +6720,22 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
             }),
     );
     warnings
+}
+
+fn bm25_fallback_warning_degraded(fail_count: u64) -> String {
+    format!(
+        "embedding backend is degraded after {fail_count} failures; using BM25-only search until recovery (retry unlikely to help)"
+    )
+}
+
+fn bm25_fallback_warning_embed_error(error: &str) -> String {
+    format!("embedding unavailable; using BM25-only search: {error} (retry may help)")
+}
+
+fn bm25_fallback_warning_timeout(deadline_secs: u64) -> String {
+    format!(
+        "embedding deadline exceeded after {deadline_secs}s; using BM25-only search (retry may help)"
+    )
 }
 
 fn stale_index_warning_from_bool(is_stale: bool) -> Option<SystemWarning> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1917,6 +1917,8 @@ pub struct StatusResponse {
     pub memory_protocol: String,
     pub endpoint_health: EndpointHealthDto,
     pub embed_status: EmbedStatusDto,
+    /// Sticky embedder circuit plus the current vector-search fallback policy.
+    pub embedder_circuit: EmbedderCircuitDto,
     pub queue_stats: QueueStatsDto,
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
@@ -1957,6 +1959,25 @@ pub struct EndpointHealthDto {
     pub llm_reachable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_latency_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct EmbedderCircuitDto {
+    /// True when the sticky embedder circuit is open and vector-search falls
+    /// back to BM25 unless the caller disables fallback entirely.
+    pub open: bool,
+    /// Consecutive embed failures since the last success, used to open the
+    /// circuit.
+    pub failure_count: u64,
+    /// Sticky-failure threshold that opens the circuit.
+    pub failure_threshold: u64,
+    /// Whether BM25 fallback is enabled at all.
+    pub bm25_fallback_enabled: bool,
+    /// Per-query vector-embedding deadline that can still trigger BM25
+    /// fallback even when the embedding endpoint itself is reachable.
+    pub search_deadline_secs: u64,
+    /// Current sticky vector-search mode derived from the circuit state.
+    pub vector_search_mode: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -3,11 +3,14 @@
 mod common;
 
 use std::fs;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::Result;
+use async_trait::async_trait;
+use axum::{Json, Router, routing::get};
 use common::harness::start as start_mock;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
@@ -87,6 +90,51 @@ impl TestHome {
             config_path,
             db_path,
         }
+    }
+}
+
+async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = Router::new().route(
+        "/v1/models",
+        get(|| async { Json(serde_json::json!({ "object": "list", "data": [] })) }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind models server");
+    let addr = listener.local_addr().expect("models server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve models server");
+    });
+    (addr, handle)
+}
+
+#[derive(Clone)]
+struct SlowEmbedderFactory;
+
+struct SlowEmbedder;
+
+#[async_trait]
+impl mempal::embed::EmbedderFactory for SlowEmbedderFactory {
+    async fn build(&self) -> std::result::Result<Box<dyn mempal::embed::Embedder>, EmbedError> {
+        Ok(Box::new(SlowEmbedder))
+    }
+}
+
+#[async_trait]
+impl mempal::embed::Embedder for SlowEmbedder {
+    async fn embed(&self, texts: &[&str]) -> std::result::Result<Vec<Vec<f32>>, EmbedError> {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        Ok(texts.iter().map(|_| vec![0.25; 4]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        4
+    }
+
+    fn name(&self) -> &str {
+        "slow-test-embedder"
     }
 }
 
@@ -176,6 +224,7 @@ async fn test_search_deadline_bm25_fallback() {
         }
     });
 
+    tokio::task::yield_now().await;
     tokio::time::advance(Duration::from_secs(5)).await;
     let response = search
         .await
@@ -183,12 +232,93 @@ async fn test_search_deadline_bm25_fallback() {
         .expect("search result")
         .0;
     assert_eq!(response.results[0].drawer_id, "bm25-hit");
+    assert_eq!(response.search_mode, "bm25_only");
     assert!(response.system_warnings.iter().any(|warning| {
-        warning.message.contains("BM25 fallback") || warning.message.contains("vector unavailable")
+        warning.message.contains("deadline exceeded after 5s")
+            && warning.message.contains("retry may help")
     }));
 
     handle.resume();
     handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_search_deadline_warning_surfaces_timeout_reason() {
+    let _guard = test_guard().await;
+    let (models_addr, models_handle) = spawn_models_server().await;
+    let config_text = embed_config(
+        std::path::Path::new("/tmp/placeholder.db"),
+        &format!("http://{models_addr}/v1"),
+        "",
+    );
+    let env =
+        TestHome::new(&config_text.replace("/tmp/placeholder.db", "/tmp/mempal-timeout-search.db"));
+    let db = Database::open(&env.db_path).expect("open db");
+    db.insert_drawer_with_project(
+        &Drawer {
+            id: "deadline-hit".to_string(),
+            content: "fallback keyword memory".to_string(),
+            wing: "test".to_string(),
+            room: Some("fallback".to_string()),
+            source_file: Some("fixtures/deadline.txt".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 2,
+            ..Drawer::default()
+        },
+        Some("default"),
+    )
+    .expect("insert drawer");
+
+    let server =
+        MempalMcpServer::new_with_factory(env.db_path.clone(), Arc::new(SlowEmbedderFactory));
+    let status = server.mempal_status().await.expect("status").0;
+    assert!(status.endpoint_health.embedding_reachable, "{status:#?}");
+    assert!(status.embedder_circuit.bm25_fallback_enabled);
+    assert_eq!(status.embedder_circuit.search_deadline_secs, 5);
+    assert_eq!(status.embedder_circuit.vector_search_mode, "hybrid");
+    assert!(!status.embedder_circuit.open, "{status:#?}");
+
+    tokio::time::pause();
+    let search = tokio::spawn({
+        let server = server.clone();
+        async move {
+            server
+                .mempal_search(Parameters(SearchRequest {
+                    query: "fallback keyword".to_string(),
+                    top_k: Some(5),
+                    ..SearchRequest::default()
+                }))
+                .await
+        }
+    });
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+    let response = search
+        .await
+        .expect("join search task")
+        .expect("search result")
+        .0;
+    assert_eq!(response.search_mode, "bm25_only");
+    assert!(
+        response
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("deadline exceeded after 5s")),
+        "{response:#?}"
+    );
+    assert!(
+        response
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("retry may help")),
+        "{response:#?}"
+    );
+
+    models_handle.abort();
+    let _ = models_handle.await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -206,14 +336,31 @@ async fn test_successful_embed_exits_degraded() {
     status.reset_for_tests();
     status.record_failure(&"synthetic failure 1");
     status.record_failure(&"synthetic failure 2");
+    let degraded_status = server.mempal_status().await.expect("status").0;
     assert!(
-        server
-            .mempal_status()
-            .await
-            .expect("status")
-            .0
-            .embed_status
-            .degraded
+        degraded_status.embed_status.degraded,
+        "{degraded_status:#?}"
+    );
+    assert!(
+        degraded_status.embedder_circuit.open,
+        "{degraded_status:#?}"
+    );
+    assert_eq!(
+        degraded_status.embedder_circuit.vector_search_mode, "bm25_only",
+        "{degraded_status:#?}"
+    );
+    assert_eq!(
+        degraded_status.embedder_circuit.failure_count, 2,
+        "{degraded_status:#?}"
+    );
+    assert_eq!(
+        degraded_status.embedder_circuit.failure_threshold, 2,
+        "{degraded_status:#?}"
+    );
+    assert!(degraded_status.embedder_circuit.bm25_fallback_enabled);
+    assert_eq!(
+        degraded_status.embedder_circuit.search_deadline_secs, 5,
+        "{degraded_status:#?}"
     );
 
     let embedder = from_config(&config).await.expect("build managed embedder");
@@ -230,6 +377,9 @@ async fn test_successful_embed_exits_degraded() {
     assert!(!snapshot.embed_status.degraded);
     assert_eq!(snapshot.embed_status.failure_count, 0);
     assert!(snapshot.embed_status.last_success_at_unix_ms.is_some());
+    assert!(!snapshot.embedder_circuit.open, "{snapshot:#?}");
+    assert_eq!(snapshot.embedder_circuit.vector_search_mode, "hybrid");
+    assert_eq!(snapshot.embedder_circuit.failure_count, 0);
 
     handle.shutdown().await;
 }


### PR DESCRIPTION
## Summary

Fixes #317 — MCP `mempal_search` returned `search_mode="bm25_only"` ("vector unavailable, BM25 fallback") while `mempal_status`, called moments earlier in the same session, reported the vector path healthy (`embedding_reachable=true`, latency 7ms, `vector_index_empty=false`, `vector_index_stale=false`). A CLI search for the same query returned vector-scored results — so status and search were **contradicting each other** with no way for an agent to tell why.

## Root cause

The two surfaces read **different signals**. `mempal_status` reported live endpoint reachability, while `mempal_search` honored a **sticky embedder circuit** (opened by accumulated embed failures — the session showed `failed_count=566`) plus a **per-query search-deadline** fallback. When the circuit was open (or a query-embed exceeded the deadline) search dropped to BM25, but status — checking only live reachability — still looked healthy. The fallback warning was the opaque "vector unavailable, BM25 fallback", giving the agent no actionable reason.

## Fix

- **`mempal_status` exposes the gating signal** (`src/mcp/server.rs`): status now surfaces the sticky embedder circuit state and the search-deadline policy, so an agent reading status can tell whether search will actually use vectors — status and search are now derived from the same source of truth and cannot silently contradict.
- **`mempal_search` explains the fallback** (`src/mcp/tools.rs`): the BM25-fallback warning now names the concrete reason (circuit open due to accumulated failures vs. query-embed deadline exceeded) and whether a retry is likely to help — an agent can now distinguish "no relevant memory" from "degraded to BM25" and know why.
- **Regression tests** (`tests/embedder_transport_scenarios.rs`): cover the timeout-vs-health mismatch (status healthy while search degrades) and degraded-state recovery, asserting status's vector-availability signal and search's fallback decision stay consistent.

## Notes

- The REST surface still carries the older wording; it is out of scope for this MCP-focused fix and is a candidate for a small follow-up (not new behavior on this branch).
- Data is local; the privacy/gating `system_warnings` are expected and unrelated.

## Acceptance

- `just fmt && just clippy && just test` green.
- Status and search no longer report contradictory vector availability; the search warning names the concrete degrade reason + retry usefulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
