### PR TITLE
fix(reindex): finalize sweep silently promoted 0 rows — vec0 set-join matched nothing (#340)

### DIFF
--- a/src/core/reindex.rs
+++ b/src/core/reindex.rs
@@ -100,44 +100,8 @@ impl ReindexProgressStore {
     ) -> Result<usize> {
         let now = now_secs();
         let conn = self.open_connection()?;
-        // Aggregate each source once, then join the summary back to running rows.
         let updated = conn.execute(
-            r#"
-            WITH source_summary AS (
-                SELECT
-                    COALESCE(d.source_file, d.id) AS source_path,
-                    COUNT(*) AS drawer_count,
-                    MAX(COALESCE(d.chunk_index, 0)) AS last_processed_chunk_id,
-                    SUM(
-                        CASE
-                            WHEN v.id IS NULL
-                              OR COALESCE(idx.value, legacy_idx.value, '') != ?1
-                              OR COALESCE(fp.value, '') != ?2
-                            THEN 1
-                            ELSE 0
-                        END
-                    ) AS stale_drawer_count
-                FROM drawers AS d
-                LEFT JOIN drawer_vectors AS v ON v.id = d.id
-                LEFT JOIN fork_ext_meta AS idx
-                  ON idx.key = 'reindex:' || d.id || ':index_version'
-                LEFT JOIN fork_ext_meta AS legacy_idx
-                  ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
-                LEFT JOIN fork_ext_meta AS fp
-                  ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
-                WHERE d.deleted_at IS NULL
-                GROUP BY COALESCE(d.source_file, d.id)
-            )
-            UPDATE reindex_progress
-            SET last_processed_chunk_id = source_summary.last_processed_chunk_id,
-                updated_at = ?3,
-                status = 'done'
-            FROM source_summary
-            WHERE reindex_progress.status = 'running'
-              AND reindex_progress.source_path = source_summary.source_path
-              AND source_summary.drawer_count > 0
-              AND source_summary.stale_drawer_count = 0
-            "#,
+            FINALIZE_COMPLETED_RUNNING_ROWS_SQL,
             params![current_index_version, target_fingerprint, now],
         )?;
         Ok(updated)
@@ -236,4 +200,74 @@ fn now_secs() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or(0)
+}
+
+const FINALIZE_COMPLETED_RUNNING_ROWS_SQL: &str = r#"
+    WITH source_summary AS (
+        SELECT
+            COALESCE(d.source_file, d.id) AS source_path,
+            COUNT(*) AS drawer_count,
+            MAX(COALESCE(d.chunk_index, 0)) AS last_processed_chunk_id,
+            SUM(
+                CASE
+                    WHEN NOT EXISTS (
+                        SELECT 1
+                        FROM drawer_vectors AS dv
+                        WHERE dv.id = d.id
+                    )
+                      OR COALESCE(idx.value, legacy_idx.value, '') != ?1
+                      OR COALESCE(fp.value, '') != ?2
+                    THEN 1
+                    ELSE 0
+                END
+            ) AS stale_drawer_count
+        FROM drawers AS d
+        LEFT JOIN fork_ext_meta AS idx
+          ON idx.key = 'reindex:' || d.id || ':index_version'
+        LEFT JOIN fork_ext_meta AS legacy_idx
+          ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
+        LEFT JOIN fork_ext_meta AS fp
+          ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
+        WHERE d.deleted_at IS NULL
+        GROUP BY COALESCE(d.source_file, d.id)
+    )
+    UPDATE reindex_progress
+    SET last_processed_chunk_id = source_summary.last_processed_chunk_id,
+        updated_at = ?3,
+        status = 'done'
+    FROM source_summary
+    WHERE reindex_progress.status = 'running'
+      AND reindex_progress.source_path = source_summary.source_path
+      AND source_summary.drawer_count > 0
+      AND source_summary.stale_drawer_count = 0
+    "#;
+
+#[cfg(test)]
+mod tests {
+    use super::FINALIZE_COMPLETED_RUNNING_ROWS_SQL;
+
+    #[test]
+    fn finalize_running_rows_uses_correlated_exists_point_lookup() {
+        assert!(
+            FINALIZE_COMPLETED_RUNNING_ROWS_SQL.contains("NOT EXISTS (")
+                && FINALIZE_COMPLETED_RUNNING_ROWS_SQL.contains("SELECT 1")
+                && FINALIZE_COMPLETED_RUNNING_ROWS_SQL.contains("FROM drawer_vectors AS dv")
+                && FINALIZE_COMPLETED_RUNNING_ROWS_SQL.contains("WHERE dv.id = d.id"),
+            "finalize must use a correlated EXISTS point lookup for vec0"
+        );
+        assert!(
+            !FINALIZE_COMPLETED_RUNNING_ROWS_SQL
+                .contains("LEFT JOIN drawer_vectors AS v ON v.id = d.id"),
+            "finalize must not use the fragile vec0 set-join"
+        );
+        assert!(
+            FINALIZE_COMPLETED_RUNNING_ROWS_SQL.contains("AND source_summary.drawer_count > 0"),
+            "finalize must keep the non-empty-source guard"
+        );
+        assert!(
+            FINALIZE_COMPLETED_RUNNING_ROWS_SQL
+                .contains("AND source_summary.stale_drawer_count = 0"),
+            "finalize must keep the zero-stale guard"
+        );
+    }
 }

--- a/tests/reindex_progress.rs
+++ b/tests/reindex_progress.rs
@@ -180,6 +180,29 @@ fn run_reindex(
     command.output().expect("run reindex command")
 }
 
+fn run_reindex_from_config(
+    home: &Path,
+    stop_after: Option<usize>,
+    resume: bool,
+    stale: bool,
+) -> std::process::Output {
+    let mut command = Command::new(mempal_bin());
+    command
+        .env("HOME", home)
+        .arg("reindex")
+        .arg("--from-config");
+    if stale {
+        command.arg("--stale");
+    }
+    if let Some(limit) = stop_after {
+        command.env("MEMPAL_TEST_REINDEX_STOP_AFTER", limit.to_string());
+    }
+    if resume {
+        command.arg("--resume");
+    }
+    command.output().expect("run reindex command")
+}
+
 fn read_reindex_progress_status_counts(db: &Database) -> (i64, i64, i64) {
     db.conn()
         .query_row(
@@ -387,4 +410,93 @@ async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
         )
         .expect("read reconciled checkpoint");
     assert_eq!(state, (49, "failed".to_string()));
+
+    db.conn()
+        .execute(
+            "UPDATE reindex_progress SET status = 'paused' WHERE source_path = 'fixtures/source.txt'",
+            [],
+        )
+        .expect("flip checkpoint to paused");
+
+    let paused = read_reindex_progress_status_counts(&db);
+    assert_eq!(paused, (0, 0, 0));
+
+    let reconciled_paused = progress
+        .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
+        .expect("reconcile paused checkpoint");
+    assert_eq!(reconciled_paused, 0);
+
+    let paused_state = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read paused checkpoint");
+    assert_eq!(paused_state, (49, "paused".to_string()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reindex_stale_finalizes_orphan_running_row_with_zero_drawers() {
+    let _guard = test_guard().await;
+    let tmp = TempDir::new().expect("tempdir");
+    let home = tmp.path().join("home");
+    let db_path = home.join(".mempal").join("palace.db");
+    let server = MockEmbeddingServer::start();
+
+    write_config(&home, &db_path, &server.base_url);
+    seed_db(&db_path);
+
+    let full = run_reindex(&home, None, false, false);
+    assert!(
+        full.status.success(),
+        "full reindex stderr: {}",
+        String::from_utf8_lossy(&full.stderr)
+    );
+    assert_eq!(server.request_count(), 50);
+
+    let db = Database::open(&db_path).expect("open db before stale reconcile");
+    let progress = ReindexProgressStore::new(&db_path);
+    progress
+        .upsert_running("fixtures/source.txt", Some(49), "openai_compat")
+        .expect("insert orphan running row");
+
+    let before = read_reindex_progress_status_counts(&db);
+    assert_eq!(before, (1, 0, 0));
+    drop(db);
+
+    let stale = run_reindex_from_config(&home, None, false, true);
+    assert!(
+        stale.status.success(),
+        "stale reindex stderr: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    assert_eq!(server.request_count(), 50);
+
+    let db = Database::open(&db_path).expect("open db after stale reconcile");
+    let after = read_reindex_progress_status_counts(&db);
+    assert_eq!(after, (0, 1, 0));
+
+    let state = db
+        .conn()
+        .query_row(
+            "SELECT last_processed_chunk_id, status FROM reindex_progress WHERE source_path = 'fixtures/source.txt'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .expect("read reconciled checkpoint");
+    assert_eq!(state, (49, "done".to_string()));
+
+    let repeat = run_reindex_from_config(&home, None, false, true);
+    assert!(
+        repeat.status.success(),
+        "repeat stale reindex stderr: {}",
+        String::from_utf8_lossy(&repeat.stderr)
+    );
+    assert_eq!(server.request_count(), 50);
+
+    let db = Database::open(&db_path).expect("open db after repeat stale reconcile");
+    let repeat_counts = read_reindex_progress_status_counts(&db);
+    assert_eq!(repeat_counts, after);
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "5c64c2b1ffd842bde7e84e647c88f6a1fef32d50"
+commit = "888ca61554e6bc3b77c3cb99a2742b8bcbf54ad4"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #340. The `reindex_progress` finalize sweep ran but silently promoted **zero** rows, leaving 1010 orphan `running` / 0 `done` in steady state.

The originally-filed premise ("sweep unreachable on the 0-drawer path") was **wrong** — `finalize_completed_running_rows` IS called unconditionally at the tail of the stale path (`src/main.rs:6084`). The real bug: its vector-existence check used a **set-based equi-join against the `drawer_vectors` `vec0` virtual table** —

```sql
LEFT JOIN drawer_vectors AS v ON v.id = d.id
... SUM(CASE WHEN v.id IS NULL OR <idx≠cur> OR <fp≠cur> THEN 1 ELSE 0 END) AS stale_drawer_count
```

In the sweep's CTE + `GROUP BY` + `UPDATE … FROM` plan at production scale (~516k drawers), this join resolves `v.id` to NULL for **every** row (vec0 is KNN-oriented; it does not serve a plain set equi-join here), so `stale_drawer_count` is non-zero for every source → no source meets `stale_drawer_count = 0` → **0 promotions**. vec0 is registered process-wide via `register_auto_extension`, so the query does not error — it just matches nothing.

### Empirical proof (live palace.db)
- All 6399 drawers behind the 1010 orphan sources are fully current (vector row present, `index_version='v2'`, `embedder_fingerprint`=current; one fingerprint covers the whole DB).
- The exact sweep predicate, but checking presence via the regular shadow table `drawer_vectors_rowids`, yields `would_promote=1010, blocked_stale=0`. The predicate logic is correct; only the vec0 set-join was broken.

## Change

- `finalize_completed_running_rows` (`src/core/reindex.rs`) now checks vector presence with a **point-lookup** that vec0 reliably serves — a correlated `EXISTS (SELECT 1 FROM drawer_vectors WHERE id = d.id)` (mirrors the proven-working `SELECT EXISTS(SELECT 1 FROM drawer_vectors WHERE id = ?1)` at `src/main.rs:10555`), replacing the set-based `LEFT JOIN drawer_vectors`.
- All other predicates unchanged — still promotes only `status='running'` rows for sources fully at the current `index_version` + fingerprint with ≥1 live drawer; never `failed`/`paused` → `done`. The #325/#338 invariant is preserved.
- Scope limited to the finalize sweep. The identical fragile pattern in stale-detection (`src/main.rs:10244`, currently working) is tracked separately as #341.

## Regression test

- Adds coverage for the finalize path classifying a current vectored source as non-stale and promoting its orphan `running` row to `done` on a 0-drawer `reindex --from-config --stale`; idempotent; `failed`/`paused` untouched. (Keeps the branch's existing 0-drawer end-to-end reconcile test.)

## Non-goals

- No embedder model / latency / gating-quality change.

## Acceptance

- `just fmt && just clippy && just test` green (full suite).
- Post-deploy: a single `mempal reindex --from-config --stale` (0 drawers) drops the orphan `running` count from 1010 → ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
