### PR TITLE
fix(llm): heartbeat long judge calls + non-fatal confirm-miss (#336)

### DIFF
--- a/src/llm/retry.rs
+++ b/src/llm/retry.rs
@@ -4,6 +4,7 @@ use super::client::{LlmError, LlmResponse};
 
 pub type HeartbeatCallback = dyn Fn() -> Result<(), LlmError> + Send + Sync;
 
+const MAX_HEARTBEAT_REFRESH_SECS: u64 = 5;
 const MAX_RETRY_AFTER_SECS: u64 = 60;
 
 pub async fn retry_llm_operation<F, Fut>(
@@ -15,8 +16,9 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<LlmResponse, LlmError>>,
 {
+    let heartbeat_interval_secs = retry_interval_secs.clamp(1, MAX_HEARTBEAT_REFRESH_SECS);
     loop {
-        match operation().await {
+        match await_with_heartbeat(operation(), heartbeat, heartbeat_interval_secs).await {
             Ok(response) => return Ok(response),
             Err(error) => {
                 if !error.is_retryable() {
@@ -25,6 +27,31 @@ where
                 let wait = retry_after_from_error(&error, retry_interval_secs);
                 refresh_heartbeat(heartbeat);
                 wait_with_heartbeat(wait, heartbeat).await;
+            }
+        }
+    }
+}
+
+async fn await_with_heartbeat<Fut, T>(
+    future: Fut,
+    heartbeat: Option<&HeartbeatCallback>,
+    heartbeat_interval_secs: u64,
+) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    match heartbeat {
+        None => future.await,
+        Some(callback) => {
+            let mut future = Box::pin(future);
+            let mut ticker = tokio::time::interval(Duration::from_secs(heartbeat_interval_secs));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    result = &mut future => return result,
+                    _ = ticker.tick() => refresh_heartbeat(Some(callback)),
+                }
             }
         }
     }

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -134,9 +134,7 @@ pub async fn run_llm_worker(
         match task_result {
             Some(Ok(())) => {
                 tracing::info!("LLM task {message_id} completed in {latency_ms}ms");
-                store
-                    .confirm(&message_id)
-                    .with_context(|| format!("failed to confirm LLM task {message_id}"))?;
+                confirm_llm_task(&store, &message_id)?;
                 write_observer.record_successful_write();
             }
             Some(Err(error)) => {
@@ -165,6 +163,23 @@ pub async fn run_llm_worker(
         }
     }
 
+    Ok(())
+}
+
+/// Confirm a completed LLM task in the pending-message store.
+pub fn confirm_llm_task(store: &PendingMessageStore, message_id: &str) -> Result<()> {
+    match store.confirm(message_id) {
+        Ok(()) => {}
+        Err(crate::core::queue::QueueError::MessageNotFound(_)) => {
+            tracing::warn!(
+                message_id,
+                "LLM task already removed before confirm; continuing"
+            );
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to confirm LLM task {message_id}"));
+        }
+    }
     Ok(())
 }
 

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -1,12 +1,19 @@
 //! Tests for fix/llm-worker-hot-reload (issue #176):
 //! LLM workers stuck after config hot-reload model change.
 
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use mempal::core::config::ConfigHandle;
+use axum::{Json, Router, routing::post};
+use mempal::core::config::{Config, ConfigHandle, IngestGatingConfig, LlmConfig, LlmJudgeConfig};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
+use mempal::llm::client::LlmClient;
+use mempal::llm::status::LlmStatus;
+use mempal::llm::worker::confirm_llm_task;
+use mempal::llm::{LlmError, LlmTaskPayload};
+use tokio::sync::Notify;
 
 // Tests in this file share the global HotReloadState (OnceLock singleton).
 // Serialize them to prevent cross-test config snapshot contamination.
@@ -16,6 +23,27 @@ static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn make_store(db: &Database) -> PendingMessageStore {
     PendingMessageStore::new(db.path()).expect("open queue")
+}
+
+fn llm_chat_response_body(content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": "test",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content
+                },
+                "finish_reason": "stop"
+            }
+        ],
+        "model": "test-model",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15
+        }
+    })
 }
 
 // ── release_claim ────────────────────────────────────────────────────────────
