### PR TITLE
fix(reindex): harden stale-detection vec0 set-join → correlated EXISTS point-lookup (#341)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10141,6 +10141,39 @@ fn append_reindex_target_filters(
 const REINDEX_SKIPPED_TABLE: &str = "tmp_reindex_skipped";
 const REINDEX_PENDING_TABLE: &str = "tmp_reindex_pending";
 
+/// Stale-detection snapshot query for the "vectors already exist" path.
+///
+/// Issue #341: vector presence MUST be checked with a correlated `EXISTS`
+/// point-lookup, never a set-based `LEFT JOIN drawer_vectors` against the
+/// sqlite-vec `vec0` virtual table. `vec0` reliably serves a point lookup by
+/// `id` but not a plain set equi-join inside a larger plan; at production scale
+/// the planner can resolve such a set-join to NULL for every row, which would
+/// mis-flag every live drawer as stale and trigger a full-DB re-embed (a strictly
+/// worse failure than the #340 finalize 0-promotion). The point lookup mirrors
+/// the proven `drawer_vector_exists` (`SELECT EXISTS(SELECT 1 FROM
+/// drawer_vectors WHERE id = ?)`) and the #340 finalize-sweep fix. `{pending_table}`
+/// is substituted with `REINDEX_PENDING_TABLE` at call time; the two `?`
+/// placeholders bind the current index version and target fingerprint.
+const REINDEX_STALE_PENDING_VECTORED_SQL: &str = r#"
+                INSERT INTO {pending_table} (id, source_path, chunk_index)
+                SELECT d.id,
+                       COALESCE(d.source_file, d.id) AS source_path,
+                       COALESCE(d.chunk_index, 0) AS chunk_index
+                FROM drawers d
+                LEFT JOIN fork_ext_meta idx
+                  ON idx.key = 'reindex:' || d.id || ':index_version'
+                LEFT JOIN fork_ext_meta legacy_idx
+                  ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
+                LEFT JOIN fork_ext_meta fp
+                  ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
+                WHERE d.deleted_at IS NULL
+                  AND (
+                      NOT EXISTS (SELECT 1 FROM drawer_vectors dv WHERE dv.id = d.id)
+                      OR COALESCE(idx.value, legacy_idx.value, '') != ?
+                      OR COALESCE(fp.value, '') != ?
+                  )
+                "#;
+
 /// Create the reindex skip TEMP table if absent. Idempotent, so any staging or
 /// query call may invoke it without coordinating with the loop.
 fn ensure_reindex_skipped_table(db: &Database) -> Result<()> {
@@ -10234,28 +10267,7 @@ fn build_reindex_stale_pending_rows(
             CURRENT_VECTOR_INDEX_VERSION.to_string(),
         ));
         values.push(rusqlite::types::Value::Text(target_fingerprint.to_string()));
-        format!(
-            r#"
-                INSERT INTO {REINDEX_PENDING_TABLE} (id, source_path, chunk_index)
-                SELECT d.id,
-                       COALESCE(d.source_file, d.id) AS source_path,
-                       COALESCE(d.chunk_index, 0) AS chunk_index
-                FROM drawers d
-                LEFT JOIN drawer_vectors v ON v.id = d.id
-                LEFT JOIN fork_ext_meta idx
-                  ON idx.key = 'reindex:' || d.id || ':index_version'
-                LEFT JOIN fork_ext_meta legacy_idx
-                  ON legacy_idx.key = 'reindex:' || d.id || ':normalize_version'
-                LEFT JOIN fork_ext_meta fp
-                  ON fp.key = 'reindex:' || d.id || ':embedder_fingerprint'
-                WHERE d.deleted_at IS NULL
-                  AND (
-                      v.id IS NULL
-                      OR COALESCE(idx.value, legacy_idx.value, '') != ?
-                      OR COALESCE(fp.value, '') != ?
-                  )
-                "#
-        )
+        REINDEX_STALE_PENDING_VECTORED_SQL.replace("{pending_table}", REINDEX_PENDING_TABLE)
     } else {
         format!(
             r#"
@@ -12660,6 +12672,27 @@ mod tests {
             rows.len(),
             3,
             "all stale drawers must be selected when nothing is skipped"
+        );
+    }
+
+    /// Issue #341 regression guard. The stale-detection snapshot must check
+    /// vector presence with a correlated `EXISTS` point-lookup that the `vec0`
+    /// virtual table reliably serves — never a set-based `LEFT JOIN
+    /// drawer_vectors`, which the planner can resolve to NULL for every row at
+    /// production scale, mis-flagging every live drawer as stale and triggering
+    /// a full-DB re-embed. Mirrors the #340 finalize-sweep fix. A behavioural
+    /// test cannot catch the regression because the set-join still works at the
+    /// small scale of unit tests, so this asserts the SQL form directly.
+    #[test]
+    fn reindex_stale_pending_vectored_sql_uses_correlated_exists_point_lookup() {
+        let sql = REINDEX_STALE_PENDING_VECTORED_SQL;
+        assert!(
+            sql.contains("NOT EXISTS (SELECT 1 FROM drawer_vectors dv WHERE dv.id = d.id)"),
+            "stale-detection must check vector presence with a correlated EXISTS point-lookup"
+        );
+        assert!(
+            !sql.contains("LEFT JOIN drawer_vectors"),
+            "stale-detection must NOT set-join the drawer_vectors vec0 virtual table"
         );
     }
 }


