### PR TITLE
fix(queue): op_state backfill + completion-writer terminal state + created_at units (#332)

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 19;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 20;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -71,6 +71,30 @@ ALTER TABLE pending_message_completions ADD COLUMN op_state TEXT NOT NULL DEFAUL
 ALTER TABLE pending_message_completions ADD COLUMN rejected_reason TEXT;
 ALTER TABLE pending_message_completions ADD COLUMN failure_detail TEXT;
 ALTER TABLE pending_message_completions ADD COLUMN result_json TEXT;
+"#;
+
+pub const FORK_EXT_V20_SCHEMA_SQL: &str = r#"
+UPDATE pending_messages
+SET op_state = CASE status
+    WHEN 'pending' THEN 'queued'
+    WHEN 'claimed' THEN 'running'
+    WHEN 'done' THEN 'completed'
+    WHEN 'failed' THEN 'failed'
+    ELSE op_state
+END
+WHERE op_state = 'queued';
+
+UPDATE pending_message_completions
+SET op_state = CASE
+    WHEN failure_detail IS NOT NULL THEN 'failed'
+    WHEN rejected_reason IS NOT NULL THEN 'rejected'
+    ELSE 'completed'
+END
+WHERE op_state = 'queued';
+
+UPDATE pending_message_completions
+SET created_at = CAST(created_at / 1000 AS INTEGER)
+WHERE created_at BETWEEN 1000000000000000 AND 9999999999999999;
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -391,6 +415,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 19,
             up: apply_v19,
         },
+        Migration {
+            version: 20,
+            up: apply_v20,
+        },
     ]
 }
 
@@ -569,6 +597,10 @@ fn apply_v19(conn: &Connection) -> rusqlite::Result<()> {
     }
 
     Ok(())
+}
+
+fn apply_v20(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V20_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -190,10 +190,7 @@ impl PendingMessageStore {
                 claim_token = ?2,
                 claimed_at = ?3,
                 heartbeat_at = ?3,
-                op_state = CASE
-                    WHEN kind = 'ingest_async' THEN 'running'
-                    ELSE op_state
-                END
+                op_state = 'running'
             WHERE id = ?1 AND status = 'pending'
             "#,
             params![id, claim_token, now],
@@ -264,10 +261,7 @@ impl PendingMessageStore {
                 claim_token = ?2,
                 claimed_at = ?3,
                 heartbeat_at = ?3,
-                op_state = CASE
-                    WHEN kind = 'ingest_async' THEN 'running'
-                    ELSE op_state
-                END
+                op_state = 'running'
             WHERE id = ?1 AND status = 'pending'
             "#,
             params![id, claim_token, now],
@@ -293,7 +287,7 @@ impl PendingMessageStore {
     pub fn confirm(&self, id: &str) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        confirm_in_tx(&tx, id)?;
+        confirm_in_tx(&tx, id, "completed")?;
         tx.commit()?;
         Ok(())
     }
@@ -328,7 +322,7 @@ impl PendingMessageStore {
                 result_json
             ],
         )?;
-        confirm_in_tx(&tx, id)?;
+        confirm_in_tx(&tx, id, op_state)?;
         tx.commit()?;
         Ok(())
     }
@@ -386,6 +380,7 @@ impl PendingMessageStore {
                 retry_backoff_ms = ?3,
                 next_attempt_at = ?4,
                 status = ?5,
+                op_state = CASE WHEN ?5 = 'failed' THEN 'failed' ELSE 'queued' END,
                 claim_token = NULL,
                 claimed_at = NULL,
                 heartbeat_at = NULL,
@@ -430,10 +425,7 @@ impl PendingMessageStore {
                 claimed_at = NULL,
                 heartbeat_at = NULL,
                 last_error = NULL,
-                op_state = CASE
-                    WHEN kind = 'ingest_async' THEN 'queued'
-                    ELSE op_state
-                END,
+                op_state = 'queued',
                 result_drawer_id = CASE
                     WHEN kind = 'ingest_async' THEN NULL
                     ELSE result_drawer_id
@@ -471,10 +463,7 @@ impl PendingMessageStore {
                 claim_token = NULL,
                 claimed_at = NULL,
                 heartbeat_at = NULL,
-                op_state = CASE
-                    WHEN kind = 'ingest_async' THEN 'queued'
-                    ELSE op_state
-                END,
+                op_state = 'queued',
                 result_drawer_id = CASE
                     WHEN kind = 'ingest_async' THEN NULL
                     ELSE result_drawer_id
@@ -549,14 +538,13 @@ impl PendingMessageStore {
     }
 }
 
-fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str) -> Result<()> {
+fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Result<()> {
     let row = tx
         .query_row(
             r#"
             SELECT kind,
                    created_at,
                    claimed_at,
-                   op_state,
                    result_drawer_id,
                    rejected_reason,
                    failure_detail,
@@ -570,11 +558,10 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str) -> Result<()> {
                     row.get::<_, String>(0)?,
                     row.get::<_, i64>(1)?,
                     row.get::<_, Option<i64>>(2)?,
-                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(3)?,
                     row.get::<_, Option<String>>(4)?,
                     row.get::<_, Option<String>>(5)?,
                     row.get::<_, Option<String>>(6)?,
-                    row.get::<_, Option<String>>(7)?,
                 ))
             },
         )
@@ -619,11 +606,11 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str) -> Result<()> {
             row.2.map(|s| s.saturating_mul(1_000)),
             completed_at,
             processing_ms,
-            row.4,
             row.3,
+            op_state,
+            row.4,
             row.5,
-            row.6,
-            row.7
+            row.6
         ],
     )?;
     let updated = tx.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
