### PR TITLE
fix(reindex): add --dry-run preview to embedder/vector reindex --stale (#344)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "reqwest",
  "rmcp",
  "rusqlite",
+ "safetensors",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,5 +81,6 @@ dotenvy = "0.15"
 axum = "0.8"
 hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
 mockito = "1"
+safetensors = "0.5"
 serde_json = "1"
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2654,9 +2654,9 @@ fn run() -> Result<()> {
                 }
                 recompute_importance_command(&db, only_zero)
             } else if embedder.is_some() || from_config {
-                if dry_run {
+                if dry_run && !stale {
                     bail!(
-                        "--dry-run is only supported by source reindex (`mempal reindex --stale --dry-run`)"
+                        "--dry-run on embedder/vector reindex requires --stale; add --stale or use `mempal reindex --stale --dry-run`"
                     );
                 }
                 if !vector_target.is_empty() && !stale {
@@ -2682,8 +2682,11 @@ fn run() -> Result<()> {
                     &db,
                     config.as_ref(),
                     &backend,
-                    resume,
-                    stale,
+                    ReindexEmbedderMode {
+                        resume,
+                        stale_only: stale,
+                        dry_run,
+                    },
                     StaleBatchTuning {
                         batch_size: batch_size.unwrap_or(1000),
                         max_batch_retries: max_batch_retries.unwrap_or(DEFAULT_MAX_BATCH_RETRIES),
@@ -5633,11 +5636,23 @@ async fn reindex_command_by_embedder(
     db: &Database,
     config: &Config,
     embedder_name: &str,
-    resume: bool,
-    stale_only: bool,
+    mode: ReindexEmbedderMode,
     batch: StaleBatchTuning,
     target: ReindexVectorTarget,
 ) -> Result<()> {
+    if mode.dry_run && !mode.stale_only {
+        bail!(
+            "--dry-run on embedder/vector reindex requires --stale; add --stale or use `mempal reindex --stale --dry-run`"
+        );
+    }
+    if mode.dry_run {
+        let stale_count = preview_reindex_stale_vector_work(db, config, embedder_name, target)
+            .await
+            .context("failed to plan stale vector reindex")?;
+        println!("would re-embed {stale_count} stale drawers");
+        println!("dry-run: no vectors were written");
+        return Ok(());
+    }
     let embedder = build_specific_embedder(config, embedder_name).await?;
     let new_dim = embedder.dimensions();
     let current_dim = current_vector_dim(db).context("failed to read embedding dim")?;
@@ -5648,7 +5663,7 @@ async fn reindex_command_by_embedder(
     let target_fingerprint = config
         .embed
         .vector_embedder_fingerprint(embedder_name, new_dim);
-    let mut resume_checkpoint = if resume {
+    let mut resume_checkpoint = if mode.resume {
         progress_store
             .latest_resumable(Some(embedder_name))
             .context("failed to load reindex checkpoint")?
@@ -5667,12 +5682,12 @@ async fn reindex_command_by_embedder(
     );
     let metric_is_current = current_metric.as_deref() == Some(VECTOR_DISTANCE_METRIC);
     let table_layout_is_current = current_dim == Some(new_dim) && metric_is_current;
-    let should_recreate_table = if stale_only {
+    let should_recreate_table = if mode.stale_only {
         !table_layout_is_current
     } else {
         resume_checkpoint.is_none() || !table_layout_is_current
     };
-    if stale_only
+    if mode.stale_only
         && should_recreate_table
         && reindex_target_narrows_store(db, &target)
             .context("failed to evaluate targeted stale reindex safety")?
@@ -5707,7 +5722,7 @@ async fn reindex_command_by_embedder(
         db.recreate_vectors_table(new_dim)
             .context("failed to recreate vectors table")?;
         stash
-    } else if stale_only {
+    } else if mode.stale_only {
         println!("stale-only reindex preserving existing drawer_vectors table");
         None
     } else {
@@ -5717,7 +5732,7 @@ async fn reindex_command_by_embedder(
     let progress_store_for_reindex = progress_store.clone();
     let target_fingerprint_for_reindex = target_fingerprint.clone();
     let embed_result: Result<()> = async move {
-    if stale_only && resume_checkpoint.is_none() {
+    if mode.stale_only && resume_checkpoint.is_none() {
         let policy = BatchRetryPolicy {
             interval: std::time::Duration::from_secs(config.embed.retry.interval_secs),
             max_retries: batch.max_batch_retries,
@@ -5734,7 +5749,7 @@ async fn reindex_command_by_embedder(
         .await;
     }
     let mut drawers = reindex_rows(db).context("failed to load active drawers for reindex")?;
-    if stale_only {
+    if mode.stale_only {
         drawers.retain(|row| {
             reindex_row_is_stale(db, row, &target_fingerprint_for_reindex).unwrap_or(true)
         });
@@ -5823,6 +5838,40 @@ async fn reindex_command_by_embedder(
         }
         Err(error) => Err(error),
     }
+}
+
+/// Resolve the fingerprint the live embedder path would write without
+/// constructing the embedder itself.
+///
+/// Dry-run uses this to snapshot stale rows without loading a model or making
+/// any network call.
+fn resolve_reindex_vector_fingerprint(config: &Config, embedder_name: &str) -> Result<String> {
+    let dim = resolve_reindex_vector_dimension(config, embedder_name)?;
+    Ok(config.embed.vector_embedder_fingerprint(embedder_name, dim))
+}
+
+fn resolve_reindex_vector_dimension(config: &Config, embedder_name: &str) -> Result<usize> {
+    match embedder_name {
+        "openai_compat" | "api" | "stub" => Ok(config.embed.resolved_openai_dim()),
+        #[cfg(feature = "onnx")]
+        "onnx" => Ok(384),
+        // The current model2vec fingerprint model in this repo is 256d
+        // (see the benchmark summary and P8 privacy spec).
+        #[cfg(feature = "model2vec")]
+        "model2vec" => Ok(256),
+        other => bail!("unsupported embed backend: {other}"),
+    }
+}
+
+async fn preview_reindex_stale_vector_work(
+    db: &Database,
+    config: &Config,
+    embedder_name: &str,
+    target: ReindexVectorTarget,
+) -> Result<usize> {
+    let target_fingerprint = resolve_reindex_vector_fingerprint(config, embedder_name)?;
+    build_reindex_stale_pending_rows(db, &target_fingerprint, &target)
+        .context("failed to snapshot stale reindex work list")
 }
 
 /// Decide the fate of a recreate-reindex's staged old vectors (#302 atomicity).
@@ -5920,6 +5969,13 @@ struct StaleBatchTuning {
     /// Max retries for a batch's embed call before it is skipped
     /// (`--max-batch-retries`, default `DEFAULT_MAX_BATCH_RETRIES`).
     max_batch_retries: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ReindexEmbedderMode {
+    resume: bool,
+    stale_only: bool,
+    dry_run: bool,
 }
 
 /// Embed one stale batch, retrying at the policy's fixed interval (no backoff,
@@ -12284,6 +12340,13 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "model2vec")]
+    fn model2vec_dry_run_config() -> Config {
+        let mut config = Config::default();
+        config.embed.backend = "model2vec".to_string();
+        config
+    }
+
     fn insert_reindex_test_drawer(
         db: &Database,
         id: &str,
@@ -12477,6 +12540,87 @@ mod tests {
             reindex_pending_ids(&db).expect("pending ids"),
             vec!["stale".to_string()],
             "drawer with current fingerprint is excluded"
+        );
+    }
+
+    #[cfg(feature = "model2vec")]
+    #[tokio::test]
+    async fn reindex_embedder_dry_run_snapshots_stale_rows_without_writes() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        db.recreate_vectors_table(256).expect("create vector table");
+
+        insert_reindex_test_drawer(&db, "fresh", "fresh content", "fixtures/source.txt", 0);
+        insert_reindex_test_drawer(&db, "stale", "stale content", "fixtures/source.txt", 1);
+
+        let config = model2vec_dry_run_config();
+        let target_fingerprint = resolve_reindex_vector_fingerprint(&config, "model2vec")
+            .expect("resolve target fingerprint");
+        let fresh_vector = vec![0.1_f32; 256];
+        let stale_vector = vec![0.2_f32; 256];
+        db.insert_vector_with_project("fresh", &fresh_vector, Some("default"))
+            .expect("insert fresh vector");
+        db.insert_vector_with_project("stale", &stale_vector, Some("default"))
+            .expect("insert stale vector");
+        record_reindex_metadata(
+            &db,
+            "fresh",
+            CURRENT_VECTOR_INDEX_VERSION,
+            &target_fingerprint,
+        )
+        .expect("record fresh fingerprint");
+
+        let before_vectors = db.vector_row_count().expect("vector count before");
+        let inserted = preview_reindex_stale_vector_work(
+            &db,
+            &config,
+            "model2vec",
+            empty_reindex_target(None),
+        )
+        .await
+        .expect("dry-run stale snapshot");
+
+        assert_eq!(inserted, 1);
+        assert_eq!(
+            reindex_pending_ids(&db).expect("pending ids"),
+            vec!["stale".to_string()]
+        );
+        assert_eq!(
+            db.vector_row_count().expect("vector count after"),
+            before_vectors,
+            "dry-run must not mutate drawer_vectors"
+        );
+    }
+
+    #[cfg(feature = "model2vec")]
+    #[tokio::test]
+    async fn reindex_embedder_dry_run_without_stale_is_rejected() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        let config = model2vec_dry_run_config();
+
+        let error = reindex_command_by_embedder(
+            &db,
+            &config,
+            "model2vec",
+            ReindexEmbedderMode {
+                resume: false,
+                stale_only: false,
+                dry_run: true,
+            },
+            StaleBatchTuning {
+                batch_size: 2,
+                max_batch_retries: 0,
+            },
+            empty_reindex_target(None),
+        )
+        .await
+        .expect_err("dry-run without stale must fail");
+
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("--stale"),
+            "error should tell the user to add --stale, got: {message}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5840,41 +5840,16 @@ async fn reindex_command_by_embedder(
     }
 }
 
-/// Resolve the fingerprint the live embedder path would write without
-/// constructing the embedder itself.
-fn resolve_reindex_vector_fingerprint(config: &Config, embedder_name: &str) -> Result<String> {
-    let dim = resolve_reindex_vector_dimension(config, embedder_name)?;
-    Ok(config.embed.vector_embedder_fingerprint(embedder_name, dim))
-}
-
-/// Deliberately model-free mirror of `Embedder::dimensions()` used only by
-/// reindex dry-run so stale rows can be snapshotted without loading a model or
-/// making any network call.
-///
-/// Keep this in sync with each backend's real `dimensions()` implementation.
-/// The guard tests
-/// `reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_dim_override`,
-/// `reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_default_dim`,
-/// and `reindex_embedder_dry_run_dimension_matches_real_embedder_model2vec`
-/// assert the equivalence.
-fn resolve_reindex_vector_dimension(config: &Config, embedder_name: &str) -> Result<usize> {
-    match embedder_name {
-        "openai_compat" | "api" | "stub" => Ok(config.embed.resolved_openai_dim()),
-        #[cfg(feature = "onnx")]
-        "onnx" => Ok(384),
-        #[cfg(feature = "model2vec")]
-        "model2vec" => Ok(256),
-        other => bail!("unsupported embed backend: {other}"),
-    }
-}
-
 async fn preview_reindex_stale_vector_work(
     db: &Database,
     config: &Config,
     embedder_name: &str,
     target: ReindexVectorTarget,
 ) -> Result<usize> {
-    let target_fingerprint = resolve_reindex_vector_fingerprint(config, embedder_name)?;
+    let embedder = build_specific_embedder(config, embedder_name).await?;
+    let target_fingerprint = config
+        .embed
+        .vector_embedder_fingerprint(embedder_name, embedder.dimensions());
     build_reindex_stale_pending_rows(db, &target_fingerprint, &target)
         .context("failed to snapshot stale reindex work list")
 }
@@ -12236,7 +12211,13 @@ fn phase3_adoption_wrap_command(db: &Database, opts: WrapCommandOpts) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "model2vec")]
+    use safetensors::tensor::TensorView;
+    #[cfg(feature = "model2vec")]
+    use safetensors::{Dtype, serialize_to_file};
     use std::collections::BTreeSet;
+    #[cfg(feature = "model2vec")]
+    use std::path::Path;
     use std::sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -12352,13 +12333,48 @@ mod tests {
         config
     }
 
-    fn openai_compat_dry_run_config(dim: Option<usize>) -> Config {
-        let mut config = Config::default();
-        config.embed.backend = "openai_compat".to_string();
-        config.embed.openai_compat.base_url = Some("http://127.0.0.1:18002/v1".to_string());
-        config.embed.openai_compat.model = Some("Qwen/Qwen3-Embedding-8B".to_string());
-        config.embed.openai_compat.dim = dim;
-        config
+    #[cfg(feature = "model2vec")]
+    fn write_model2vec_fixture(model_dir: &Path, dimensions: usize) {
+        std::fs::create_dir_all(model_dir).expect("create model2vec fixture dir");
+
+        let tokenizer = serde_json::json!({
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {
+                    "[UNK]": 0
+                },
+                "unk_token": "[UNK]"
+            }
+        });
+        std::fs::write(
+            model_dir.join("tokenizer.json"),
+            serde_json::to_vec(&tokenizer).expect("serialize tokenizer"),
+        )
+        .expect("write tokenizer.json");
+
+        let embedding_bytes = vec![1.0_f32; dimensions]
+            .into_iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect::<Vec<u8>>();
+        let tensor = TensorView::new(Dtype::F32, vec![1, dimensions], &embedding_bytes)
+            .expect("create embeddings tensor");
+        serialize_to_file(
+            [(String::from("embeddings"), tensor)],
+            &None,
+            &model_dir.join("model.safetensors"),
+        )
+        .expect("write model.safetensors");
+
+        std::fs::write(model_dir.join("config.json"), r#"{"normalize":true}"#)
+            .expect("write config.json");
     }
 
     fn insert_reindex_test_drawer(
@@ -12562,16 +12578,22 @@ mod tests {
     async fn reindex_embedder_dry_run_snapshots_stale_rows_without_writes() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
-        db.recreate_vectors_table(256).expect("create vector table");
+        let model_dir = tmp.path().join("model2vec-fixture");
+        write_model2vec_fixture(&model_dir, 1024);
+        let mut config = model2vec_dry_run_config();
+        config.embed.model = Some(model_dir.display().to_string());
+        let embedder = build_specific_embedder(&config, "model2vec")
+            .await
+            .expect("build local model2vec embedder");
+        let dim = embedder.dimensions();
+        db.recreate_vectors_table(dim).expect("create vector table");
 
         insert_reindex_test_drawer(&db, "fresh", "fresh content", "fixtures/source.txt", 0);
         insert_reindex_test_drawer(&db, "stale", "stale content", "fixtures/source.txt", 1);
 
-        let config = model2vec_dry_run_config();
-        let target_fingerprint = resolve_reindex_vector_fingerprint(&config, "model2vec")
-            .expect("resolve target fingerprint");
-        let fresh_vector = vec![0.1_f32; 256];
-        let stale_vector = vec![0.2_f32; 256];
+        let target_fingerprint = config.embed.vector_embedder_fingerprint("model2vec", dim);
+        let fresh_vector = vec![0.1_f32; dim];
+        let stale_vector = vec![0.2_f32; dim];
         db.insert_vector_with_project("fresh", &fresh_vector, Some("default"))
             .expect("insert fresh vector");
         db.insert_vector_with_project("stale", &stale_vector, Some("default"))
@@ -12636,43 +12658,6 @@ mod tests {
             message.contains("--stale"),
             "error should tell the user to add --stale, got: {message}"
         );
-    }
-
-    async fn assert_reindex_dry_run_matches_real_embedder(config: &Config, embedder_name: &str) {
-        let dry_run_fingerprint = resolve_reindex_vector_fingerprint(config, embedder_name)
-            .expect("resolve dry-run fingerprint");
-        let embedder = build_specific_embedder(config, embedder_name)
-            .await
-            .expect("build real embedder");
-
-        assert_eq!(
-            dry_run_fingerprint,
-            config
-                .embed
-                .vector_embedder_fingerprint(embedder_name, embedder.dimensions()),
-            "dry-run fingerprint must match the live embedder's dimensions"
-        );
-    }
-
-    #[tokio::test]
-    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_dim_override() {
-        let config = openai_compat_dry_run_config(Some(4096));
-        assert_reindex_dry_run_matches_real_embedder(&config, "openai_compat").await;
-    }
-
-    #[tokio::test]
-    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_default_dim() {
-        let config = openai_compat_dry_run_config(None);
-        assert_reindex_dry_run_matches_real_embedder(&config, "openai_compat").await;
-    }
-
-    // `onnx` is omitted here because `OnnxEmbedder::new_or_download()` fetches
-    // model assets from external URLs.
-    #[cfg(feature = "model2vec")]
-    #[tokio::test]
-    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_model2vec() {
-        let config = model2vec_dry_run_config();
-        assert_reindex_dry_run_matches_real_embedder(&config, "model2vec").await;
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5842,21 +5842,26 @@ async fn reindex_command_by_embedder(
 
 /// Resolve the fingerprint the live embedder path would write without
 /// constructing the embedder itself.
-///
-/// Dry-run uses this to snapshot stale rows without loading a model or making
-/// any network call.
 fn resolve_reindex_vector_fingerprint(config: &Config, embedder_name: &str) -> Result<String> {
     let dim = resolve_reindex_vector_dimension(config, embedder_name)?;
     Ok(config.embed.vector_embedder_fingerprint(embedder_name, dim))
 }
 
+/// Deliberately model-free mirror of `Embedder::dimensions()` used only by
+/// reindex dry-run so stale rows can be snapshotted without loading a model or
+/// making any network call.
+///
+/// Keep this in sync with each backend's real `dimensions()` implementation.
+/// The guard tests
+/// `reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_dim_override`,
+/// `reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_default_dim`,
+/// and `reindex_embedder_dry_run_dimension_matches_real_embedder_model2vec`
+/// assert the equivalence.
 fn resolve_reindex_vector_dimension(config: &Config, embedder_name: &str) -> Result<usize> {
     match embedder_name {
         "openai_compat" | "api" | "stub" => Ok(config.embed.resolved_openai_dim()),
         #[cfg(feature = "onnx")]
         "onnx" => Ok(384),
-        // The current model2vec fingerprint model in this repo is 256d
-        // (see the benchmark summary and P8 privacy spec).
         #[cfg(feature = "model2vec")]
         "model2vec" => Ok(256),
         other => bail!("unsupported embed backend: {other}"),
@@ -12347,6 +12352,15 @@ mod tests {
         config
     }
 
+    fn openai_compat_dry_run_config(dim: Option<usize>) -> Config {
+        let mut config = Config::default();
+        config.embed.backend = "openai_compat".to_string();
+        config.embed.openai_compat.base_url = Some("http://127.0.0.1:18002/v1".to_string());
+        config.embed.openai_compat.model = Some("Qwen/Qwen3-Embedding-8B".to_string());
+        config.embed.openai_compat.dim = dim;
+        config
+    }
+
     fn insert_reindex_test_drawer(
         db: &Database,
         id: &str,
@@ -12622,6 +12636,43 @@ mod tests {
             message.contains("--stale"),
             "error should tell the user to add --stale, got: {message}"
         );
+    }
+
+    async fn assert_reindex_dry_run_matches_real_embedder(config: &Config, embedder_name: &str) {
+        let dry_run_fingerprint = resolve_reindex_vector_fingerprint(config, embedder_name)
+            .expect("resolve dry-run fingerprint");
+        let embedder = build_specific_embedder(config, embedder_name)
+            .await
+            .expect("build real embedder");
+
+        assert_eq!(
+            dry_run_fingerprint,
+            config
+                .embed
+                .vector_embedder_fingerprint(embedder_name, embedder.dimensions()),
+            "dry-run fingerprint must match the live embedder's dimensions"
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_dim_override() {
+        let config = openai_compat_dry_run_config(Some(4096));
+        assert_reindex_dry_run_matches_real_embedder(&config, "openai_compat").await;
+    }
+
+    #[tokio::test]
+    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_openai_compat_default_dim() {
+        let config = openai_compat_dry_run_config(None);
+        assert_reindex_dry_run_matches_real_embedder(&config, "openai_compat").await;
+    }
+
+    // `onnx` is omitted here because `OnnxEmbedder::new_or_download()` fetches
+    // model assets from external URLs.
+    #[cfg(feature = "model2vec")]
+    #[tokio::test]
+    async fn reindex_embedder_dry_run_dimension_matches_real_embedder_model2vec() {
+        let config = model2vec_dry_run_config();
+        assert_reindex_dry_run_matches_real_embedder(&config, "model2vec").await;
     }
 
     #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "888ca61554e6bc3b77c3cb99a2742b8bcbf54ad4"
+commit = "3c1d49e645b0b15db46ee35196b6a67b08cc12c0"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Closes #344. Makes the embedder/vector reindex `--stale` path support `--dry-run`, symmetric with source reindex (which already does).

Previously `mempal reindex --from-config --stale --dry-run` (and `--embedder <name> --stale --dry-run`) hard-bailed:

```
error: --dry-run is only supported by source reindex (`mempal reindex --stale --dry-run`)
```

so there was no way to preview *"how many drawers are stale / would be re-embedded"* on the embedder/vector axis without actually running the re-embed — operators had to fall back to hand-querying `fork_ext_meta` fingerprint coverage.

## Change

- Remove the `--dry-run` bail in the embedder/vector reindex branch (`src/main.rs`).
- Thread `dry_run` into the embedder reindex path; when `--dry-run --stale`, build the stale candidate snapshot, print the candidate count + a "nothing re-embedded" line, and return **without** entering the embed batch loop — zero corpus re-embeds, zero vector writes, zero `reindex_progress`/`fork_ext_meta` mutations.
- **Single source of truth for the staleness dimension**: to decide which drawers are stale, the dry-run derives the target embedding dimension from the *same* place the live re-embed does — it builds the embedder via `build_specific_embedder(config, embedder_name)` and reads `.dimensions()`, then computes the staleness fingerprint `{backend}:{model}:{base_url}:{dim}`. This makes the preview's stale-set match a real `--stale` re-embed **by construction** for every backend. (This replaces an earlier approach that hardcoded a per-backend dimension; the model2vec dimension is *probed at runtime* and the model is configurable, so any hardcoded value would mis-preview staleness whenever the configured model isn't that exact size.)
- `--dry-run` without `--stale` on the embedder path returns an actionable error (full non-stale re-embed dry-run is out of scope).
- Honors the existing target filters (project/wing/room/drawer-id/limit) so a scoped preview is possible.

Building the embedder is cheap relative to a full-corpus re-embed (openai_compat construction is network-free; model2vec/onnx load a *local* model, consistent with the project's "零外部 LLM API 依赖（本地 model2vec / ONNX 可接受）" constraint — a real `--stale` re-embed would load it anyway). No change to actual re-embed behavior or to source reindex dry-run.

## Test

- `reindex_embedder_dry_run_snapshots_stale_rows_without_writes`: seeds drawers and runs the dry-run against a deterministic **1024-dim** model2vec fixture, asserting (a) the reported candidate count equals the seeded stale count and (b) the `drawer_vectors` row count is **unchanged** — the proof that zero corpus re-embedding happened. Because the fixture dimension is 1024 (not 256), this test **fails if anyone reintroduces a hardcoded dimension**, which is exactly the regression the review caught.
- `reindex_embedder_dry_run_without_stale_is_rejected`: asserts the non-stale dry-run path errors out.

## Gates

- [x] `just test` green
- [x] `cargo fmt` / `just clippy` clean
- [ ] `csa review --range main...HEAD` PASS  <!-- round-3, codex-tier — flip to [x] only after it passes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
