### PR TITLE
fix(reindex): finalize successful vector-reindex progress rows (#338, supersedes #325)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5714,6 +5714,8 @@ async fn reindex_command_by_embedder(
         println!("resume checkpoint found; preserving existing drawer_vectors table");
         None
     };
+    let progress_store_for_reindex = progress_store.clone();
+    let target_fingerprint_for_reindex = target_fingerprint.clone();
     let embed_result: Result<()> = async move {
     if stale_only && resume_checkpoint.is_none() {
         let policy = BatchRetryPolicy {
@@ -5724,7 +5726,7 @@ async fn reindex_command_by_embedder(
             db,
             embedder.as_ref(),
             embedder_name,
-            &target_fingerprint,
+            &target_fingerprint_for_reindex,
             batch.batch_size,
             target,
             policy,
@@ -5733,7 +5735,9 @@ async fn reindex_command_by_embedder(
     }
     let mut drawers = reindex_rows(db).context("failed to load active drawers for reindex")?;
     if stale_only {
-        drawers.retain(|row| reindex_row_is_stale(db, row, &target_fingerprint).unwrap_or(true));
+        drawers.retain(|row| {
+            reindex_row_is_stale(db, row, &target_fingerprint_for_reindex).unwrap_or(true)
+        });
     }
     let total = drawers.len();
     println!("re-embedding {total} drawers...");
@@ -5759,14 +5763,14 @@ async fn reindex_command_by_embedder(
             && let Some((sp, ci)) = last_processed.as_ref()
             && sp == prev_src
         {
-            progress_store
+            progress_store_for_reindex
                 .mark_done(sp, Some(*ci), embedder_name)
                 .context("failed to mark completed reindex source")?;
         }
         active_source = Some(row.source_path.clone());
         let single_input = [row.content.as_str()];
         let embed_future = embedder.embed(&single_input);
-        let vectors = tokio::select! { _ = tokio::signal::ctrl_c() => { if let Some((sp, ci)) = last_processed.as_ref() { progress_store.mark_paused(sp, Some(*ci), embedder_name).context("failed to persist paused reindex checkpoint")?; } bail!("reindex interrupted; resume with `mempal reindex --embedder {embedder_name} --resume`"); } result = embed_future => result.context("embedding failed during reindex")? };
+        let vectors = tokio::select! { _ = tokio::signal::ctrl_c() => { if let Some((sp, ci)) = last_processed.as_ref() { progress_store_for_reindex.mark_paused(sp, Some(*ci), embedder_name).context("failed to persist paused reindex checkpoint")?; } bail!("reindex interrupted; resume with `mempal reindex --embedder {embedder_name} --resume`"); } result = embed_future => result.context("embedding failed during reindex")? };
         let vector = vectors
             .into_iter()
             .next()
@@ -5780,24 +5784,24 @@ async fn reindex_command_by_embedder(
             db,
             &row.id,
             CURRENT_VECTOR_INDEX_VERSION,
-            &target_fingerprint,
+            &target_fingerprint_for_reindex,
         )
         .with_context(|| format!("failed to record reindex metadata for {}", row.id))?;
-        progress_store
+        progress_store_for_reindex
             .upsert_running(&row.source_path, Some(row.chunk_index), embedder_name)
             .context("failed to persist reindex checkpoint")?;
         done += 1;
         last_processed = Some((row.source_path.clone(), row.chunk_index));
         println!("  {done}/{total}");
         if test_stop_after.is_some_and(|limit| done >= limit) {
-            progress_store
+            progress_store_for_reindex
                 .mark_paused(&row.source_path, Some(row.chunk_index), embedder_name)
                 .context("failed to persist paused reindex checkpoint")?;
             bail!("reindex interrupted for test after {done} drawers");
         }
     }
     if let Some((sp, ci)) = last_processed.as_ref() {
-        progress_store
+        progress_store_for_reindex
             .mark_done(sp, Some(*ci), embedder_name)
             .context("failed to finalize reindex checkpoint")?;
     }
@@ -5806,7 +5810,19 @@ async fn reindex_command_by_embedder(
     }
     .await;
 
-    finalize_reindex_atomicity(db, reindex_stash, embed_result)
+    match finalize_reindex_atomicity(db, reindex_stash, embed_result) {
+        Ok(()) => {
+            // Safety net: successful embedder/vector reindex runs should settle
+            // any still-running checkpoints to `done`, but only for rows that
+            // are already current. This preserves the #325 invariant: promote
+            // `running` -> `done` only, and never resurrect `failed` rows.
+            progress_store
+                .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+                .context("failed to finalize completed reindex checkpoints")?;
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Decide the fate of a recreate-reindex's staged old vectors (#302 atomicity).

--- a/tests/reindex_progress.rs
+++ b/tests/reindex_progress.rs
@@ -180,6 +180,28 @@ fn run_reindex(
     command.output().expect("run reindex command")
 }
 
+fn read_reindex_progress_status_counts(db: &Database) -> (i64, i64, i64) {
+    db.conn()
+        .query_row(
+            r#"
+            SELECT
+                COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0)
+            FROM reindex_progress
+            "#,
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .expect("read reindex progress status counts")
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_reindex_resume_from_checkpoint() {
     let _guard = test_guard().await;
@@ -246,6 +268,10 @@ async fn test_reindex_stale_finalizes_progress() {
     write_config(&home, &db_path, &server.base_url);
     seed_db(&db_path);
 
+    let db = Database::open(&db_path).expect("open db before stale reindex");
+    let before = read_reindex_progress_status_counts(&db);
+    drop(db);
+
     let output = run_reindex(&home, None, false, true);
     assert!(
         output.status.success(),
@@ -255,6 +281,20 @@ async fn test_reindex_stale_finalizes_progress() {
     assert_eq!(server.request_count(), 1);
 
     let db = Database::open(&db_path).expect("open db after stale reindex");
+    let after = read_reindex_progress_status_counts(&db);
+    assert_eq!(
+        after.0, before.0,
+        "successful stale reindex must not leave extra running rows"
+    );
+    assert_eq!(
+        after.1,
+        before.1 + 1,
+        "successful stale reindex must settle one additional row to done"
+    );
+    assert_eq!(
+        after.2, before.2,
+        "successful stale reindex must not resurrect failed rows"
+    );
     let state = db
         .conn()
         .query_row(
@@ -300,6 +340,7 @@ async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
         )
         .expect("read running checkpoint");
     assert_eq!(running, "running");
+    let before = read_reindex_progress_status_counts(&db);
 
     let target_fingerprint = format!(
         "openai_compat:Qwen/Qwen3-Embedding-8B:{}:{}",
@@ -310,6 +351,32 @@ async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
         .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
         .expect("reconcile orphan running row");
     assert_eq!(reconciled, 1);
+    let after_first = read_reindex_progress_status_counts(&db);
+    assert_eq!(after_first.0, before.0 - 1);
+    assert_eq!(after_first.1, before.1 + 1);
+    assert_eq!(after_first.2, before.2);
+
+    let reconciled_again = progress
+        .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+        .expect("reconcile orphan running row twice");
+    assert_eq!(reconciled_again, 0);
+    let after_second = read_reindex_progress_status_counts(&db);
+    assert_eq!(after_second, after_first);
+
+    db.conn()
+        .execute(
+            "UPDATE reindex_progress SET status = 'failed' WHERE source_path = 'fixtures/source.txt'",
+            [],
+        )
+        .expect("flip checkpoint to failed");
+
+    let failed = read_reindex_progress_status_counts(&db);
+    assert_eq!(failed, (0, 0, 1));
+
+    let reconciled_failed = progress
+        .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+        .expect("reconcile failed checkpoint");
+    assert_eq!(reconciled_failed, 0);
 
     let state = db
         .conn()
@@ -319,5 +386,5 @@ async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .expect("read reconciled checkpoint");
-    assert_eq!(state, (49, "done".to_string()));
+    assert_eq!(state, (49, "failed".to_string()));
 }


### PR DESCRIPTION
## Summary

Fixes #338 (supersedes closed #325). The `reindex_progress` table was a broken completion ledger: **1010 rows, all `status='running'`, zero `'done'`/`'failed'`**. #325 (PR #330) added the `running→done` finalize for the **source** reindex path only; the **embedder/vector** path (`reindex --from-config --stale` / `--embedder <name> --stale`) kept writing `'running'` rows that were never finalized (~123 leaked per day; reproduced live — a 20-drawer backfill added a `running` row with `started_at == updated_at`, never promoted).

## Change

- **Finalize-on-success sweep**: a successful embedder/vector reindex (`reindex --from-config --stale` / `--embedder <name> --stale`) now calls the existing `finalize_completed_running_rows` sweep, which promotes **every** `status='running'` row whose source's vector metadata is already at the current fingerprint → `'done'`. This both finalizes the current run AND reconciles pre-existing orphans on the next successful run — no separate one-time migration needed.
- **Conservative & idempotent**: the reconcile SQL does not match `failed`/`paused` rows, nor sources not fully at the current fingerprint, so a genuinely-interrupted run stays resumable and `failed` is never resurrected (honors #325's `running→done`-only invariant). Safe to run repeatedly.
- **Regression test** (`tests/reindex_progress.rs`): asserts a stale reindex processing ≥1 drawer leaves its row `'done'` (status-count check, no net `running` increment), reconcile idempotency, and that `failed` is not resurrected.

## Non-goals

- No embedder model / latency / gating-quality change.

## Acceptance

- `just fmt && just clippy && just test` green (full suite).
- Every `reindex_progress` writer has a matching finalize (no write-without-finalize remains).
- Existing orphan `running` rows reconciled idempotently after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