### PR DESCRIPTION
## Summary

Hardens the reindex stale-detection snapshot (`build_reindex_stale_pending_rows`, `src/main.rs`) against the same `vec0` set-join failure mode that broke the finalize sweep in #340. Fixes #341.

The "vectors already exist" branch selected stale drawers with:

```sql
FROM drawers d
LEFT JOIN drawer_vectors v ON v.id = d.id
...
WHERE d.deleted_at IS NULL AND (v.id IS NULL OR <idx != cur> OR <fp != cur>)
```

`drawer_vectors` is the sqlite-vec `vec0` virtual table. `vec0` reliably serves a **point lookup** by `id` but not a plain **set equi-join** inside a larger plan. At production scale the planner can resolve `v.id` to NULL for every row (the exact mechanism diagnosed in #340), which would mis-flag **every** live drawer as stale and trigger a full-DB re-embed — strictly worse than the finalize 0-promotion.

It works today only because the small flat `INSERT … SELECT` plan happens to pick `drawers`-outer + per-row vec0 point lookup. That is latent and plan-dependent: a SQLite upgrade, `ANALYZE`, or a data-distribution shift could flip it.

## Change

- Replace the set-based `LEFT JOIN drawer_vectors` + `v.id IS NULL` with a correlated `NOT EXISTS (SELECT 1 FROM drawer_vectors dv WHERE dv.id = d.id)` point lookup — the form `vec0` reliably serves, mirroring the proven `drawer_vector_exists` (`src/main.rs`) and the #340/#342 finalize fix. Semantically identical (`LEFT JOIN … WHERE x IS NULL` ≡ `NOT EXISTS`); index-version / fingerprint predicates, skip-exclusion, ordering and `LIMIT` are unchanged.
- Extract the vectored-branch SQL to a documented const `REINDEX_STALE_PENDING_VECTORED_SQL` so the form is assertable.

## Regression test

- `reindex_stale_pending_vectored_sql_uses_correlated_exists_point_lookup` asserts the SQL uses the correlated `NOT EXISTS` point lookup and contains no `LEFT JOIN drawer_vectors`. A behavioural test cannot guard this — the set-join still works at unit-test scale (which is exactly why the #340 finalize bug shipped undetected by the existing 50-row integration tests).
- Existing behavioural coverage stays green, proving semantic equivalence at small scale: `reindex_stale_pending_snapshot_excludes_current_fingerprint` (vectored branch — current-fingerprint drawer excluded, missing-vector drawer included), `reindex_stale_skip_exclusion_survives_more_than_sqlite_var_limit`, `reindex_pending_pull_preserves_snapshot_order`, `reindex_stale_pending_snapshot_returns_all_when_nothing_skipped`.

## Non-goals

- No change to the finalize sweep (#340/#342, already fixed) or to embedder behaviour.

## Acceptance

- `just fmt && just clippy && just test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
