### PR TITLE
fix(rest): share vector-search circuit/fallback wording with MCP (#333)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -26,8 +26,10 @@ use crate::core::{
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
 use crate::search::{
-    SearchMode, SearchOptions, resolve_route, search_bm25_only_with_options,
-    search_with_vector_and_scope_options,
+    SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
+    bm25_fallback_warning_dimension_mismatch, bm25_fallback_warning_embed_error,
+    bm25_fallback_warning_missing_query_vector, bm25_fallback_warning_timeout, resolve_route,
+    search_bm25_only_with_options, search_with_vector_and_scope_options,
 };
 use axum::{
     Json, Router,
@@ -340,6 +342,7 @@ struct StatusResponse {
     db_size_bytes: u64,
     embedding_status: String,
     search_mode: String,
+    embedder_circuit: EmbedderCircuitStatus,
     write_queue: WriteQueueStats,
     feature_flags: FeatureFlags,
     hermes_compat_version: String,
@@ -347,6 +350,29 @@ struct StatusResponse {
     wings: Vec<ScopeCount>,
     source_type_distribution: Vec<SourceTypeCount>,
     turn_storage: TurnStorageStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct EmbedderCircuitStatus {
+    open: bool,
+    failure_count: u64,
+    failure_threshold: u64,
+    bm25_fallback_enabled: bool,
+    search_deadline_secs: u64,
+    vector_search_mode: String,
+}
+
+impl From<VectorSearchCircuit> for EmbedderCircuitStatus {
+    fn from(value: VectorSearchCircuit) -> Self {
+        Self {
+            open: value.open,
+            failure_count: value.failure_count,
+            failure_threshold: value.failure_threshold,
+            bm25_fallback_enabled: value.bm25_fallback_enabled,
+            search_deadline_secs: value.search_deadline_secs,
+            vector_search_mode: value.vector_search_mode.as_str().to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -471,30 +497,31 @@ async fn search_handler(
         ..SearchOptions::default()
     };
     let top_k = query.top_k.unwrap_or(10);
+    let embed_snapshot = crate::embed::global_embed_status().snapshot();
+    let vector_search_circuit =
+        VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let mut search_mode = SearchMode::Hybrid;
     let mut warnings = Vec::new();
-    let query_vector = if config.search.bm25_fallback
-        && crate::embed::global_embed_status().is_degraded()
+    let query_vector = if vector_search_circuit.bm25_fallback_enabled && vector_search_circuit.open
     {
         search_mode = SearchMode::Bm25Only;
-        warnings.push("embedding backend is degraded; using BM25-only search".to_string());
+        warnings.push(bm25_fallback_warning_degraded(
+            vector_search_circuit.failure_count,
+        ));
         None
     } else {
         match state.embedder_factory.build().await {
             Ok(embedder) => match tokio::time::timeout(
-                Duration::from_secs(config.embed.retry.search_deadline_secs),
+                Duration::from_secs(vector_search_circuit.search_deadline_secs),
                 embedder.embed(&[query.q.as_str()]),
             )
             .await
             {
                 Ok(Ok(vectors)) => match vectors.into_iter().next() {
                     Some(vector) => Some(vector),
-                    None if config.search.bm25_fallback => {
+                    None if vector_search_circuit.bm25_fallback_enabled => {
                         search_mode = SearchMode::Bm25Only;
-                        warnings.push(
-                            "embedding returned no query vector; using BM25-only search"
-                                .to_string(),
-                        );
+                        warnings.push(bm25_fallback_warning_missing_query_vector());
                         None
                     }
                     None => {
@@ -504,19 +531,19 @@ async fn search_handler(
                         ));
                     }
                 },
-                Ok(Err(error)) if config.search.bm25_fallback => {
+                Ok(Err(error)) if vector_search_circuit.bm25_fallback_enabled => {
                     search_mode = SearchMode::Bm25Only;
-                    warnings.push(format!(
-                        "embedding unavailable; using BM25-only search: {}",
-                        crate::core::config::scrub_sensitive_text(&error.to_string())
+                    warnings.push(bm25_fallback_warning_embed_error(
+                        &crate::core::config::scrub_sensitive_text(&error.to_string()),
                     ));
                     None
                 }
                 Ok(Err(error)) => return Err(internal_error(error)),
-                Err(_) if config.search.bm25_fallback => {
+                Err(_) if vector_search_circuit.bm25_fallback_enabled => {
                     search_mode = SearchMode::Bm25Only;
-                    warnings
-                        .push("embedding deadline exceeded; using BM25-only search".to_string());
+                    warnings.push(bm25_fallback_warning_timeout(
+                        vector_search_circuit.search_deadline_secs,
+                    ));
                     None
                 }
                 Err(_) => {
@@ -526,11 +553,10 @@ async fn search_handler(
                     ));
                 }
             },
-            Err(error) if config.search.bm25_fallback => {
+            Err(error) if vector_search_circuit.bm25_fallback_enabled => {
                 search_mode = SearchMode::Bm25Only;
-                warnings.push(format!(
-                    "embedding unavailable; using BM25-only search: {}",
-                    crate::core::config::scrub_sensitive_text(&error.to_string())
+                warnings.push(bm25_fallback_warning_embed_error(
+                    &crate::core::config::scrub_sensitive_text(&error.to_string()),
                 ));
                 None
             }
@@ -551,13 +577,14 @@ async fn search_handler(
             top_k,
         ) {
             Ok(results) => results,
-            Err(error @ crate::search::SearchError::VectorDimensionMismatch { .. })
-                if config.search.bm25_fallback =>
-            {
+            Err(crate::search::SearchError::VectorDimensionMismatch {
+                current_dim,
+                new_dim,
+            }) if vector_search_circuit.bm25_fallback_enabled => {
                 search_mode = SearchMode::Bm25Only;
-                warnings.push(format!(
-                    "{}; using BM25-only search",
-                    crate::core::config::scrub_sensitive_text(&error.to_string())
+                warnings.push(bm25_fallback_warning_dimension_mismatch(
+                    new_dim,
+                    current_dim,
                 ));
                 search_bm25_only_with_options(&db, &query.q, route, &scope, search_options, top_k)
                     .map_err(internal_error)?
@@ -936,6 +963,9 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
     let db = Database::open(&state.db_path).map_err(internal_error)?;
     let drawer_count = db.drawer_count().map_err(internal_error)?;
     let config = ConfigHandle::current();
+    let embed_snapshot = crate::embed::global_embed_status().snapshot();
+    let vector_search_circuit =
+        VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let raw_turn_count = count_raw_turn_drawers(&db, &config.turns).map_err(internal_error)?;
     let taxonomy_count = db.taxonomy_count().map_err(internal_error)?;
     let db_size_bytes = db.database_size_bytes().map_err(internal_error)?;
@@ -963,8 +993,12 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         drawer_count,
         taxonomy_count,
         db_size_bytes,
-        embedding_status: current_embedding_status().to_string(),
-        search_mode: current_search_mode(config.as_ref()).to_string(),
+        embedding_status: current_embedding_status(&embed_snapshot).to_string(),
+        search_mode: vector_search_circuit
+            .vector_search_mode
+            .as_str()
+            .to_string(),
+        embedder_circuit: vector_search_circuit.into(),
         write_queue: state.write_queue().stats(),
         feature_flags: FeatureFlags {
             typed_ingest: true,
@@ -988,22 +1022,13 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
     }))
 }
 
-fn current_embedding_status() -> &'static str {
-    let snapshot = crate::embed::global_embed_status().snapshot();
+fn current_embedding_status(snapshot: &crate::embed::EmbedHealthSnapshot) -> &'static str {
     if snapshot.degraded {
         "degraded"
     } else if snapshot.fail_count > 0 && snapshot.last_success_at_unix_ms.is_none() {
         "unavailable"
     } else {
         "healthy"
-    }
-}
-
-fn current_search_mode(config: &crate::core::config::Config) -> &'static str {
-    if config.search.bm25_fallback && crate::embed::global_embed_status().is_degraded() {
-        SearchMode::Bm25Only.as_str()
-    } else {
-        SearchMode::Hybrid.as_str()
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -69,8 +69,9 @@ use crate::knowledge_lifecycle::{
     promote_knowledge,
 };
 use crate::search::{
-    SearchFilters, SearchMode, SearchOptions, dispatch_access_update, resolve_route,
-    search_bm25_only_with_options, search_with_vector_and_scope_options,
+    SearchFilters, SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
+    bm25_fallback_warning_embed_error, bm25_fallback_warning_timeout, dispatch_access_update,
+    resolve_route, search_bm25_only_with_options, search_with_vector_and_scope_options,
 };
 use anyhow::Context;
 use rmcp::{
@@ -1723,6 +1724,8 @@ impl MempalMcpServer {
             .map(|(project_id, count)| PinnedFactProjectCount { project_id, count })
             .collect();
         let mut system_warnings = current_system_warnings();
+        let vector_search_circuit =
+            VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
         if null_project_backfill_pending > 0 {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
@@ -1812,16 +1815,15 @@ impl MempalMcpServer {
                 last_success_at_unix_ms: embed_snapshot.last_success_at_unix_ms,
             },
             embedder_circuit: EmbedderCircuitDto {
-                open: embed_snapshot.degraded,
-                failure_count: embed_snapshot.fail_count,
-                failure_threshold: config.embed.degradation.degrade_after_n_failures,
-                bm25_fallback_enabled: config.search.bm25_fallback,
-                search_deadline_secs: config.embed.retry.search_deadline_secs,
-                vector_search_mode: if config.search.bm25_fallback && embed_snapshot.degraded {
-                    SearchMode::Bm25Only.as_str().to_string()
-                } else {
-                    SearchMode::Hybrid.as_str().to_string()
-                },
+                open: vector_search_circuit.open,
+                failure_count: vector_search_circuit.failure_count,
+                failure_threshold: vector_search_circuit.failure_threshold,
+                bm25_fallback_enabled: vector_search_circuit.bm25_fallback_enabled,
+                search_deadline_secs: vector_search_circuit.search_deadline_secs,
+                vector_search_mode: vector_search_circuit
+                    .vector_search_mode
+                    .as_str()
+                    .to_string(),
             },
             queue_stats: QueueStatsDto {
                 pending: queue_stats.pending,
@@ -1964,9 +1966,8 @@ impl MempalMcpServer {
                 Ok(embedder) => Some(embedder),
                 Err(error) if config.search.bm25_fallback => {
                     search_mode = SearchMode::Bm25Only;
-                    let warning = format!(
-                        "embedding unavailable; using BM25-only search: {} (retry may help)",
-                        crate::core::config::scrub_sensitive_text(&error.to_string())
+                    let warning = bm25_fallback_warning_embed_error(
+                        &crate::core::config::scrub_sensitive_text(&error.to_string()),
                     );
                     response_warnings.push(warning.clone());
                     extra_warnings.push(SystemWarning {
@@ -6720,22 +6721,6 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
             }),
     );
     warnings
-}
-
-fn bm25_fallback_warning_degraded(fail_count: u64) -> String {
-    format!(
-        "embedding backend is degraded after {fail_count} failures; using BM25-only search until recovery (retry unlikely to help)"
-    )
-}
-
-fn bm25_fallback_warning_embed_error(error: &str) -> String {
-    format!("embedding unavailable; using BM25-only search: {error} (retry may help)")
-}
-
-fn bm25_fallback_warning_timeout(deadline_secs: u64) -> String {
-    format!(
-        "embedding deadline exceeded after {deadline_secs}s; using BM25-only search (retry may help)"
-    )
 }
 
 fn stale_index_warning_from_bool(is_stale: bool) -> Option<SystemWarning> {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -59,6 +59,87 @@ impl SearchMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorSearchCircuit {
+    /// True when the sticky embedder circuit is open and vector search falls
+    /// back to BM25 unless fallback is disabled.
+    pub open: bool,
+    /// Consecutive embed failures since the last success.
+    pub failure_count: u64,
+    /// Sticky-failure threshold that opens the circuit.
+    pub failure_threshold: u64,
+    /// Whether BM25 fallback is enabled at all.
+    pub bm25_fallback_enabled: bool,
+    /// Per-query vector-embedding deadline that can still trigger BM25
+    /// fallback even when the embedding endpoint itself is reachable.
+    pub search_deadline_secs: u64,
+    /// Current sticky vector-search mode derived from the circuit state.
+    pub vector_search_mode: SearchMode,
+}
+
+impl VectorSearchCircuit {
+    /// Snapshot the current vector-search availability policy from the global
+    /// embed health state and the active configuration.
+    pub fn current() -> Self {
+        let config = crate::core::config::ConfigHandle::current();
+        let embed_snapshot = global_embed_status().snapshot();
+        Self::from_config_and_snapshot(config.as_ref(), &embed_snapshot)
+    }
+
+    /// Build a vector-search policy snapshot from an explicit config/snapshot
+    /// pair. This keeps callers on one shared decision path without forcing an
+    /// extra status read.
+    pub fn from_config_and_snapshot(
+        config: &crate::core::config::Config,
+        embed_snapshot: &crate::embed::EmbedHealthSnapshot,
+    ) -> Self {
+        Self {
+            open: embed_snapshot.degraded,
+            failure_count: embed_snapshot.fail_count,
+            failure_threshold: config.embed.degradation.degrade_after_n_failures,
+            bm25_fallback_enabled: config.search.bm25_fallback,
+            search_deadline_secs: config.embed.retry.search_deadline_secs,
+            vector_search_mode: if config.search.bm25_fallback && embed_snapshot.degraded {
+                SearchMode::Bm25Only
+            } else {
+                SearchMode::Hybrid
+            },
+        }
+    }
+}
+
+/// Wording for the sticky embedder circuit opening after repeated failures.
+pub fn bm25_fallback_warning_degraded(fail_count: u64) -> String {
+    format!(
+        "embedding backend is degraded after {fail_count} failures; using BM25-only search until recovery (retry unlikely to help)"
+    )
+}
+
+/// Wording for embedding build/runtime failures while BM25 fallback is enabled.
+pub fn bm25_fallback_warning_embed_error(error: &str) -> String {
+    format!("embedding unavailable; using BM25-only search: {error} (retry may help)")
+}
+
+/// Wording for query-embedding deadline expiry while BM25 fallback is enabled.
+pub fn bm25_fallback_warning_timeout(deadline_secs: u64) -> String {
+    format!(
+        "embedding deadline exceeded after {deadline_secs}s; using BM25-only search (retry may help)"
+    )
+}
+
+/// Wording for the edge case where the embedder returns no query vector.
+pub fn bm25_fallback_warning_missing_query_vector() -> String {
+    "embedding returned no query vector; using BM25-only search".to_string()
+}
+
+/// Wording for the edge case where the query vector dimension mismatches the
+/// stored vector index.
+pub fn bm25_fallback_warning_dimension_mismatch(new_dim: usize, current_dim: usize) -> String {
+    format!(
+        "embedding dimension mismatch ({new_dim}d query vs {current_dim}d index); using BM25-only search"
+    )
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchOutcome {
     pub results: Vec<SearchResult>,
@@ -229,8 +310,8 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
         return Ok(SearchOutcome::hybrid(Vec::new()));
     }
 
-    let config = crate::core::config::ConfigHandle::current();
-    if config.search.bm25_fallback && global_embed_status().is_degraded() {
+    let vector_search_circuit = VectorSearchCircuit::current();
+    if vector_search_circuit.bm25_fallback_enabled && vector_search_circuit.open {
         return bm25_fallback_outcome(
             db,
             query,
@@ -238,13 +319,13 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
             scope,
             options,
             top_k,
-            "embedding backend is degraded; using BM25-only search".to_string(),
+            bm25_fallback_warning_degraded(vector_search_circuit.failure_count),
         );
     }
 
     let embeddings = match embedder.embed(&[query]).await {
         Ok(embeddings) => embeddings,
-        Err(error) if config.search.bm25_fallback => {
+        Err(error) if vector_search_circuit.bm25_fallback_enabled => {
             return bm25_fallback_outcome(
                 db,
                 query,
@@ -252,16 +333,15 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 scope,
                 options,
                 top_k,
-                format!(
-                    "embedding unavailable; using BM25-only search: {}",
-                    crate::core::config::scrub_sensitive_text(&error.to_string())
-                ),
+                bm25_fallback_warning_embed_error(&crate::core::config::scrub_sensitive_text(
+                    &error.to_string(),
+                )),
             );
         }
         Err(error) => return Err(SearchError::EmbedQuery(error)),
     };
     let Some(query_vector) = embeddings.into_iter().next() else {
-        if config.search.bm25_fallback {
+        if vector_search_circuit.bm25_fallback_enabled {
             return bm25_fallback_outcome(
                 db,
                 query,
@@ -269,7 +349,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 scope,
                 options,
                 top_k,
-                "embedding returned no query vector; using BM25-only search".to_string(),
+                bm25_fallback_warning_missing_query_vector(),
             );
         }
         return Err(SearchError::MissingQueryVector);
@@ -277,7 +357,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
     if let Some(current_dim) = current_vector_dim(db).map_err(SearchError::KeywordSearch)?
         && current_dim != query_vector.len()
     {
-        if config.search.bm25_fallback {
+        if vector_search_circuit.bm25_fallback_enabled {
             return bm25_fallback_outcome(
                 db,
                 query,
@@ -285,10 +365,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 scope,
                 options,
                 top_k,
-                format!(
-                    "embedding dimension mismatch ({new_dim}d query vs {current_dim}d index); using BM25-only search",
-                    new_dim = query_vector.len()
-                ),
+                bm25_fallback_warning_dimension_mismatch(query_vector.len(), current_dim),
             );
         }
         return Err(SearchError::VectorDimensionMismatch {

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -48,6 +48,13 @@ enabled = false
 [search]
 bm25_fallback = true
 
+[embed.retry]
+search_deadline_secs = 5
+
+[embed.degradation]
+degrade_after_n_failures = 2
+block_writes_when_degraded = true
+
 [api]
 write_queue_capacity = 10
 write_drain_timeout_secs = 2
@@ -319,6 +326,12 @@ async fn test_bm25_fallback_when_embedder_down() {
             .expect("warnings")
             .is_empty()
     );
+    assert_eq!(
+        results[0]["warnings"][0].as_str(),
+        Some(
+            "embedding unavailable; using BM25-only search: embedding runtime error: embedder down (retry may help)"
+        )
+    );
     assert!(
         results[0]["content"]
             .as_str()
@@ -331,7 +344,7 @@ async fn test_bm25_fallback_when_embedder_down() {
 async fn test_status_shows_degraded_mode() {
     let _guard = TEST_LOCK.lock().await;
     let env = TestEnv::new();
-    for _ in 0..10 {
+    for _ in 0..2 {
         global_embed_status().record_failure(&EmbedError::Runtime("down".to_string()));
     }
     let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
@@ -341,6 +354,76 @@ async fn test_status_shows_degraded_mode() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["embedding_status"], "degraded");
     assert_eq!(body["search_mode"], "bm25_only");
+    let circuit = body["embedder_circuit"]
+        .as_object()
+        .expect("embedder circuit");
+    assert_eq!(circuit.get("open").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        circuit.get("failure_count").and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        circuit.get("failure_threshold").and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        circuit
+            .get("bm25_fallback_enabled")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        circuit.get("search_deadline_secs").and_then(Value::as_u64),
+        Some(5)
+    );
+    assert_eq!(
+        circuit.get("vector_search_mode").and_then(Value::as_str),
+        Some("bm25_only")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_search_deadline_warning_surfaces_timeout_reason() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    insert_search_drawer(&env.db());
+    let started = Arc::new(Notify::new());
+    let released = Arc::new(Notify::new());
+    let has_started = Arc::new(AtomicBool::new(false));
+    let state = env.state(Arc::new(BlockingEmbedderFactory {
+        started: Arc::clone(&started),
+        released: Arc::clone(&released),
+        has_started: Arc::clone(&has_started),
+    }));
+
+    tokio::time::pause();
+    let request = tokio::spawn({
+        let state = state.clone();
+        async move { get_json(state, "/api/search?q=alpha&top_k=5").await }
+    });
+
+    while !has_started.load(Ordering::SeqCst) {
+        started.notified().await;
+    }
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(5)).await;
+
+    let (status, headers, body) = request.await.expect("join search request");
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers.get("search-mode").and_then(|v| v.to_str().ok()),
+        Some("bm25_only")
+    );
+    assert_eq!(
+        headers.get("degraded").and_then(|v| v.to_str().ok()),
+        Some("true")
+    );
+    let results = body.as_array().expect("search response array");
+    assert_eq!(results[0]["search_mode"], "bm25_only");
+    assert_eq!(
+        results[0]["warnings"][0].as_str(),
+        Some("embedding deadline exceeded after 5s; using BM25-only search (retry may help)")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #333. The feature-gated REST surface (`mempal-api`) still carried the pre-#317 generic status/search wording and did not surface the embedder circuit / search-deadline signal — so a REST client could see a healthy-looking status while search silently degraded to BM25, with no actionable reason. #317 fixed this for MCP; this PR brings REST to parity by sharing one source of truth instead of duplicating wording.

## Change

- **Shared helper** (`src/search/mod.rs`): the vector-search circuit state + BM25-fallback reason/retry wording are consolidated into one helper. REST, MCP, and the core search path all consume it, so the two surfaces cannot diverge again (the failure mode #333 was about).
- **REST handlers** (`src/api/handlers.rs`): `/api/status` now exposes the `embedder_circuit` signal, and `/api/search` reports the concrete BM25-fallback reason (circuit-open-due-to-accumulated-failures vs query-embed-deadline-exceeded) + retry usefulness — identical semantics to `mempal_status` / `mempal_search`.
- **MCP** (`src/mcp/server.rs`): rewired onto the same shared helper (no behavior change — the existing `mempal_status`/`mempal_search` semantics from #317 are preserved; the degraded-write contract `degraded_write_error()` → "writes are paused" is unchanged).
- **Regression tests** (`tests/rest_reliability.rs`): assert REST `/api/status` exposes the circuit signal and `/api/search` names the concrete fallback reason for both the build-failure and timeout paths — mirroring #317's `embedder_transport_scenarios` coverage.

## Notes

- The REST API stays feature-gated; the project remains CLI/MCP-first. This is a divergence-proofing consistency fix (delegate to the shared core), not an endorsement of REST as a primary surface.
- Data is local; privacy/gating `system_warnings` are expected and unrelated.

## Acceptance

- `just fmt && just clippy && just test` green (full suite, including the `rest` feature).
- REST status/search vector-availability semantics now match the MCP surface via the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