@@ -231,6 +259,130 @@ async fn test_worker_select_cancels_on_gen_change() {
         "slow operation must be cancelled when generation changes"
     );
     handle.await.expect("spawned task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_llm_process_refreshes_heartbeat_during_long_judge_call() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::new(&db_path).expect("queue store");
+
+    let payload = LlmTaskPayload {
+        task_type: "gating".to_string(),
+        drawer_id: "drawer-heartbeat-test".to_string(),
+        drawer_ids: vec![],
+        content: "long judge content".to_string(),
+        system_prompt: None,
+    };
+    let payload_json = serde_json::to_string(&payload).expect("serialize payload");
+    let id = store
+        .enqueue("llm_task", &payload_json)
+        .expect("enqueue llm task");
+    let claimed = store
+        .claim_next_by_kind("worker-a", 1, "llm_task")
+        .expect("claim llm task")
+        .expect("claimed message");
+    assert_eq!(claimed.id, id);
+
+    let request_started = Arc::new(Notify::new());
+    let request_started_for_server = Arc::clone(&request_started);
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let request_started = Arc::clone(&request_started_for_server);
+            async move {
+                request_started.notify_one();
+                tokio::time::sleep(Duration::from_secs(4)).await;
+                Json(llm_chat_response_body(
+                    "{\"verdict\":\"keep\",\"score\":0.9}",
+                ))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind llm server");
+    let addr = listener.local_addr().expect("llm server addr");
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve llm server");
+    });
+
+    let llm_config = LlmConfig {
+        enabled: true,
+        base_url: Some(format!("http://{addr}/v1")),
+        model: Some("test-model".to_string()),
+        request_timeout_secs: 10,
+        retry_interval_secs: 1,
+        ..Default::default()
+    };
+    let client = LlmClient::from_config(&llm_config).expect("build llm client");
+    let status = Arc::new(LlmStatus::new(5));
+    let judge_config = Config {
+        ingest_gating: IngestGatingConfig {
+            llm_judge: Some(LlmJudgeConfig {
+                enabled: true,
+                threshold: 0.5,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let heartbeat_store = store.clone();
+    let heartbeat_message_id = claimed.id.clone();
+    let heartbeat_worker_id = "worker-a".to_string();
+    let payload = claimed.payload.clone();
+    let process = async move {
+        let heartbeat: Box<mempal::llm::retry::HeartbeatCallback> = Box::new(move || {
+            heartbeat_store
+                .refresh_heartbeat(&heartbeat_message_id, &heartbeat_worker_id)
+                .map_err(|error| {
+                    LlmError::MissingConfiguration(format!("heartbeat failed: {error}"))
+                })?;
+            Ok(())
+        });
+
+        mempal::llm::process_llm_task(
+            &client,
+            status.as_ref(),
+            &db,
+            &payload,
+            &judge_config,
+            Some(heartbeat.as_ref()),
+        )
+        .await
+    };
+
+    let claim_probe = {
+        let store = store.clone();
+        async move {
+            request_started.notified().await;
+            tokio::time::sleep(Duration::from_millis(2600)).await;
+
+            let second_claim = store
+                .claim_next_by_kind("worker-b", 1, "llm_task")
+                .expect("second claim");
+            assert!(
+                second_claim.is_none(),
+                "active LLM task must not be reclaimed while heartbeat refresh is running"
+            );
+        }
+    };
+
+    let (process_result, _) = tokio::join!(process, claim_probe);
+    process_result.expect("process llm task");
+
+    confirm_llm_task(&store, &claimed.id).expect("confirm llm task");
+
+    let after_confirm = store
+        .claim_next_by_kind("worker-c", 1, "llm_task")
+        .expect("claim after confirm");
+    assert!(after_confirm.is_none(), "confirmed task must be gone");
+
+    server_handle.abort();
+    let _ = server_handle.await;
 }
 
 /// Verify that the per-request timeout on LlmClient is set from config.

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -6,6 +6,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::{
     LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig, QueueFailureDisposition,
 };
+use mempal::llm::worker::confirm_llm_task;
 use rusqlite::Connection;
 use tempfile::TempDir;
 use tokio::sync::Barrier;
@@ -93,6 +94,29 @@ fn test_confirm_deletes_row() {
         )
         .expect("read completion op_state");
     assert_eq!(completion_op_state, "completed");
+}
+
+#[test]
+fn test_confirm_llm_task_missing_row_is_benign() {
+    let (_tmp, db_path, store) = new_store();
+    let id = store
+        .enqueue(
+            "llm_task",
+            r#"{"task_type":"gating","drawer_id":"drawer-1","drawer_ids":[],"content":"content","system_prompt":null}"#,
+        )
+        .expect("enqueue llm task");
+    let claimed = store
+        .claim_next_by_kind("worker-a", 60, "llm_task")
+        .expect("claim llm task")
+        .expect("claimed message");
+    assert_eq!(claimed.id, id);
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute("DELETE FROM pending_messages WHERE id = ?1", [&id])
+        .expect("delete claimed row");
+    drop(conn);
+
+    confirm_llm_task(&store, &id).expect("confirm missing LLM task");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #336. The mempal daemon's unified queue chronically wedged (`daemon write stall detected ... last_error=none` recurring for days; daemon ending in `D` uninterruptible disk-sleep on the 9.7 GB `palace.db`). Root cause was **queue-claim correctness, not gating latency**: the LLM gating worker did not refresh its heartbeat during a long in-flight judge call, so `reclaim_stale` re-handed the still-running task to a second worker → duplicate processing → the loser's `confirm` hit `pending message not found` → a **fatal worker error** that killed the worker. Under any sustained gating load (every judge call longer than the heartbeat window) workers died one-by-one until throughput collapsed.

This is a **quality-preserving** fix — the 27B gating judge, its latency, and `enable_thinking` are all unchanged. Only the queue-claim machinery is corrected.

## Change

- **Heartbeat during long judge calls**: the LLM gating worker now refreshes the task heartbeat on an interval shorter than the reclaim TTL while the judge call is in flight, mirroring the embedder retry loop. A task actively held by a live worker is no longer reclaimed.
- **Non-fatal confirm-miss**: a `confirm` that finds the message already gone (`pending message not found`) is now a warn-and-continue, never a fatal error that removes a worker. Defense in depth against any future double-claim.
- **Regression test**: simulates an in-flight task whose processing exceeds the reclaim TTL and asserts (a) heartbeat refresh keeps it single-claimed (no reclaim), and (b) confirm against an already-removed message is non-fatal.

## Non-goals

- No gating-quality change: model, thinking mode, and judge timeout are untouched (operator requires the 27B judge at its current latency).

## Acceptance

- `just fmt && just clippy && just test` green (full suite).
- Under sustained gating with per-call latency > reclaim TTL, journal shows zero `fatal error` / `pending message not found` / duplicate `claimed task <same-id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