@@ -800,19 +787,16 @@ pub fn failure_headline_count(live_fail_count: u64, queue_stats: &QueueStats) ->
 fn reclaim_stale_tx(conn: &rusqlite::Transaction<'_>, stale_cutoff: i64) -> rusqlite::Result<u64> {
     let updated = conn.execute(
         r#"
-        UPDATE pending_messages
-        SET status = 'pending',
-            claim_token = NULL,
-            claimed_at = NULL,
-            heartbeat_at = NULL,
-            op_state = CASE
-                WHEN kind = 'ingest_async' THEN 'queued'
-                ELSE op_state
-            END,
-            result_drawer_id = CASE
-                WHEN kind = 'ingest_async' THEN NULL
-                ELSE result_drawer_id
-            END,
+            UPDATE pending_messages
+            SET status = 'pending',
+                claim_token = NULL,
+                claimed_at = NULL,
+                heartbeat_at = NULL,
+                op_state = 'queued',
+                result_drawer_id = CASE
+                    WHEN kind = 'ingest_async' THEN NULL
+                    ELSE result_drawer_id
+                END,
             rejected_reason = CASE
                 WHEN kind = 'ingest_async' THEN NULL
                 ELSE rejected_reason
@@ -841,10 +825,7 @@ fn reclaim_stale_conn(conn: &Connection, stale_cutoff: i64) -> rusqlite::Result<
             claim_token = NULL,
             claimed_at = NULL,
             heartbeat_at = NULL,
-            op_state = CASE
-                WHEN kind = 'ingest_async' THEN 'queued'
-                ELSE op_state
-            END,
+            op_state = 'queued',
             result_drawer_id = CASE
                 WHEN kind = 'ingest_async' THEN NULL
                 ELSE result_drawer_id

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -280,6 +280,167 @@ fn test_fork_ext_v18_to_v19_adds_async_ingest_columns_idempotently() {
 }
 
 #[test]
+fn test_fork_ext_v19_to_v20_backfills_op_state_and_normalizes_completion_created_at() {
+    let conn = Connection::open_in_memory().expect("open sqlite connection");
+    let schema_version = current_schema_version();
+    conn.execute_batch(&format!(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '19');
+
+        CREATE TABLE pending_messages (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            claim_token TEXT,
+            claimed_at INTEGER,
+            heartbeat_at INTEGER,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            retry_backoff_ms INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL CHECK(status IN ('pending', 'claimed', 'done', 'failed')),
+            payload TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            last_error TEXT,
+            result_drawer_id TEXT,
+            op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed')),
+            rejected_reason TEXT,
+            failure_detail TEXT,
+            result_json TEXT
+        );
+
+        CREATE TABLE pending_message_completions (
+            message_id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            claimed_at INTEGER,
+            completed_at INTEGER NOT NULL,
+            processing_ms INTEGER,
+            result_drawer_id TEXT,
+            op_state TEXT NOT NULL DEFAULT 'queued' CHECK(op_state IN ('queued', 'running', 'completed', 'rejected', 'failed')),
+            rejected_reason TEXT,
+            failure_detail TEXT,
+            result_json TEXT
+        );
+
+        INSERT INTO pending_messages (
+            id,
+            kind,
+            source_hash,
+            claim_token,
+            claimed_at,
+            heartbeat_at,
+            retry_count,
+            retry_backoff_ms,
+            next_attempt_at,
+            status,
+            payload,
+            created_at,
+            last_error,
+            result_drawer_id,
+            op_state,
+            rejected_reason,
+            failure_detail,
+            result_json
+        )
+        VALUES
+            ('pm-pending', 'hook_event', 'hash-pending', NULL, NULL, NULL, 0, 0, 0, 'pending', 'payload-pending', 1700000000, NULL, NULL, 'queued', NULL, NULL, NULL),
+            ('pm-claimed', 'hook_event', 'hash-claimed', 'worker:claim', 1700000001, 1700000001, 0, 0, 1700000001, 'claimed', 'payload-claimed', 1700000001, NULL, NULL, 'queued', NULL, NULL, NULL),
+            ('pm-done', 'hook_event', 'hash-done', NULL, NULL, NULL, 0, 0, 0, 'done', 'payload-done', 1700000002, NULL, NULL, 'queued', NULL, NULL, NULL),
+            ('pm-failed', 'hook_event', 'hash-failed', NULL, NULL, NULL, 0, 0, 0, 'failed', 'payload-failed', 1700000003, 'boom', NULL, 'queued', NULL, NULL, NULL);
+
+        INSERT INTO pending_message_completions (
+            message_id,
+            kind,
+            created_at,
+            claimed_at,
+            completed_at,
+            processing_ms,
+            result_drawer_id,
+            op_state,
+            rejected_reason,
+            failure_detail,
+            result_json
+        )
+        VALUES
+            ('comp-completed', 'hook_event', 1700000000000001, 1700000001, 1700000001234, 1234, 'drawer-1', 'queued', NULL, NULL, '{{"state":"completed"}}'),
+            ('comp-rejected', 'hook_event', 1700000000000002, 1700000002, 1700000002234, 1234, NULL, 'queued', 'policy', NULL, '{{"state":"rejected"}}'),
+            ('comp-failed', 'hook_event', 1700000000000003, 1700000003, 1700000003234, 1234, NULL, 'queued', NULL, 'boom', '{{"state":"failed"}}');
+
+        PRAGMA user_version = {schema_version};
+        "#
+    ))
+    .expect("create v19 schema");
+
+    apply_fork_ext_migrations_to(&conn, 20).expect("first v20 migration");
+    apply_fork_ext_migrations_to(&conn, 20).expect("second v20 migration");
+
+    for (id, expected_status, expected_op_state) in [
+        ("pm-pending", "pending", "queued"),
+        ("pm-claimed", "claimed", "running"),
+        ("pm-done", "done", "completed"),
+        ("pm-failed", "failed", "failed"),
+    ] {
+        let (status, op_state): (String, String) = conn
+            .query_row(
+                "SELECT status, op_state FROM pending_messages WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read pending row");
+        assert_eq!(status, expected_status, "{id}");
+        assert_eq!(op_state, expected_op_state, "{id}");
+    }
+
+    for (id, expected_op_state) in [
+        ("comp-completed", "completed"),
+        ("comp-rejected", "rejected"),
+        ("comp-failed", "failed"),
+    ] {
+        let op_state: String = conn
+            .query_row(
+                "SELECT op_state FROM pending_message_completions WHERE message_id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .expect("read completion row");
+        assert_eq!(op_state, expected_op_state, "{id}");
+    }
+
+    let queued_completions: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_message_completions WHERE op_state = 'queued'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count queued completions");
+    assert_eq!(queued_completions, 0);
+
+    let (min_created_len, max_created_len): (i64, i64) = conn
+        .query_row(
+            r#"
+            SELECT
+                MIN(LENGTH(CAST(created_at AS TEXT))),
+                MAX(LENGTH(CAST(created_at AS TEXT)))
+            FROM pending_message_completions
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read created_at lengths");
+    assert_eq!((min_created_len, max_created_len), (13, 13));
+
+    assert_eq!(read_fork_ext_version(&conn).expect("read version"), 20);
+    let user_version = conn
+        .query_row("PRAGMA user_version", [], |row| row.get::<_, u32>(0))
+        .expect("read user_version");
+    assert_eq!(user_version, schema_version);
+}
+
+#[test]
 fn test_fork_ext_meta_table_exists_after_init() {
     let (_tmp, _db_path, db) = new_test_db();
 

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -36,6 +36,15 @@ fn test_release_claim_returns_task_to_pending() {
         .expect("claim_next_by_kind")
         .expect("claimed message");
     assert_eq!(msg.id, id);
+    let op_state: String = db
+        .conn()
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read claimed op_state");
+    assert_eq!(op_state, "running");
 
     let stats_claimed = store.stats().expect("stats");
     assert_eq!(stats_claimed.claimed, 1);
@@ -43,6 +52,15 @@ fn test_release_claim_returns_task_to_pending() {
 
     // Release back to pending — simulates worker cancellation due to config change.
     store.release_claim(&id).expect("release_claim");
+    let released_op_state: String = db
+        .conn()
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read released op_state");
+    assert_eq!(released_op_state, "queued");
 
     let stats_after = store.stats().expect("stats after release");
     assert_eq!(stats_after.claimed, 0, "task must be pending after release");

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -29,7 +29,7 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
 
 #[test]
 fn test_enqueue_then_claim_returns_same_payload() {
-    let (_tmp, _db_path, store) = new_store();
+    let (_tmp, db_path, store) = new_store();
 
     let id = store
         .enqueue("hook_event", r#"{"tool":"Bash"}"#)
@@ -43,6 +43,16 @@ fn test_enqueue_then_claim_returns_same_payload() {
     assert_eq!(claimed.kind, "hook_event");
     assert_eq!(claimed.payload, r#"{"tool":"Bash"}"#);
     assert_eq!(claimed.retry_count, 0);
+
+    let op_state: String = Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read claim op_state");
+    assert_eq!(op_state, "running");
 }
 
 #[test]
@@ -64,7 +74,7 @@ fn test_confirm_deletes_row() {
     assert_eq!(stats.claimed, 0);
     assert_eq!(stats.failed, 0);
 
-    let remaining = Connection::open(db_path)
+    let remaining = Connection::open(&db_path)
         .expect("open sqlite")
         .query_row(
             "SELECT COUNT(*) FROM pending_messages WHERE id = ?1",
@@ -73,6 +83,16 @@ fn test_confirm_deletes_row() {
         )
         .expect("count confirmed row");
     assert_eq!(remaining, 0);
+
+    let completion_op_state: String = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT op_state FROM pending_message_completions WHERE message_id = ?1",
+            [&claimed.id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read completion op_state");
+    assert_eq!(completion_op_state, "completed");
 }
 
 #[test]
@@ -101,17 +121,27 @@ fn test_mark_failed_sets_backoff_next_attempt() {
     store.mark_failed(&id, "timeout").expect("mark failed");
 
     let conn = Connection::open(db_path).expect("open sqlite");
-    let (retry_count, retry_backoff_ms, next_attempt_at, status, last_error): (
+    let (retry_count, retry_backoff_ms, next_attempt_at, status, op_state, last_error): (
         i64,
         i64,
         i64,
         String,
+        String,
         Option<String>,
     ) = conn
         .query_row(
-            "SELECT retry_count, retry_backoff_ms, next_attempt_at, status, last_error FROM pending_messages WHERE id = ?1",
+            "SELECT retry_count, retry_backoff_ms, next_attempt_at, status, op_state, last_error FROM pending_messages WHERE id = ?1",
             [&id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
         )
         .expect("read row");
 
@@ -120,6 +150,7 @@ fn test_mark_failed_sets_backoff_next_attempt() {
     assert!(next_attempt_at >= before + 5);
     assert!(next_attempt_at < before + 15);
     assert_eq!(status, "pending");
+    assert_eq!(op_state, "queued");
     assert_eq!(last_error.as_deref(), Some("timeout"));
 }
 
@@ -165,7 +196,7 @@ fn test_terminal_failure_dead_letters_immediately() {
         )
         .expect("mark terminal failure");
 
-    let (status, retry_count, next_attempt_at): (String, i64, i64) = Connection::open(db_path)
+    let (status, retry_count, next_attempt_at): (String, i64, i64) = Connection::open(&db_path)
         .expect("open sqlite")
         .query_row(
             "SELECT status, retry_count, next_attempt_at FROM pending_messages WHERE id = ?1",
@@ -176,6 +207,15 @@ fn test_terminal_failure_dead_letters_immediately() {
     assert_eq!(status, "failed");
     assert_eq!(retry_count, 1);
     assert!(next_attempt_at <= now_secs());
+    let op_state: String = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read terminal op_state");
+    assert_eq!(op_state, "failed");
     assert!(
         store
             .claim_next("worker-b", 60)
@@ -347,6 +387,14 @@ fn test_retry_failed_embed_messages_requeues_only_failed_embed_items() {
         assert_eq!(retry_count, expected_retry_count, "{id}");
         assert_eq!(last_error.as_deref(), expected_error, "{id}");
     }
+    let op_state: String = conn
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&failed_embed],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read retried op_state");
+    assert_eq!(op_state, "queued");
     drop(conn);
 
     let recovered = store
@@ -426,7 +474,7 @@ fn test_store_startup_auto_reclaims_stale() {
     drop(store);
 
     let restarted = PendingMessageStore::new(&db_path).expect("restart store");
-    let reclaimed = Connection::open(db_path)
+    let reclaimed = Connection::open(&db_path)
         .expect("reopen sqlite")
         .query_row(
             "SELECT status, claimed_at, heartbeat_at FROM pending_messages WHERE id = ?1",
@@ -444,6 +492,15 @@ fn test_store_startup_auto_reclaims_stale() {
     assert_eq!(reclaimed.0, "pending");
     assert!(reclaimed.1.is_none());
     assert!(reclaimed.2.is_none());
+    let op_state: String = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT op_state FROM pending_messages WHERE id = ?1",
+            [&id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read reclaimed op_state");
+    assert_eq!(op_state, "queued");
     assert_eq!(restarted.stats().expect("stats").pending, 1);
 }
 


### PR DESCRIPTION
## Summary

Fixes #332. The `op_state` column (`DEFAULT 'queued'`, added to `pending_messages` + `pending_message_completions` by the receipt-based async-ingest work) was never backfilled and the completion writer never set it from the real terminal state, leaving `op_state` uniformly `'queued'` and contradicting each row's true disposition: 242,411 already-completed completion records stuck at `'queued'`, 566 live `status='failed'` queue rows showing `op_state='queued'`, plus mixed ms/µs `created_at` units in the completions archive.

## Root cause

- **Read side is fine**: `op_state` is a *status mirror*, not a queue-selection predicate — there is no `WHERE op_state ...` read path, so the stale values never caused spurious re-processing (data-hygiene, not functional, on the read side).
- **Write side had a real bug**: `complete_operation()` hard-wrote completion records as `"completed"` regardless of the actual terminal state, so failed/rejected async-ingest operations were mis-archived as completed (this surfaced as two `mcp::server` ingest-state test failures). `mark_failed_with_disposition` and `reclaim_stale` updated `status` but left `op_state` stale, producing the live divergence.
- **Migration miss**: `ALTER TABLE … ADD COLUMN op_state … DEFAULT 'queued'` applied the DEFAULT to all pre-existing rows with no backfill.

## Fix

- **fork-ext migration v20** (idempotent, set-based — no per-row correlated subqueries, avoiding the #325/#73 O(N·M) trap): backfills `op_state` from ground truth — `pending_message_completions` → `'completed'`; `pending_messages` → derived from `status` (`failed→'failed'`, `done→'completed'`, `claimed→'running'`, `pending→'queued'`) — and normalizes `pending_message_completions.created_at` from µs (16-digit) to ms.
- **Writer fixes** (`src/core/queue.rs`): `complete_operation()` now persists the *real* terminal `op_state` into the completion record (failed/rejected/completed) instead of forcing `'completed'`; `confirm()` correctly keeps `'completed'`; `mark_failed_with_disposition` and `reclaim_stale` keep `op_state` aligned with `status` so the two axes can no longer diverge.
- **Regression tests** (`tests/fork_ext_schema_axis.rs`, `tests/queue_claim_confirm.rs`, `tests/llm_worker_hot_reload.rs`): seed v19 dirty data (stale `'queued'` completed rows + a µs `created_at`), migrate to v20, and assert no completion row remains `'queued'`, `created_at` is single-unit, and the claim/confirm/fail/release/reclaim lifecycle writes the correct `op_state`.

## Notes

- Observation (out of scope, noted for a possible follow-up): `pending_messages.created_at` is stored in seconds while the completions archive uses ms — a cross-table unit inconsistency, but no code path compares the two, so left unchanged here.
- Data is local; privacy/gating `system_warnings` are expected and unrelated.

## Acceptance

- `just fmt && just clippy && just test` green.
- No `pending_message_completions` row has `op_state='queued'` after migration; `created_at` single-unit; queue `op_state` consistent with `status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
