### PR TITLE
Fix mempal daemon and MCP async queue stalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ integration = []
 model2vec = ["dep:model2vec-rs"]
 onnx = ["dep:ort", "dep:tokenizers"]
 rest = ["dep:axum", "dep:tower", "dep:tower-http", "model2vec"]
+# Test-only seam: exposes `AsyncDb::with_read_delay` so the runtime-liveness /
+# read-concurrency regression tests (#345) can inject cold-read latency without
+# a multi-GB database. The default build does NOT carry this overhead.
+db-test-seam = []
 
 [dependencies]
 anyhow = "1"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,5 +21,7 @@ pre-commit:
 
 pre-push:
   commands:
+    branch-protection:
+      run: scripts/hooks/branch-protection.sh
     review-check:
       run: scripts/hooks/review-check.sh

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -173,6 +173,23 @@ impl AsyncDb {
         exec(Arc::clone(&self.readers), delay, f).await
     }
 
+    /// Run a read-only closure that returns [`anyhow::Result`] off the runtime.
+    ///
+    /// This is for higher-level orchestration paths that already compose
+    /// database calls with filesystem, parsing, or domain validation errors.
+    /// The same self-containment rules as [`run_read`](Self::run_read) apply.
+    pub async fn run_read_anyhow<F, R>(&self, f: F) -> anyhow::Result<R>
+    where
+        F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.read_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay: Option<Duration> = None;
+        exec_anyhow(Arc::clone(&self.readers), delay, f).await
+    }
+
     /// Run a read-write closure against the single writer connection off the
     /// runtime. Writes are serialized by the 1-permit writer semaphore; the same
     /// self-containment rules as [`run_read`](Self::run_read) apply.
@@ -182,6 +199,19 @@ impl AsyncDb {
         R: Send + 'static,
     {
         exec(Arc::clone(&self.writer), None, f).await
+    }
+
+    /// Run a read-write closure that returns [`anyhow::Result`] off the runtime.
+    ///
+    /// Writes are still serialized by the single writer connection. Use this
+    /// only when the closure needs to compose `Database` calls with non-DB
+    /// errors; pure database operations should prefer [`run_write`](Self::run_write).
+    pub async fn run_write_anyhow<F, R>(&self, f: F) -> anyhow::Result<R>
+    where
+        F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        exec_anyhow(Arc::clone(&self.writer), None, f).await
     }
 }
 
@@ -203,12 +233,15 @@ where
         })?;
     let conn = pool.take_or_open()?;
     let checkin_pool = Arc::clone(&pool);
+    let dispatch = tracing::dispatcher::get_default(Clone::clone);
     let join = tokio::task::spawn_blocking(move || {
-        if let Some(d) = delay {
-            std::thread::sleep(d);
-        }
-        let out = f(&conn);
-        (conn, out)
+        tracing::dispatcher::with_default(&dispatch, || {
+            if let Some(d) = delay {
+                std::thread::sleep(d);
+            }
+            let out = f(&conn);
+            (conn, out)
+        })
     })
     .await;
     match join {
@@ -220,6 +253,43 @@ where
         Err(join_err) => {
             drop(permit);
             Err(DbError::BlockingTaskFailed(join_err.to_string()))
+        }
+    }
+}
+
+async fn exec_anyhow<F, R>(pool: Arc<ConnPool>, delay: Option<Duration>, f: F) -> anyhow::Result<R>
+where
+    F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
+    R: Send + 'static,
+{
+    let permit = pool
+        .sem
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| anyhow::anyhow!("connection pool semaphore closed"))?;
+    let conn = pool.take_or_open()?;
+    let checkin_pool = Arc::clone(&pool);
+    let dispatch = tracing::dispatcher::get_default(Clone::clone);
+    let join = tokio::task::spawn_blocking(move || {
+        tracing::dispatcher::with_default(&dispatch, || {
+            if let Some(d) = delay {
+                std::thread::sleep(d);
+            }
+            let out = f(&conn);
+            (conn, out)
+        })
+    })
+    .await;
+    match join {
+        Ok((conn, out)) => {
+            checkin_pool.checkin(conn);
+            drop(permit);
+            out
+        }
+        Err(join_err) => {
+            drop(permit);
+            Err(anyhow::anyhow!("blocking database task failed: {join_err}"))
         }
     }
 }

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -52,7 +52,7 @@ const PAGE_CACHE_BUDGET_MIB: i64 = 1536;
 /// Bounded connection pool: a tokio [`Semaphore`] whose permit count equals the
 /// connection count, paired with the idle connections themselves. Acquiring a
 /// permit guarantees a connection is available (or can be reopened to self-heal
-/// after a cancelled checkout lost one).
+/// after a panicking checkout lost one).
 struct ConnPool {
     sem: Arc<Semaphore>,
     idle: Mutex<Vec<Database>>,
@@ -219,9 +219,11 @@ impl AsyncDb {
 ///
 /// Acquires a permit, hands the owned connection to the closure, then checks the
 /// connection back in *before* releasing the permit so a waiter never wakes to
-/// an empty pool on the happy path. On a closure panic (only observable with
-/// unwinding builds) the connection is dropped on the blocking thread and the
-/// pool self-heals on the next checkout.
+/// an empty pool. The permit lives inside the blocking closure, so cancelling
+/// the async caller cannot release capacity while the connection is still
+/// checked out. On a closure panic (only observable with unwinding builds) the
+/// connection is dropped on the blocking thread and the pool self-heals on the
+/// next checkout.
 async fn exec<F, R>(pool: Arc<ConnPool>, delay: Option<Duration>, f: F) -> Result<R, DbError>
 where
     F: FnOnce(&Database) -> Result<R, DbError> + Send + 'static,
@@ -235,25 +237,21 @@ where
     let checkin_pool = Arc::clone(&pool);
     let dispatch = tracing::dispatcher::get_default(Clone::clone);
     let join = tokio::task::spawn_blocking(move || {
+        let permit = permit;
         tracing::dispatcher::with_default(&dispatch, || {
             if let Some(d) = delay {
                 std::thread::sleep(d);
             }
             let out = f(&conn);
-            (conn, out)
+            checkin_pool.checkin(conn);
+            drop(permit);
+            out
         })
     })
     .await;
     match join {
-        Ok((conn, out)) => {
-            checkin_pool.checkin(conn);
-            drop(permit);
-            out
-        }
-        Err(join_err) => {
-            drop(permit);
-            Err(DbError::BlockingTaskFailed(join_err.to_string()))
-        }
+        Ok(out) => out,
+        Err(join_err) => Err(DbError::BlockingTaskFailed(join_err.to_string())),
     }
 }
 
@@ -272,25 +270,21 @@ where
     let checkin_pool = Arc::clone(&pool);
     let dispatch = tracing::dispatcher::get_default(Clone::clone);
     let join = tokio::task::spawn_blocking(move || {
+        let permit = permit;
         tracing::dispatcher::with_default(&dispatch, || {
             if let Some(d) = delay {
                 std::thread::sleep(d);
             }
             let out = f(&conn);
-            (conn, out)
+            checkin_pool.checkin(conn);
+            drop(permit);
+            out
         })
     })
     .await;
     match join {
-        Ok((conn, out)) => {
-            checkin_pool.checkin(conn);
-            drop(permit);
-            out
-        }
-        Err(join_err) => {
-            drop(permit);
-            Err(anyhow::anyhow!("blocking database task failed: {join_err}"))
-        }
+        Ok(out) => out,
+        Err(join_err) => Err(anyhow::anyhow!("blocking database task failed: {join_err}")),
     }
 }
 
@@ -420,5 +414,85 @@ mod tests {
             matches!(result, Err(DbError::PoolCacheBudgetExceeded { .. })),
             "oversized pool must be rejected with PoolCacheBudgetExceeded"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_db_error_read_keeps_permit_until_checkin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 1).expect("open async db");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let adb_for_cancel = adb.clone();
+
+        let handle = tokio::spawn(async move {
+            adb_for_cancel
+                .run_read(move |_db| {
+                    let _ = started_tx.send(());
+                    std::thread::sleep(Duration::from_millis(300));
+                    Ok::<_, DbError>(1_i64)
+                })
+                .await
+        });
+
+        started_rx.await.expect("blocking read started");
+        handle.abort();
+        let abort_err = handle.await.expect_err("read task should be cancelled");
+        assert!(abort_err.is_cancelled(), "read task must be cancelled");
+
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(100),
+            adb.run_read(|_db| Ok::<_, DbError>(2_i64)),
+        )
+        .await;
+        assert!(
+            blocked.is_err(),
+            "cancelled read must retain its permit until the blocking task checks the connection in"
+        );
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let out = adb
+            .run_read(|_db| Ok::<_, DbError>(3_i64))
+            .await
+            .expect("reader recovers after cancelled blocking task returns");
+        assert_eq!(out, 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_anyhow_read_keeps_permit_until_checkin() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 1).expect("open async db");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let adb_for_cancel = adb.clone();
+
+        let handle = tokio::spawn(async move {
+            adb_for_cancel
+                .run_read_anyhow(move |_db| {
+                    let _ = started_tx.send(());
+                    std::thread::sleep(Duration::from_millis(300));
+                    Ok(1_i64)
+                })
+                .await
+        });
+
+        started_rx.await.expect("blocking read started");
+        handle.abort();
+        let abort_err = handle.await.expect_err("read task should be cancelled");
+        assert!(abort_err.is_cancelled(), "read task must be cancelled");
+
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(100),
+            adb.run_read_anyhow(|_db| Ok(2_i64)),
+        )
+        .await;
+        assert!(
+            blocked.is_err(),
+            "cancelled anyhow read must retain its permit until the blocking task checks the connection in"
+        );
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        let out = adb
+            .run_read_anyhow(|_db| Ok(3_i64))
+            .await
+            .expect("reader recovers after cancelled blocking task returns");
+        assert_eq!(out, 3);
     }
 }

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -116,6 +116,8 @@ pub struct AsyncDb {
     /// regression tests (#345). Never present in production builds.
     #[cfg(any(test, feature = "db-test-seam"))]
     read_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    write_delay: Option<Duration>,
 }
 
 impl AsyncDb {
@@ -145,6 +147,8 @@ impl AsyncDb {
             writer: Arc::new(writer),
             #[cfg(any(test, feature = "db-test-seam"))]
             read_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            write_delay: None,
         })
     }
 
@@ -152,6 +156,13 @@ impl AsyncDb {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_read_delay(mut self, delay: Duration) -> Self {
         self.read_delay = Some(delay);
+        self
+    }
+
+    /// Inject a synthetic cold-write delay into every `run_write` (tests only).
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_write_delay(mut self, delay: Duration) -> Self {
+        self.write_delay = Some(delay);
         self
     }
 
@@ -198,7 +209,11 @@ impl AsyncDb {
         F: FnOnce(&Database) -> Result<R, DbError> + Send + 'static,
         R: Send + 'static,
     {
-        exec(Arc::clone(&self.writer), None, f).await
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.write_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay: Option<Duration> = None;
+        exec(Arc::clone(&self.writer), delay, f).await
     }
 
     /// Run a read-write closure that returns [`anyhow::Result`] off the runtime.
@@ -211,7 +226,11 @@ impl AsyncDb {
         F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
         R: Send + 'static,
     {
-        exec_anyhow(Arc::clone(&self.writer), None, f).await
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.write_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay: Option<Duration> = None;
+        exec_anyhow(Arc::clone(&self.writer), delay, f).await
     }
 }
 

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -1,0 +1,354 @@
+#![warn(clippy::all)]
+//! Off-runtime async facade over the synchronous [`Database`].
+//!
+//! Issue #345: the daemon and the MCP server ran synchronous `rusqlite` calls
+//! directly on their tokio worker threads, behind a single
+//! `Arc<AsyncMutex<Database>>`. On a multi-GB `palace.db` whose working set
+//! exceeds the page cache, a read cold-misses into a blocking `pread`; the
+//! worker thread parks in `D` state while still holding the global lock, so the
+//! whole runtime stalls and the queue makes zero progress.
+//!
+//! [`AsyncDb`] removes that pathology by running every `Database` call on a
+//! dedicated blocking thread (via [`tokio::task::spawn_blocking`]) over a small
+//! bounded pool of pre-opened connections: `n_read` `query_only` readers and
+//! exactly one writer. The tokio worker is never the thread that blocks on disk,
+//! and a connection is never held across an unrelated `.await` — each closure is
+//! self-contained and returns before the connection is checked back in.
+//!
+//! ## Connection model
+//!
+//! * **Readers** — `n_read` connections opened read-write-capable, then flipped
+//!   to `PRAGMA query_only=ON`. Opening them read-write avoids the read-only-WAL
+//!   `-shm` creation footgun while still enforcing read-only semantics at the
+//!   SQLite layer. A [`tokio::sync::Semaphore`] of `n_read` permits caps
+//!   concurrent reads at exactly the connection count.
+//! * **Writer** — a single read-write connection (size-1 pool); the 1-permit
+//!   semaphore makes the single-writer invariant structural.
+//!
+//! ## Invariants
+//!
+//! * One SQL transaction lives entirely within one `run_write` closure — no
+//!   open `Transaction` is ever handed across calls.
+//! * A task holds at most one pooled connection at a time, so the pool can never
+//!   self-deadlock waiting on its own checkout.
+//! * `(n_read + 1) × 256 MiB` page cache stays under a 1.5 GiB cap (issue #311);
+//!   `mmap_size` stays `0`.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+use tokio::sync::Semaphore;
+
+use super::db::{Database, DbError, SQLITE_CACHE_SIZE_KIB_256_MIB};
+
+/// Hard cap on the aggregate SQLite page cache across all pooled connections.
+///
+/// Each connection carries a 256 MiB cache ([`SQLITE_CACHE_SIZE_KIB_256_MIB`]);
+/// the default `n_read = 4` plus the writer is `5 × 256 MiB = 1.28 GiB`, well
+/// under this 1.5 GiB cap and far below issue #311's 4 GiB peak-memory budget.
+const PAGE_CACHE_BUDGET_MIB: i64 = 1536;
+
+/// Bounded connection pool: a tokio [`Semaphore`] whose permit count equals the
+/// connection count, paired with the idle connections themselves. Acquiring a
+/// permit guarantees a connection is available (or can be reopened to self-heal
+/// after a cancelled checkout lost one).
+struct ConnPool {
+    sem: Arc<Semaphore>,
+    idle: Mutex<Vec<Database>>,
+    path: PathBuf,
+    query_only: bool,
+}
+
+impl ConnPool {
+    /// Pre-open `count` connections at `path`. Readers (`query_only == true`)
+    /// are opened read-write-capable then flipped to `PRAGMA query_only=ON`.
+    fn open(path: &Path, count: usize, query_only: bool) -> Result<Self, DbError> {
+        let mut idle = Vec::with_capacity(count);
+        for _ in 0..count {
+            idle.push(Self::open_one(path, query_only)?);
+        }
+        Ok(Self {
+            sem: Arc::new(Semaphore::new(count)),
+            idle: Mutex::new(idle),
+            path: path.to_path_buf(),
+            query_only,
+        })
+    }
+
+    fn open_one(path: &Path, query_only: bool) -> Result<Database, DbError> {
+        let db = Database::open(path)?;
+        if query_only {
+            db.conn().pragma_update(None, "query_only", "ON")?;
+        }
+        Ok(db)
+    }
+
+    /// Pop an idle connection; reopen a fresh one if the pool was transiently
+    /// drained by a cancelled checkout (self-heal — the pool never shrinks).
+    fn take_or_open(&self) -> Result<Database, DbError> {
+        let popped = self
+            .idle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .pop();
+        match popped {
+            Some(db) => Ok(db),
+            None => Self::open_one(&self.path, self.query_only),
+        }
+    }
+
+    fn checkin(&self, db: Database) {
+        self.idle
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(db);
+    }
+}
+
+/// Off-runtime async facade over the sync [`Database`]. Cheap to clone (the
+/// connection pools live behind `Arc`s).
+#[derive(Clone)]
+pub struct AsyncDb {
+    readers: Arc<ConnPool>,
+    writer: Arc<ConnPool>,
+    /// Injected cold-read latency for the runtime-liveness / read-concurrency
+    /// regression tests (#345). Never present in production builds.
+    #[cfg(any(test, feature = "db-test-seam"))]
+    read_delay: Option<Duration>,
+}
+
+impl AsyncDb {
+    /// Open an [`AsyncDb`] backed by the database at `path` with `n_read`
+    /// read-only connections plus one writer.
+    ///
+    /// Rejects pools whose aggregate page cache would exceed
+    /// [`PAGE_CACHE_BUDGET_MIB`] (issue #311). `n_read` is clamped up to at
+    /// least 1 so the read pool always has a connection to hand out.
+    pub fn open(path: &Path, n_read: usize) -> Result<Self, DbError> {
+        let n_read = n_read.max(1);
+        let per_conn_mib = (-SQLITE_CACHE_SIZE_KIB_256_MIB) / 1024;
+        let conns = (n_read as i64) + 1;
+        let requested_mib = conns * per_conn_mib;
+        if requested_mib > PAGE_CACHE_BUDGET_MIB {
+            return Err(DbError::PoolCacheBudgetExceeded {
+                conns: conns as usize,
+                requested_mib,
+                budget_mib: PAGE_CACHE_BUDGET_MIB,
+            });
+        }
+
+        let readers = ConnPool::open(path, n_read, true)?;
+        let writer = ConnPool::open(path, 1, false)?;
+        Ok(Self {
+            readers: Arc::new(readers),
+            writer: Arc::new(writer),
+            #[cfg(any(test, feature = "db-test-seam"))]
+            read_delay: None,
+        })
+    }
+
+    /// Inject a synthetic cold-read delay into every `run_read` (tests only).
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_read_delay(mut self, delay: Duration) -> Self {
+        self.read_delay = Some(delay);
+        self
+    }
+
+    /// Run a read-only closure against a pooled reader connection off the
+    /// runtime.
+    ///
+    /// The closure receives a `&Database` and must be self-contained: it MUST
+    /// NOT span an `.await` (it runs on a blocking thread) and any SQL
+    /// transaction it opens MUST commit or roll back before it returns.
+    pub async fn run_read<F, R>(&self, f: F) -> Result<R, DbError>
+    where
+        F: FnOnce(&Database) -> Result<R, DbError> + Send + 'static,
+        R: Send + 'static,
+    {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.read_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay: Option<Duration> = None;
+        exec(Arc::clone(&self.readers), delay, f).await
+    }
+
+    /// Run a read-write closure against the single writer connection off the
+    /// runtime. Writes are serialized by the 1-permit writer semaphore; the same
+    /// self-containment rules as [`run_read`](Self::run_read) apply.
+    pub async fn run_write<F, R>(&self, f: F) -> Result<R, DbError>
+    where
+        F: FnOnce(&Database) -> Result<R, DbError> + Send + 'static,
+        R: Send + 'static,
+    {
+        exec(Arc::clone(&self.writer), None, f).await
+    }
+}
+
+/// Execute `f` on a blocking thread over a connection borrowed from `pool`.
+///
+/// Acquires a permit, hands the owned connection to the closure, then checks the
+/// connection back in *before* releasing the permit so a waiter never wakes to
+/// an empty pool on the happy path. On a closure panic (only observable with
+/// unwinding builds) the connection is dropped on the blocking thread and the
+/// pool self-heals on the next checkout.
+async fn exec<F, R>(pool: Arc<ConnPool>, delay: Option<Duration>, f: F) -> Result<R, DbError>
+where
+    F: FnOnce(&Database) -> Result<R, DbError> + Send + 'static,
+    R: Send + 'static,
+{
+    let permit =
+        pool.sem.clone().acquire_owned().await.map_err(|_| {
+            DbError::BlockingTaskFailed("connection pool semaphore closed".to_string())
+        })?;
+    let conn = pool.take_or_open()?;
+    let checkin_pool = Arc::clone(&pool);
+    let join = tokio::task::spawn_blocking(move || {
+        if let Some(d) = delay {
+            std::thread::sleep(d);
+        }
+        let out = f(&conn);
+        (conn, out)
+    })
+    .await;
+    match join {
+        Ok((conn, out)) => {
+            checkin_pool.checkin(conn);
+            drop(permit);
+            out
+        }
+        Err(join_err) => {
+            drop(permit);
+            Err(DbError::BlockingTaskFailed(join_err.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// T1 — runtime-liveness (the core #345 property). On a single-worker
+    /// runtime a ticker must keep advancing while an off-runtime read with a
+    /// 300 ms cold-read delay is outstanding. RED if `run_read` ran its closure
+    /// inline on the worker (ticker frozen at 0); GREEN with `spawn_blocking`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn t1_runtime_liveness_read_off_runtime() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(300));
+
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticks_bg = Arc::clone(&ticks);
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                ticks_bg.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let out: i64 = adb.run_read(|_db| Ok(1)).await.expect("off-runtime read");
+        ticker.abort();
+
+        assert_eq!(out, 1);
+        let observed = ticks.load(Ordering::SeqCst);
+        assert!(
+            observed >= 5,
+            "ticker advanced {observed} times during a 300ms off-runtime read; expected >= 5 \
+             (read must not occupy the only runtime worker)"
+        );
+    }
+
+    /// T2 — read concurrency up to N. Four concurrent 200 ms reads must finish
+    /// in well under their serial sum. RED on a single-shared-connection model
+    /// (serializes to ~800 ms); GREEN on the `n_read = 4` read pool (~200 ms).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn t2_read_concurrency_up_to_n() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(200));
+
+        let start = std::time::Instant::now();
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let adb = adb.clone();
+            handles.push(tokio::spawn(
+                async move { adb.run_read(|_db| Ok(1_i64)).await },
+            ));
+        }
+        for handle in handles {
+            handle.await.expect("join").expect("read");
+        }
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "4 concurrent 200ms reads took {elapsed:?}; expected < 400ms (reads run in parallel \
+             across the pool, not serialized)"
+        );
+    }
+
+    /// Every reader connection must enforce `query_only` and carry no `mmap`
+    /// (issue #311 RSS budget).
+    #[tokio::test]
+    async fn readers_are_query_only_without_mmap() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 4).expect("open async db");
+
+        let (query_only, mmap_size): (i64, i64) = adb
+            .run_read(|db| {
+                let query_only = db
+                    .conn()
+                    .query_row("PRAGMA query_only", [], |row| row.get(0))?;
+                let mmap_size = db
+                    .conn()
+                    .query_row("PRAGMA mmap_size", [], |row| row.get(0))?;
+                Ok((query_only, mmap_size))
+            })
+            .await
+            .expect("read pragmas");
+
+        assert_eq!(query_only, 1, "readers must be query_only");
+        assert_eq!(mmap_size, 0, "issue #311: pooled readers must not add mmap");
+    }
+
+    /// The writer connection must be writable (not flagged `query_only`).
+    #[tokio::test]
+    async fn writer_is_writable() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), 4).expect("open async db");
+
+        let query_only: i64 = adb
+            .run_write(|db| {
+                Ok(db
+                    .conn()
+                    .query_row("PRAGMA query_only", [], |row| row.get(0))?)
+            })
+            .await
+            .expect("read writer pragma");
+
+        assert_eq!(query_only, 0, "writer must allow writes");
+    }
+
+    /// Startup must reject a read pool whose aggregate page cache would blow the
+    /// issue #311 budget; the default-sized pool must be accepted.
+    #[test]
+    fn open_rejects_oversized_read_pool() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let path = tmp.path().join("palace.db");
+
+        // (n_read + 1) × 256 MiB: n_read = 5 ⇒ 6 conns ⇒ 1536 MiB == budget (ok).
+        AsyncDb::open(&path, 5).expect("at-budget pool opens");
+
+        // n_read = 6 ⇒ 7 conns ⇒ 1792 MiB > 1536 MiB budget (rejected before any
+        // connection is opened).
+        let result = AsyncDb::open(&path, 6);
+        assert!(
+            matches!(result, Err(DbError::PoolCacheBudgetExceeded { .. })),
+            "oversized pool must be rejected with PoolCacheBudgetExceeded"
+        );
+    }
+}

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -258,6 +258,27 @@ pub struct Database {
     path: PathBuf,
 }
 
+/// Novelty audit row to insert with a database-side mutation.
+#[derive(Debug, Clone, Copy)]
+pub struct NoveltyAuditInsert<'a> {
+    pub candidate_hash: &'a str,
+    pub action: NoveltyAction,
+    pub near_drawer_id: Option<&'a str>,
+    pub cosine: Option<f32>,
+    pub audit_decision: Option<&'a str>,
+    pub project_id: Option<&'a str>,
+}
+
+struct DrawerMergeUpdate<'a> {
+    drawer_id: &'a str,
+    merged_content: &'a str,
+    updated_at: &'a str,
+    content_hash: &'a str,
+    vector_json: &'a str,
+    vector_len: usize,
+    expected_merge_count: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GatingDropCounts {
     pub total: Option<u64>,
@@ -775,43 +796,15 @@ impl Database {
         let content_hash = content_hash_hex(merged_content);
         self.conn.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> Result<(), DbError> {
-            let updated = self.conn.execute(
-                r#"
-                UPDATE drawers
-                SET content = ?2,
-                    updated_at = ?3,
-                    content_hash = ?4,
-                    merge_count = COALESCE(merge_count, 0) + 1
-                WHERE id = ?1
-                  AND deleted_at IS NULL
-                  AND COALESCE(merge_count, 0) = ?5
-                "#,
-                params![
-                    drawer_id,
-                    merged_content,
-                    updated_at,
-                    content_hash,
-                    expected_merge_count
-                ],
-            )?;
-            if updated == 0 {
-                return Err(DbError::DrawerMergeConflict {
-                    drawer_id: drawer_id.to_string(),
-                    expected_merge_count,
-                });
-            }
-            self.conn
-                .execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
-            let project_id = self.conn.query_row(
-                "SELECT project_id FROM drawers WHERE id = ?1",
-                [drawer_id],
-                |row| row.get::<_, Option<String>>(0),
-            )?;
-            self.conn.execute(
-                "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
-                params![drawer_id, vector_json, project_id],
-            )?;
-            self.record_current_vector_metadata(drawer_id, vector.len())?;
+            self.apply_drawer_merge_update(DrawerMergeUpdate {
+                drawer_id,
+                merged_content,
+                updated_at,
+                content_hash: &content_hash,
+                vector_json: &vector_json,
+                vector_len: vector.len(),
+                expected_merge_count,
+            })?;
             Ok(())
         })();
         match result {
@@ -826,6 +819,87 @@ impl Database {
         }
     }
 
+    pub fn update_drawer_after_merge_and_record_novelty_audit(
+        &self,
+        drawer_id: &str,
+        merged_content: &str,
+        updated_at: &str,
+        vector: &[f32],
+        expected_merge_count: u32,
+        audit: NoveltyAuditInsert<'_>,
+    ) -> Result<(), DbError> {
+        self.ensure_vectors_table(vector.len())?;
+        let vector_json = serde_json::to_string(vector)?;
+        let content_hash = content_hash_hex(merged_content);
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> Result<(), DbError> {
+            self.apply_drawer_merge_update(DrawerMergeUpdate {
+                drawer_id,
+                merged_content,
+                updated_at,
+                content_hash: &content_hash,
+                vector_json: &vector_json,
+                vector_len: vector.len(),
+                expected_merge_count,
+            })?;
+            self.insert_novelty_audit_row(audit)?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    fn apply_drawer_merge_update(&self, update: DrawerMergeUpdate<'_>) -> Result<(), DbError> {
+        let updated = self.conn.execute(
+            r#"
+            UPDATE drawers
+            SET content = ?2,
+                updated_at = ?3,
+                content_hash = ?4,
+                merge_count = COALESCE(merge_count, 0) + 1
+            WHERE id = ?1
+              AND deleted_at IS NULL
+              AND COALESCE(merge_count, 0) = ?5
+            "#,
+            params![
+                update.drawer_id,
+                update.merged_content,
+                update.updated_at,
+                update.content_hash,
+                update.expected_merge_count
+            ],
+        )?;
+        if updated == 0 {
+            return Err(DbError::DrawerMergeConflict {
+                drawer_id: update.drawer_id.to_string(),
+                expected_merge_count: update.expected_merge_count,
+            });
+        }
+        self.conn.execute(
+            "DELETE FROM drawer_vectors WHERE id = ?1",
+            [update.drawer_id],
+        )?;
+        let project_id = self.conn.query_row(
+            "SELECT project_id FROM drawers WHERE id = ?1",
+            [update.drawer_id],
+            |row| row.get::<_, Option<String>>(0),
+        )?;
+        self.conn.execute(
+            "INSERT INTO drawer_vectors (id, embedding, project_id) VALUES (?1, vec_f32(?2), ?3)",
+            params![update.drawer_id, update.vector_json, project_id],
+        )?;
+        self.record_current_vector_metadata(update.drawer_id, update.vector_len)?;
+        Ok(())
+    }
+
     pub fn record_novelty_audit(
         &self,
         candidate_hash: &str,
@@ -835,6 +909,17 @@ impl Database {
         audit_decision: Option<&str>,
         project_id: Option<&str>,
     ) -> Result<(), DbError> {
+        self.insert_novelty_audit_row(NoveltyAuditInsert {
+            candidate_hash,
+            action,
+            near_drawer_id,
+            cosine,
+            audit_decision,
+            project_id,
+        })
+    }
+
+    fn insert_novelty_audit_row(&self, audit: NoveltyAuditInsert<'_>) -> Result<(), DbError> {
         let created_at = super::utils::current_timestamp()
             .parse::<i64>()
             .unwrap_or_default();
@@ -842,13 +927,15 @@ impl Database {
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_nanos())
             .unwrap_or_default();
-        let decision = audit_decision
+        let decision = audit
+            .audit_decision
             .map(ToOwned::to_owned)
-            .unwrap_or_else(|| action.as_str().to_string());
+            .unwrap_or_else(|| audit.action.as_str().to_string());
         let id_seed = format!(
-            "{candidate_hash}:{created_at}:{unique_nanos}:{decision}:{}:{}",
-            near_drawer_id.unwrap_or_default(),
-            cosine.unwrap_or_default()
+            "{}:{created_at}:{unique_nanos}:{decision}:{}:{}",
+            audit.candidate_hash,
+            audit.near_drawer_id.unwrap_or_default(),
+            audit.cosine.unwrap_or_default()
         );
         let id = format!("novelty_{}", blake3::hash(id_seed.as_bytes()).to_hex());
         self.conn.execute(
@@ -858,12 +945,12 @@ impl Database {
             "#,
             params![
                 id,
-                candidate_hash,
+                audit.candidate_hash,
                 decision,
-                near_drawer_id,
-                cosine,
+                audit.near_drawer_id,
+                audit.cosine,
                 created_at,
-                project_id
+                audit.project_id
             ],
         )?;
         Ok(())

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -228,6 +228,16 @@ pub enum DbError {
     CompactionDrawerNotFound { drawer_id: String },
     #[error("LLM compaction not yet implemented")]
     LlmCompactionNotImplemented,
+    #[error("off-runtime database task failed to complete: {0}")]
+    BlockingTaskFailed(String),
+    #[error(
+        "read-pool cache budget exceeded: {conns} connections request {requested_mib} MiB of page cache, over the {budget_mib} MiB cap (issue #311)"
+    )]
+    PoolCacheBudgetExceeded {
+        conns: usize,
+        requested_mib: i64,
+        budget_mib: i64,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -226,6 +226,13 @@ pub enum DbError {
     CompactionClusterEmpty,
     #[error("compaction drawer {drawer_id} was not found, inactive, or already compacted")]
     CompactionDrawerNotFound { drawer_id: String },
+    #[error(
+        "drawer {drawer_id} changed during novelty merge: expected merge_count {expected_merge_count}"
+    )]
+    DrawerMergeConflict {
+        drawer_id: String,
+        expected_merge_count: u32,
+    },
     #[error("LLM compaction not yet implemented")]
     LlmCompactionNotImplemented,
     #[error("off-runtime database task failed to complete: {0}")]
@@ -761,13 +768,14 @@ impl Database {
         merged_content: &str,
         updated_at: &str,
         vector: &[f32],
+        expected_merge_count: u32,
     ) -> Result<(), DbError> {
         self.ensure_vectors_table(vector.len())?;
         let vector_json = serde_json::to_string(vector)?;
         let content_hash = content_hash_hex(merged_content);
         self.conn.execute_batch("BEGIN IMMEDIATE")?;
         let result = (|| -> Result<(), DbError> {
-            self.conn.execute(
+            let updated = self.conn.execute(
                 r#"
                 UPDATE drawers
                 SET content = ?2,
@@ -775,9 +783,23 @@ impl Database {
                     content_hash = ?4,
                     merge_count = COALESCE(merge_count, 0) + 1
                 WHERE id = ?1
+                  AND deleted_at IS NULL
+                  AND COALESCE(merge_count, 0) = ?5
                 "#,
-                params![drawer_id, merged_content, updated_at, content_hash],
+                params![
+                    drawer_id,
+                    merged_content,
+                    updated_at,
+                    content_hash,
+                    expected_merge_count
+                ],
             )?;
+            if updated == 0 {
+                return Err(DbError::DrawerMergeConflict {
+                    drawer_id: drawer_id.to_string(),
+                    expected_merge_count,
+                });
+            }
             self.conn
                 .execute("DELETE FROM drawer_vectors WHERE id = ?1", [drawer_id])?;
             let project_id = self.conn.query_row(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,9 +1,11 @@
 #![warn(clippy::all)]
 
 pub mod anchor;
+pub mod async_db;
 pub mod compaction;
 pub mod config;
 pub mod db;
+pub use async_db::AsyncDb;
 pub mod decay;
 pub mod hot_reload;
 pub mod patterns;

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -21,6 +21,8 @@ pub enum QueueError {
     Sqlite(#[from] rusqlite::Error),
     #[error("pending message not found: {0}")]
     MessageNotFound(String),
+    #[error("pending message claim lost: {0}")]
+    ClaimLost(String),
     #[error("retry count does not fit in u32 for message {id}")]
     RetryCountOverflow { id: String },
     #[error("blocking queue task failed: {0}")]
@@ -163,13 +165,13 @@ impl AsyncPendingMessageStore {
             .await
     }
 
-    pub async fn confirm(&self, id: String) -> Result<()> {
-        self.run(move |store| store.confirm(&id)).await
+    pub async fn confirm(&self, claim: ClaimedMessage) -> Result<()> {
+        self.run(move |store| store.confirm(&claim)).await
     }
 
     pub async fn complete_operation(
         &self,
-        id: String,
+        claim: ClaimedMessage,
         op_state: String,
         result_drawer_id: Option<String>,
         rejected_reason: Option<String>,
@@ -178,7 +180,7 @@ impl AsyncPendingMessageStore {
     ) -> Result<()> {
         self.run(move |store| {
             store.complete_operation(
-                &id,
+                &claim,
                 &op_state,
                 result_drawer_id.as_deref(),
                 rejected_reason.as_deref(),
@@ -193,22 +195,23 @@ impl AsyncPendingMessageStore {
         self.run(move |store| store.operation_status(&id)).await
     }
 
-    pub async fn mark_failed(&self, id: String, error: String) -> Result<()> {
-        self.run(move |store| store.mark_failed(&id, &error)).await
+    pub async fn mark_failed(&self, claim: ClaimedMessage, error: String) -> Result<()> {
+        self.run(move |store| store.mark_failed(&claim, &error))
+            .await
     }
 
     pub async fn mark_failed_with_disposition(
         &self,
-        id: String,
+        claim: ClaimedMessage,
         error: String,
         disposition: QueueFailureDisposition,
     ) -> Result<()> {
-        self.run(move |store| store.mark_failed_with_disposition(&id, &error, disposition))
+        self.run(move |store| store.mark_failed_with_disposition(&claim, &error, disposition))
             .await
     }
 
-    pub async fn release_claim(&self, id: String) -> Result<()> {
-        self.run(move |store| store.release_claim(&id)).await
+    pub async fn release_claim(&self, claim: ClaimedMessage) -> Result<()> {
+        self.run(move |store| store.release_claim(&claim)).await
     }
 
     pub async fn refresh_heartbeat(&self, id: String, worker_id: String) -> Result<()> {
@@ -446,17 +449,17 @@ impl PendingMessageStore {
         }))
     }
 
-    pub fn confirm(&self, id: &str) -> Result<()> {
+    pub fn confirm(&self, claim: &ClaimedMessage) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        confirm_in_tx(&tx, id, "completed")?;
+        confirm_in_tx(&tx, claim, "completed")?;
         tx.commit()?;
         Ok(())
     }
 
     pub fn complete_operation(
         &self,
-        id: &str,
+        claim: &ClaimedMessage,
         op_state: &str,
         result_drawer_id: Option<&str>,
         rejected_reason: Option<&str>,
@@ -465,7 +468,7 @@ impl PendingMessageStore {
     ) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        tx.execute(
+        let updated = tx.execute(
             r#"
             UPDATE pending_messages
             SET op_state = ?2,
@@ -473,18 +476,22 @@ impl PendingMessageStore {
                 rejected_reason = ?4,
                 failure_detail = ?5,
                 result_json = ?6
-            WHERE id = ?1 AND status = 'claimed'
+            WHERE id = ?1 AND status = 'claimed' AND claim_token = ?7
             "#,
             params![
-                id,
+                claim.id,
                 op_state,
                 result_drawer_id,
                 rejected_reason,
                 failure_detail,
-                result_json
+                result_json,
+                claim.claim_token
             ],
         )?;
-        confirm_in_tx(&tx, id, op_state)?;
+        if updated == 0 {
+            return Err(claim_miss_error(&tx, &claim.id)?);
+        }
+        confirm_in_tx(&tx, claim, op_state)?;
         tx.commit()?;
         Ok(())
     }
@@ -497,31 +504,40 @@ impl PendingMessageStore {
         operation_status_from_completion(&conn, id)
     }
 
-    pub fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
-        self.mark_failed_with_disposition(id, error, QueueFailureDisposition::Retryable)
+    pub fn mark_failed(&self, claim: &ClaimedMessage, error: &str) -> Result<()> {
+        self.mark_failed_with_disposition(claim, error, QueueFailureDisposition::Retryable)
     }
 
     /// Record a failed processing attempt with explicit retry/dead-letter policy.
     pub fn mark_failed_with_disposition(
         &self,
-        id: &str,
+        claim: &ClaimedMessage,
         error: &str,
         disposition: QueueFailureDisposition,
     ) -> Result<()> {
         let mut conn = self.open_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let redacted_error = sanitize_last_error(error);
-        let current_retry = tx
+        let current_retry = match tx
             .query_row(
-                "SELECT retry_count FROM pending_messages WHERE id = ?1",
-                [id],
+                r#"
+                SELECT retry_count
+                FROM pending_messages
+                WHERE id = ?1 AND status = 'claimed' AND claim_token = ?2
+                "#,
+                params![claim.id, claim.claim_token],
                 |row| row.get::<_, i64>(0),
             )
             .optional()?
-            .ok_or_else(|| QueueError::MessageNotFound(id.to_string()))?;
+        {
+            Some(retry_count) => retry_count,
+            None => return Err(claim_miss_error(&tx, &claim.id)?),
+        };
         let next_retry = current_retry.saturating_add(1);
-        let next_retry_u32 = u32::try_from(next_retry)
-            .map_err(|_| QueueError::RetryCountOverflow { id: id.to_string() })?;
+        let next_retry_u32 =
+            u32::try_from(next_retry).map_err(|_| QueueError::RetryCountOverflow {
+                id: claim.id.clone(),
+            })?;
         let terminal = disposition == QueueFailureDisposition::Terminal;
         let backoff_ms = if terminal {
             0
@@ -547,19 +563,20 @@ impl PendingMessageStore {
                 claimed_at = NULL,
                 heartbeat_at = NULL,
                 last_error = ?6
-            WHERE id = ?1
+            WHERE id = ?1 AND status = 'claimed' AND claim_token = ?7
             "#,
             params![
-                id,
+                claim.id,
                 next_retry,
                 backoff_ms,
                 next_attempt_at,
                 status,
-                redacted_error
+                redacted_error,
+                claim.claim_token
             ],
         )?;
         if updated == 0 {
-            return Err(QueueError::MessageNotFound(id.to_string()));
+            return Err(claim_miss_error(&tx, &claim.id)?);
         }
 
         tx.commit()?;
@@ -616,9 +633,10 @@ impl PendingMessageStore {
     ///
     /// Used by LLM workers cancelled due to a config hot-reload so the task is
     /// retried with the new configuration rather than charged a retry.
-    pub fn release_claim(&self, id: &str) -> Result<()> {
-        let conn = self.open_connection()?;
-        let updated = conn.execute(
+    pub fn release_claim(&self, claim: &ClaimedMessage) -> Result<()> {
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let updated = tx.execute(
             r#"
             UPDATE pending_messages
             SET status = 'pending',
@@ -642,13 +660,14 @@ impl PendingMessageStore {
                     WHEN kind = 'ingest_async' THEN NULL
                     ELSE result_json
                 END
-            WHERE id = ?1 AND status = 'claimed'
+            WHERE id = ?1 AND status = 'claimed' AND claim_token = ?2
             "#,
-            [id],
+            params![claim.id, claim.claim_token],
         )?;
         if updated == 0 {
-            return Err(QueueError::MessageNotFound(id.to_string()));
+            return Err(claim_miss_error(&tx, &claim.id)?);
         }
+        tx.commit()?;
         Ok(())
     }
 
@@ -700,8 +719,12 @@ impl PendingMessageStore {
     }
 }
 
-fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Result<()> {
-    let row = tx
+fn confirm_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    claim: &ClaimedMessage,
+    op_state: &str,
+) -> Result<()> {
+    let row = match tx
         .query_row(
             r#"
             SELECT kind,
@@ -712,9 +735,9 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Re
                    failure_detail,
                    result_json
             FROM pending_messages
-            WHERE id = ?1
+            WHERE id = ?1 AND status = 'claimed' AND claim_token = ?2
             "#,
-            [id],
+            params![claim.id, claim.claim_token],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -728,7 +751,10 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Re
             },
         )
         .optional()?
-        .ok_or_else(|| QueueError::MessageNotFound(id.to_string()))?;
+    {
+        Some(row) => row,
+        None => return Err(claim_miss_error(tx, &claim.id)?),
+    };
     let completed_at = now_millis();
     let processing_ms = row
         .2
@@ -762,7 +788,7 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Re
             result_json = excluded.result_json
         "#,
         params![
-            id,
+            claim.id,
             row.0,
             row.1.saturating_mul(1_000),
             row.2.map(|s| s.saturating_mul(1_000)),
@@ -775,11 +801,31 @@ fn confirm_in_tx(tx: &rusqlite::Transaction<'_>, id: &str, op_state: &str) -> Re
             row.6
         ],
     )?;
-    let updated = tx.execute("DELETE FROM pending_messages WHERE id = ?1", [id])?;
+    let updated = tx.execute(
+        r#"
+        DELETE FROM pending_messages
+        WHERE id = ?1 AND status = 'claimed' AND claim_token = ?2
+        "#,
+        params![claim.id, claim.claim_token],
+    )?;
     if updated == 0 {
-        return Err(QueueError::MessageNotFound(id.to_string()));
+        return Err(claim_miss_error(tx, &claim.id)?);
     }
     Ok(())
+}
+
+fn claim_miss_error(conn: &Connection, id: &str) -> Result<QueueError> {
+    let exists = conn
+        .query_row("SELECT 1 FROM pending_messages WHERE id = ?1", [id], |_| {
+            Ok(())
+        })
+        .optional()?
+        .is_some();
+    if exists {
+        Ok(QueueError::ClaimLost(id.to_string()))
+    } else {
+        Ok(QueueError::MessageNotFound(id.to_string()))
+    }
 }
 
 fn operation_status_from_pending(
@@ -1116,10 +1162,7 @@ mod tests {
             .await
             .expect("claim")
             .expect("claimed message");
-        store
-            .confirm(claimed.id)
-            .await
-            .expect("confirm off runtime");
+        store.confirm(claimed).await.expect("confirm off runtime");
         ticker.abort();
 
         let observed = ticks.load(Ordering::SeqCst);

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1,10 +1,12 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use blake3::Hasher;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 use thiserror::Error;
+use tokio::sync::Semaphore;
 
 use super::config::scrub_sensitive_text;
 
@@ -21,6 +23,8 @@ pub enum QueueError {
     MessageNotFound(String),
     #[error("retry count does not fit in u32 for message {id}")]
     RetryCountOverflow { id: String },
+    #[error("blocking queue task failed: {0}")]
+    BlockingTaskFailed(String),
 }
 
 pub type Result<T> = std::result::Result<T, QueueError>;
@@ -94,6 +98,164 @@ impl Default for QueueConfig {
 pub struct PendingMessageStore {
     db_path: PathBuf,
     config: QueueConfig,
+}
+
+/// Bounded async facade for [`PendingMessageStore`].
+///
+/// The queue store intentionally remains a synchronous SQLite API for CLI and
+/// test callers. Daemon and MCP async tasks must use this facade so claim,
+/// confirm, retry, release, heartbeat, and stats calls run on Tokio's blocking
+/// pool instead of occupying runtime worker threads.
+#[derive(Debug, Clone)]
+pub struct AsyncPendingMessageStore {
+    inner: PendingMessageStore,
+    permits: Arc<Semaphore>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    blocking_delay: Option<Duration>,
+}
+
+impl AsyncPendingMessageStore {
+    const DEFAULT_BLOCKING_PERMITS: usize = 4;
+
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        PendingMessageStore::new(path).map(Self::from_store)
+    }
+
+    pub fn new_without_reclaim(path: impl AsRef<Path>) -> Self {
+        Self::from_store(PendingMessageStore::new_without_reclaim(path))
+    }
+
+    pub fn from_store(inner: PendingMessageStore) -> Self {
+        Self {
+            inner,
+            permits: Arc::new(Semaphore::new(Self::DEFAULT_BLOCKING_PERMITS)),
+            #[cfg(any(test, feature = "db-test-seam"))]
+            blocking_delay: None,
+        }
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_blocking_delay(mut self, delay: Duration) -> Self {
+        self.blocking_delay = Some(delay);
+        self
+    }
+
+    pub async fn enqueue(&self, kind: String, payload: String) -> Result<String> {
+        self.run(move |store| store.enqueue(&kind, &payload)).await
+    }
+
+    pub async fn claim_next(
+        &self,
+        worker_id: String,
+        claim_ttl_secs: i64,
+    ) -> Result<Option<ClaimedMessage>> {
+        self.run(move |store| store.claim_next(&worker_id, claim_ttl_secs))
+            .await
+    }
+
+    pub async fn claim_next_by_kind(
+        &self,
+        worker_id: String,
+        claim_ttl_secs: i64,
+        kind_filter: String,
+    ) -> Result<Option<ClaimedMessage>> {
+        self.run(move |store| store.claim_next_by_kind(&worker_id, claim_ttl_secs, &kind_filter))
+            .await
+    }
+
+    pub async fn confirm(&self, id: String) -> Result<()> {
+        self.run(move |store| store.confirm(&id)).await
+    }
+
+    pub async fn complete_operation(
+        &self,
+        id: String,
+        op_state: String,
+        result_drawer_id: Option<String>,
+        rejected_reason: Option<String>,
+        failure_detail: Option<String>,
+        result_json: Option<String>,
+    ) -> Result<()> {
+        self.run(move |store| {
+            store.complete_operation(
+                &id,
+                &op_state,
+                result_drawer_id.as_deref(),
+                rejected_reason.as_deref(),
+                failure_detail.as_deref(),
+                result_json.as_deref(),
+            )
+        })
+        .await
+    }
+
+    pub async fn operation_status(&self, id: String) -> Result<Option<PendingOperationRecord>> {
+        self.run(move |store| store.operation_status(&id)).await
+    }
+
+    pub async fn mark_failed(&self, id: String, error: String) -> Result<()> {
+        self.run(move |store| store.mark_failed(&id, &error)).await
+    }
+
+    pub async fn mark_failed_with_disposition(
+        &self,
+        id: String,
+        error: String,
+        disposition: QueueFailureDisposition,
+    ) -> Result<()> {
+        self.run(move |store| store.mark_failed_with_disposition(&id, &error, disposition))
+            .await
+    }
+
+    pub async fn release_claim(&self, id: String) -> Result<()> {
+        self.run(move |store| store.release_claim(&id)).await
+    }
+
+    pub async fn refresh_heartbeat(&self, id: String, worker_id: String) -> Result<()> {
+        self.run(move |store| store.refresh_heartbeat(&id, &worker_id))
+            .await
+    }
+
+    pub async fn reclaim_stale(&self, stale_secs: i64) -> Result<u64> {
+        self.run(move |store| store.reclaim_stale(stale_secs)).await
+    }
+
+    pub async fn stats(&self) -> Result<QueueStats> {
+        self.run(|store| store.stats()).await
+    }
+
+    async fn run<F, R>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(PendingMessageStore) -> Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        let permit =
+            self.permits.clone().acquire_owned().await.map_err(|_| {
+                QueueError::BlockingTaskFailed("queue semaphore closed".to_string())
+            })?;
+        let store = self.inner.clone();
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.blocking_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay: Option<Duration> = None;
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let join = tokio::task::spawn_blocking(move || {
+            let permit = permit;
+            tracing::dispatcher::with_default(&dispatch, || {
+                if let Some(delay) = delay {
+                    std::thread::sleep(delay);
+                }
+                let out = f(store);
+                drop(permit);
+                out
+            })
+        })
+        .await;
+        match join {
+            Ok(out) => out,
+            Err(error) => Err(QueueError::BlockingTaskFailed(error.to_string())),
+        }
+    }
 }
 
 impl PendingMessageStore {
@@ -920,4 +1082,51 @@ fn truncate_to_byte_limit(mut value: String, max_bytes: usize) -> String {
     }
     value.truncate(truncate_at);
     value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::Database;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_claim_confirm_run_off_runtime() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let sync_store = PendingMessageStore::new(&db_path).expect("open queue");
+        sync_store
+            .enqueue("hook_user_prompt", "{\"event\":\"UserPromptSubmit\"}")
+            .expect("enqueue");
+        let store = AsyncPendingMessageStore::from_store(sync_store)
+            .with_blocking_delay(Duration::from_millis(300));
+
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticks_bg = Arc::clone(&ticks);
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                ticks_bg.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+
+        let claimed = store
+            .claim_next("worker-a".to_string(), 60)
+            .await
+            .expect("claim")
+            .expect("claimed message");
+        store
+            .confirm(claimed.id)
+            .await
+            .expect("confirm off runtime");
+        ticker.abort();
+
+        let observed = ticks.load(Ordering::SeqCst);
+        assert!(
+            observed >= 5,
+            "ticker advanced {observed} times while delayed claim/confirm ran; \
+             queue SQLite must run off the Tokio worker"
+        );
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,6 +8,7 @@ use std::{future::Future, pin::Pin};
 
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
+    AsyncDb,
     db::Database,
     project::resolve_project_id,
     queue::{ClaimedMessage, PendingMessageStore, QueueFailureDisposition},
@@ -219,22 +220,19 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         {
             ClaimPollResult::Claimed(message) => {
                 let message_id = message.id.clone();
-                let result = {
-                    let db = context.db.lock().await;
-                    process_claimed_message_with_embedder(
-                        &db,
-                        &context.store,
-                        &worker_id,
-                        &message,
-                        &embedder,
-                        DaemonIngestContext {
-                            prototype_classifier: prototype_classifier.as_ref(),
-                            config: context.config.as_ref(),
-                            mempal_home: &context.mempal_home,
-                        },
-                    )
-                    .await
-                };
+                let result = process_claimed_message_with_embedder(
+                    &context.async_db,
+                    &context.store,
+                    &worker_id,
+                    &message,
+                    &embedder,
+                    DaemonIngestContext {
+                        prototype_classifier: prototype_classifier.as_ref(),
+                        config: context.config.as_ref(),
+                        mempal_home: &context.mempal_home,
+                    },
+                )
+                .await;
 
                 match result {
                     Ok(_) => {
@@ -352,7 +350,7 @@ pub struct DaemonIngestContext<'a> {
 }
 
 struct DrawerIngestContext<'a, E: Embedder + ?Sized> {
-    db: &'a Database,
+    db: &'a AsyncDb,
     store: &'a PendingMessageStore,
     worker_id: &'a str,
     message: &'a ClaimedMessage,
@@ -382,7 +380,7 @@ where
 }
 
 pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
-    db: &Database,
+    db: &AsyncDb,
     store: &PendingMessageStore,
     worker_id: &str,
     message: &ClaimedMessage,
@@ -391,7 +389,13 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
 ) -> Result<String> {
     let envelope: CapturedHookEnvelope =
         serde_json::from_str(&message.payload).context("failed to decode queued hook envelope")?;
-    let records = build_drawer_records(db, &envelope, context.config, context.mempal_home)?;
+    let records = {
+        let envelope = envelope.clone();
+        let config = (*context.config).clone();
+        let mempal_home = context.mempal_home.to_path_buf();
+        db.run_write_anyhow(move |db| build_drawer_records(db, &envelope, &config, &mempal_home))
+            .await?
+    };
     let drawer_context = DrawerIngestContext {
         db,
         store,
@@ -404,13 +408,22 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
     let mut last_drawer_id = None;
     for record in records {
         let drawer_id = ingest_drawer_record(&drawer_context, record).await?;
-        if let Err(error) = suggest_for_drawer(
-            db,
-            context.config,
-            context.mempal_home,
-            &drawer_id,
-            GenerationOptions::default(),
-        ) {
+        let suggest_result = {
+            let config = (*context.config).clone();
+            let mempal_home = context.mempal_home.to_path_buf();
+            let drawer_id_for_suggest = drawer_id.clone();
+            db.run_read_anyhow(move |db| {
+                suggest_for_drawer(
+                    db,
+                    &config,
+                    &mempal_home,
+                    &drawer_id_for_suggest,
+                    GenerationOptions::default(),
+                )
+            })
+            .await
+        };
+        if let Err(error) = suggest_result {
             tracing::warn!(?error, drawer_id, "hotpatch suggestion generation failed");
         }
         last_drawer_id = Some(drawer_id);
@@ -815,20 +828,26 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     context: &DrawerIngestContext<'_, E>,
     record: DrawerRecord,
 ) -> Result<String> {
-    let (drawer_id, exists) = context
-        .db
-        .resolve_ingest_drawer_id(
-            &record.wing,
-            Some(record.room.as_str()),
-            &record.content,
-            record.project_id.as_deref(),
-        )
-        .with_context(|| {
-            format!(
-                "failed to resolve drawer identity for {}/{}",
-                record.wing, record.room
-            )
-        })?;
+    let (drawer_id, exists) = {
+        let record = record.clone();
+        context
+            .db
+            .run_read_anyhow(move |db| {
+                db.resolve_ingest_drawer_id(
+                    &record.wing,
+                    Some(record.room.as_str()),
+                    &record.content,
+                    record.project_id.as_deref(),
+                )
+                .with_context(|| {
+                    format!(
+                        "failed to resolve drawer identity for {}/{}",
+                        record.wing, record.room
+                    )
+                })
+            })
+            .await?
+    };
     if exists {
         return Ok(drawer_id);
     }
@@ -848,15 +867,14 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if let Some(decision) = gating_decision.as_ref()
         && decision.is_rejected()
     {
-        context
-            .db
-            .record_gating_audit(
-                &drawer_id,
-                decision,
-                record.project_id.as_deref(),
-                Some(&candidate.content),
-            )
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        record_gating_audit_async(
+            context.db,
+            &drawer_id,
+            decision,
+            record.project_id.clone(),
+            &candidate.content,
+        )
+        .await?;
         return Ok(drawer_id);
     }
 
@@ -890,15 +908,14 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                 .embedding_classifier
                 .threshold,
         );
-        context
-            .db
-            .record_gating_audit(
-                &drawer_id,
-                &decision,
-                record.project_id.as_deref(),
-                Some(&candidate.content),
-            )
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        record_gating_audit_async(
+            context.db,
+            &drawer_id,
+            &decision,
+            record.project_id.clone(),
+            &candidate.content,
+        )
+        .await?;
         gating_audit_recorded = true;
         if decision.is_rejected() {
             return Ok(drawer_id);
@@ -907,15 +924,14 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         vector = Some(candidate_vector);
     }
     if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
-        context
-            .db
-            .record_gating_audit(
-                &drawer_id,
-                decision,
-                record.project_id.as_deref(),
-                Some(&candidate.content),
-            )
-            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        record_gating_audit_async(
+            context.db,
+            &drawer_id,
+            decision,
+            record.project_id.clone(),
+            &candidate.content,
+        )
+        .await?;
     }
 
     if should_enqueue_llm_gating(context.daemon.config, &gating_decision) {
@@ -957,51 +973,54 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         }
     };
     if record.bypass_novelty {
-        insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+        insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
+            .await?;
         return Ok(drawer_id);
     }
 
-    let novelty = evaluate_novelty(
-        context.db,
-        &NoveltyCandidate {
+    let novelty = {
+        let candidate = NoveltyCandidate {
             wing: record.wing.clone(),
             room: Some(record.room.clone()),
             project_id: record.project_id.clone(),
-        },
-        &vector,
-        &context.daemon.config.ingest_gating.novelty,
-    );
+        };
+        let vector = vector.clone();
+        let config = context.daemon.config.ingest_gating.novelty.clone();
+        context
+            .db
+            .run_read_anyhow(move |db| Ok(evaluate_novelty(db, &candidate, &vector, &config)))
+            .await?
+    };
     match novelty.action {
         NoveltyAction::Insert => {
             if novelty.should_audit {
-                context
-                    .db
-                    .record_novelty_audit(
-                        &drawer_id,
-                        NoveltyAction::Insert,
-                        novelty.near_drawer_id.as_deref(),
-                        novelty.cosine,
-                        novelty.audit_decision,
-                        record.project_id.as_deref(),
-                    )
-                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                record_novelty_audit_async(
+                    context.db,
+                    &drawer_id,
+                    NoveltyAction::Insert,
+                    novelty.near_drawer_id.clone(),
+                    novelty.cosine,
+                    novelty.audit_decision.map(ToOwned::to_owned),
+                    record.project_id.clone(),
+                )
+                .await?;
             }
-            insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+            insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
+                .await?;
             Ok(drawer_id)
         }
         NoveltyAction::Drop => {
             if novelty.should_audit {
-                context
-                    .db
-                    .record_novelty_audit(
-                        &drawer_id,
-                        NoveltyAction::Drop,
-                        novelty.near_drawer_id.as_deref(),
-                        novelty.cosine,
-                        novelty.audit_decision,
-                        record.project_id.as_deref(),
-                    )
-                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+                record_novelty_audit_async(
+                    context.db,
+                    &drawer_id,
+                    NoveltyAction::Drop,
+                    novelty.near_drawer_id.clone(),
+                    novelty.cosine,
+                    novelty.audit_decision.map(ToOwned::to_owned),
+                    record.project_id.clone(),
+                )
+                .await?;
             }
             Ok(novelty.near_drawer_id.unwrap_or(drawer_id))
         }
@@ -1022,11 +1041,19 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                     .with_context(|| format!("failed to lock merge target {}", target_id))?,
                 )
             };
-            let (existing_content, merge_count) = context
-                .db
-                .drawer_merge_state(&target_id)
-                .with_context(|| format!("failed to load merge target {}", target_id))?
-                .ok_or_else(|| anyhow::anyhow!("novelty merge target missing: {}", target_id))?;
+            let (existing_content, merge_count) = {
+                let target_id = target_id.clone();
+                context
+                    .db
+                    .run_read_anyhow(move |db| {
+                        db.drawer_merge_state(&target_id)
+                            .with_context(|| format!("failed to load merge target {}", target_id))?
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("novelty merge target missing: {}", target_id)
+                            })
+                    })
+                    .await?
+            };
             let merged_at = current_timestamp();
             let merged_content = format!(
                 "{existing_content}\n---\nSUPPLEMENTARY ({merged_at}):\n{}",
@@ -1047,18 +1074,23 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         .novelty
                         .max_content_bytes_per_drawer;
             if capped {
-                context
-                    .db
-                    .record_novelty_audit(
-                        &drawer_id,
-                        NoveltyAction::Insert,
-                        Some(target_id.as_str()),
-                        novelty.cosine,
-                        Some("insert_due_to_merge_cap"),
-                        record.project_id.as_deref(),
-                    )
-                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-                insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+                record_novelty_audit_async(
+                    context.db,
+                    &drawer_id,
+                    NoveltyAction::Insert,
+                    Some(target_id),
+                    novelty.cosine,
+                    Some("insert_due_to_merge_cap".to_string()),
+                    record.project_id.clone(),
+                )
+                .await?;
+                insert_drawer_with_vector_async(
+                    context.db,
+                    &drawer_id,
+                    record.clone(),
+                    vector.clone(),
+                )
+                .await?;
                 Ok(drawer_id)
             } else {
                 let merged_vector = match embed_text_with_heartbeat(
@@ -1076,47 +1108,114 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                             merged_content_bytes = merged_content.len(),
                             "novelty merge re-embed failed; fail-open insert"
                         );
-                        context
-                            .db
-                            .record_novelty_audit(
-                                &drawer_id,
-                                NoveltyAction::Insert,
-                                Some(target_id.as_str()),
-                                novelty.cosine,
-                                Some("insert_due_to_embed_error"),
-                                record.project_id.as_deref(),
-                            )
-                            .with_context(|| {
-                                format!("failed to record novelty audit {}", drawer_id)
-                            })?;
-                        insert_drawer_with_vector(context.db, &drawer_id, &record, &vector)?;
+                        record_novelty_audit_async(
+                            context.db,
+                            &drawer_id,
+                            NoveltyAction::Insert,
+                            Some(target_id),
+                            novelty.cosine,
+                            Some("insert_due_to_embed_error".to_string()),
+                            record.project_id.clone(),
+                        )
+                        .await?;
+                        insert_drawer_with_vector_async(
+                            context.db,
+                            &drawer_id,
+                            record.clone(),
+                            vector.clone(),
+                        )
+                        .await?;
                         return Ok(drawer_id);
                     }
                 };
+                let drawer_id_for_merge = drawer_id.clone();
+                let target_id_for_merge = target_id.clone();
+                let audit_decision = novelty.audit_decision.map(ToOwned::to_owned);
+                let project_id = record.project_id.clone();
                 context
                     .db
-                    .record_novelty_audit(
-                        &drawer_id,
-                        NoveltyAction::Merge,
-                        Some(target_id.as_str()),
-                        novelty.cosine,
-                        novelty.audit_decision,
-                        record.project_id.as_deref(),
-                    )
-                    .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
-                context
-                    .db
-                    .update_drawer_after_merge(
-                        &target_id,
-                        &merged_content,
-                        &merged_at,
-                        &merged_vector,
-                    )
-                    .with_context(|| format!("failed to merge hook drawer {}", target_id))?;
+                    .run_write_anyhow(move |db| {
+                        db.record_novelty_audit(
+                            &drawer_id_for_merge,
+                            NoveltyAction::Merge,
+                            Some(target_id_for_merge.as_str()),
+                            novelty.cosine,
+                            audit_decision.as_deref(),
+                            project_id.as_deref(),
+                        )
+                        .with_context(|| {
+                            format!("failed to record novelty audit {}", drawer_id_for_merge)
+                        })?;
+                        db.update_drawer_after_merge(
+                            &target_id_for_merge,
+                            &merged_content,
+                            &merged_at,
+                            &merged_vector,
+                        )
+                        .with_context(|| {
+                            format!("failed to merge hook drawer {}", target_id_for_merge)
+                        })?;
+                        Ok(())
+                    })
+                    .await?;
                 Ok(target_id)
             }
         }
     }
+}
+
+async fn record_gating_audit_async(
+    db: &AsyncDb,
+    drawer_id: &str,
+    decision: &GatingDecision,
+    project_id: Option<String>,
+    content: &str,
+) -> Result<()> {
+    let drawer_id = drawer_id.to_string();
+    let decision = decision.clone();
+    let content = content.to_string();
+    db.run_write_anyhow(move |db| {
+        db.record_gating_audit(&drawer_id, &decision, project_id.as_deref(), Some(&content))
+            .with_context(|| format!("failed to record gating audit {}", drawer_id))?;
+        Ok(())
+    })
+    .await
+}
+
+async fn record_novelty_audit_async(
+    db: &AsyncDb,
+    drawer_id: &str,
+    action: NoveltyAction,
+    near_drawer_id: Option<String>,
+    cosine: Option<f32>,
+    audit_decision: Option<String>,
+    project_id: Option<String>,
+) -> Result<()> {
+    let drawer_id = drawer_id.to_string();
+    db.run_write_anyhow(move |db| {
+        db.record_novelty_audit(
+            &drawer_id,
+            action,
+            near_drawer_id.as_deref(),
+            cosine,
+            audit_decision.as_deref(),
+            project_id.as_deref(),
+        )
+        .with_context(|| format!("failed to record novelty audit {}", drawer_id))?;
+        Ok(())
+    })
+    .await
+}
+
+async fn insert_drawer_with_vector_async(
+    db: &AsyncDb,
+    drawer_id: &str,
+    record: DrawerRecord,
+    vector: Vec<f32>,
+) -> Result<()> {
+    let drawer_id = drawer_id.to_string();
+    db.run_write_anyhow(move |db| insert_drawer_with_vector(db, &drawer_id, &record, &vector))
+        .await
 }
 
 fn insert_drawer_with_vector(
@@ -1363,6 +1462,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::core::{
+        AsyncDb,
         config::{Config, TurnStorageMode},
         db::Database,
         queue::{ClaimedMessage, PendingMessageStore, QueueError},
@@ -1468,6 +1568,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
         let store = PendingMessageStore::new(db.path()).expect("open queue");
         let captured_at = "2026-05-01T12:34:56Z";
         let hook_payload = serde_json::json!({
@@ -1502,7 +1603,7 @@ mod tests {
         let mut config = Config::default();
         config.project.id = Some("timestamp-test".to_string());
         process_claimed_message_with_embedder(
-            &db,
+            &async_db,
             &store,
             "timestamp-test-worker",
             &message,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,7 +12,7 @@ use crate::core::{
     AsyncDb,
     db::{Database, DbError},
     project::resolve_project_id,
-    queue::{ClaimedMessage, PendingMessageStore, QueueFailureDisposition},
+    queue::{AsyncPendingMessageStore, ClaimedMessage, QueueFailureDisposition},
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{BootstrapEvidenceArgs, Drawer, SourceType},
     utils::{current_timestamp, route_room_from_taxonomy, synthetic_source_file},
@@ -164,6 +164,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     let reclaimed = context
         .store
         .reclaim_stale(claim_ttl_secs)
+        .await
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
     let stall_watchdog_handle = spawn_stall_watchdog(
@@ -213,7 +214,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
 
     let mut hook_workers = JoinSet::new();
     loop {
-        context.write_observer.maybe_log_stall(&context.store);
+        context.write_observer.maybe_log_stall(&context.store).await;
         drain_finished_hook_workers(&mut hook_workers);
 
         if shutdown_requested() {
@@ -280,10 +281,14 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     let _ = stall_watchdog_handle.await;
 
     // Release any tasks still claimed by workers that were aborted or did not finish.
-    let released = context.store.reclaim_stale(0).unwrap_or_else(|error| {
-        tracing::warn!(?error, "failed to release claimed messages on shutdown");
-        0
-    });
+    let released = context
+        .store
+        .reclaim_stale(0)
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!(?error, "failed to release claimed messages on shutdown");
+            0
+        });
     if released > 0 {
         tracing::info!("released {released} claimed messages back to pending on shutdown");
     }
@@ -293,7 +298,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
 
 struct HookWorkerState {
     async_db: AsyncDb,
-    store: PendingMessageStore,
+    store: AsyncPendingMessageStore,
     worker_id: String,
     embedder: Arc<DaemonEmbedder>,
     prototype_classifier: Arc<Option<PrototypeClassifier>>,
@@ -330,7 +335,7 @@ async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMes
 
     match result {
         Ok(_) => {
-            if let Err(error) = state.store.confirm(&message_id) {
+            if let Err(error) = state.store.confirm(message_id.clone()).await {
                 tracing::error!(?error, "failed to confirm {message_id}");
                 state
                     .write_observer
@@ -343,11 +348,11 @@ async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMes
             tracing::error!("daemon message {message_id} failed: {error}");
             state.write_observer.record_error(error.to_string());
             let disposition = queue_failure_disposition(&error);
-            if let Err(mark_error) = state.store.mark_failed_with_disposition(
-                &message_id,
-                &error.to_string(),
-                disposition,
-            ) {
+            if let Err(mark_error) = state
+                .store
+                .mark_failed_with_disposition(message_id.clone(), error.to_string(), disposition)
+                .await
+            {
                 tracing::error!(?mark_error, "failed to mark_failed {message_id}");
                 state
                     .write_observer
@@ -414,7 +419,7 @@ fn handle_hook_worker_join(result: std::result::Result<(), tokio::task::JoinErro
 
 fn spawn_stall_watchdog(
     observer: crate::daemon_bootstrap::DaemonWriteObserver,
-    store: PendingMessageStore,
+    store: AsyncPendingMessageStore,
     interval: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -425,26 +430,27 @@ fn spawn_stall_watchdog(
             if shutdown_requested() {
                 break;
             }
-            observer.maybe_log_stall(&store);
+            observer.maybe_log_stall(&store).await;
         }
     })
 }
 
 trait ClaimNextSource {
-    fn claim_next(
-        &self,
-        worker_id: &str,
+    fn claim_next<'a>(
+        &'a self,
+        worker_id: &'a str,
         claim_ttl_secs: i64,
-    ) -> crate::core::queue::Result<Option<ClaimedMessage>>;
+    ) -> Pin<Box<dyn Future<Output = crate::core::queue::Result<Option<ClaimedMessage>>> + Send + 'a>>;
 }
 
-impl ClaimNextSource for PendingMessageStore {
-    fn claim_next(
-        &self,
-        worker_id: &str,
+impl ClaimNextSource for AsyncPendingMessageStore {
+    fn claim_next<'a>(
+        &'a self,
+        worker_id: &'a str,
         claim_ttl_secs: i64,
-    ) -> crate::core::queue::Result<Option<ClaimedMessage>> {
-        PendingMessageStore::claim_next(self, worker_id, claim_ttl_secs)
+    ) -> Pin<Box<dyn Future<Output = crate::core::queue::Result<Option<ClaimedMessage>>> + Send + 'a>>
+    {
+        Box::pin(async move { self.claim_next(worker_id.to_string(), claim_ttl_secs).await })
     }
 }
 
@@ -464,7 +470,7 @@ pub struct DaemonIngestContext<'a> {
 
 struct DrawerIngestContext<'a, E: Embedder + ?Sized> {
     db: &'a AsyncDb,
-    store: &'a PendingMessageStore,
+    store: &'a AsyncPendingMessageStore,
     worker_id: &'a str,
     message: &'a ClaimedMessage,
     embedder: &'a E,
@@ -481,7 +487,7 @@ async fn poll_claim_next<'a, S>(
 where
     S: Fn(Duration) -> SleepFuture<'a>,
 {
-    match store.claim_next(worker_id, claim_ttl_secs) {
+    match store.claim_next(worker_id, claim_ttl_secs).await {
         Ok(Some(message)) => ClaimPollResult::Claimed(message),
         Ok(None) => ClaimPollResult::Idle,
         Err(error) => {
@@ -494,7 +500,7 @@ where
 
 pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
     db: &AsyncDb,
-    store: &PendingMessageStore,
+    store: &AsyncPendingMessageStore,
     worker_id: &str,
     message: &ClaimedMessage,
     embedder: &E,
@@ -995,9 +1001,18 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     let heartbeat_message_id = context.message.id.clone();
     let heartbeat_worker_id = context.worker_id.to_string();
     let heartbeat = move || -> crate::embed::Result<()> {
-        heartbeat_store
-            .refresh_heartbeat(&heartbeat_message_id, &heartbeat_worker_id)
-            .map_err(|error| EmbedError::Runtime(format!("refresh heartbeat failed: {error}")))?;
+        let store = heartbeat_store.clone();
+        let message_id = heartbeat_message_id.clone();
+        let worker_id = heartbeat_worker_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = store.refresh_heartbeat(message_id.clone(), worker_id).await {
+                tracing::warn!(
+                    ?error,
+                    message_id,
+                    "failed to refresh daemon ingest heartbeat"
+                );
+            }
+        });
         Ok(())
     };
 
@@ -1292,8 +1307,8 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
 }
 
 async fn enqueue_llm_gating_after_durable_insert(
-    db: &AsyncDb,
-    store: &PendingMessageStore,
+    _db: &AsyncDb,
+    store: &AsyncPendingMessageStore,
     config: &crate::core::config::Config,
     gating_decision: &Option<GatingDecision>,
     drawer_id: &str,
@@ -1316,21 +1331,17 @@ async fn enqueue_llm_gating_after_durable_insert(
         system_prompt,
     })
     .context("failed to serialize LLM gating payload")?;
-    let store = store.clone();
     let drawer_id = drawer_id.to_string();
-    db.run_write_anyhow(move |_db| {
-        if let Err(error) = store.enqueue("llm_task", &payload) {
-            tracing::warn!(
-                ?error,
-                "failed to enqueue LLM gating task for {}",
-                drawer_id
-            );
-        } else {
-            tracing::info!("enqueued LLM gating task for {}", drawer_id);
-        }
-        Ok(())
-    })
-    .await
+    if let Err(error) = store.enqueue("llm_task".to_string(), payload).await {
+        tracing::warn!(
+            ?error,
+            "failed to enqueue LLM gating task for {}",
+            drawer_id
+        );
+    } else {
+        tracing::info!("enqueued LLM gating task for {}", drawer_id);
+    }
+    Ok(())
 }
 
 async fn record_gating_audit_async(
@@ -1636,11 +1647,12 @@ mod tests {
         AsyncDb,
         config::{Config, LlmJudgeConfig, TurnStorageMode},
         db::Database,
-        queue::{ClaimedMessage, PendingMessageStore, QueueError},
+        queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueError},
         types::{Drawer, SourceType},
     };
     use crate::embed::{EmbedError, Embedder};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
+    use std::pin::Pin;
 
     use super::{
         ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext, HookWorkerState,
@@ -1661,16 +1673,22 @@ mod tests {
     }
 
     impl ClaimNextSource for StubClaimSource {
-        fn claim_next(
-            &self,
-            _worker_id: &str,
+        fn claim_next<'a>(
+            &'a self,
+            _worker_id: &'a str,
             _claim_ttl_secs: i64,
-        ) -> crate::core::queue::Result<Option<ClaimedMessage>> {
-            self.responses
-                .lock()
-                .expect("responses mutex")
-                .pop_front()
-                .expect("stub response")
+        ) -> Pin<
+            Box<
+                dyn Future<Output = crate::core::queue::Result<Option<ClaimedMessage>>> + Send + 'a,
+            >,
+        > {
+            Box::pin(std::future::ready(
+                self.responses
+                    .lock()
+                    .expect("responses mutex")
+                    .pop_front()
+                    .expect("stub response"),
+            ))
         }
     }
 
@@ -1829,6 +1847,7 @@ mod tests {
         Database::open(&db_path).expect("open db");
         let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
         let store = PendingMessageStore::new(&db_path).expect("store");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
 
         let hook_payload = serde_json::json!({
             "tool_name": "Bash",
@@ -1877,7 +1896,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
-                store,
+                store: async_store,
                 worker_id: worker_id.to_string(),
                 embedder: std::sync::Arc::new(DaemonEmbedder {
                     primary: Box::new(HeartbeatProbeEmbedder {
@@ -1925,6 +1944,7 @@ mod tests {
             .expect("insert target vector");
         let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
         let store = PendingMessageStore::new(&db_path).expect("store");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
 
         let hook_payload = serde_json::json!({
             "tool_name": "Bash",
@@ -1968,7 +1988,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
-                store: store.clone(),
+                store: async_store,
                 worker_id: "merge-conflict-worker".to_string(),
                 embedder: Arc::new(DaemonEmbedder {
                     primary: Box::new(MergeConflictProbeEmbedder {
@@ -2055,6 +2075,7 @@ mod tests {
         let db = Database::open(&db_path).expect("open db");
         let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
         let store = PendingMessageStore::new(db.path()).expect("open queue");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
         let captured_at = "2026-05-01T12:34:56Z";
         let hook_payload = serde_json::json!({
             "tool_name": "Bash",
@@ -2089,7 +2110,7 @@ mod tests {
         config.project.id = Some("timestamp-test".to_string());
         process_claimed_message_with_embedder(
             &async_db,
-            &store,
+            &async_store,
             "timestamp-test-worker",
             &message,
             &StaticEmbedder,
@@ -2122,6 +2143,7 @@ mod tests {
         let db = Database::open(&db_path).expect("open db");
         let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
         let store = PendingMessageStore::new(db.path()).expect("open queue");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
         let hook_payload = serde_json::json!({
             "tool_name": "Bash",
             "input": "printf race",
@@ -2163,7 +2185,7 @@ mod tests {
         };
         let drawer_id = process_claimed_message_with_embedder(
             &async_db,
-            &store,
+            &async_store,
             "llm-race-worker",
             &message,
             &embedder,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,7 @@ use std::{future::Future, pin::Pin};
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     AsyncDb,
-    db::{Database, DbError},
+    db::{Database, DbError, NoveltyAuditInsert},
     project::resolve_project_id,
     queue::{AsyncPendingMessageStore, ClaimedMessage, QueueFailureDisposition},
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
@@ -1349,23 +1349,20 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                 context
                     .db
                     .run_write_anyhow(move |db| {
-                        db.record_novelty_audit(
-                            &drawer_id_for_merge,
-                            NoveltyAction::Merge,
-                            Some(target_id_for_merge.as_str()),
-                            novelty.cosine,
-                            audit_decision.as_deref(),
-                            project_id.as_deref(),
-                        )
-                        .with_context(|| {
-                            format!("failed to record novelty audit {}", drawer_id_for_merge)
-                        })?;
-                        db.update_drawer_after_merge(
+                        db.update_drawer_after_merge_and_record_novelty_audit(
                             &target_id_for_merge,
                             &merged_content,
                             &merged_at,
                             &merged_vector,
                             merge_count,
+                            NoveltyAuditInsert {
+                                candidate_hash: &drawer_id_for_merge,
+                                action: NoveltyAction::Merge,
+                                near_drawer_id: Some(target_id_for_merge.as_str()),
+                                cosine: novelty.cosine,
+                                audit_decision: audit_decision.as_deref(),
+                                project_id: project_id.as_deref(),
+                            },
                         )
                         .map_err(|error| match error {
                             DbError::DrawerMergeConflict { .. } => anyhow::Error::new(error),
@@ -2209,6 +2206,18 @@ mod tests {
         assert!(content.contains("other supplement"));
         assert!(!content.contains("candidate supplement"));
         assert_eq!(merge_count, 1);
+
+        let merge_audit_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM novelty_audit WHERE decision = 'merge' AND near_drawer_id = 'existing-target'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count merge audit rows");
+        assert_eq!(
+            merge_audit_count, 0,
+            "conflicted daemon merge must not record a successful merge audit row"
+        );
     }
 
     struct LlmClaimRaceProbeEmbedder {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -347,7 +347,7 @@ async fn run_hook_worker(state: HookWorkerState, claim_ttl_secs: i64, poll_inter
         .await
         {
             ClaimPollResult::Claimed(message) => {
-                process_hook_worker_message(state.clone(), message).await;
+                process_hook_worker_message(state.clone(), message, claim_ttl_secs).await;
             }
             ClaimPollResult::Idle => tokio::time::sleep(poll_interval).await,
             ClaimPollResult::RetryAfterError => continue,
@@ -355,8 +355,18 @@ async fn run_hook_worker(state: HookWorkerState, claim_ttl_secs: i64, poll_inter
     }
 }
 
-async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMessage) {
+async fn process_hook_worker_message(
+    state: HookWorkerState,
+    message: ClaimedMessage,
+    claim_ttl_secs: i64,
+) {
     let message_id = message.id.clone();
+    let heartbeat_handle = spawn_hook_message_heartbeat(
+        state.store.clone(),
+        message_id.clone(),
+        state.worker_id.clone(),
+        hook_message_heartbeat_interval(claim_ttl_secs),
+    );
     let result = process_claimed_message_with_embedder(
         &state.async_db,
         &state.store,
@@ -398,6 +408,41 @@ async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMes
             }
         }
     }
+    heartbeat_handle.abort();
+    let _ = heartbeat_handle.await;
+}
+
+fn spawn_hook_message_heartbeat(
+    store: AsyncPendingMessageStore,
+    message_id: String,
+    worker_id: String,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if shutdown_requested() {
+                break;
+            }
+            if let Err(error) = store
+                .refresh_heartbeat(message_id.clone(), worker_id.clone())
+                .await
+            {
+                tracing::warn!(
+                    ?error,
+                    message_id,
+                    "failed to refresh hook message heartbeat"
+                );
+            }
+        }
+    })
+}
+
+fn hook_message_heartbeat_interval(claim_ttl_secs: i64) -> Duration {
+    let ttl_secs = claim_ttl_secs.max(1) as u64;
+    Duration::from_secs((ttl_secs / 3).max(1))
 }
 
 async fn wait_for_hook_worker_or_tick(hook_workers: &mut JoinSet<()>, tick: Duration) {
@@ -2038,6 +2083,7 @@ mod tests {
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
             },
             message,
+            60,
         )
         .await;
     }
@@ -2128,6 +2174,7 @@ mod tests {
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
             },
             message,
+            60,
         )
         .await;
         assert!(
@@ -2167,6 +2214,117 @@ mod tests {
     struct LlmClaimRaceProbeEmbedder {
         store: PendingMessageStore,
         embed_calls: AtomicUsize,
+    }
+
+    struct SlowEmbedder {
+        delay: Duration,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for SlowEmbedder {
+        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+            tokio::time::sleep(self.delay).await;
+            Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            3
+        }
+
+        fn name(&self) -> &str {
+            "slow-test"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hook_worker_heartbeats_long_message_processing_until_confirm() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let mempal_home = tmp.path().join(".mempal");
+        std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+        Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(&db_path).expect("store");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
+
+        let hook_payload = serde_json::json!({
+            "tool_name": "Bash",
+            "input": "printf slow",
+            "output": "slow processing",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(hook_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: hook_payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+        let queued_id = store
+            .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+            .expect("enqueue hook envelope");
+        let worker_id = "long-processing-worker";
+        let message = store
+            .claim_next(worker_id, 1)
+            .expect("claim next")
+            .expect("claimed message");
+        assert_eq!(message.id, queued_id);
+
+        let config = Config::default();
+        assert!(
+            !config.llm.enabled,
+            "test runtime config must keep LLM disabled"
+        );
+        let worker = tokio::spawn(super::process_hook_worker_message(
+            HookWorkerState {
+                async_db,
+                store: async_store.clone(),
+                worker_id: worker_id.to_string(),
+                embedder: Arc::new(DaemonEmbedder {
+                    primary: Box::new(SlowEmbedder {
+                        delay: Duration::from_secs(3),
+                    }),
+                    fallback: None,
+                }),
+                prototype_classifier: Arc::new(None),
+                config: Arc::new(config),
+                mempal_home,
+                write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+            },
+            message,
+            1,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+        let duplicate = async_store
+            .claim_next("stealing-worker".to_string(), 1)
+            .await
+            .expect("stealing worker claim_next");
+        assert!(
+            duplicate.is_none(),
+            "long-running hook processing must heartbeat so claim_next cannot reclaim it"
+        );
+
+        tokio::time::timeout(Duration::from_secs(3), worker)
+            .await
+            .expect("worker should finish")
+            .expect("worker task should not panic");
+        let completed: i64 = rusqlite::Connection::open(&db_path)
+            .expect("open sqlite")
+            .query_row(
+                "SELECT COUNT(*) FROM pending_message_completions WHERE message_id = ?1",
+                [queued_id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("count completions");
+        assert_eq!(completed, 1);
     }
 
     #[async_trait::async_trait]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -934,33 +934,6 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         .await?;
     }
 
-    if should_enqueue_llm_gating(context.daemon.config, &gating_decision) {
-        let system_prompt = context
-            .daemon
-            .config
-            .ingest_gating
-            .llm_judge
-            .as_ref()
-            .and_then(|j| j.system_prompt.clone());
-        let payload = serde_json::to_string(&crate::llm::LlmTaskPayload {
-            task_type: "gating".to_string(),
-            drawer_id: drawer_id.clone(),
-            drawer_ids: vec![drawer_id.clone()],
-            content: analysis_content(&record.content).to_string(),
-            system_prompt,
-        })
-        .context("failed to serialize LLM gating payload")?;
-        if let Err(error) = context.store.enqueue("llm_task", &payload) {
-            tracing::warn!(
-                ?error,
-                "failed to enqueue LLM gating task for {}",
-                drawer_id
-            );
-        } else {
-            tracing::info!("enqueued LLM gating task for {}", drawer_id);
-        }
-    }
-
     let vector = match vector {
         Some(vector) => vector,
         None => {
@@ -975,6 +948,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if record.bypass_novelty {
         insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
             .await?;
+        enqueue_llm_gating_after_durable_insert(
+            context.db,
+            context.store,
+            context.daemon.config,
+            &gating_decision,
+            &drawer_id,
+            &candidate.content,
+        )
+        .await?;
         return Ok(drawer_id);
     }
 
@@ -1007,6 +989,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             }
             insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
                 .await?;
+            enqueue_llm_gating_after_durable_insert(
+                context.db,
+                context.store,
+                context.daemon.config,
+                &gating_decision,
+                &drawer_id,
+                &candidate.content,
+            )
+            .await?;
             Ok(drawer_id)
         }
         NoveltyAction::Drop => {
@@ -1091,6 +1082,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                     vector.clone(),
                 )
                 .await?;
+                enqueue_llm_gating_after_durable_insert(
+                    context.db,
+                    context.store,
+                    context.daemon.config,
+                    &gating_decision,
+                    &drawer_id,
+                    &candidate.content,
+                )
+                .await?;
                 Ok(drawer_id)
             } else {
                 let merged_vector = match embed_text_with_heartbeat(
@@ -1123,6 +1123,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                             &drawer_id,
                             record.clone(),
                             vector.clone(),
+                        )
+                        .await?;
+                        enqueue_llm_gating_after_durable_insert(
+                            context.db,
+                            context.store,
+                            context.daemon.config,
+                            &gating_decision,
+                            &drawer_id,
+                            &candidate.content,
                         )
                         .await?;
                         return Ok(drawer_id);
@@ -1162,6 +1171,48 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             }
         }
     }
+}
+
+async fn enqueue_llm_gating_after_durable_insert(
+    db: &AsyncDb,
+    store: &PendingMessageStore,
+    config: &crate::core::config::Config,
+    gating_decision: &Option<GatingDecision>,
+    drawer_id: &str,
+    content: &str,
+) -> Result<()> {
+    if !should_enqueue_llm_gating(config, gating_decision) {
+        return Ok(());
+    }
+
+    let system_prompt = config
+        .ingest_gating
+        .llm_judge
+        .as_ref()
+        .and_then(|j| j.system_prompt.clone());
+    let payload = serde_json::to_string(&crate::llm::LlmTaskPayload {
+        task_type: "gating".to_string(),
+        drawer_id: drawer_id.to_string(),
+        drawer_ids: vec![drawer_id.to_string()],
+        content: content.to_string(),
+        system_prompt,
+    })
+    .context("failed to serialize LLM gating payload")?;
+    let store = store.clone();
+    let drawer_id = drawer_id.to_string();
+    db.run_write_anyhow(move |_db| {
+        if let Err(error) = store.enqueue("llm_task", &payload) {
+            tracing::warn!(
+                ?error,
+                "failed to enqueue LLM gating task for {}",
+                drawer_id
+            );
+        } else {
+            tracing::info!("enqueued LLM gating task for {}", drawer_id);
+        }
+        Ok(())
+    })
+    .await
 }
 
 async fn record_gating_audit_async(
@@ -1463,11 +1514,11 @@ mod tests {
 
     use crate::core::{
         AsyncDb,
-        config::{Config, TurnStorageMode},
+        config::{Config, LlmJudgeConfig, TurnStorageMode},
         db::Database,
         queue::{ClaimedMessage, PendingMessageStore, QueueError},
     };
-    use crate::embed::Embedder;
+    use crate::embed::{EmbedError, Embedder};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
 
     use super::{
@@ -1563,6 +1614,35 @@ mod tests {
         }
     }
 
+    struct LlmClaimRaceProbeEmbedder {
+        store: PendingMessageStore,
+        embed_calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for LlmClaimRaceProbeEmbedder {
+        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+            self.embed_calls.fetch_add(1, Ordering::SeqCst);
+            let claim = self
+                .store
+                .claim_next_by_kind("llm-race-probe", 60, "llm_task")
+                .map_err(|error| EmbedError::Runtime(format!("claim llm task failed: {error}")))?;
+            assert!(
+                claim.is_none(),
+                "LLM gating task must not be claimable before drawer/vector insert completes"
+            );
+            Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            3
+        }
+
+        fn name(&self) -> &str {
+            "llm-race-probe"
+        }
+    }
+
     #[tokio::test]
     async fn test_daemon_uses_envelope_captured_at_for_drawer_added_at() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -1628,6 +1708,94 @@ mod tests {
         assert_eq!(added_at, captured_at);
         assert_eq!(source_type, "system_generated");
         assert!((confidence - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_daemon_enqueues_llm_gating_after_drawer_vector_is_durable() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(db.path()).expect("open queue");
+        let hook_payload = serde_json::json!({
+            "tool_name": "Bash",
+            "input": "printf race",
+            "output": "durable before llm",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(hook_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: hook_payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+        let queued_id = store
+            .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+            .expect("enqueue hook envelope");
+        let message = store
+            .claim_next("llm-race-worker", 60)
+            .expect("claim next")
+            .expect("claimed message");
+        assert_eq!(message.id, queued_id);
+
+        let mut config = Config::default();
+        config.llm.enabled = true;
+        config.ingest_gating.llm_judge = Some(LlmJudgeConfig {
+            enabled: true,
+            ..LlmJudgeConfig::default()
+        });
+        let embedder = LlmClaimRaceProbeEmbedder {
+            store: store.clone(),
+            embed_calls: AtomicUsize::new(0),
+        };
+        let drawer_id = process_claimed_message_with_embedder(
+            &async_db,
+            &store,
+            "llm-race-worker",
+            &message,
+            &embedder,
+            DaemonIngestContext {
+                prototype_classifier: None,
+                config: &config,
+                mempal_home: tmp.path(),
+            },
+        )
+        .await
+        .expect("process hook envelope");
+
+        assert_eq!(embedder.embed_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            db.drawer_exists(&drawer_id).expect("drawer exists query"),
+            "drawer must exist before LLM task is claimable"
+        );
+        let vector_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM drawer_vectors WHERE id = ?1",
+                [drawer_id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("query vector");
+        assert_eq!(
+            vector_count, 1,
+            "vector must exist before LLM task is claimable"
+        );
+
+        let llm_task = store
+            .claim_next_by_kind("llm-race-final", 60, "llm_task")
+            .expect("claim llm task")
+            .expect("llm task should be queued after durable insert");
+        let task: crate::llm::LlmTaskPayload =
+            serde_json::from_str(&llm_task.payload).expect("decode llm task");
+        assert_eq!(task.drawer_id, drawer_id);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -383,7 +383,7 @@ async fn process_hook_worker_message(
 
     match result {
         Ok(_) => {
-            if let Err(error) = state.store.confirm(message_id.clone()).await {
+            if let Err(error) = state.store.confirm(message.clone()).await {
                 tracing::error!(?error, "failed to confirm {message_id}");
                 state
                     .write_observer
@@ -398,7 +398,7 @@ async fn process_hook_worker_message(
             let disposition = queue_failure_disposition(&error);
             if let Err(mark_error) = state
                 .store
-                .mark_failed_with_disposition(message_id.clone(), error.to_string(), disposition)
+                .mark_failed_with_disposition(message.clone(), error.to_string(), disposition)
                 .await
             {
                 tracing::error!(?mark_error, "failed to mark_failed {message_id}");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -28,6 +29,7 @@ use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evalua
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 use crate::daemon_bootstrap::DaemonContext;
 use crate::hook::CapturedHookEnvelope;
@@ -42,6 +44,7 @@ const SESSION_REVIEW_REJECTED_TOTAL_KEY: &str = "session_review.rejected.total";
 /// Budget given to LLM workers to finish in-flight tasks during graceful shutdown.
 /// Coupled to the orphan reaper grace period in `src/main.rs`.
 pub const DAEMON_DRAIN_BUDGET: Duration = Duration::from_secs(30);
+const DAEMON_HOOK_WORKER_LIMIT: usize = 4;
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     run_command_with_bootstrap_events(config_path, foreground, None)
@@ -144,14 +147,17 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         return Ok(());
     }
 
-    let embedder = DaemonEmbedder::from_config(context.config.as_ref())
-        .await
-        .context("failed to build daemon embedder")?;
-    let prototype_classifier =
-        compile_classifier_from_embedder(&embedder, &context.config.ingest_gating)
+    let embedder = Arc::new(
+        DaemonEmbedder::from_config(context.config.as_ref())
+            .await
+            .context("failed to build daemon embedder")?,
+    );
+    let prototype_classifier = Arc::new(
+        compile_classifier_from_embedder(embedder.as_ref(), &context.config.ingest_gating)
             .await
             .map_err(|error| anyhow::anyhow!(error.to_string()))
-            .context("gating prototype init failed")?;
+            .context("gating prototype init failed")?,
+    );
     let worker_id = format!("mempal-daemon-{}", std::process::id());
     let claim_ttl_secs = context.config.hooks.daemon_claim_ttl_secs as i64;
     let poll_interval = Duration::from_millis(context.config.hooks.daemon_poll_interval_ms);
@@ -205,12 +211,21 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         vec![]
     };
 
+    let mut hook_workers = JoinSet::new();
+    let mut hook_worker_seq: u64 = 0;
+
     loop {
         context.write_observer.maybe_log_stall(&context.store);
+        drain_finished_hook_workers(&mut hook_workers);
 
         if shutdown_requested() {
             tracing::info!("shutdown requested; stopping daemon loop");
             break;
+        }
+
+        if hook_workers.len() >= DAEMON_HOOK_WORKER_LIMIT {
+            wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
+            continue;
         }
 
         match poll_claim_next(&context.store, &worker_id, claim_ttl_secs, |duration| {
@@ -219,50 +234,30 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .await
         {
             ClaimPollResult::Claimed(message) => {
-                let message_id = message.id.clone();
-                let result = process_claimed_message_with_embedder(
-                    &context.async_db,
-                    &context.store,
-                    &worker_id,
-                    &message,
-                    &embedder,
-                    DaemonIngestContext {
-                        prototype_classifier: prototype_classifier.as_ref(),
-                        config: context.config.as_ref(),
-                        mempal_home: &context.mempal_home,
+                hook_worker_seq = hook_worker_seq.saturating_add(1);
+                spawn_hook_worker(
+                    &mut hook_workers,
+                    HookWorkerState {
+                        async_db: context.async_db.clone(),
+                        store: context.store.clone(),
+                        worker_id: format!("{worker_id}-hook-{hook_worker_seq}"),
+                        embedder: Arc::clone(&embedder),
+                        prototype_classifier: Arc::clone(&prototype_classifier),
+                        config: Arc::clone(&context.config),
+                        mempal_home: context.mempal_home.clone(),
+                        write_observer: context.write_observer.clone(),
                     },
-                )
-                .await;
-
-                match result {
-                    Ok(_) => {
-                        context
-                            .store
-                            .confirm(&message_id)
-                            .with_context(|| format!("failed to confirm {message_id}"))?;
-                        context.write_observer.record_successful_write();
-                    }
-                    Err(error) => {
-                        tracing::error!("daemon message {message_id} failed: {error}");
-                        context.write_observer.record_error(error.to_string());
-                        let disposition = queue_failure_disposition(&error);
-                        context
-                            .store
-                            .mark_failed_with_disposition(
-                                &message_id,
-                                &error.to_string(),
-                                disposition,
-                            )
-                            .with_context(|| format!("failed to mark_failed {message_id}"))?;
-                    }
-                }
+                    message,
+                );
             }
             ClaimPollResult::Idle => {
-                tokio::time::sleep(poll_interval).await;
+                wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
             }
             ClaimPollResult::RetryAfterError => continue,
         }
     }
+
+    drain_hook_workers_with_budget(&mut hook_workers, DAEMON_DRAIN_BUDGET).await;
 
     // Give LLM workers a window to finish their current tasks, then abort.
     let drain_start = tokio::time::Instant::now();
@@ -297,6 +292,127 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     }
 
     Ok(())
+}
+
+struct HookWorkerState {
+    async_db: AsyncDb,
+    store: PendingMessageStore,
+    worker_id: String,
+    embedder: Arc<DaemonEmbedder>,
+    prototype_classifier: Arc<Option<PrototypeClassifier>>,
+    config: Arc<crate::core::config::Config>,
+    mempal_home: PathBuf,
+    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
+}
+
+fn spawn_hook_worker(
+    hook_workers: &mut JoinSet<()>,
+    state: HookWorkerState,
+    message: ClaimedMessage,
+) {
+    hook_workers.spawn(async move {
+        process_hook_worker_message(state, message).await;
+    });
+}
+
+async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMessage) {
+    let message_id = message.id.clone();
+    let result = process_claimed_message_with_embedder(
+        &state.async_db,
+        &state.store,
+        &state.worker_id,
+        &message,
+        state.embedder.as_ref(),
+        DaemonIngestContext {
+            prototype_classifier: state.prototype_classifier.as_ref().as_ref(),
+            config: state.config.as_ref(),
+            mempal_home: &state.mempal_home,
+        },
+    )
+    .await;
+
+    match result {
+        Ok(_) => {
+            if let Err(error) = state.store.confirm(&message_id) {
+                tracing::error!(?error, "failed to confirm {message_id}");
+                state
+                    .write_observer
+                    .record_error(format!("failed to confirm {message_id}: {error}"));
+            } else {
+                state.write_observer.record_successful_write();
+            }
+        }
+        Err(error) => {
+            tracing::error!("daemon message {message_id} failed: {error}");
+            state.write_observer.record_error(error.to_string());
+            let disposition = queue_failure_disposition(&error);
+            if let Err(mark_error) = state.store.mark_failed_with_disposition(
+                &message_id,
+                &error.to_string(),
+                disposition,
+            ) {
+                tracing::error!(?mark_error, "failed to mark_failed {message_id}");
+                state
+                    .write_observer
+                    .record_error(format!("failed to mark_failed {message_id}: {mark_error}"));
+            }
+        }
+    }
+}
+
+fn drain_finished_hook_workers(hook_workers: &mut JoinSet<()>) {
+    while let Some(result) = hook_workers.try_join_next() {
+        handle_hook_worker_join(result);
+    }
+}
+
+async fn wait_for_hook_worker_or_tick(hook_workers: &mut JoinSet<()>, tick: Duration) {
+    if hook_workers.is_empty() {
+        tokio::time::sleep(tick).await;
+        return;
+    }
+
+    tokio::select! {
+        result = hook_workers.join_next() => {
+            if let Some(result) = result {
+                handle_hook_worker_join(result);
+            }
+        }
+        () = tokio::time::sleep(tick) => {}
+    }
+}
+
+async fn drain_hook_workers_with_budget(hook_workers: &mut JoinSet<()>, budget: Duration) {
+    let drain_start = tokio::time::Instant::now();
+    while !hook_workers.is_empty() {
+        let elapsed = drain_start.elapsed();
+        let remaining = budget.saturating_sub(elapsed);
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, hook_workers.join_next()).await {
+            Ok(Some(result)) => handle_hook_worker_join(result),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+
+    if !hook_workers.is_empty() {
+        tracing::warn!(
+            remaining = hook_workers.len(),
+            "hook workers did not exit within drain deadline; task claims will be released on shutdown"
+        );
+        hook_workers.abort_all();
+        while let Some(result) = hook_workers.join_next().await {
+            handle_hook_worker_join(result);
+        }
+    }
+}
+
+fn handle_hook_worker_join(result: std::result::Result<(), tokio::task::JoinError>) {
+    if let Err(error) = result {
+        tracing::error!(?error, "hook worker task failed");
+    }
 }
 
 fn spawn_stall_watchdog(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -212,8 +212,6 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     };
 
     let mut hook_workers = JoinSet::new();
-    let mut hook_worker_seq: u64 = 0;
-
     loop {
         context.write_observer.maybe_log_stall(&context.store);
         drain_finished_hook_workers(&mut hook_workers);
@@ -234,13 +232,12 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .await
         {
             ClaimPollResult::Claimed(message) => {
-                hook_worker_seq = hook_worker_seq.saturating_add(1);
                 spawn_hook_worker(
                     &mut hook_workers,
                     HookWorkerState {
                         async_db: context.async_db.clone(),
                         store: context.store.clone(),
-                        worker_id: format!("{worker_id}-hook-{hook_worker_seq}"),
+                        worker_id: worker_id.clone(),
                         embedder: Arc::clone(&embedder),
                         prototype_classifier: Arc::clone(&prototype_classifier),
                         config: Arc::clone(&context.config),
@@ -1625,8 +1622,10 @@ impl Embedder for DaemonEmbedder {
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::path::PathBuf;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::core::{
         AsyncDb,
@@ -1638,8 +1637,9 @@ mod tests {
     use crate::hook::{CapturedHookEnvelope, HookEvent};
 
     use super::{
-        ClaimNextSource, ClaimPollResult, DaemonIngestContext, build_drawer_records,
-        poll_claim_next, process_claimed_message_with_embedder, wing_from_cwd,
+        ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext, HookWorkerState,
+        build_drawer_records, poll_claim_next, process_claimed_message_with_embedder,
+        wing_from_cwd,
     };
 
     struct StubClaimSource {
@@ -1679,6 +1679,13 @@ mod tests {
             created_at: 0,
             claimed_at: 0,
         }
+    }
+
+    fn unix_now_secs() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before unix epoch")
+            .as_secs() as i64
     }
 
     #[tokio::test]
@@ -1728,6 +1735,124 @@ mod tests {
         fn name(&self) -> &str {
             "static-test"
         }
+    }
+
+    struct HeartbeatProbeEmbedder {
+        db_path: PathBuf,
+        message_id: String,
+        stale_heartbeat_at: i64,
+        attempts: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for HeartbeatProbeEmbedder {
+        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+            let attempt = self.attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 0 {
+                return Err(EmbedError::Runtime("transient test failure".to_string()));
+            }
+
+            let heartbeat_at: Option<i64> = rusqlite::Connection::open(&self.db_path)
+                .expect("open heartbeat probe db")
+                .query_row(
+                    "SELECT heartbeat_at FROM pending_messages WHERE id = ?1",
+                    [self.message_id.as_str()],
+                    |row| row.get(0),
+                )
+                .expect("read heartbeat");
+            assert!(
+                heartbeat_at.unwrap_or_default() > self.stale_heartbeat_at,
+                "bounded hook worker must heartbeat using the same worker id that claimed the row"
+            );
+
+            Ok(texts.iter().map(|_| vec![0.1, 0.2, 0.3]).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            3
+        }
+
+        fn name(&self) -> &str {
+            "heartbeat-probe"
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bounded_hook_worker_heartbeats_with_claim_worker_id() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let mempal_home = tmp.path().join(".mempal");
+        std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+        Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(&db_path).expect("store");
+
+        let hook_payload = serde_json::json!({
+            "tool_name": "Bash",
+            "input": "printf heartbeat",
+            "output": "ok",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(hook_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: hook_payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+        let queued_id = store
+            .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+            .expect("enqueue hook envelope");
+        let worker_id = "bounded-hook-worker";
+        let message = store
+            .claim_next(worker_id, 60)
+            .expect("claim next")
+            .expect("claimed message");
+        assert_eq!(message.id, queued_id);
+
+        let stale_heartbeat_at = unix_now_secs() - 30;
+        rusqlite::Connection::open(&db_path)
+            .expect("open sqlite")
+            .execute(
+                "UPDATE pending_messages SET claimed_at = ?2, heartbeat_at = ?2 WHERE id = ?1",
+                rusqlite::params![queued_id, stale_heartbeat_at],
+            )
+            .expect("age heartbeat");
+
+        let config = Config::default();
+        assert!(
+            !config.llm.enabled,
+            "test runtime config must keep LLM disabled"
+        );
+        super::process_hook_worker_message(
+            HookWorkerState {
+                async_db,
+                store,
+                worker_id: worker_id.to_string(),
+                embedder: std::sync::Arc::new(DaemonEmbedder {
+                    primary: Box::new(HeartbeatProbeEmbedder {
+                        db_path,
+                        message_id: message.id.clone(),
+                        stale_heartbeat_at,
+                        attempts: AtomicUsize::new(0),
+                    }),
+                    fallback: None,
+                }),
+                prototype_classifier: std::sync::Arc::new(None),
+                config: std::sync::Arc::new(config),
+                mempal_home,
+                write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+            },
+            message,
+        )
+        .await;
     }
 
     struct LlmClaimRaceProbeEmbedder {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -180,7 +180,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                 let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
                 let llm_store = std::sync::Arc::new(context.store.clone());
                 let llm_client = std::sync::Arc::new(llm_client);
-                let shared_db = context.db.clone();
+                let async_db = context.async_db.clone();
                 let write_observer = context.write_observer.clone();
                 tracing::info!("spawning {num_workers} LLM worker tasks");
                 (0..num_workers)
@@ -188,7 +188,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
                         let store = llm_store.clone();
                         let client = llm_client.clone();
                         let status = llm_status.clone();
-                        let db = shared_db.clone();
+                        let db = async_db.clone();
                         let observer = write_observer.clone();
                         tokio::spawn(async move {
                             if let Err(e) = crate::llm::worker::run_llm_worker(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,7 @@ use std::{future::Future, pin::Pin};
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     AsyncDb,
-    db::Database,
+    db::{Database, DbError},
     project::resolve_project_id,
     queue::{ClaimedMessage, PendingMessageStore, QueueFailureDisposition},
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
@@ -1273,9 +1273,14 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                             &merged_content,
                             &merged_at,
                             &merged_vector,
+                            merge_count,
                         )
-                        .with_context(|| {
-                            format!("failed to merge hook drawer {}", target_id_for_merge)
+                        .map_err(|error| match error {
+                            DbError::DrawerMergeConflict { .. } => anyhow::Error::new(error),
+                            error => anyhow::Error::new(error).context(format!(
+                                "failed to merge hook drawer {}",
+                                target_id_for_merge
+                            )),
                         })?;
                         Ok(())
                     })
@@ -1623,8 +1628,8 @@ impl Embedder for DaemonEmbedder {
 mod tests {
     use std::collections::VecDeque;
     use std::path::PathBuf;
-    use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use crate::core::{
@@ -1632,6 +1637,7 @@ mod tests {
         config::{Config, LlmJudgeConfig, TurnStorageMode},
         db::Database,
         queue::{ClaimedMessage, PendingMessageStore, QueueError},
+        types::{Drawer, SourceType},
     };
     use crate::embed::{EmbedError, Embedder};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
@@ -1777,6 +1783,43 @@ mod tests {
         }
     }
 
+    struct MergeConflictProbeEmbedder {
+        db_path: PathBuf,
+        injected: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for MergeConflictProbeEmbedder {
+        async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+            if texts.iter().any(|text| text.contains("SUPPLEMENTARY"))
+                && self
+                    .injected
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            {
+                let db = Database::open(&self.db_path)
+                    .map_err(|error| EmbedError::Runtime(format!("open db failed: {error}")))?;
+                db.update_drawer_after_merge(
+                    "existing-target",
+                    "original target\n---\nSUPPLEMENTARY (other):\nother supplement",
+                    "1713000001",
+                    &[0.8, 0.2, 0.0],
+                    0,
+                )
+                .map_err(|error| EmbedError::Runtime(format!("inject merge failed: {error}")))?;
+            }
+            Ok(texts.iter().map(|_| vec![0.9, 0.435_889_9, 0.0]).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            3
+        }
+
+        fn name(&self) -> &str {
+            "merge-conflict-probe"
+        }
+    }
+
     #[tokio::test]
     async fn test_bounded_hook_worker_heartbeats_with_claim_worker_id() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -1853,6 +1896,127 @@ mod tests {
             message,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_hook_worker_retries_stale_novelty_merge_without_overwrite() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let mempal_home = tmp.path().join(".mempal");
+        std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db = Database::open(&db_path).expect("open db");
+        let project_id = Some("merge-conflict-project");
+        db.insert_drawer_with_project(
+            &Drawer {
+                id: "existing-target".to_string(),
+                content: "original target".to_string(),
+                wing: "hooks-raw".to_string(),
+                room: Some("Bash".to_string()),
+                source_file: Some("existing-target.md".to_string()),
+                source_type: SourceType::SystemGenerated,
+                added_at: "1713000000".to_string(),
+                chunk_index: Some(0),
+                ..Drawer::default()
+            },
+            project_id,
+        )
+        .expect("insert target drawer");
+        db.insert_vector_with_project("existing-target", &[1.0, 0.0, 0.0], project_id)
+            .expect("insert target vector");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(&db_path).expect("store");
+
+        let hook_payload = serde_json::json!({
+            "tool_name": "Bash",
+            "input": "printf candidate",
+            "output": "candidate supplement",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(hook_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: hook_payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+        let queued_id = store
+            .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+            .expect("enqueue hook envelope");
+        let message = store
+            .claim_next("merge-conflict-worker", 60)
+            .expect("claim next")
+            .expect("claimed message");
+        assert_eq!(message.id, queued_id);
+
+        let mut config = Config::default();
+        config.project.id = project_id.map(ToOwned::to_owned);
+        config.ingest_gating.novelty.enabled = true;
+        config.ingest_gating.novelty.merge_threshold = 0.85;
+        config.ingest_gating.novelty.duplicate_threshold = 0.95;
+        assert!(
+            !config.llm.enabled,
+            "test runtime config must keep LLM disabled"
+        );
+        let injected = Arc::new(AtomicBool::new(false));
+        super::process_hook_worker_message(
+            HookWorkerState {
+                async_db,
+                store: store.clone(),
+                worker_id: "merge-conflict-worker".to_string(),
+                embedder: Arc::new(DaemonEmbedder {
+                    primary: Box::new(MergeConflictProbeEmbedder {
+                        db_path: db_path.clone(),
+                        injected: Arc::clone(&injected),
+                    }),
+                    fallback: None,
+                }),
+                prototype_classifier: Arc::new(None),
+                config: Arc::new(config),
+                mempal_home,
+                write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+            },
+            message,
+        )
+        .await;
+        assert!(
+            injected.load(Ordering::SeqCst),
+            "test embedder must inject a concurrent merge during re-embed"
+        );
+
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite");
+        let (status, retry_count, last_error): (String, i64, Option<String>) = conn
+            .query_row(
+                "SELECT status, retry_count, last_error FROM pending_messages WHERE id = ?1",
+                [queued_id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("query queue row");
+        assert_eq!(status, "pending");
+        assert_eq!(retry_count, 1);
+        assert!(
+            last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("changed during novelty merge")),
+            "last_error={last_error:?}"
+        );
+
+        let (content, merge_count): (String, i64) = conn
+            .query_row(
+                "SELECT content, merge_count FROM drawers WHERE id = 'existing-target'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("query target drawer");
+        assert!(content.contains("other supplement"));
+        assert!(!content.contains("candidate supplement"));
+        assert_eq!(merge_count, 1);
     }
 
     struct LlmClaimRaceProbeEmbedder {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -212,47 +212,41 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         vec![]
     };
 
+    let hook_worker_state = HookWorkerState {
+        async_db: context.async_db.clone(),
+        store: context.store.clone(),
+        worker_id: worker_id.clone(),
+        embedder: Arc::clone(&embedder),
+        prototype_classifier: Arc::clone(&prototype_classifier),
+        config: Arc::clone(&context.config),
+        mempal_home: context.mempal_home.clone(),
+        write_observer: context.write_observer.clone(),
+    };
     let mut hook_workers = JoinSet::new();
+    let mut next_hook_worker_index = 0;
+    spawn_hook_workers_until_limit(
+        &mut hook_workers,
+        &hook_worker_state,
+        &mut next_hook_worker_index,
+        claim_ttl_secs,
+        poll_interval,
+    );
     loop {
         context.write_observer.maybe_log_stall(&context.store).await;
-        drain_finished_hook_workers(&mut hook_workers);
 
         if shutdown_requested() {
             tracing::info!("shutdown requested; stopping daemon loop");
             break;
         }
 
-        if hook_workers.len() >= DAEMON_HOOK_WORKER_LIMIT {
-            wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
-            continue;
-        }
-
-        match poll_claim_next(&context.store, &worker_id, claim_ttl_secs, |duration| {
-            Box::pin(tokio::time::sleep(duration))
-        })
-        .await
-        {
-            ClaimPollResult::Claimed(message) => {
-                spawn_hook_worker(
-                    &mut hook_workers,
-                    HookWorkerState {
-                        async_db: context.async_db.clone(),
-                        store: context.store.clone(),
-                        worker_id: worker_id.clone(),
-                        embedder: Arc::clone(&embedder),
-                        prototype_classifier: Arc::clone(&prototype_classifier),
-                        config: Arc::clone(&context.config),
-                        mempal_home: context.mempal_home.clone(),
-                        write_observer: context.write_observer.clone(),
-                    },
-                    message,
-                );
-            }
-            ClaimPollResult::Idle => {
-                wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
-            }
-            ClaimPollResult::RetryAfterError => continue,
-        }
+        spawn_hook_workers_until_limit(
+            &mut hook_workers,
+            &hook_worker_state,
+            &mut next_hook_worker_index,
+            claim_ttl_secs,
+            poll_interval,
+        );
+        wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
     }
 
     drain_hook_workers_with_budget(&mut hook_workers, DAEMON_DRAIN_BUDGET).await;
@@ -296,6 +290,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone)]
 struct HookWorkerState {
     async_db: AsyncDb,
     store: AsyncPendingMessageStore,
@@ -307,14 +302,57 @@ struct HookWorkerState {
     write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
 }
 
+fn spawn_hook_workers_until_limit(
+    hook_workers: &mut JoinSet<()>,
+    state: &HookWorkerState,
+    next_worker_index: &mut usize,
+    claim_ttl_secs: i64,
+    poll_interval: Duration,
+) {
+    while hook_workers.len() < DAEMON_HOOK_WORKER_LIMIT {
+        let worker_index = *next_worker_index;
+        *next_worker_index = (*next_worker_index).saturating_add(1);
+        spawn_hook_worker(
+            hook_workers,
+            state.clone(),
+            worker_index,
+            claim_ttl_secs,
+            poll_interval,
+        );
+    }
+}
+
 fn spawn_hook_worker(
     hook_workers: &mut JoinSet<()>,
-    state: HookWorkerState,
-    message: ClaimedMessage,
+    mut state: HookWorkerState,
+    worker_index: usize,
+    claim_ttl_secs: i64,
+    poll_interval: Duration,
 ) {
+    state.worker_id = format!("{}-hook-{worker_index}", state.worker_id);
     hook_workers.spawn(async move {
-        process_hook_worker_message(state, message).await;
+        run_hook_worker(state, claim_ttl_secs, poll_interval).await;
     });
+}
+
+async fn run_hook_worker(state: HookWorkerState, claim_ttl_secs: i64, poll_interval: Duration) {
+    loop {
+        if shutdown_requested() {
+            break;
+        }
+
+        match poll_claim_next(&state.store, &state.worker_id, claim_ttl_secs, |duration| {
+            Box::pin(tokio::time::sleep(duration))
+        })
+        .await
+        {
+            ClaimPollResult::Claimed(message) => {
+                process_hook_worker_message(state.clone(), message).await;
+            }
+            ClaimPollResult::Idle => tokio::time::sleep(poll_interval).await,
+            ClaimPollResult::RetryAfterError => continue,
+        }
+    }
 }
 
 async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMessage) {
@@ -359,12 +397,6 @@ async fn process_hook_worker_message(state: HookWorkerState, message: ClaimedMes
                     .record_error(format!("failed to mark_failed {message_id}: {mark_error}"));
             }
         }
-    }
-}
-
-fn drain_finished_hook_workers(hook_workers: &mut JoinSet<()>) {
-    while let Some(result) = hook_workers.try_join_next() {
-        handle_hook_worker_join(result);
     }
 }
 
@@ -1641,7 +1673,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use crate::core::{
         AsyncDb,
@@ -1657,7 +1689,7 @@ mod tests {
     use super::{
         ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext, HookWorkerState,
         build_drawer_records, poll_claim_next, process_claimed_message_with_embedder,
-        wing_from_cwd,
+        run_hook_worker, wing_from_cwd,
     };
 
     struct StubClaimSource {
@@ -1742,6 +1774,99 @@ mod tests {
                 panic!("expected claimed message on retry")
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_bounded_hook_worker_continues_claiming_after_completed_batch() {
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let mempal_home = tmp.path().join(".mempal");
+        std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+        Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(&db_path).expect("store");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
+
+        for label in ["first", "second"] {
+            let hook_payload = serde_json::json!({
+                "tool_name": "Bash",
+                "input": format!("printf {label}"),
+                "output": label,
+                "exit_code": 0
+            })
+            .to_string();
+            let envelope = CapturedHookEnvelope {
+                event: HookEvent::PostToolUse.display_name().to_string(),
+                kind: HookEvent::PostToolUse.queue_kind().to_string(),
+                agent: "codex".to_string(),
+                captured_at: "2026-05-01T12:34:56Z".to_string(),
+                claude_cwd: tmp.path().to_string_lossy().to_string(),
+                payload: Some(hook_payload.clone()),
+                payload_path: None,
+                payload_preview: None,
+                original_size_bytes: hook_payload.len(),
+                truncated: false,
+            };
+            let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+            store
+                .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+                .expect("enqueue hook envelope");
+        }
+
+        let config = Config::default();
+        assert!(
+            !config.llm.enabled,
+            "test runtime config must keep LLM disabled"
+        );
+        let worker = tokio::spawn(run_hook_worker(
+            HookWorkerState {
+                async_db,
+                store: async_store,
+                worker_id: "bounded-continuation-worker".to_string(),
+                embedder: Arc::new(DaemonEmbedder {
+                    primary: Box::new(StaticEmbedder),
+                    fallback: None,
+                }),
+                prototype_classifier: Arc::new(None),
+                config: Arc::new(config),
+                mempal_home,
+                write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+            },
+            60,
+            Duration::from_millis(10),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let completed: i64 = rusqlite::Connection::open(&db_path)
+                    .expect("open sqlite")
+                    .query_row(
+                        "SELECT COUNT(*) FROM pending_message_completions WHERE kind = ?1",
+                        [HookEvent::PostToolUse.queue_kind()],
+                        |row| row.get(0),
+                    )
+                    .expect("count completions");
+                if completed == 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("worker should continue claiming after first completion");
+
+        let stats = store.stats().expect("queue stats");
+        assert_eq!(stats.pending, 0);
+        assert_eq!(stats.claimed, 0);
+
+        super::SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+        tokio::time::timeout(Duration::from_secs(1), worker)
+            .await
+            .expect("worker should observe shutdown")
+            .expect("worker task should not panic");
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
     }
 
     struct StaticEmbedder;

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -12,7 +12,7 @@ use crate::core::{
     AsyncDb,
     config::{Config, ConfigHandle},
     db::Database,
-    queue::PendingMessageStore,
+    queue::AsyncPendingMessageStore,
 };
 use anyhow::{Context, Result};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
@@ -46,7 +46,7 @@ pub struct DaemonContext {
     pub runtime: tokio::runtime::Runtime,
     pub db: SharedDatabase,
     pub async_db: AsyncDb,
-    pub store: PendingMessageStore,
+    pub store: AsyncPendingMessageStore,
     pub write_observer: DaemonWriteObserver,
     pub config: std::sync::Arc<crate::core::config::Config>,
     pub mempal_home: PathBuf,
@@ -87,9 +87,9 @@ impl DaemonWriteObserver {
         }
     }
 
-    pub fn maybe_log_stall(&self, store: &PendingMessageStore) {
+    pub async fn maybe_log_stall(&self, store: &AsyncPendingMessageStore) {
         let now = unix_secs();
-        let Some(diagnostic) = self.stall_diagnostic(store, now) else {
+        let Some(diagnostic) = self.stall_diagnostic(store, now).await else {
             return;
         };
         let last_log = self.inner.last_stall_log_secs.load(Ordering::Relaxed);
@@ -114,12 +114,12 @@ impl DaemonWriteObserver {
         );
     }
 
-    fn stall_diagnostic(
+    async fn stall_diagnostic(
         &self,
-        store: &PendingMessageStore,
+        store: &AsyncPendingMessageStore,
         now_secs: u64,
     ) -> Option<DaemonStallDiagnostic> {
-        let stats = match store.stats() {
+        let stats = match store.stats().await {
             Ok(stats) => stats,
             Err(error) => {
                 tracing::warn!(?error, "daemon stall detector failed to read queue stats");
@@ -242,7 +242,7 @@ fn bootstrap_inner(
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::DbOpen);
     let db = Database::open(&db_path).context("failed to open daemon database")?;
     let async_db = AsyncDb::open(&db_path, 4).context("failed to open daemon async database")?;
-    let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
+    let store = AsyncPendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     let db = Arc::new(AsyncMutex::new(db));
     let write_observer = DaemonWriteObserver::new();
 
@@ -425,16 +425,18 @@ fn redirect_stdin_to_dev_null() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::queue::PendingMessageStore;
 
-    #[test]
-    fn write_observer_reports_stall_when_queue_has_work_and_no_recent_writes() {
+    #[tokio::test]
+    async fn write_observer_reports_stall_when_queue_has_work_and_no_recent_writes() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
         Database::open(&db_path).expect("open db");
-        let store = PendingMessageStore::new(&db_path).expect("open queue");
-        store
+        let sync_store = PendingMessageStore::new(&db_path).expect("open queue");
+        sync_store
             .enqueue("hook:user-prompt-submit", "{}")
             .expect("enqueue pending message");
+        let store = AsyncPendingMessageStore::from_store(sync_store);
 
         let observer = DaemonWriteObserver::new();
         let now = unix_secs();
@@ -443,24 +445,26 @@ mod tests {
 
         let diagnostic = observer
             .stall_diagnostic(&store, now)
+            .await
             .expect("stall diagnostic");
         assert_eq!(diagnostic.queued_count, 1);
         assert!(diagnostic.seconds_since_successful_write >= DAEMON_STALL_SECONDS);
         assert_eq!(diagnostic.last_error, "failed to merge drawer");
     }
 
-    #[test]
-    fn write_observer_ignores_empty_queue() {
+    #[tokio::test]
+    async fn write_observer_ignores_empty_queue() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
         Database::open(&db_path).expect("open db");
-        let store = PendingMessageStore::new(&db_path).expect("open queue");
+        let sync_store = PendingMessageStore::new(&db_path).expect("open queue");
+        let store = AsyncPendingMessageStore::from_store(sync_store);
 
         let observer = DaemonWriteObserver::new();
         let now = unix_secs();
         observer.force_last_successful_write_for_test(now.saturating_sub(DAEMON_STALL_SECONDS));
 
-        assert_eq!(observer.stall_diagnostic(&store, now), None);
+        assert_eq!(observer.stall_diagnostic(&store, now).await, None);
     }
 
     #[test]

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -70,6 +70,11 @@ impl DaemonWriteObserver {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::new()
+    }
+
     pub fn record_successful_write(&self) {
         self.inner
             .last_successful_write_secs

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -9,6 +9,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
+    AsyncDb,
     config::{Config, ConfigHandle},
     db::Database,
     queue::PendingMessageStore,
@@ -44,6 +45,7 @@ struct DaemonStallDiagnostic {
 pub struct DaemonContext {
     pub runtime: tokio::runtime::Runtime,
     pub db: SharedDatabase,
+    pub async_db: AsyncDb,
     pub store: PendingMessageStore,
     pub write_observer: DaemonWriteObserver,
     pub config: std::sync::Arc<crate::core::config::Config>,
@@ -234,6 +236,7 @@ fn bootstrap_inner(
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::DbOpen);
     let db = Database::open(&db_path).context("failed to open daemon database")?;
+    let async_db = AsyncDb::open(&db_path, 4).context("failed to open daemon async database")?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     let db = Arc::new(AsyncMutex::new(db));
     let write_observer = DaemonWriteObserver::new();
@@ -249,6 +252,7 @@ fn bootstrap_inner(
     Ok(DaemonContext {
         runtime,
         db,
+        async_db,
         store,
         write_observer,
         config,

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::AsyncDb;
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
-use crate::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
+use crate::core::queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore};
 use crate::daemon_bootstrap::DaemonWriteObserver;
 
 use super::client::{LlmClient, LlmMessage, LlmRequest};
@@ -145,14 +145,14 @@ pub async fn run_llm_worker(
         match task_result {
             Some(Ok(())) => {
                 tracing::info!("LLM task {message_id} completed in {latency_ms}ms");
-                confirm_llm_task_async(&store, &message_id).await?;
+                confirm_llm_task_async(&store, message.clone()).await?;
                 write_observer.record_successful_write();
             }
             Some(Err(error)) => {
                 tracing::error!("LLM task {message_id} failed after {latency_ms}ms: {error}");
                 write_observer.record_error(error.to_string());
                 store
-                    .mark_failed(message_id.clone(), error.to_string())
+                    .mark_failed(message.clone(), error.to_string())
                     .await
                     .with_context(|| format!("failed to mark_failed LLM task {message_id}"))?;
             }
@@ -162,7 +162,7 @@ pub async fn run_llm_worker(
                     message_id,
                     "LLM worker restarting due to config change; releasing task back to pending"
                 );
-                if let Err(error) = store.release_claim(message_id.clone()).await {
+                if let Err(error) = store.release_claim(message.clone()).await {
                     tracing::warn!(
                         ?error,
                         message_id,
@@ -179,8 +179,12 @@ pub async fn run_llm_worker(
 }
 
 /// Confirm a completed LLM task in the pending-message store.
-async fn confirm_llm_task_async(store: &AsyncPendingMessageStore, message_id: &str) -> Result<()> {
-    match store.confirm(message_id.to_string()).await {
+async fn confirm_llm_task_async(
+    store: &AsyncPendingMessageStore,
+    claim: ClaimedMessage,
+) -> Result<()> {
+    let message_id = claim.id.clone();
+    match store.confirm(claim).await {
         Ok(()) => {}
         Err(crate::core::queue::QueueError::MessageNotFound(_)) => {
             tracing::warn!(
@@ -199,8 +203,9 @@ async fn confirm_llm_task_async(store: &AsyncPendingMessageStore, message_id: &s
 ///
 /// Async daemon workers use `confirm_llm_task_async` so queue SQLite does not
 /// run on Tokio worker threads.
-pub fn confirm_llm_task(store: &PendingMessageStore, message_id: &str) -> Result<()> {
-    match store.confirm(message_id) {
+pub fn confirm_llm_task(store: &PendingMessageStore, claim: &ClaimedMessage) -> Result<()> {
+    let message_id = claim.id.clone();
+    match store.confirm(claim) {
         Ok(()) => {}
         Err(crate::core::queue::QueueError::MessageNotFound(_)) => {
             tracing::warn!(

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -4,10 +4,11 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::core::AsyncDb;
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
 use crate::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
-use crate::daemon_bootstrap::{DaemonWriteObserver, SharedDatabase};
+use crate::daemon_bootstrap::DaemonWriteObserver;
 
 use super::client::{LlmClient, LlmMessage, LlmRequest};
 use super::retry::{self, HeartbeatCallback};
@@ -36,7 +37,7 @@ pub async fn run_llm_worker(
     store: Arc<AsyncPendingMessageStore>,
     client: Arc<LlmClient>,
     status: Arc<LlmStatus>,
-    db: SharedDatabase,
+    db: AsyncDb,
     write_observer: DaemonWriteObserver,
 ) -> Result<()> {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -217,7 +218,7 @@ pub fn confirm_llm_task(store: &PendingMessageStore, message_id: &str) -> Result
 async fn process_llm_task_shared(
     client: &LlmClient,
     status: &LlmStatus,
-    db: &SharedDatabase,
+    db: &AsyncDb,
     payload: &str,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
@@ -234,14 +235,24 @@ async fn process_llm_task_shared(
 async fn process_gating_task(
     client: &LlmClient,
     status: &LlmStatus,
-    db: &SharedDatabase,
+    db: &AsyncDb,
     task: &LlmTaskPayload,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<()> {
     let (verdict, score) = request_gating_verdict(client, status, task, config, heartbeat).await?;
-    let db = db.lock().await;
-    apply_gating_verdict(&db, task, config, &verdict, score)
+    apply_gating_verdict_async(db, task.clone(), config.clone(), verdict, score).await
+}
+
+async fn apply_gating_verdict_async(
+    db: &AsyncDb,
+    task: LlmTaskPayload,
+    config: crate::core::config::Config,
+    verdict: String,
+    score: f64,
+) -> Result<()> {
+    db.run_write_anyhow(move |db| apply_gating_verdict(db, &task, &config, &verdict, score))
+        .await
 }
 
 pub async fn process_llm_task(
@@ -388,5 +399,93 @@ fn parse_gating_verdict(content: &str) -> (String, f64) {
         ("reject".to_string(), 0.1)
     } else {
         ("keep".to_string(), 0.8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::Config;
+    use crate::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
+    use rusqlite::params;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn spawn_runtime_ticker() -> (Arc<AtomicU64>, tokio::task::JoinHandle<()>) {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticks_bg = Arc::clone(&ticks);
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                ticks_bg.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        (ticks, ticker)
+    }
+
+    fn assert_runtime_ticked(ticks: &AtomicU64, label: &str) {
+        let observed = ticks.load(Ordering::SeqCst);
+        assert!(
+            observed >= 5,
+            "{label} advanced ticker {observed} times; LLM DB verdict work must not block Tokio worker"
+        );
+    }
+
+    fn insert_drawer(db: &Database, id: &str) {
+        db.insert_drawer(&Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+            id: id.to_string(),
+            content: "LLM verdict runtime liveness drawer".to_string(),
+            wing: "llm".to_string(),
+            room: Some("runtime".to_string()),
+            source_file: Some("llm-runtime.md".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 3,
+        }))
+        .expect("insert drawer");
+    }
+
+    fn drawer_is_deleted(db: &Database, id: &str) -> bool {
+        db.conn()
+            .query_row(
+                "SELECT deleted_at IS NOT NULL FROM drawers WHERE id = ?1",
+                params![id],
+                |row| row.get::<_, bool>(0),
+            )
+            .expect("read drawer deletion state")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_llm_verdict_db_work_runs_off_runtime() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        insert_drawer(&db, "llm-verdict-offruntime");
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_write_delay(Duration::from_millis(300));
+        let task = LlmTaskPayload {
+            task_type: "gating".to_string(),
+            drawer_id: "llm-verdict-offruntime".to_string(),
+            drawer_ids: vec!["llm-verdict-offruntime".to_string()],
+            content: "judge me".to_string(),
+            system_prompt: None,
+        };
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        apply_gating_verdict_async(
+            &async_db,
+            task,
+            Config::default(),
+            "reject".to_string(),
+            0.1,
+        )
+        .await
+        .expect("apply verdict");
+        ticker.abort();
+
+        assert_runtime_ticked(&ticks, "LLM verdict");
+        assert!(drawer_is_deleted(&db, "llm-verdict-offruntime"));
     }
 }

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::config::ConfigHandle;
 use crate::core::db::Database;
-use crate::core::queue::PendingMessageStore;
+use crate::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
 use crate::daemon_bootstrap::{DaemonWriteObserver, SharedDatabase};
 
-use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest};
+use super::client::{LlmClient, LlmMessage, LlmRequest};
 use super::retry::{self, HeartbeatCallback};
 use super::status::LlmStatus;
 
@@ -33,7 +33,7 @@ pub struct LlmTaskPayload {
 }
 
 pub async fn run_llm_worker(
-    store: Arc<PendingMessageStore>,
+    store: Arc<AsyncPendingMessageStore>,
     client: Arc<LlmClient>,
     status: Arc<LlmStatus>,
     db: SharedDatabase,
@@ -48,6 +48,7 @@ pub async fn run_llm_worker(
     if idx == 0 {
         let reclaimed = store
             .reclaim_stale(LLM_CLAIM_TTL_SECS)
+            .await
             .context("LLM worker failed to reclaim stale claims")?;
         if reclaimed > 0 {
             tracing::info!("LLM worker reclaimed {reclaimed} stale tasks");
@@ -79,7 +80,13 @@ pub async fn run_llm_worker(
             tracing::info!("LLM worker: concurrency updated to {new_max}");
         }
 
-        let message = match store.claim_next_by_kind(&worker_id, LLM_CLAIM_TTL_SECS, LLM_TASK_KIND)
+        let message = match store
+            .claim_next_by_kind(
+                worker_id.clone(),
+                LLM_CLAIM_TTL_SECS,
+                LLM_TASK_KIND.to_string(),
+            )
+            .await
         {
             Ok(Some(msg)) => msg,
             Ok(None) => {
@@ -105,11 +112,14 @@ pub async fn run_llm_worker(
         let heartbeat_message_id = message.id.clone();
         let heartbeat_worker_id = worker_id.clone();
         let heartbeat: Box<HeartbeatCallback> = Box::new(move || {
-            heartbeat_store
-                .refresh_heartbeat(&heartbeat_message_id, &heartbeat_worker_id)
-                .map_err(|error| {
-                    LlmError::MissingConfiguration(format!("heartbeat failed: {error}"))
-                })?;
+            let store = heartbeat_store.clone();
+            let message_id = heartbeat_message_id.clone();
+            let worker_id = heartbeat_worker_id.clone();
+            tokio::spawn(async move {
+                if let Err(error) = store.refresh_heartbeat(message_id.clone(), worker_id).await {
+                    tracing::warn!(?error, message_id, "failed to refresh LLM task heartbeat");
+                }
+            });
             Ok(())
         });
 
@@ -134,14 +144,15 @@ pub async fn run_llm_worker(
         match task_result {
             Some(Ok(())) => {
                 tracing::info!("LLM task {message_id} completed in {latency_ms}ms");
-                confirm_llm_task(&store, &message_id)?;
+                confirm_llm_task_async(&store, &message_id).await?;
                 write_observer.record_successful_write();
             }
             Some(Err(error)) => {
                 tracing::error!("LLM task {message_id} failed after {latency_ms}ms: {error}");
                 write_observer.record_error(error.to_string());
                 store
-                    .mark_failed(&message_id, &error.to_string())
+                    .mark_failed(message_id.clone(), error.to_string())
+                    .await
                     .with_context(|| format!("failed to mark_failed LLM task {message_id}"))?;
             }
             None => {
@@ -150,7 +161,7 @@ pub async fn run_llm_worker(
                     message_id,
                     "LLM worker restarting due to config change; releasing task back to pending"
                 );
-                if let Err(error) = store.release_claim(&message_id) {
+                if let Err(error) = store.release_claim(message_id.clone()).await {
                     tracing::warn!(
                         ?error,
                         message_id,
@@ -167,6 +178,26 @@ pub async fn run_llm_worker(
 }
 
 /// Confirm a completed LLM task in the pending-message store.
+async fn confirm_llm_task_async(store: &AsyncPendingMessageStore, message_id: &str) -> Result<()> {
+    match store.confirm(message_id.to_string()).await {
+        Ok(()) => {}
+        Err(crate::core::queue::QueueError::MessageNotFound(_)) => {
+            tracing::warn!(
+                message_id,
+                "LLM task already removed before confirm; continuing"
+            );
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to confirm LLM task {message_id}"));
+        }
+    }
+    Ok(())
+}
+
+/// Confirm a completed LLM task for synchronous callers and legacy tests.
+///
+/// Async daemon workers use `confirm_llm_task_async` so queue SQLite does not
+/// run on Tokio worker threads.
 pub fn confirm_llm_task(store: &PendingMessageStore, message_id: &str) -> Result<()> {
     match store.confirm(message_id) {
         Ok(()) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3702,7 +3702,7 @@ async fn ingest_stdin_command(
             no_gate: resolved.no_gate,
             bypass_novelty: resolved.bypass_novelty,
         };
-        let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
+        let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone())?;
         let response = server
             .mempal_ingest_with_controls(wait_request, controls)
             .await
@@ -4075,7 +4075,7 @@ async fn operation_command(
     config: &Config,
     command: OperationCommands,
 ) -> Result<()> {
-    let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone());
+    let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone())?;
     match command {
         OperationCommands::Status { operation_id } => {
             let response = server
@@ -9600,7 +9600,7 @@ async fn serve_command(config: &Config, mcp: bool) -> Result<()> {
 }
 
 async fn serve_mcp_command(config: &Config) -> Result<()> {
-    let server = MempalMcpServer::new(expand_home(&config.db_path), config.clone());
+    let server = MempalMcpServer::new(expand_home(&config.db_path), config.clone())?;
     let service = server.serve_stdio().await?;
     service.waiting().await?;
     Ok(())
@@ -9626,7 +9626,7 @@ async fn serve_mcp_and_rest_command(config: &Config) -> Result<()> {
             .await
             .context("REST server failed")
     });
-    let server = MempalMcpServer::new(db_path, config.clone());
+    let server = MempalMcpServer::new(db_path, config.clone())?;
     let service = server.serve_stdio().await?;
     let mut mcp_task = Box::pin(async move {
         service.waiting().await.context("MCP server failed")?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3534,6 +3534,7 @@ impl MempalMcpServer {
                                     &merged_content,
                                     &merged_at,
                                     &merged_vector,
+                                    merge_count,
                                 )
                                 .map_err(db_error)?;
                                 db.record_novelty_audit(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -11,7 +11,10 @@ use crate::core::{
     AsyncDb,
     anchor::{self, DerivedAnchor},
     config::ConfigHandle,
-    db::{CURRENT_VECTOR_INDEX_VERSION, Database, VECTOR_DISTANCE_METRIC, read_fork_ext_version},
+    db::{
+        CURRENT_VECTOR_INDEX_VERSION, Database, NoveltyAuditInsert, VECTOR_DISTANCE_METRIC,
+        read_fork_ext_version,
+    },
     phase3::{
         EvaluatorAdviceInput, RuntimeAdoptionCaptureInput, RuntimeAdoptionCheckedRecordReport,
         RuntimeAdoptionRecordPlanInput, RuntimeAdoptionReviewFilters,
@@ -3949,21 +3952,20 @@ impl MempalMcpServer {
                         Ok(merged_vectors) => match merged_vectors.into_iter().next() {
                             Some(merged_vector) => {
                                 ensure_vector_dim_matches(&db, merged_vector.len())?;
-                                db.update_drawer_after_merge(
+                                db.update_drawer_after_merge_and_record_novelty_audit(
                                     &target_id,
                                     &merged_content,
                                     &merged_at,
                                     &merged_vector,
                                     merge_count,
-                                )
-                                .map_err(db_error)?;
-                                db.record_novelty_audit(
-                                    &drawer_id,
-                                    NoveltyAction::Merge,
-                                    Some(target_id.as_str()),
-                                    novelty.cosine,
-                                    novelty.audit_decision,
-                                    project_id.as_deref(),
+                                    NoveltyAuditInsert {
+                                        candidate_hash: &drawer_id,
+                                        action: NoveltyAction::Merge,
+                                        near_drawer_id: Some(target_id.as_str()),
+                                        cosine: novelty.cosine,
+                                        audit_decision: novelty.audit_decision,
+                                        project_id: project_id.as_deref(),
+                                    },
                                 )
                                 .map_err(db_error)?;
                                 novelty_action = Some(NoveltyAction::Merge);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,6 +8,7 @@ use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
 use crate::context::assemble_context_with_vector;
 use crate::core::{
+    AsyncDb,
     anchor::{self, DerivedAnchor},
     config::ConfigHandle,
     db::{CURRENT_VECTOR_INDEX_VERSION, Database, VECTOR_DISTANCE_METRIC, read_fork_ext_version},
@@ -22,13 +23,14 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
+    queue::AsyncPendingMessageStore,
     reindex::ReindexProgressStore,
     strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
-        AnchorKind, BootstrapIdentityParts, Drawer, ExplicitTunnel, KnowledgeCardFilter,
-        KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
-        RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack, SourceType,
-        TriggerHints, Triple, default_confidence,
+        AnchorKind, BootstrapIdentityParts, Drawer, DrawerSummary, ExplicitTunnel,
+        KnowledgeCardFilter, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance,
+        RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
+        SourceType, TriggerHints, Triple, default_confidence,
     },
     utils::{
         build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, iso_timestamp,
@@ -117,6 +119,8 @@ use super::tools::{
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
+    async_db: AsyncDb,
+    async_queue: AsyncPendingMessageStore,
     gating_runtime: Arc<GatingRuntime>,
     embedder_factory: Arc<dyn EmbedderFactory>,
     tool_router: ToolRouter<Self>,
@@ -153,8 +157,13 @@ impl MempalMcpServer {
         config: crate::core::config::Config,
         embedder_factory: Arc<dyn EmbedderFactory>,
     ) -> Self {
+        let async_db =
+            AsyncDb::open(&db_path, 4).expect("MCP async database pool should open at server init");
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path);
         Self {
             db_path,
+            async_db,
+            async_queue,
             gating_runtime: Arc::new(GatingRuntime::new(config, Arc::clone(&embedder_factory))),
             embedder_factory,
             tool_router: Self::tool_router(),
@@ -164,6 +173,12 @@ impl MempalMcpServer {
             session_hit_drawers: Arc::new(Mutex::new(HashSet::new())),
             ingest_worker_started: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_async_db_for_test(mut self, async_db: AsyncDb) -> Self {
+        self.async_db = async_db;
+        self
     }
 
     pub async fn serve_stdio(
@@ -290,10 +305,17 @@ impl MempalMcpServer {
             std::process::id(),
             Arc::as_ptr(&self.ingest_worker_started) as usize
         );
-        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&self.db_path);
+        let queue = self.async_queue.clone();
 
         loop {
-            match queue.claim_next_by_kind(&worker_id, INGEST_CLAIM_TTL_SECS, INGEST_ASYNC_KIND) {
+            match queue
+                .claim_next_by_kind(
+                    worker_id.clone(),
+                    INGEST_CLAIM_TTL_SECS,
+                    INGEST_ASYNC_KIND.to_string(),
+                )
+                .await
+            {
                 Ok(Some(claim)) => {
                     if let Err(error) = self.process_ingest_claim(&queue, &worker_id, claim).await {
                         tracing::warn!(error = %error, "async ingest worker failed to process op");
@@ -310,7 +332,7 @@ impl MempalMcpServer {
 
     async fn process_ingest_claim(
         &self,
-        queue: &crate::core::queue::PendingMessageStore,
+        queue: &AsyncPendingMessageStore,
         worker_id: &str,
         claim: crate::core::queue::ClaimedMessage,
     ) -> anyhow::Result<()> {
@@ -328,7 +350,7 @@ impl MempalMcpServer {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        if let Err(error) = heartbeat_queue.refresh_heartbeat(&heartbeat_id, &heartbeat_worker_id) {
+                        if let Err(error) = heartbeat_queue.refresh_heartbeat(heartbeat_id.clone(), heartbeat_worker_id.clone()).await {
                             tracing::warn!(error = %error, claim_id = %heartbeat_id, "failed to refresh async ingest heartbeat");
                             break;
                         }
@@ -381,13 +403,14 @@ impl MempalMcpServer {
                 };
                 queue
                     .complete_operation(
-                        &claim.id,
-                        state.as_str(),
-                        result_drawer_id,
-                        rejected_reason.as_deref(),
+                        claim.id.clone(),
+                        state.as_str().to_string(),
+                        result_drawer_id.map(ToOwned::to_owned),
+                        rejected_reason.clone(),
                         None,
-                        Some(&result_json),
+                        Some(result_json),
                     )
+                    .await
                     .map_err(|error| {
                         anyhow::anyhow!("failed to store async ingest result: {error}")
                     })?;
@@ -406,13 +429,14 @@ impl MempalMcpServer {
                     .context("failed to serialize failed ingest response")?;
                 queue
                     .complete_operation(
-                        &claim.id,
-                        IngestOperationState::Failed.as_str(),
+                        claim.id.clone(),
+                        IngestOperationState::Failed.as_str().to_string(),
                         None,
                         None,
-                        Some(&detail),
-                        Some(&result_json),
+                        Some(detail),
+                        Some(result_json),
                     )
+                    .await
                     .map_err(|error| {
                         anyhow::anyhow!("failed to store async ingest failure: {error}")
                     })?;
@@ -426,6 +450,81 @@ impl MempalMcpServer {
         Database::open(&self.db_path).map_err(|error| {
             ErrorData::internal_error(format!("failed to open database: {error}"), None)
         })
+    }
+
+    async fn load_status_db_snapshot(
+        &self,
+        project_scope: ProjectSearchScope,
+        turns_config: crate::core::config::TurnsConfig,
+    ) -> std::result::Result<StatusDbSnapshot, ErrorData> {
+        self.async_db
+            .run_read_anyhow(move |db| {
+                let schema_version = db.schema_version()?;
+                let fork_ext_version = read_fork_ext_version(db.conn())?;
+                let stale_drawer_count = db.stale_drawer_count(CURRENT_NORMALIZE_VERSION)? as u64;
+                let vector_index_stale = db.vector_index_is_stale().unwrap_or(false);
+                let drawer_count = db.drawer_count()?;
+                let vector_rows = db.vector_row_count()?;
+                let vector_index_empty = vector_rows == 0 && drawer_count > 0;
+                let consolidation_stats = db.consolidation_stats()?;
+                let pending_card_count = db.pending_auto_generated_knowledge_card_count()?;
+                let last_crystallization_at = db.last_crystallization_at()?;
+                let raw_turn_count = count_raw_turn_drawers(db, &turns_config)?;
+                let null_project_backfill_pending = db.null_project_backfill_pending_count()?;
+                let taxonomy_count = db.taxonomy_count()?;
+                let db_size_bytes = db.database_size_bytes()?;
+                let diary_rollup_days = db.diary_rollup_days()?;
+                let scopes = db
+                    .scope_counts_for_search_scope(&project_scope)?
+                    .into_iter()
+                    .map(|(wing, room, drawer_count)| ScopeCount {
+                        wing,
+                        room,
+                        drawer_count,
+                    })
+                    .collect();
+                let source_type_distribution = db
+                    .source_type_counts()?
+                    .into_iter()
+                    .map(|(source_type, count)| SourceTypeCount {
+                        source_type: source_type.to_string(),
+                        count,
+                    })
+                    .collect();
+                let pinned_fact_counts = db
+                    .pinned_fact_counts_by_project()?
+                    .into_iter()
+                    .map(|(project_id, count)| PinnedFactProjectCount { project_id, count })
+                    .collect();
+                Ok(StatusDbSnapshot {
+                    schema_version,
+                    fork_ext_version,
+                    stale_drawer_count,
+                    vector_index_stale,
+                    drawer_count,
+                    vector_rows,
+                    vector_index_empty,
+                    total_compacted_drawers: consolidation_stats.total_compacted_drawers,
+                    consolidation_runs: consolidation_stats.consolidation_runs,
+                    last_consolidation_at: consolidation_stats.last_consolidation_at,
+                    last_sleep_at: consolidation_stats.last_sleep_at,
+                    sleep_items_pruned: consolidation_stats.sleep_items_pruned,
+                    sleep_items_compacted: consolidation_stats.sleep_items_compacted,
+                    sleep_conflicts_resolved: consolidation_stats.sleep_conflicts_resolved,
+                    pending_card_count,
+                    last_crystallization_at,
+                    raw_turn_count,
+                    null_project_backfill_pending,
+                    taxonomy_count,
+                    db_size_bytes,
+                    diary_rollup_days,
+                    scopes,
+                    source_type_distribution,
+                    pinned_fact_counts,
+                })
+            })
+            .await
+            .map_err(db_error)
     }
 
     pub(super) async fn resolve_mcp_project_id(
@@ -1027,6 +1126,33 @@ impl Drop for IngestDrainWorkerStartedGuard {
     fn drop(&mut self) {
         self.started.store(false, Ordering::Release);
     }
+}
+
+struct StatusDbSnapshot {
+    schema_version: u32,
+    fork_ext_version: u32,
+    stale_drawer_count: u64,
+    vector_index_stale: bool,
+    drawer_count: i64,
+    vector_rows: i64,
+    vector_index_empty: bool,
+    total_compacted_drawers: u64,
+    consolidation_runs: u64,
+    last_consolidation_at: Option<String>,
+    last_sleep_at: Option<String>,
+    sleep_items_pruned: u64,
+    sleep_items_compacted: u64,
+    sleep_conflicts_resolved: u64,
+    pending_card_count: i64,
+    last_crystallization_at: Option<String>,
+    raw_turn_count: i64,
+    null_project_backfill_pending: i64,
+    taxonomy_count: i64,
+    db_size_bytes: u64,
+    diary_rollup_days: u32,
+    scopes: Vec<ScopeCount>,
+    source_type_distribution: Vec<SourceTypeCount>,
+    pinned_fact_counts: Vec<PinnedFactProjectCount>,
 }
 
 fn validate_temporal_param(name: &str, value: Option<&str>) -> std::result::Result<(), ErrorData> {
@@ -1646,7 +1772,6 @@ impl MempalMcpServer {
         });
         let cfg_meta = ConfigHandle::snapshot_meta();
         let config = ConfigHandle::current();
-        let db = self.open_db()?;
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await?;
@@ -1664,85 +1789,37 @@ impl MempalMcpServer {
                 },
             },
         };
-        let queue_stats = crate::core::queue::PendingMessageStore::new(db.path())
-            .map_err(|error| {
-                ErrorData::internal_error(format!("queue init failed: {error}"), None)
-            })?
-            .stats()
-            .map_err(|error| {
-                ErrorData::internal_error(format!("queue stats failed: {error}"), None)
-            })?;
+        let queue_stats = self.async_queue.stats().await.map_err(|error| {
+            ErrorData::internal_error(format!("queue stats failed: {error}"), None)
+        })?;
+        let db_snapshot = self
+            .load_status_db_snapshot(project_scope, config.turns.clone())
+            .await?;
         let endpoint_health = crate::endpoint_health::probe_endpoints(config.as_ref()).await;
         let embed_snapshot = global_embed_status().snapshot();
         let intelligence_snapshot = crate::intelligence::global_intelligence_status().snapshot();
-        let schema_version = db.schema_version().map_err(db_error)?;
-        let fork_ext_version = read_fork_ext_version(db.conn()).map_err(db_error)?;
-        let stale_drawer_count = db
-            .stale_drawer_count(CURRENT_NORMALIZE_VERSION)
-            .map_err(db_error)? as u64;
-        // This sqlite_master read is once per request so external reindex clears the warning immediately.
-        let vector_index_stale = db.vector_index_is_stale().unwrap_or(false);
-        let drawer_count = db.drawer_count().map_err(db_error)?;
-        // #302: row count exposes a vector table emptied by a failed
-        // recreate-reindex, which the metric-only staleness check above misses.
-        let vector_rows = db.vector_row_count().map_err(db_error)?;
-        let vector_index_empty = vector_rows == 0 && drawer_count > 0;
-        let consolidation_stats = db.consolidation_stats().map_err(db_error)?;
-        let pending_card_count = db
-            .pending_auto_generated_knowledge_card_count()
-            .map_err(db_error)?;
-        let last_crystallization_at = db.last_crystallization_at().map_err(db_error)?;
-        let raw_turn_count = count_raw_turn_drawers(&db, &config.turns).map_err(db_error)?;
-        let null_project_backfill_pending =
-            db.null_project_backfill_pending_count().map_err(db_error)?;
-        let taxonomy_count = db.taxonomy_count().map_err(db_error)?;
-        let db_size_bytes = db.database_size_bytes().map_err(db_error)?;
-        let diary_rollup_days = db.diary_rollup_days().map_err(db_error)?;
-        let scopes = db
-            .scope_counts_for_search_scope(&project_scope)
-            .map_err(db_error)?
-            .into_iter()
-            .map(|(wing, room, drawer_count)| ScopeCount {
-                wing,
-                room,
-                drawer_count,
-            })
-            .collect();
-        let source_type_distribution = db
-            .source_type_counts()
-            .map_err(db_error)?
-            .into_iter()
-            .map(|(source_type, count)| SourceTypeCount {
-                source_type: source_type.to_string(),
-                count,
-            })
-            .collect();
-        let pinned_fact_counts = db
-            .pinned_fact_counts_by_project()
-            .map_err(db_error)?
-            .into_iter()
-            .map(|(project_id, count)| PinnedFactProjectCount { project_id, count })
-            .collect();
         let mut system_warnings = current_system_warnings();
         let vector_search_circuit =
             VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
-        if null_project_backfill_pending > 0 {
+        if db_snapshot.null_project_backfill_pending > 0 {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
                 message: format!(
-                    "{null_project_backfill_pending} drawers still have NULL project_id; run `mempal project migrate --project <id>` to backfill historical records"
+                    "{} drawers still have NULL project_id; run `mempal project migrate --project <id>` to backfill historical records",
+                    db_snapshot.null_project_backfill_pending
                 ),
                 source: "project_isolation".to_string(),
             });
         }
-        if let Some(warning) = stale_index_warning_from_bool(vector_index_stale) {
+        if let Some(warning) = stale_index_warning_from_bool(db_snapshot.vector_index_stale) {
             system_warnings.push(warning);
         }
-        if vector_index_empty {
+        if db_snapshot.vector_index_empty {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
                 message: format!(
-                    "drawer_vectors index is empty ({vector_rows} vectors for {drawer_count} drawers); vector recall is disabled (BM25-only) until `mempal reindex --from-config` repopulates it"
+                    "drawer_vectors index is empty ({} vectors for {} drawers); vector recall is disabled (BM25-only) until `mempal reindex --from-config` repopulates it",
+                    db_snapshot.vector_rows, db_snapshot.drawer_count
                 ),
                 source: "vector_index".to_string(),
             });
@@ -1759,32 +1836,32 @@ impl MempalMcpServer {
             crate::core::queue::failure_headline_count(embed_snapshot.fail_count, &queue_stats);
 
         Ok(Json(StatusResponse {
-            schema_version,
-            fork_ext_version,
+            schema_version: db_snapshot.schema_version,
+            fork_ext_version: db_snapshot.fork_ext_version,
             normalize_version_current: CURRENT_NORMALIZE_VERSION,
-            stale_drawer_count,
-            vector_index_stale,
-            vector_rows,
-            vector_index_empty,
+            stale_drawer_count: db_snapshot.stale_drawer_count,
+            vector_index_stale: db_snapshot.vector_index_stale,
+            vector_rows: db_snapshot.vector_rows,
+            vector_index_empty: db_snapshot.vector_index_empty,
             search_decay_mode: config.search.decay.mode.to_string(),
-            drawer_count,
-            total_compacted_drawers: consolidation_stats.total_compacted_drawers,
-            consolidation_runs: consolidation_stats.consolidation_runs,
-            last_consolidation_at: consolidation_stats.last_consolidation_at,
-            last_sleep_at: consolidation_stats.last_sleep_at,
-            sleep_items_pruned: consolidation_stats.sleep_items_pruned,
-            sleep_items_compacted: consolidation_stats.sleep_items_compacted,
-            sleep_conflicts_resolved: consolidation_stats.sleep_conflicts_resolved,
-            pending_card_count,
-            last_crystallization_at,
-            taxonomy_count,
-            db_size_bytes,
-            diary_rollup_days,
+            drawer_count: db_snapshot.drawer_count,
+            total_compacted_drawers: db_snapshot.total_compacted_drawers,
+            consolidation_runs: db_snapshot.consolidation_runs,
+            last_consolidation_at: db_snapshot.last_consolidation_at,
+            last_sleep_at: db_snapshot.last_sleep_at,
+            sleep_items_pruned: db_snapshot.sleep_items_pruned,
+            sleep_items_compacted: db_snapshot.sleep_items_compacted,
+            sleep_conflicts_resolved: db_snapshot.sleep_conflicts_resolved,
+            pending_card_count: db_snapshot.pending_card_count,
+            last_crystallization_at: db_snapshot.last_crystallization_at,
+            taxonomy_count: db_snapshot.taxonomy_count,
+            db_size_bytes: db_snapshot.db_size_bytes,
+            diary_rollup_days: db_snapshot.diary_rollup_days,
             config_version: cfg_meta.version,
             config_loaded_at_unix_ms: cfg_meta.loaded_at_unix_ms,
-            scopes,
-            source_type_distribution,
-            pinned_fact_counts,
+            scopes: db_snapshot.scopes,
+            source_type_distribution: db_snapshot.source_type_distribution,
+            pinned_fact_counts: db_snapshot.pinned_fact_counts,
             aaak_spec: match detail {
                 StatusDetail::Compact => String::new(),
                 StatusDetail::Full => crate::aaak::generate_spec(),
@@ -1854,7 +1931,7 @@ impl MempalMcpServer {
             turn_storage: TurnStorageStatusDto {
                 storage_mode: config.turns.storage_mode.to_string(),
                 default_importance: config.turns.default_importance,
-                raw_turn_count,
+                raw_turn_count: db_snapshot.raw_turn_count,
                 raw_turn_wings: config.turns.raw_turn_wings.clone(),
                 raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
             },
@@ -1915,14 +1992,6 @@ impl MempalMcpServer {
             request.all_projects.unwrap_or(false),
             config.search.strict_project_isolation,
         );
-        let db = self.open_db()?;
-        let route = resolve_route(
-            &db,
-            &request.query,
-            request.wing.as_deref(),
-            request.room.as_deref(),
-        )
-        .map_err(|error| ErrorData::internal_error(format!("routing failed: {error}"), None))?;
         let top_k = request.top_k.unwrap_or(10);
         let search_options = SearchOptions {
             filters: SearchFilters {
@@ -1937,6 +2006,18 @@ impl MempalMcpServer {
             include_raw_turns: request.include_raw_turns.unwrap_or(false),
             include_expired: request.include_expired.unwrap_or(false),
         };
+        let route = {
+            let query = request.query.clone();
+            let wing = request.wing.clone();
+            let room = request.room.clone();
+            self.async_db
+                .run_read_anyhow(move |db| {
+                    resolve_route(db, &query, wing.as_deref(), room.as_deref())
+                        .map_err(|error| anyhow::anyhow!("routing failed: {error}"))
+                })
+                .await
+                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+        };
         let mut extra_warnings = Vec::new();
         let mut search_mode = SearchMode::Hybrid;
         let mut response_warnings = Vec::new();
@@ -1950,17 +2031,17 @@ impl MempalMcpServer {
                 message: warning,
                 source: "embed".to_string(),
             });
-            search_bm25_only_with_options(
-                &db,
-                &request.query,
-                route.clone(),
-                &scope,
-                search_options.clone(),
-                top_k,
-            )
-            .map_err(|error| {
-                ErrorData::internal_error(format!("BM25 fallback search failed: {error}"), None)
-            })?
+            let query = request.query.clone();
+            let route = route.clone();
+            let scope = scope.clone();
+            let search_options = search_options.clone();
+            self.async_db
+                .run_read_anyhow(move |db| {
+                    search_bm25_only_with_options(db, &query, route, &scope, search_options, top_k)
+                        .map_err(|error| anyhow::anyhow!("BM25 fallback search failed: {error}"))
+                })
+                .await
+                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
         } else {
             let embedder = match self.embedder_factory.build().await {
                 Ok(embedder) => Some(embedder),
@@ -1995,18 +2076,25 @@ impl MempalMcpServer {
                         let query_vector = vectors.into_iter().next().ok_or_else(|| {
                             ErrorData::internal_error("embedder returned no query vector", None)
                         })?;
-                        search_with_vector_and_scope_options(
-                            &db,
-                            &request.query,
-                            &query_vector,
-                            route.clone(),
-                            &scope,
-                            search_options.clone(),
-                            top_k,
-                        )
-                        .map_err(|error| {
-                            ErrorData::internal_error(format!("search failed: {error}"), None)
-                        })?
+                        let query = request.query.clone();
+                        let route = route.clone();
+                        let scope = scope.clone();
+                        let search_options = search_options.clone();
+                        self.async_db
+                            .run_read_anyhow(move |db| {
+                                search_with_vector_and_scope_options(
+                                    db,
+                                    &query,
+                                    &query_vector,
+                                    route,
+                                    &scope,
+                                    search_options,
+                                    top_k,
+                                )
+                                .map_err(|error| anyhow::anyhow!("search failed: {error}"))
+                            })
+                            .await
+                            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
                     }
                     Ok(Err(error)) => {
                         search_mode = SearchMode::Bm25Only;
@@ -2019,22 +2107,28 @@ impl MempalMcpServer {
                             message: warning,
                             source: "embed".to_string(),
                         });
-                        search_bm25_only_with_options(
-                            &db,
-                            &request.query,
-                            route.clone(),
-                            &scope,
-                            search_options.clone(),
-                            top_k,
-                        )
-                        .map_err(|bm25_error| {
-                            ErrorData::internal_error(
-                                format!(
-                                    "search failed after vector fallback: {error}; bm25 fallback failed: {bm25_error}"
-                                ),
-                                None,
-                            )
-                        })?
+                        let query = request.query.clone();
+                        let route = route.clone();
+                        let scope = scope.clone();
+                        let search_options = search_options.clone();
+                        self.async_db
+                            .run_read_anyhow(move |db| {
+                                search_bm25_only_with_options(
+                                    db,
+                                    &query,
+                                    route,
+                                    &scope,
+                                    search_options,
+                                    top_k,
+                                )
+                                .map_err(|bm25_error| {
+                                    anyhow::anyhow!(
+                                        "search failed after vector fallback: {error}; bm25 fallback failed: {bm25_error}"
+                                    )
+                                })
+                            })
+                            .await
+                            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
                     }
                     Err(_) => {
                         search_mode = SearchMode::Bm25Only;
@@ -2046,37 +2140,49 @@ impl MempalMcpServer {
                             message: warning,
                             source: "embed".to_string(),
                         });
-                        search_bm25_only_with_options(
-                            &db,
-                            &request.query,
-                            route.clone(),
-                            &scope,
-                            search_options.clone(),
-                            top_k,
-                        )
-                        .map_err(|error| {
-                            ErrorData::internal_error(
-                                format!("search deadline fallback failed: {error}"),
-                                None,
-                            )
-                        })?
+                        let query = request.query.clone();
+                        let route = route.clone();
+                        let scope = scope.clone();
+                        let search_options = search_options.clone();
+                        self.async_db
+                            .run_read_anyhow(move |db| {
+                                search_bm25_only_with_options(
+                                    db,
+                                    &query,
+                                    route,
+                                    &scope,
+                                    search_options,
+                                    top_k,
+                                )
+                                .map_err(|error| {
+                                    anyhow::anyhow!("search deadline fallback failed: {error}")
+                                })
+                            })
+                            .await
+                            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
                     }
                 }
             } else {
-                search_bm25_only_with_options(
-                    &db,
-                    &request.query,
-                    route.clone(),
-                    &scope,
-                    search_options.clone(),
-                    top_k,
-                )
-                .map_err(|error| {
-                    ErrorData::internal_error(
-                        format!("search failed after embedder build fallback: {error}"),
-                        None,
-                    )
-                })?
+                let query = request.query.clone();
+                let route = route.clone();
+                let scope = scope.clone();
+                let search_options = search_options.clone();
+                self.async_db
+                    .run_read_anyhow(move |db| {
+                        search_bm25_only_with_options(
+                            db,
+                            &query,
+                            route,
+                            &scope,
+                            search_options,
+                            top_k,
+                        )
+                        .map_err(|error| {
+                            anyhow::anyhow!("search failed after embedder build fallback: {error}")
+                        })
+                    })
+                    .await
+                    .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
             }
         };
 
@@ -2091,7 +2197,12 @@ impl MempalMcpServer {
 
         let mut system_warnings = current_system_warnings();
         system_warnings.extend(extra_warnings);
-        if let Some(warning) = stale_index_warning(&db) {
+        let vector_index_stale = self
+            .async_db
+            .run_read(|db| db.vector_index_is_stale())
+            .await
+            .unwrap_or(false);
+        if let Some(warning) = stale_index_warning_from_bool(vector_index_stale) {
             system_warnings.push(warning);
         }
         if unresolved_scope && config.search.strict_project_isolation {
@@ -2760,13 +2871,16 @@ impl MempalMcpServer {
         self.spawn_ingest_drain_worker();
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let room = request.room.as_deref();
-        let db = self.open_db()?;
         // Snapshot the request-wide warnings once so every early-return path reports a
         // consistent set from a single `sqlite_master` read. A mid-request embed transition
         // to degraded is not lost: the synchronous degraded-write guard below
         // (`should_block_writes`) re-reads fresh status via `degraded_write_error()` and
         // rejects before any success response that would carry this snapshot is built.
-        let request_system_warnings = system_warnings_with_stale_index(&db);
+        let request_system_warnings = self
+            .async_db
+            .run_read_anyhow(|db| Ok(system_warnings_with_stale_index(db)))
+            .await
+            .map_err(db_error)?;
         let dry_run = request.dry_run.unwrap_or(false);
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
@@ -2803,22 +2917,22 @@ impl MempalMcpServer {
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await?;
-        let prepared = self.prepare_async_ingest_operation(
-            &request,
-            controls,
-            config.as_ref(),
-            compiled_privacy.as_ref(),
-            &db,
-            project_id,
-        )?;
+        let prepared = self
+            .prepare_async_ingest_operation(
+                &request,
+                controls,
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await?;
         let payload = serde_json::to_string(&prepared).map_err(|error| {
             ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
         })?;
-        let queue = crate::core::queue::PendingMessageStore::new(db.path()).map_err(|error| {
-            ErrorData::internal_error(format!("failed to open ingest queue: {error}"), None)
-        })?;
-        let operation_id = queue
-            .enqueue(INGEST_ASYNC_KIND, &payload)
+        let operation_id = self
+            .async_queue
+            .enqueue(INGEST_ASYNC_KIND.to_string(), payload)
+            .await
             .map_err(|error| {
                 ErrorData::internal_error(
                     format!("failed to enqueue ingest operation: {error}"),
@@ -2871,13 +2985,12 @@ impl MempalMcpServer {
         Ok(Json(queued_response))
     }
 
-    fn prepare_async_ingest_operation(
+    async fn prepare_async_ingest_operation(
         &self,
         request: &IngestRequest,
         controls: IngestControls,
         config: &crate::core::config::Config,
         compiled_privacy: &crate::core::config::CompiledPrivacyConfig,
-        db: &Database,
         project_id: Option<String>,
     ) -> std::result::Result<PreparedIngestOperation, ErrorData> {
         let scrubbed_content =
@@ -2901,15 +3014,15 @@ impl MempalMcpServer {
             .replace_text
             .as_deref()
             .map(|text| config.scrub_content_with_compiled(text, compiled_privacy));
-        let replacement_target = db
-            .resolve_replacement_target(
-                request.supersedes.as_deref(),
-                scrubbed_replace_text.as_deref(),
-                &request.wing,
-                room,
-                project_id.as_deref(),
+        let replacement_target = self
+            .resolve_replacement_target_async(
+                request.supersedes.clone(),
+                scrubbed_replace_text.clone(),
+                request.wing.clone(),
+                request.room.clone(),
+                project_id.clone(),
             )
-            .map_err(replacement_db_error)?;
+            .await?;
         let mut request = request.clone();
         request.content = scrubbed_content.clone();
         request.source = scrubbed_source;
@@ -2928,6 +3041,28 @@ impl MempalMcpServer {
             raw_turn,
             drawer_importance,
         })
+    }
+
+    async fn resolve_replacement_target_async(
+        &self,
+        supersedes: Option<String>,
+        replace_text: Option<String>,
+        wing: String,
+        room: Option<String>,
+        project_id: Option<String>,
+    ) -> std::result::Result<Option<DrawerSummary>, ErrorData> {
+        self.async_db
+            .run_read(move |db| {
+                db.resolve_replacement_target(
+                    supersedes.as_deref(),
+                    replace_text.as_deref(),
+                    &wing,
+                    room.as_deref(),
+                    project_id.as_deref(),
+                )
+            })
+            .await
+            .map_err(replacement_db_error)
     }
 
     async fn mempal_ingest_sync(
@@ -3780,11 +3915,15 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<OperationStatusRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
-        let db = self.open_db()?;
-        let store = crate::core::queue::PendingMessageStore::new_without_reclaim(db.path());
-        let system_warnings = system_warnings_with_stale_index(&db);
-        let record = store
-            .operation_status(&request.operation_id)
+        let system_warnings = self
+            .async_db
+            .run_read_anyhow(|db| Ok(system_warnings_with_stale_index(db)))
+            .await
+            .map_err(db_error)?;
+        let record = self
+            .async_queue
+            .operation_status(request.operation_id.clone())
+            .await
             .map_err(|error| {
                 ErrorData::internal_error(format!("queue lookup failed: {error}"), None)
             })?
@@ -7020,7 +7159,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::time::Duration;
 
     use async_trait::async_trait;
@@ -7247,6 +7386,105 @@ mod tests {
         .expect("insert drawer");
         db.insert_vector(id, &[0.1, 0.2, 0.3])
             .expect("insert vector");
+    }
+
+    fn spawn_runtime_ticker() -> (Arc<AtomicU64>, tokio::task::JoinHandle<()>) {
+        let ticks = Arc::new(AtomicU64::new(0));
+        let ticks_bg = Arc::clone(&ticks);
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                ticks_bg.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        (ticks, ticker)
+    }
+
+    fn assert_runtime_ticked(ticks: &AtomicU64, label: &str) {
+        let observed = ticks.load(Ordering::SeqCst);
+        assert!(
+            observed >= 5,
+            "{label} advanced ticker {observed} times; MCP DB work must not block Tokio worker"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_status_db_work_runs_off_runtime() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(300));
+        let server = server.with_async_db_for_test(async_db);
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        let status = server.mempal_status().await.expect("status").0;
+        ticker.abort();
+
+        assert!(status.schema_version > 0);
+        assert_runtime_ticked(&ticks, "mempal_status");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_search_db_work_runs_off_runtime() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "offruntime-search",
+            "offruntime search marker",
+            "mcp",
+            Some("runtime"),
+            "offruntime-search.md",
+            3,
+        );
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(300));
+        let server = server.with_async_db_for_test(async_db);
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        let response = server
+            .mempal_search(Parameters(SearchRequest {
+                query: "offruntime search marker".to_string(),
+                wing: Some("mcp".to_string()),
+                room: Some("runtime".to_string()),
+                top_k: Some(1),
+                ..SearchRequest::default()
+            }))
+            .await
+            .expect("search")
+            .0;
+        ticker.abort();
+
+        assert!(!response.results.is_empty());
+        assert_runtime_ticked(&ticks, "mempal_search");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_admission_db_work_runs_off_runtime() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(300));
+        let server = server.with_async_db_for_test(async_db);
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "offruntime ingest admission".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("runtime".to_string()),
+                dry_run: Some(false),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest")
+            .0;
+        ticker.abort();
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.operation_id.is_some());
+        assert_runtime_ticked(&ticks, "mempal_ingest admission");
     }
 
     fn recreate_vectors_with_metric(db_path: &Path, metric: &str) {
@@ -10089,7 +10327,6 @@ enabled = true
         };
 
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
-        let db = server.open_db().expect("open db");
         let project_id = server
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await
@@ -10100,9 +10337,9 @@ enabled = true
                 IngestControls::default(),
                 config.as_ref(),
                 compiled_privacy.as_ref(),
-                &db,
                 project_id,
             )
+            .await
             .expect("prepare async ingest");
         let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
         let decoded: PreparedIngestOperation =
@@ -10141,7 +10378,6 @@ enabled = true
                 vector: vec![0.4, 0.5, 0.6],
             }),
         );
-        let db = server.open_db().expect("open db");
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let request = IngestRequest {
             content: "status tool async ingest".to_string(),
@@ -10161,9 +10397,9 @@ enabled = true
                 IngestControls::default(),
                 config.as_ref(),
                 compiled_privacy.as_ref(),
-                &db,
                 project_id,
             )
+            .await
             .expect("prepare async ingest");
         let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
         let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
@@ -10182,6 +10418,7 @@ enabled = true
             .claim_next_by_kind("worker-a", 60, INGEST_ASYNC_KIND)
             .expect("claim queued op")
             .expect("claimed queued op");
+        let db = server.open_db().expect("open db");
         db.conn()
             .execute(
                 "UPDATE pending_messages SET claimed_at = ?2, heartbeat_at = ?2 WHERE id = ?1",
@@ -10200,8 +10437,9 @@ enabled = true
             .claim_next_by_kind("worker-b", 60, INGEST_ASYNC_KIND)
             .expect("reclaim claim")
             .expect("reclaimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
         server
-            .process_ingest_claim(&queue, "worker-b", reclaimed_claim)
+            .process_ingest_claim(&async_queue, "worker-b", reclaimed_claim)
             .await
             .expect("process reclaimed op");
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -403,9 +403,14 @@ impl MempalMcpServer {
             }
         });
 
-        let outcome = self
+        let outcome = match self
             .run_prepared_ingest_off_runtime(prepared.request.clone(), prepared.controls)
-            .await;
+            .await
+        {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(error)) => Err(error.to_string()),
+            Err(error) => Err(error.to_string()),
+        };
 
         let _ = stop_tx.send(());
         let _ = heartbeat.await;
@@ -458,8 +463,7 @@ impl MempalMcpServer {
                         anyhow::anyhow!("failed to store async ingest result: {error}")
                     })?;
             }
-            Err(error) => {
-                let detail = error.to_string();
+            Err(detail) => {
                 let mut finalized = finalize_failed_ingest_response(
                     claim.id.clone(),
                     claim.created_at,
@@ -493,7 +497,7 @@ impl MempalMcpServer {
         &self,
         request: IngestRequest,
         controls: IngestControls,
-    ) -> anyhow::Result<IngestResponse> {
+    ) -> anyhow::Result<std::result::Result<IngestResponse, ErrorData>> {
         let worker = self.clone();
         #[cfg(any(test, feature = "db-test-seam"))]
         let ingest_processing_delay = self.ingest_processing_delay;
@@ -508,10 +512,9 @@ impl MempalMcpServer {
                     .enable_all()
                     .build()
                     .context("failed to build blocking ingest runtime")?;
-                runtime
+                Ok(runtime
                     .block_on(worker.mempal_ingest_sync(request, controls))
-                    .map(|response| response.0)
-                    .map_err(|error| anyhow::anyhow!(error.to_string()))
+                    .map(|response| response.0))
             })
         })
         .await
@@ -3144,7 +3147,29 @@ impl MempalMcpServer {
             }));
         }
         if dry_run {
-            return self.mempal_ingest_sync(request, controls).await;
+            let response = match tokio::time::timeout(
+                self.ingest_admission_deadline,
+                self.run_prepared_ingest_off_runtime(request, controls),
+            )
+            .await
+            {
+                Ok(Ok(Ok(response))) => response,
+                Ok(Ok(Err(error))) => return Err(error),
+                Ok(Err(error)) => {
+                    return Err(ErrorData::internal_error(
+                        format!("failed to run dry-run ingest off runtime: {error}"),
+                        None,
+                    ));
+                }
+                Err(_) => {
+                    return Err(mcp_stage_timeout_error(
+                        "mempal_ingest",
+                        "dry-run admission",
+                        self.ingest_admission_deadline,
+                    ));
+                }
+            };
+            return Ok(Json(response));
         }
         if global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
@@ -7898,6 +7923,75 @@ mod tests {
             error
                 .to_string()
                 .contains("mempal_ingest admission preparation exceeded"),
+            "unexpected error: {error}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(180)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_dry_run_sync_preview_runs_off_runtime() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server.with_ingest_processing_delay_for_test(Duration::from_millis(300));
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "dry-run preview must not block the MCP runtime".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("runtime".to_string()),
+                dry_run: Some(true),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("dry-run ingest")
+            .0;
+        ticker.abort();
+
+        assert!(response.operation_id.is_none());
+        assert!(response.state.is_none());
+        assert_eq!(response.chunk_count, 1);
+        assert!(!response.drawer_id.is_empty());
+        assert_runtime_ticked(&ticks, "mempal_ingest dry-run preview");
+
+        let db = Database::open(&db_path).expect("open db");
+        let drawer_count: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM drawers", [], |row| row.get(0))
+            .expect("count drawers");
+        assert_eq!(drawer_count, 0, "dry-run ingest must not persist drawers");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_dry_run_returns_error_when_preview_exceeds_deadline() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server
+            .with_ingest_processing_delay_for_test(Duration::from_millis(150))
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "bounded dry-run preview".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("deadline".to_string()),
+                dry_run: Some(true),
+                wait: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP dry-run ingest should return before client timeout");
+        let error = match result {
+            Ok(_) => panic!("slow dry-run preview should not claim success"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("mempal_ingest dry-run admission exceeded"),
             "unexpected error: {error}"
         );
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -30,7 +30,7 @@ use crate::core::{
         AnchorKind, BootstrapIdentityParts, Drawer, DrawerSummary, ExplicitTunnel,
         KnowledgeCardFilter, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance,
         RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
-        SourceType, TriggerHints, Triple, default_confidence,
+        SearchResult, SourceType, TriggerHints, Triple, default_confidence,
     },
     utils::{
         build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, iso_timestamp,
@@ -116,6 +116,12 @@ use super::tools::{
     TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
+const MCP_SEARCH_ROUTE_DEADLINE: Duration = Duration::from_secs(5);
+const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
+const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
+const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
+const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
+
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
@@ -133,6 +139,11 @@ pub struct MempalMcpServer {
     /// Flushed and boosted on the next `mempal_ingest` call (P13).
     session_hit_drawers: Arc<Mutex<HashSet<String>>>,
     ingest_worker_started: Arc<AtomicBool>,
+    search_route_deadline: Duration,
+    search_db_deadline: Duration,
+    search_stale_index_deadline: Duration,
+    ingest_admission_deadline: Duration,
+    operation_status_deadline: Duration,
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_processing_delay: Option<Duration>,
 }
@@ -181,6 +192,11 @@ impl MempalMcpServer {
             client_peer: Arc::new(Mutex::new(None)),
             session_hit_drawers: Arc::new(Mutex::new(HashSet::new())),
             ingest_worker_started: Arc::new(AtomicBool::new(false)),
+            search_route_deadline: MCP_SEARCH_ROUTE_DEADLINE,
+            search_db_deadline: MCP_SEARCH_DB_DEADLINE,
+            search_stale_index_deadline: MCP_SEARCH_STALE_INDEX_DEADLINE,
+            ingest_admission_deadline: MCP_INGEST_ADMISSION_DEADLINE,
+            operation_status_deadline: MCP_OPERATION_STATUS_DEADLINE,
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
         })
@@ -195,6 +211,16 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_ingest_processing_delay_for_test(mut self, delay: Duration) -> Self {
         self.ingest_processing_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_mcp_deadline_for_test(mut self, deadline: Duration) -> Self {
+        self.search_route_deadline = deadline;
+        self.search_db_deadline = deadline;
+        self.search_stale_index_deadline = deadline;
+        self.ingest_admission_deadline = deadline;
+        self.operation_status_deadline = deadline;
         self
     }
 
@@ -680,6 +706,61 @@ impl MempalMcpServer {
                 format!("timed out waiting for ingest operation {operation_id}"),
                 None,
             )),
+        }
+    }
+
+    async fn run_read_anyhow_bounded<F, R>(
+        &self,
+        f: F,
+        deadline: Duration,
+    ) -> anyhow::Result<Option<R>>
+    where
+        F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        match tokio::time::timeout(deadline, self.async_db.run_read_anyhow(f)).await {
+            Ok(result) => result.map(Some),
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn run_bm25_search_bounded(
+        &self,
+        query: String,
+        route: crate::core::types::RouteDecision,
+        scope: ProjectSearchScope,
+        search_options: SearchOptions,
+        top_k: usize,
+    ) -> anyhow::Result<Option<Vec<SearchResult>>> {
+        self.run_read_anyhow_bounded(
+            move |db| {
+                search_bm25_only_with_options(db, &query, route, &scope, search_options, top_k)
+                    .map_err(|error| anyhow::anyhow!("BM25 search failed: {error}"))
+            },
+            self.search_db_deadline,
+        )
+        .await
+    }
+
+    async fn system_warnings_with_stale_index_bounded(
+        &self,
+        deadline: Duration,
+    ) -> std::result::Result<Vec<SystemWarning>, ErrorData> {
+        match self
+            .run_read_anyhow_bounded(|db| Ok(system_warnings_with_stale_index(db)), deadline)
+            .await
+            .map_err(db_error)?
+        {
+            Some(warnings) => Ok(warnings),
+            None => {
+                let mut warnings = current_system_warnings();
+                warnings.push(SystemWarning {
+                    level: "warn".to_string(),
+                    message: mcp_stage_timeout_warning("stale vector index check", deadline),
+                    source: "mcp_timeout".to_string(),
+                });
+                Ok(warnings)
+            }
         }
     }
 
@@ -2052,21 +2133,46 @@ impl MempalMcpServer {
             include_raw_turns: request.include_raw_turns.unwrap_or(false),
             include_expired: request.include_expired.unwrap_or(false),
         };
+        let mut extra_warnings = Vec::new();
+        let mut search_mode = SearchMode::Hybrid;
+        let mut response_warnings = Vec::new();
         let route = {
             let query = request.query.clone();
             let wing = request.wing.clone();
             let room = request.room.clone();
-            self.async_db
-                .run_read_anyhow(move |db| {
-                    resolve_route(db, &query, wing.as_deref(), room.as_deref())
-                        .map_err(|error| anyhow::anyhow!("routing failed: {error}"))
-                })
+            let fallback_route = crate::core::types::RouteDecision {
+                wing: wing.clone(),
+                room: room.clone(),
+                confidence: if wing.is_some() || room.is_some() {
+                    1.0
+                } else {
+                    0.0
+                },
+                reason: "bounded MCP fallback: route resolution timed out".to_string(),
+            };
+            match self
+                .run_read_anyhow_bounded(
+                    move |db| {
+                        resolve_route(db, &query, wing.as_deref(), room.as_deref())
+                            .map_err(|error| anyhow::anyhow!("routing failed: {error}"))
+                    },
+                    self.search_route_deadline,
+                )
                 .await
                 .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+            {
+                Some(route) => route,
+                None => {
+                    push_mcp_timeout_warning(
+                        &mut response_warnings,
+                        &mut extra_warnings,
+                        "search route resolution",
+                        self.search_route_deadline,
+                    );
+                    fallback_route
+                }
+            }
         };
-        let mut extra_warnings = Vec::new();
-        let mut search_mode = SearchMode::Hybrid;
-        let mut response_warnings = Vec::new();
         let embed_snapshot = global_embed_status().snapshot();
         let results = if config.search.bm25_fallback && embed_snapshot.degraded {
             search_mode = SearchMode::Bm25Only;
@@ -2081,13 +2187,22 @@ impl MempalMcpServer {
             let route = route.clone();
             let scope = scope.clone();
             let search_options = search_options.clone();
-            self.async_db
-                .run_read_anyhow(move |db| {
-                    search_bm25_only_with_options(db, &query, route, &scope, search_options, top_k)
-                        .map_err(|error| anyhow::anyhow!("BM25 fallback search failed: {error}"))
-                })
+            match self
+                .run_bm25_search_bounded(query, route, scope, search_options, top_k)
                 .await
                 .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+            {
+                Some(results) => results,
+                None => {
+                    push_mcp_timeout_warning(
+                        &mut response_warnings,
+                        &mut extra_warnings,
+                        "BM25 fallback search",
+                        self.search_db_deadline,
+                    );
+                    Vec::new()
+                }
+            }
         } else {
             let embedder = match self.embedder_factory.build().await {
                 Ok(embedder) => Some(embedder),
@@ -2123,24 +2238,66 @@ impl MempalMcpServer {
                             ErrorData::internal_error("embedder returned no query vector", None)
                         })?;
                         let query = request.query.clone();
-                        let route = route.clone();
-                        let scope = scope.clone();
-                        let search_options = search_options.clone();
-                        self.async_db
-                            .run_read_anyhow(move |db| {
-                                search_with_vector_and_scope_options(
-                                    db,
-                                    &query,
-                                    &query_vector,
-                                    route,
-                                    &scope,
-                                    search_options,
-                                    top_k,
-                                )
-                                .map_err(|error| anyhow::anyhow!("search failed: {error}"))
-                            })
+                        let hybrid_route = route.clone();
+                        let hybrid_scope = scope.clone();
+                        let hybrid_options = search_options.clone();
+                        match self
+                            .run_read_anyhow_bounded(
+                                move |db| {
+                                    search_with_vector_and_scope_options(
+                                        db,
+                                        &query,
+                                        &query_vector,
+                                        hybrid_route,
+                                        &hybrid_scope,
+                                        hybrid_options,
+                                        top_k,
+                                    )
+                                    .map_err(|error| anyhow::anyhow!("search failed: {error}"))
+                                },
+                                self.search_db_deadline,
+                            )
                             .await
                             .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+                        {
+                            Some(results) => results,
+                            None => {
+                                search_mode = SearchMode::Bm25Only;
+                                push_mcp_timeout_warning(
+                                    &mut response_warnings,
+                                    &mut extra_warnings,
+                                    "hybrid search",
+                                    self.search_db_deadline,
+                                );
+                                let query = request.query.clone();
+                                let route = route.clone();
+                                let scope = scope.clone();
+                                let search_options = search_options.clone();
+                                match self
+                                    .run_bm25_search_bounded(
+                                        query,
+                                        route,
+                                        scope,
+                                        search_options,
+                                        top_k,
+                                    )
+                                    .await
+                                    .map_err(|error| {
+                                        ErrorData::internal_error(error.to_string(), None)
+                                    })? {
+                                    Some(results) => results,
+                                    None => {
+                                        push_mcp_timeout_warning(
+                                            &mut response_warnings,
+                                            &mut extra_warnings,
+                                            "BM25 fallback search",
+                                            self.search_db_deadline,
+                                        );
+                                        Vec::new()
+                                    }
+                                }
+                            }
+                        }
                     }
                     Ok(Err(error)) => {
                         search_mode = SearchMode::Bm25Only;
@@ -2157,24 +2314,28 @@ impl MempalMcpServer {
                         let route = route.clone();
                         let scope = scope.clone();
                         let search_options = search_options.clone();
-                        self.async_db
-                            .run_read_anyhow(move |db| {
-                                search_bm25_only_with_options(
-                                    db,
-                                    &query,
-                                    route,
-                                    &scope,
-                                    search_options,
-                                    top_k,
-                                )
-                                .map_err(|bm25_error| {
-                                    anyhow::anyhow!(
-                                        "search failed after vector fallback: {error}; bm25 fallback failed: {bm25_error}"
-                                    )
-                                })
-                            })
+                        match self
+                            .run_bm25_search_bounded(query, route, scope, search_options, top_k)
                             .await
-                            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+                            .map_err(|bm25_error| {
+                                ErrorData::internal_error(
+                                    format!(
+                                        "search failed after vector fallback: {error}; bm25 fallback failed: {bm25_error}"
+                                    ),
+                                    None,
+                                )
+                            })? {
+                            Some(results) => results,
+                            None => {
+                                push_mcp_timeout_warning(
+                                    &mut response_warnings,
+                                    &mut extra_warnings,
+                                    "BM25 fallback search",
+                                    self.search_db_deadline,
+                                );
+                                Vec::new()
+                            }
+                        }
                     }
                     Err(_) => {
                         search_mode = SearchMode::Bm25Only;
@@ -2190,22 +2351,26 @@ impl MempalMcpServer {
                         let route = route.clone();
                         let scope = scope.clone();
                         let search_options = search_options.clone();
-                        self.async_db
-                            .run_read_anyhow(move |db| {
-                                search_bm25_only_with_options(
-                                    db,
-                                    &query,
-                                    route,
-                                    &scope,
-                                    search_options,
-                                    top_k,
-                                )
-                                .map_err(|error| {
-                                    anyhow::anyhow!("search deadline fallback failed: {error}")
-                                })
-                            })
+                        match self
+                            .run_bm25_search_bounded(query, route, scope, search_options, top_k)
                             .await
-                            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+                            .map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("search deadline fallback failed: {error}"),
+                                    None,
+                                )
+                            })? {
+                            Some(results) => results,
+                            None => {
+                                push_mcp_timeout_warning(
+                                    &mut response_warnings,
+                                    &mut extra_warnings,
+                                    "BM25 fallback search",
+                                    self.search_db_deadline,
+                                );
+                                Vec::new()
+                            }
+                        }
                     }
                 }
             } else {
@@ -2213,22 +2378,26 @@ impl MempalMcpServer {
                 let route = route.clone();
                 let scope = scope.clone();
                 let search_options = search_options.clone();
-                self.async_db
-                    .run_read_anyhow(move |db| {
-                        search_bm25_only_with_options(
-                            db,
-                            &query,
-                            route,
-                            &scope,
-                            search_options,
-                            top_k,
-                        )
-                        .map_err(|error| {
-                            anyhow::anyhow!("search failed after embedder build fallback: {error}")
-                        })
-                    })
+                match self
+                    .run_bm25_search_bounded(query, route, scope, search_options, top_k)
                     .await
-                    .map_err(|error| ErrorData::internal_error(error.to_string(), None))?
+                    .map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("search failed after embedder build fallback: {error}"),
+                            None,
+                        )
+                    })? {
+                    Some(results) => results,
+                    None => {
+                        push_mcp_timeout_warning(
+                            &mut response_warnings,
+                            &mut extra_warnings,
+                            "BM25 fallback search",
+                            self.search_db_deadline,
+                        );
+                        Vec::new()
+                    }
+                }
             }
         };
 
@@ -2243,13 +2412,35 @@ impl MempalMcpServer {
 
         let mut system_warnings = current_system_warnings();
         system_warnings.extend(extra_warnings);
-        let vector_index_stale = self
-            .async_db
-            .run_read(|db| db.vector_index_is_stale())
+        match self
+            .run_read_anyhow_bounded(
+                |db| Ok(db.vector_index_is_stale().unwrap_or(false)),
+                self.search_stale_index_deadline,
+            )
             .await
-            .unwrap_or(false);
-        if let Some(warning) = stale_index_warning_from_bool(vector_index_stale) {
-            system_warnings.push(warning);
+        {
+            Ok(Some(vector_index_stale)) => {
+                if let Some(warning) = stale_index_warning_from_bool(vector_index_stale) {
+                    system_warnings.push(warning);
+                }
+            }
+            Ok(None) => {
+                system_warnings.push(SystemWarning {
+                    level: "warn".to_string(),
+                    message: mcp_stage_timeout_warning(
+                        "stale vector index check",
+                        self.search_stale_index_deadline,
+                    ),
+                    source: "mcp_timeout".to_string(),
+                });
+            }
+            Err(error) => {
+                system_warnings.push(SystemWarning {
+                    level: "warn".to_string(),
+                    message: format!("stale vector index check failed: {error}"),
+                    source: "vector_index".to_string(),
+                });
+            }
         }
         if unresolved_scope && config.search.strict_project_isolation {
             system_warnings.push(SystemWarning {
@@ -2923,10 +3114,8 @@ impl MempalMcpServer {
         // (`should_block_writes`) re-reads fresh status via `degraded_write_error()` and
         // rejects before any success response that would carry this snapshot is built.
         let request_system_warnings = self
-            .async_db
-            .run_read_anyhow(|db| Ok(system_warnings_with_stale_index(db)))
-            .await
-            .map_err(db_error)?;
+            .system_warnings_with_stale_index_bounded(self.ingest_admission_deadline)
+            .await?;
         let dry_run = request.dry_run.unwrap_or(false);
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
@@ -2963,28 +3152,53 @@ impl MempalMcpServer {
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await?;
-        let prepared = self
-            .prepare_async_ingest_operation(
+        let prepared = match tokio::time::timeout(
+            self.ingest_admission_deadline,
+            self.prepare_async_ingest_operation(
                 &request,
                 controls,
                 config.as_ref(),
                 compiled_privacy.as_ref(),
                 project_id,
-            )
-            .await?;
+            ),
+        )
+        .await
+        {
+            Ok(Ok(prepared)) => prepared,
+            Ok(Err(error)) => return Err(error),
+            Err(_) => {
+                return Err(mcp_stage_timeout_error(
+                    "mempal_ingest",
+                    "admission preparation",
+                    self.ingest_admission_deadline,
+                ));
+            }
+        };
         let payload = serde_json::to_string(&prepared).map_err(|error| {
             ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
         })?;
-        let operation_id = self
-            .async_queue
-            .enqueue(INGEST_ASYNC_KIND.to_string(), payload)
-            .await
-            .map_err(|error| {
-                ErrorData::internal_error(
+        let operation_id = match tokio::time::timeout(
+            self.ingest_admission_deadline,
+            self.async_queue
+                .enqueue(INGEST_ASYNC_KIND.to_string(), payload),
+        )
+        .await
+        {
+            Ok(Ok(operation_id)) => operation_id,
+            Ok(Err(error)) => {
+                return Err(ErrorData::internal_error(
                     format!("failed to enqueue ingest operation: {error}"),
                     None,
-                )
-            })?;
+                ));
+            }
+            Err(_) => {
+                return Err(mcp_stage_timeout_error(
+                    "mempal_ingest",
+                    "queue admission",
+                    self.ingest_admission_deadline,
+                ));
+            }
+        };
 
         let queued_response = IngestResponse {
             operation_id: Some(operation_id),
@@ -3962,23 +4176,36 @@ impl MempalMcpServer {
         Parameters(request): Parameters<OperationStatusRequest>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let system_warnings = self
-            .async_db
-            .run_read_anyhow(|db| Ok(system_warnings_with_stale_index(db)))
-            .await
-            .map_err(db_error)?;
-        let record = self
-            .async_queue
-            .operation_status(request.operation_id.clone())
-            .await
-            .map_err(|error| {
-                ErrorData::internal_error(format!("queue lookup failed: {error}"), None)
-            })?
-            .ok_or_else(|| {
-                ErrorData::invalid_params(
-                    format!("operation not found: {}", request.operation_id),
+            .system_warnings_with_stale_index_bounded(self.operation_status_deadline)
+            .await?;
+        let record = match tokio::time::timeout(
+            self.operation_status_deadline,
+            self.async_queue
+                .operation_status(request.operation_id.clone()),
+        )
+        .await
+        {
+            Ok(Ok(record)) => record,
+            Ok(Err(error)) => {
+                return Err(ErrorData::internal_error(
+                    format!("queue lookup failed: {error}"),
                     None,
-                )
-            })?;
+                ));
+            }
+            Err(_) => {
+                return Err(mcp_stage_timeout_error(
+                    "mempal_operation_status",
+                    "queue lookup",
+                    self.operation_status_deadline,
+                ));
+            }
+        }
+        .ok_or_else(|| {
+            ErrorData::invalid_params(
+                format!("operation not found: {}", request.operation_id),
+                None,
+            )
+        })?;
 
         Ok(Json(operation_record_to_response(record, system_warnings)))
     }
@@ -6909,6 +7136,47 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
     warnings
 }
 
+fn format_deadline(deadline: Duration) -> String {
+    let millis = deadline.as_millis();
+    if millis >= 1_000 && millis % 1_000 == 0 {
+        format!("{}s", deadline.as_secs())
+    } else {
+        format!("{millis}ms")
+    }
+}
+
+fn mcp_stage_timeout_warning(stage: &str, deadline: Duration) -> String {
+    format!(
+        "{stage} exceeded {}; returning a bounded diagnostic before the MCP client timeout",
+        format_deadline(deadline)
+    )
+}
+
+fn mcp_stage_timeout_error(operation: &str, stage: &str, deadline: Duration) -> ErrorData {
+    ErrorData::internal_error(
+        format!(
+            "{operation} {stage} exceeded {}; no durable result was confirmed before returning",
+            format_deadline(deadline)
+        ),
+        None,
+    )
+}
+
+fn push_mcp_timeout_warning(
+    response_warnings: &mut Vec<String>,
+    system_warnings: &mut Vec<SystemWarning>,
+    stage: &str,
+    deadline: Duration,
+) {
+    let warning = mcp_stage_timeout_warning(stage, deadline);
+    response_warnings.push(warning.clone());
+    system_warnings.push(SystemWarning {
+        level: "warn".to_string(),
+        message: warning,
+        source: "mcp_timeout".to_string(),
+    });
+}
+
 fn stale_index_warning_from_bool(is_stale: bool) -> Option<SystemWarning> {
     is_stale.then(|| SystemWarning {
         level: "warn".to_string(),
@@ -7507,6 +7775,70 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_search_returns_diagnostic_when_db_reads_exceed_deadline() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "bounded-search",
+            "bounded search marker",
+            "mcp",
+            Some("deadline"),
+            "bounded-search.md",
+            3,
+        );
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(150));
+        let server = server
+            .with_async_db_for_test(async_db)
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_search(Parameters(SearchRequest {
+                query: "bounded search marker".to_string(),
+                wing: Some("mcp".to_string()),
+                room: Some("deadline".to_string()),
+                top_k: Some(1),
+                disable_progressive: Some(true),
+                ..SearchRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP search should return before client timeout")
+        .expect("bounded diagnostic response")
+        .0;
+
+        assert_eq!(response.search_mode, SearchMode::Bm25Only.as_str());
+        assert!(response.results.is_empty());
+        assert!(
+            response
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("hybrid search exceeded")),
+            "hybrid timeout warning missing: {:?}",
+            response.warnings
+        );
+        assert!(
+            response
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("BM25 fallback search exceeded")),
+            "BM25 timeout warning missing: {:?}",
+            response.warnings
+        );
+        assert!(
+            response
+                .system_warnings
+                .iter()
+                .any(|warning| warning.source == "mcp_timeout"),
+            "system warning should expose bounded MCP timeout"
+        );
+
+        tokio::time::sleep(Duration::from_millis(180)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_mcp_ingest_admission_db_work_runs_off_runtime() {
         let (_tempdir, db_path, server) = setup_server();
         let async_db = AsyncDb::open(&db_path, 4)
@@ -7532,6 +7864,44 @@ mod tests {
         assert_eq!(response.state, Some(IngestOperationState::Queued));
         assert!(response.operation_id.is_some());
         assert_runtime_ticked(&ticks, "mempal_ingest admission");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_admission_returns_error_when_db_reads_exceed_deadline() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_db = AsyncDb::open(&db_path, 4)
+            .expect("open async db")
+            .with_read_delay(Duration::from_millis(150));
+        let server = server
+            .with_async_db_for_test(async_db)
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "bounded ingest admission".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("deadline".to_string()),
+                dry_run: Some(false),
+                wait: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP ingest should return before client timeout");
+        let error = match result {
+            Ok(_) => panic!("slow admission should not claim durable acceptance"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("mempal_ingest admission preparation exceeded"),
+            "unexpected error: {error}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(180)).await;
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -89,6 +89,7 @@ use rmcp::{
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::OnceCell;
 
 use super::timeline::{TimelineRequest, TimelineResponse};
 use super::tools::{
@@ -128,7 +129,7 @@ const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
-    async_db: AsyncDb,
+    async_db: Arc<OnceCell<AsyncDb>>,
     async_queue: AsyncPendingMessageStore,
     gating_runtime: Arc<GatingRuntime>,
     embedder_factory: Arc<dyn EmbedderFactory>,
@@ -176,16 +177,10 @@ impl MempalMcpServer {
         config: crate::core::config::Config,
         embedder_factory: Arc<dyn EmbedderFactory>,
     ) -> anyhow::Result<Self> {
-        let async_db = AsyncDb::open(&db_path, 4).with_context(|| {
-            format!(
-                "failed to open MCP async database pool for {}",
-                db_path.display()
-            )
-        })?;
         let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path);
         Ok(Self {
             db_path,
-            async_db,
+            async_db: Arc::new(OnceCell::new()),
             async_queue,
             gating_runtime: Arc::new(GatingRuntime::new(config, Arc::clone(&embedder_factory))),
             embedder_factory,
@@ -207,7 +202,9 @@ impl MempalMcpServer {
 
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_async_db_for_test(mut self, async_db: AsyncDb) -> Self {
-        self.async_db = async_db;
+        let cell = Arc::new(OnceCell::new());
+        debug_assert!(cell.set(async_db).is_ok());
+        self.async_db = cell;
         self
     }
 
@@ -536,12 +533,31 @@ impl MempalMcpServer {
         })
     }
 
+    async fn async_db(&self) -> anyhow::Result<AsyncDb> {
+        let db_path = self.db_path.clone();
+        let async_db = self
+            .async_db
+            .get_or_try_init(|| async move {
+                let display_path = db_path.display().to_string();
+                tokio::task::spawn_blocking(move || {
+                    AsyncDb::open(&db_path, 4).with_context(|| {
+                        format!("failed to open MCP async database pool for {display_path}")
+                    })
+                })
+                .await
+                .context("blocking MCP async database pool open failed")?
+            })
+            .await?;
+        Ok(async_db.clone())
+    }
+
     async fn load_status_db_snapshot(
         &self,
         project_scope: ProjectSearchScope,
         turns_config: crate::core::config::TurnsConfig,
     ) -> std::result::Result<StatusDbSnapshot, ErrorData> {
-        self.async_db
+        let async_db = self.async_db().await.map_err(db_error)?;
+        async_db
             .run_read_anyhow(move |db| {
                 let schema_version = db.schema_version()?;
                 let fork_ext_version = read_fork_ext_version(db.conn())?;
@@ -730,7 +746,8 @@ impl MempalMcpServer {
         F: FnOnce(&Database) -> anyhow::Result<R> + Send + 'static,
         R: Send + 'static,
     {
-        match tokio::time::timeout(deadline, self.async_db.run_read_anyhow(f)).await {
+        let async_db = self.async_db().await?;
+        match tokio::time::timeout(deadline, async_db.run_read_anyhow(f)).await {
             Ok(result) => result.map(Some),
             Err(_) => Ok(None),
         }
@@ -3336,7 +3353,8 @@ impl MempalMcpServer {
         room: Option<String>,
         project_id: Option<String>,
     ) -> std::result::Result<Option<DrawerSummary>, ErrorData> {
-        self.async_db
+        let async_db = self.async_db().await.map_err(db_error)?;
+        async_db
             .run_read(move |db| {
                 db.resolve_replacement_target(
                     supersedes.as_deref(),
@@ -7603,6 +7621,25 @@ mod tests {
     fn setup_server() -> (TempDir, PathBuf, MempalMcpServer) {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let db_path = tempdir.path().join("palace.db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db fixture");
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server")
+        .with_async_db_for_test(async_db);
+        (tempdir, db_path, server)
+    }
+
+    #[tokio::test]
+    async fn test_mcp_doctor_missing_db_is_read_only_after_server_construction() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_dir = tempdir.path().join("missing-home").join(".mempal");
+        let db_path = db_dir.join("palace.db");
+        assert!(!db_dir.exists());
+
         let server = MempalMcpServer::new_with_factory(
             db_path.clone(),
             Arc::new(StubEmbedderFactory {
@@ -7610,7 +7647,26 @@ mod tests {
             }),
         )
         .expect("create MCP server");
-        (tempdir, db_path, server)
+        assert!(
+            !db_dir.exists(),
+            "server construction must not create db dir"
+        );
+
+        let response = server
+            .mempal_doctor(Parameters(DoctorRequest {}))
+            .await
+            .expect("doctor")
+            .0;
+
+        assert_eq!(response.db.path, db_path.display().to_string());
+        assert!(!response.db.exists);
+        assert_eq!(response.db.schema_version, None);
+        assert!(response.db.compatible);
+        assert!(!db_path.exists(), "doctor must not create database file");
+        assert!(
+            !db_dir.exists(),
+            "doctor must not create database directory"
+        );
     }
 
     fn knowledge_card(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -212,6 +212,12 @@ impl MempalMcpServer {
     }
 
     #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_async_queue_for_test(mut self, async_queue: AsyncPendingMessageStore) -> Self {
+        self.async_queue = async_queue;
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_ingest_processing_delay_for_test(mut self, delay: Duration) -> Self {
         self.ingest_processing_delay = Some(delay);
         self
@@ -3205,25 +3211,16 @@ impl MempalMcpServer {
         let payload = serde_json::to_string(&prepared).map_err(|error| {
             ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
         })?;
-        let operation_id = match tokio::time::timeout(
-            self.ingest_admission_deadline,
-            self.async_queue
-                .enqueue(INGEST_ASYNC_KIND.to_string(), payload),
-        )
-        .await
+        let operation_id = match self
+            .async_queue
+            .enqueue(INGEST_ASYNC_KIND.to_string(), payload)
+            .await
         {
-            Ok(Ok(operation_id)) => operation_id,
-            Ok(Err(error)) => {
+            Ok(operation_id) => operation_id,
+            Err(error) => {
                 return Err(ErrorData::internal_error(
                     format!("failed to enqueue ingest operation: {error}"),
                     None,
-                ));
-            }
-            Err(_) => {
-                return Err(mcp_stage_timeout_error(
-                    "mempal_ingest",
-                    "queue admission",
-                    self.ingest_admission_deadline,
                 ));
             }
         };
@@ -7929,6 +7926,44 @@ mod tests {
         );
 
         tokio::time::sleep(Duration::from_millis(180)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_queue_admission_waits_for_receipt_after_deadline() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_blocking_delay(Duration::from_millis(150));
+        let server = server
+            .with_async_queue_for_test(async_queue)
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "slow queue admission still returns a receipt".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("receipt".to_string()),
+                dry_run: Some(false),
+                wait: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP ingest should wait for queue admission receipt")
+        .expect("slow queue admission should still succeed")
+        .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response
+            .operation_id
+            .as_deref()
+            .expect("queued response must include operation id");
+        let record = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("load queued operation status")
+            .expect("operation must be durable when receipt is returned");
+        assert_eq!(record.id, operation_id);
+        assert_eq!(record.kind, INGEST_ASYNC_KIND);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,7 +26,7 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
-    queue::AsyncPendingMessageStore,
+    queue::{AsyncPendingMessageStore, ClaimedMessage},
     reindex::ReindexProgressStore,
     strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
@@ -383,11 +383,17 @@ impl MempalMcpServer {
         &self,
         queue: &AsyncPendingMessageStore,
         worker_id: &str,
-        claim: crate::core::queue::ClaimedMessage,
+        claim: ClaimedMessage,
     ) -> anyhow::Result<()> {
-        let prepared: PreparedIngestOperation = serde_json::from_str(&claim.payload)
-            .with_context(|| format!("failed to decode ingest operation {}", claim.id))?;
         let queue_wait_ms = queue_wait_ms(claim.created_at, claim.claimed_at);
+        let prepared: PreparedIngestOperation = match serde_json::from_str(&claim.payload) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let detail = format!("failed to decode ingest operation {}: {error}", claim.id);
+                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
+                return Ok(());
+            }
+        };
 
         let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
         let heartbeat_queue = queue.clone();
@@ -457,7 +463,7 @@ impl MempalMcpServer {
                 };
                 queue
                     .complete_operation(
-                        claim.id.clone(),
+                        claim.clone(),
                         state.as_str().to_string(),
                         result_drawer_id.map(ToOwned::to_owned),
                         rejected_reason.clone(),
@@ -470,29 +476,7 @@ impl MempalMcpServer {
                     })?;
             }
             Err(detail) => {
-                let mut finalized = finalize_failed_ingest_response(
-                    claim.id.clone(),
-                    claim.created_at,
-                    detail.clone(),
-                );
-                finalized
-                    .timings
-                    .insert("queue_wait_ms".to_string(), queue_wait_ms);
-                let result_json = serde_json::to_string(&finalized)
-                    .context("failed to serialize failed ingest response")?;
-                queue
-                    .complete_operation(
-                        claim.id.clone(),
-                        IngestOperationState::Failed.as_str().to_string(),
-                        None,
-                        None,
-                        Some(detail),
-                        Some(result_json),
-                    )
-                    .await
-                    .map_err(|error| {
-                        anyhow::anyhow!("failed to store async ingest failure: {error}")
-                    })?;
+                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
             }
         }
 
@@ -7254,6 +7238,33 @@ fn queue_wait_ms(created_at_secs: i64, claimed_at_secs: i64) -> u64 {
         .saturating_mul(1_000) as u64
 }
 
+async fn complete_failed_ingest_claim(
+    queue: &AsyncPendingMessageStore,
+    claim: &ClaimedMessage,
+    queue_wait_ms: u64,
+    detail: String,
+) -> anyhow::Result<()> {
+    let mut finalized =
+        finalize_failed_ingest_response(claim.id.clone(), claim.created_at, detail.clone());
+    finalized
+        .timings
+        .insert("queue_wait_ms".to_string(), queue_wait_ms);
+    let result_json =
+        serde_json::to_string(&finalized).context("failed to serialize failed ingest response")?;
+    queue
+        .complete_operation(
+            claim.clone(),
+            IngestOperationState::Failed.as_str().to_string(),
+            None,
+            None,
+            Some(detail),
+            Some(result_json),
+        )
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to store async ingest failure: {error}"))?;
+    Ok(())
+}
+
 fn rfc3339_from_secs(secs: i64) -> String {
     crate::cowork::peek::format_rfc3339(UNIX_EPOCH + Duration::from_secs(secs.max(0) as u64))
 }
@@ -8145,6 +8156,46 @@ mod tests {
         assert!(!completed.drawer_id.is_empty());
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_async_ingest_malformed_payload_records_failed_receipt() {
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, "{not json")
+            .expect("enqueue malformed async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-malformed", 60, INGEST_ASYNC_KIND)
+            .expect("claim malformed op")
+            .expect("claimed malformed op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+
+        server
+            .process_ingest_claim(&async_queue, "worker-malformed", claim)
+            .await
+            .expect("process malformed payload");
+
+        let failed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("failed status");
+        assert_eq!(failed.state, Some(IngestOperationState::Failed));
+        assert!(failed.drawer_id.is_empty());
+        assert!(
+            failed
+                .failure_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("failed to decode ingest operation")),
+            "{failed:?}"
+        );
+
+        let record = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Failed.as_str());
+        assert!(record.completed_at.is_some());
+    }
+
     fn recreate_vectors_with_metric(db_path: &Path, metric: &str) {
         let db = Database::open(db_path).expect("open db");
         db.conn()
@@ -8235,7 +8286,7 @@ mod tests {
             .expect("failed fixture row");
         store
             .mark_failed_with_disposition(
-                &failed.id,
+                &failed,
                 "boom",
                 crate::core::queue::QueueFailureDisposition::Terminal,
             )

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -133,10 +133,12 @@ pub struct MempalMcpServer {
     /// Flushed and boosted on the next `mempal_ingest` call (P13).
     session_hit_drawers: Arc<Mutex<HashSet<String>>>,
     ingest_worker_started: Arc<AtomicBool>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    ingest_processing_delay: Option<Duration>,
 }
 
 impl MempalMcpServer {
-    pub fn new(db_path: PathBuf, config: crate::core::config::Config) -> Self {
+    pub fn new(db_path: PathBuf, config: crate::core::config::Config) -> anyhow::Result<Self> {
         Self::new_with_factory_and_config(
             db_path,
             config.clone(),
@@ -144,7 +146,10 @@ impl MempalMcpServer {
         )
     }
 
-    pub fn new_with_factory(db_path: PathBuf, embedder_factory: Arc<dyn EmbedderFactory>) -> Self {
+    pub fn new_with_factory(
+        db_path: PathBuf,
+        embedder_factory: Arc<dyn EmbedderFactory>,
+    ) -> anyhow::Result<Self> {
         Self::new_with_factory_and_config(
             db_path,
             ConfigHandle::current().as_ref().clone(),
@@ -156,11 +161,15 @@ impl MempalMcpServer {
         db_path: PathBuf,
         config: crate::core::config::Config,
         embedder_factory: Arc<dyn EmbedderFactory>,
-    ) -> Self {
-        let async_db =
-            AsyncDb::open(&db_path, 4).expect("MCP async database pool should open at server init");
+    ) -> anyhow::Result<Self> {
+        let async_db = AsyncDb::open(&db_path, 4).with_context(|| {
+            format!(
+                "failed to open MCP async database pool for {}",
+                db_path.display()
+            )
+        })?;
         let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path);
-        Self {
+        Ok(Self {
             db_path,
             async_db,
             async_queue,
@@ -172,12 +181,20 @@ impl MempalMcpServer {
             client_peer: Arc::new(Mutex::new(None)),
             session_hit_drawers: Arc::new(Mutex::new(HashSet::new())),
             ingest_worker_started: Arc::new(AtomicBool::new(false)),
-        }
+            #[cfg(any(test, feature = "db-test-seam"))]
+            ingest_processing_delay: None,
+        })
     }
 
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_async_db_for_test(mut self, async_db: AsyncDb) -> Self {
         self.async_db = async_db;
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_ingest_processing_delay_for_test(mut self, delay: Duration) -> Self {
+        self.ingest_processing_delay = Some(delay);
         self
     }
 
@@ -361,14 +378,14 @@ impl MempalMcpServer {
         });
 
         let outcome = self
-            .mempal_ingest_sync(prepared.request.clone(), prepared.controls)
+            .run_prepared_ingest_off_runtime(prepared.request.clone(), prepared.controls)
             .await;
 
         let _ = stop_tx.send(());
         let _ = heartbeat.await;
 
         match outcome {
-            Ok(Json(mut response)) => {
+            Ok(mut response) => {
                 let rejected_reason = response
                     .gating_decision
                     .as_ref()
@@ -444,6 +461,35 @@ impl MempalMcpServer {
         }
 
         Ok(())
+    }
+
+    async fn run_prepared_ingest_off_runtime(
+        &self,
+        request: IngestRequest,
+        controls: IngestControls,
+    ) -> anyhow::Result<IngestResponse> {
+        let worker = self.clone();
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let ingest_processing_delay = self.ingest_processing_delay;
+        let dispatcher = tracing::dispatcher::get_default(Clone::clone);
+        tokio::task::spawn_blocking(move || {
+            tracing::dispatcher::with_default(&dispatcher, || {
+                #[cfg(any(test, feature = "db-test-seam"))]
+                if let Some(delay) = ingest_processing_delay {
+                    std::thread::sleep(delay);
+                }
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .context("failed to build blocking ingest runtime")?;
+                runtime
+                    .block_on(worker.mempal_ingest_sync(request, controls))
+                    .map(|response| response.0)
+                    .map_err(|error| anyhow::anyhow!(error.to_string()))
+            })
+        })
+        .await
+        .context("blocking ingest worker task failed")?
     }
 
     pub(super) fn open_db(&self) -> std::result::Result<Database, ErrorData> {
@@ -7270,7 +7316,8 @@ mod tests {
             Arc::new(StubEmbedderFactory {
                 vector: vec![0.1, 0.2, 0.3],
             }),
-        );
+        )
+        .expect("create MCP server");
         (tempdir, db_path, server)
     }
 
@@ -7485,6 +7532,60 @@ mod tests {
         assert_eq!(response.state, Some(IngestOperationState::Queued));
         assert!(response.operation_id.is_some());
         assert_runtime_ticked(&ticks, "mempal_ingest admission");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_drain_worker_runs_sync_ingest_off_runtime() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server.with_ingest_processing_delay_for_test(Duration::from_millis(300));
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "offruntime queued ingest drain".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("runtime".to_string()),
+            project_id: Some("project-drain".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls::default(),
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-drain", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+        let (ticks, ticker) = spawn_runtime_ticker();
+
+        server
+            .process_ingest_claim(&async_queue, "worker-drain", claim)
+            .await
+            .expect("process queued ingest");
+        ticker.abort();
+
+        assert_runtime_ticked(&ticks, "mempal_ingest drain worker");
+        let completed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(!completed.drawer_id.is_empty());
     }
 
     fn recreate_vectors_with_metric(db_path: &Path, metric: &str) {
@@ -10132,7 +10233,8 @@ mod tests {
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
             }),
-        );
+        )
+        .expect("create MCP server");
 
         let response = tokio::time::timeout(
             Duration::from_secs(2),
@@ -10166,7 +10268,10 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("read queued op_state");
-        assert_eq!(op_state, "queued");
+        assert!(
+            matches!(op_state.as_str(), "queued" | "running"),
+            "receipt may return before or just after the drain worker claims the op, got {op_state}"
+        );
 
         gate.notify_one();
         let completed = server
@@ -10192,7 +10297,8 @@ mod tests {
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
             }),
-        );
+        )
+        .expect("create MCP server");
 
         let request = IngestRequest {
             content: "wait path should return the final ingest result".to_string(),
@@ -10258,7 +10364,8 @@ mod tests {
                 call_count: Arc::new(AtomicUsize::new(0)),
                 gate: Arc::clone(&gate),
             }),
-        );
+        )
+        .expect("create MCP server");
 
         let response = server
             .mempal_ingest(Parameters(IngestRequest {
@@ -10277,7 +10384,14 @@ mod tests {
 
         assert_eq!(response.state, Some(IngestOperationState::Queued));
         assert!(response.timed_out);
-        assert!(response.operation_id.is_some());
+        let operation_id = response.operation_id.expect("operation id");
+
+        gate.notify_one();
+        let completed = server
+            .wait_for_operation_completion(&operation_id)
+            .await
+            .expect("cleanup ingest completion");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
     }
 
     #[tokio::test]
@@ -10377,7 +10491,8 @@ enabled = true
             Arc::new(StubEmbedderFactory {
                 vector: vec![0.4, 0.5, 0.6],
             }),
-        );
+        )
+        .expect("create MCP server");
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let request = IngestRequest {
             content: "status tool async ingest".to_string(),
@@ -10610,7 +10725,8 @@ enabled = false
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
             }),
-        );
+        )
+        .expect("create MCP server");
 
         let response = server
             .mempal_ingest(Parameters(IngestRequest {

--- a/src/session_review.rs
+++ b/src/session_review.rs
@@ -400,12 +400,14 @@ fn linked_session_id(wing: &str, source_type: &str, content: &str) -> Option<Str
         return None;
     }
 
-    if source_type != "conversation" {
+    if !matches!(source_type, "agent_observation" | "conversation") {
         return None;
     }
 
     // Round-4 security fix: hooks-raw linkage must trust only daemon-persisted
     // metadata already stored in the drawer, never attacker-chosen disk paths.
+    // `conversation` is the legacy persisted value; modern daemon writes use
+    // `agent_observation`.
     split_hooks_raw_metadata(content)
         .1
         .session_id

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -167,21 +167,25 @@ fn record_novelty_audit(db_path: &Path, drawer_id: &str, action: NoveltyAction, 
 
 fn seed_queue_rows(db_path: &Path) {
     let store = PendingMessageStore::new(db_path).expect("queue store");
-    let _pending = store
-        .enqueue("hook", "pending payload")
-        .expect("enqueue pending");
+    let _failed = store
+        .enqueue("hook", "failed payload")
+        .expect("enqueue failed");
     let _claimed = store
         .enqueue("hook", "claimed payload")
         .expect("enqueue claimed");
-    let failed = store
-        .enqueue("hook", "failed payload")
-        .expect("enqueue failed");
-    let _claim = store
-        .claim_next("dashboard-test", 120)
+    let _pending = store
+        .enqueue("hook", "pending payload")
+        .expect("enqueue pending");
+    let failed_claim = store
+        .claim_next("dashboard-failed", 120)
+        .expect("claim next")
+        .expect("failed message");
+    let _claimed_claim = store
+        .claim_next("dashboard-claimed", 120)
         .expect("claim next")
         .expect("claimed message");
     store
-        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
+        .mark_failed_with_disposition(&failed_claim, "boom", QueueFailureDisposition::Terminal)
         .expect("mark terminal failed");
 }
 

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -118,7 +118,7 @@ impl TestEnv {
     }
 
     fn server(&self, factory: Arc<dyn EmbedderFactory>) -> MempalMcpServer {
-        MempalMcpServer::new_with_factory(self.db_path.clone(), factory)
+        MempalMcpServer::new_with_factory(self.db_path.clone(), factory).expect("create MCP server")
     }
 
     fn db(&self) -> Database {

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -33,7 +33,8 @@ fn setup_mcp_server() -> (TempDir, Database, MempalMcpServer) {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     let db = Database::open(&db_path).expect("open db");
-    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory));
+    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory))
+        .expect("create MCP server");
     (tmp, db, server)
 }
 

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -6,7 +6,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use mempal::core::{AsyncDb, db::Database, queue::PendingMessageStore};
+use mempal::core::{
+    AsyncDb,
+    db::Database,
+    queue::{AsyncPendingMessageStore, PendingMessageStore},
+};
 use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
 use mempal::embed::{EmbedError, Embedder};
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
@@ -104,9 +108,10 @@ async fn test_daemon_heartbeat_fires_during_embed_retry() {
 
     let config = mempal::core::config::Config::default();
     let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+    let async_store = AsyncPendingMessageStore::from_store(store.clone());
     process_claimed_message_with_embedder(
         &async_db,
-        &store,
+        &async_store,
         "worker-heartbeat",
         &claimed,
         &embedder,
@@ -212,9 +217,10 @@ enabled = true
     };
 
     let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+    let async_store = AsyncPendingMessageStore::from_store(store.clone());
     let drawer_id = process_claimed_message_with_embedder(
         &async_db,
-        &store,
+        &async_store,
         "worker-hotpatch-project",
         &claimed,
         &embedder,

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use mempal::core::{db::Database, queue::PendingMessageStore};
+use mempal::core::{AsyncDb, db::Database, queue::PendingMessageStore};
 use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
 use mempal::embed::{EmbedError, Embedder};
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
@@ -103,8 +103,9 @@ async fn test_daemon_heartbeat_fires_during_embed_retry() {
     };
 
     let config = mempal::core::config::Config::default();
+    let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
     process_claimed_message_with_embedder(
-        &Database::open(&db_path).expect("reopen db"),
+        &async_db,
         &store,
         "worker-heartbeat",
         &claimed,
@@ -210,8 +211,9 @@ enabled = true
         fail_before_success: 0,
     };
 
+    let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
     let drawer_id = process_claimed_message_with_embedder(
-        &Database::open(&db_path).expect("reopen db"),
+        &async_db,
         &store,
         "worker-hotpatch-project",
         &claimed,

--- a/tests/embedder_degraded_state.rs
+++ b/tests/embedder_degraded_state.rs
@@ -74,7 +74,8 @@ async fn test_degraded_state_blocks_mcp_writes() {
     let tmp = TempDir::new().expect("tempdir");
     let _config_path = bootstrap_config(&tmp);
     let db_path = tmp.path().join("palace.db");
-    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory));
+    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory))
+        .expect("create MCP server");
     let status = global_embed_status();
     status.reset_for_tests();
 

--- a/tests/embedder_dim_mismatch.rs
+++ b/tests/embedder_dim_mismatch.rs
@@ -66,7 +66,7 @@ request_timeout_secs = 5
     .expect("parse config");
     global_embed_status().reset_for_tests();
 
-    let service = MempalMcpServer::new(db_path, config);
+    let service = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = service
         .ingest_json_for_test(
             serde_json::to_value(IngestRequest {

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -65,7 +65,7 @@ async fn test_embedder_fallback_to_model2vec_when_lan_unreachable() {
         std::env::set_var("XDG_CACHE_HOME", &xdg_cache_home);
     }
 
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server
         .ingest_json_for_test(
             serde_json::to_value(IngestRequest {

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -1066,6 +1066,7 @@ async fn test_stale_reindex_skips_concurrent_real_merge_update() {
         "drawer content 0\n\nSUPPLEMENTARY (test): merged while stale embed was in flight",
         "1713009999",
         &fresh_vector,
+        0,
     )
     .expect("simulate concurrent novelty merge update");
 

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -328,7 +328,8 @@ async fn test_search_and_ingest_during_partial_reindex() {
         Arc::new(StubEmbedderFactory {
             vector: vec![0.2, 0.3, 0.4, 0.5],
         }),
-    );
+    )
+    .expect("create MCP server");
     let search = server
         .mempal_search(Parameters(SearchRequest {
             query: "drawer content".to_string(),
@@ -1267,7 +1268,7 @@ block_writes_when_degraded = true
     );
     ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
     let config = Config::load_from(&config_path).expect("load config");
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let status = global_embed_status();
     status.reset_for_tests();
     status.record_failure(&"synthetic 1");
@@ -1310,7 +1311,8 @@ async fn test_embed_degraded_allows_writes_when_not_configured() {
     status.record_failure(&"synthetic 1");
     status.record_failure(&"synthetic 2");
 
-    let server = MempalMcpServer::new(env.db_path.clone(), config.clone());
+    let server =
+        MempalMcpServer::new(env.db_path.clone(), config.clone()).expect("create MCP server");
     let response = tokio::time::timeout(
         Duration::from_secs(2),
         server.mempal_ingest(Parameters(IngestRequest {

--- a/tests/embedder_reload.rs
+++ b/tests/embedder_reload.rs
@@ -394,7 +394,7 @@ async fn test_openai_compat_section_requires_restart() {
     assert_eq!(ConfigHandle::version(), old_version);
 
     let config = Config::load_from(&env.config_path).expect("load changed config");
-    let server = MempalMcpServer::new(env.db_path.clone(), config);
+    let server = MempalMcpServer::new(env.db_path.clone(), config).expect("create MCP server");
     let status = server.mempal_status().await.expect("mcp status").0;
     assert!(status.system_warnings.iter().any(|warning| {
         warning
@@ -456,7 +456,7 @@ async fn test_dim_mismatch_fail_fast() {
     let (addr, _handle) = start_mock(0).await.expect("start mock");
     let config = Config::parse(&config_text(&db_path, &format!("http://{addr}/v1"), ""))
         .expect("parse config");
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server
         .ingest_json_for_test(
             serde_json::to_value(IngestRequest {

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -209,7 +209,7 @@ async fn test_search_deadline_bm25_fallback() {
     )
     .expect("insert drawer");
 
-    let server = MempalMcpServer::new(env.db_path.clone(), config);
+    let server = MempalMcpServer::new(env.db_path.clone(), config).expect("create MCP server");
     tokio::time::pause();
     let search = tokio::spawn({
         let server = server.clone();
@@ -272,7 +272,8 @@ async fn test_search_deadline_warning_surfaces_timeout_reason() {
     .expect("insert drawer");
 
     let server =
-        MempalMcpServer::new_with_factory(env.db_path.clone(), Arc::new(SlowEmbedderFactory));
+        MempalMcpServer::new_with_factory(env.db_path.clone(), Arc::new(SlowEmbedderFactory))
+            .expect("create MCP server");
     let status = server.mempal_status().await.expect("status").0;
     assert!(status.endpoint_health.embedding_reachable, "{status:#?}");
     assert!(status.embedder_circuit.bm25_fallback_enabled);
@@ -331,7 +332,8 @@ async fn test_successful_embed_exits_degraded() {
         "",
     ));
     let config = Config::load_from(&env.config_path).expect("load config");
-    let server = MempalMcpServer::new(env.db_path.clone(), config.clone());
+    let server =
+        MempalMcpServer::new(env.db_path.clone(), config.clone()).expect("create MCP server");
     let status = global_embed_status();
     status.reset_for_tests();
     status.record_failure(&"synthetic failure 1");
@@ -385,7 +387,7 @@ async fn test_successful_embed_exits_degraded() {
 }
 
 async fn ingest_with_config(db_path: PathBuf, config: Config) -> Result<serde_json::Value> {
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server
         .mempal_ingest(Parameters(IngestRequest {
             content: "blocked until recover".to_string(),
@@ -437,7 +439,8 @@ async fn test_ingest_returns_receipt_when_block_writes_false() {
         .get("operation_id")
         .and_then(|value| value.as_str())
         .expect("operation id");
-    let status_server = MempalMcpServer::new(env.db_path.clone(), config);
+    let status_server =
+        MempalMcpServer::new(env.db_path.clone(), config).expect("create MCP server");
     let completed = status_server
         .wait_for_operation_completion(operation_id)
         .await
@@ -470,7 +473,8 @@ block_writes_when_degraded = true
     let server = MempalMcpServer::new(
         std::path::PathBuf::from("/tmp/mempal-server-info.db"),
         config,
-    );
+    )
+    .expect("create MCP server");
     let tmp = TempDir::new().expect("tempdir");
     let config_path = tmp.path().join("config.toml");
     write_config(
@@ -579,7 +583,8 @@ async fn test_status_exposes_embed_status() {
         "",
     ));
     let config = Config::load_from(&env.config_path).expect("load config");
-    let server = MempalMcpServer::new(env.db_path.clone(), config.clone());
+    let server =
+        MempalMcpServer::new(env.db_path.clone(), config.clone()).expect("create MCP server");
     let embedder = from_config(&config).await.expect("build managed embedder");
     embedder
         .embed(&["status update"])

--- a/tests/hermes_integration.rs
+++ b/tests/hermes_integration.rs
@@ -160,10 +160,12 @@ impl TestEnv {
                 vector: vec![0.2, 0.4, 0.6, 0.8],
             }),
         )
+        .expect("create MCP server")
     }
 
     fn server_with_factory(&self, factory: Arc<dyn EmbedderFactory>) -> MempalMcpServer {
         MempalMcpServer::new_with_factory_and_config(self.db_path.clone(), self.config(), factory)
+            .expect("create MCP server")
     }
 }
 

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -9,7 +9,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use common::harness::{BootstrapObserver, DaemonSupervisor, start as start_embed_mock};
+use common::harness::{BootstrapObserver, DaemonSupervisor, FailMode, start as start_embed_mock};
 use mempal::bootstrap_events::BootstrapEvent;
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
@@ -139,6 +139,19 @@ fn latest_drawer_row(db_path: &Path) -> (String, String, String, String) {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .expect("latest drawer row")
+}
+
+fn drawer_content_contains(db_path: &Path, marker: &str) -> bool {
+    let pattern = format!("%{marker}%");
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM drawers WHERE content LIKE ?1 AND deleted_at IS NULL)",
+            [pattern],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query drawer content marker")
+        != 0
 }
 
 fn message_status(db_path: &Path, id: &str) -> Option<(String, i64)> {
@@ -390,6 +403,106 @@ async fn test_daemon_processes_hook_post_tool_to_drawer() {
         "privacy scrub must affect stored preview: {body}"
     );
     assert!(!body.contains(raw_secret), "raw secret leaked into drawer");
+
+    daemon.sigterm();
+    let status = daemon.wait().await.expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_daemon_slow_hook_does_not_block_later_hook() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    handle.set_fail_mode(FailMode::Timeout).await;
+    handle
+        .set_fail_if_input_contains(Some("slow-marker".to_string()))
+        .await;
+    write_config(
+        &config_path,
+        &db_path,
+        true,
+        20,
+        60,
+        Some(&format!("http://{addr}/v1")),
+    );
+
+    let slow_id = enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                serde_json::json!({
+                    "tool_name": "Bash",
+                    "input": "printf slow",
+                    "output": "slow-marker",
+                    "exit_code": 0
+                })
+                .to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 128,
+            truncated: false,
+        },
+    );
+    let fast_id = enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "124".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                serde_json::json!({
+                    "tool_name": "Bash",
+                    "input": "printf fast",
+                    "output": "fast-marker",
+                    "exit_code": 0
+                })
+                .to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 128,
+            truncated: false,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+
+    wait_for_condition(Duration::from_secs(10), || {
+        message_status(&db_path, &fast_id).is_none()
+            && drawer_content_contains(&db_path, "fast-marker")
+    })
+    .await;
+    assert!(
+        matches!(message_status(&db_path, &slow_id), Some((ref status, _)) if status == "claimed"),
+        "slow hook should still be isolated in one claimed worker"
+    );
+
+    handle.set_fail_if_input_contains(None).await;
+    handle.set_fail_mode(FailMode::Ok).await;
+    wait_for_condition(Duration::from_secs(10), || {
+        message_status(&db_path, &slow_id).is_none()
+            && drawer_content_contains(&db_path, "slow-marker")
+    })
+    .await;
 
     daemon.sigterm();
     let status = daemon.wait().await.expect("wait daemon");

--- a/tests/hook_project_promotion.rs
+++ b/tests/hook_project_promotion.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
+use mempal::core::AsyncDb;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
@@ -43,7 +44,6 @@ impl Embedder for StaticEmbedder {
 struct TestEnv {
     _tmp: TempDir,
     config: Config,
-    db: Database,
     db_path: PathBuf,
     mempal_home: PathBuf,
     project_dir: PathBuf,
@@ -102,7 +102,6 @@ enabled = false
         Self {
             _tmp: tmp,
             config,
-            db,
             db_path,
             mempal_home,
             project_dir,
@@ -141,8 +140,9 @@ enabled = false
             .claim_next("hook-project-promotion-test", 120)
             .expect("claim next")
             .expect("claimed message");
+        let async_db = AsyncDb::open(&self.db_path, 4).expect("open async db");
         process_claimed_message_with_embedder(
-            &self.db,
+            &async_db,
             &self.store,
             "hook-project-promotion-test",
             &claimed,
@@ -263,7 +263,6 @@ fn count_drawers_by_wing_only(db_path: &Path, wing: &str) -> i64 {
 struct MinimalEnv {
     _tmp: TempDir,
     config: Config,
-    db: Database,
     db_path: PathBuf,
     mempal_home: PathBuf,
     store: PendingMessageStore,
@@ -324,7 +323,6 @@ enabled = false
         Self {
             _tmp: tmp,
             config,
-            db,
             db_path,
             mempal_home,
             store,
@@ -362,8 +360,9 @@ enabled = false
             .claim_next("wing-routing-test", 120)
             .expect("claim next")
             .expect("claimed message");
+        let async_db = AsyncDb::open(&self.db_path, 4).expect("open async db");
         process_claimed_message_with_embedder(
-            &self.db,
+            &async_db,
             &self.store,
             "wing-routing-test",
             &claimed,

--- a/tests/hook_project_promotion.rs
+++ b/tests/hook_project_promotion.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use mempal::core::AsyncDb;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
-use mempal::core::queue::PendingMessageStore;
+use mempal::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
 use mempal::core::types::TaxonomyEntry;
 use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
 use mempal::embed::{EmbedError, Embedder};
@@ -141,9 +141,10 @@ enabled = false
             .expect("claim next")
             .expect("claimed message");
         let async_db = AsyncDb::open(&self.db_path, 4).expect("open async db");
+        let async_store = AsyncPendingMessageStore::from_store(self.store.clone());
         process_claimed_message_with_embedder(
             &async_db,
-            &self.store,
+            &async_store,
             "hook-project-promotion-test",
             &claimed,
             &StaticEmbedder,
@@ -361,9 +362,10 @@ enabled = false
             .expect("claim next")
             .expect("claimed message");
         let async_db = AsyncDb::open(&self.db_path, 4).expect("open async db");
+        let async_store = AsyncPendingMessageStore::from_store(self.store.clone());
         process_claimed_message_with_embedder(
             &async_db,
-            &self.store,
+            &async_store,
             "wing-routing-test",
             &claimed,
             &StaticEmbedder,

--- a/tests/ingest_chunker.rs
+++ b/tests/ingest_chunker.rs
@@ -159,7 +159,8 @@ async fn test_mcp_ingest_short_content_single_chunk() {
         dim: 4,
         max_tokens: 100,
     });
-    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory)
+        .expect("create MCP server");
 
     let content = make_content(10);
     let response = server
@@ -196,7 +197,8 @@ async fn test_mcp_ingest_large_content_multi_chunk() {
         dim: 4,
         max_tokens: 50,
     });
-    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory)
+        .expect("create MCP server");
 
     let content = make_content(100);
     let response = server
@@ -263,7 +265,8 @@ async fn test_mcp_ingest_dry_run_returns_chunk_info() {
         dim: 4,
         max_tokens: 50,
     });
-    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory);
+    let server = MempalMcpServer::new_with_factory_and_config(env.db_path.clone(), config, factory)
+        .expect("create MCP server");
 
     let content = make_content(100);
     let response = server

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -803,7 +803,8 @@ prototypes = ["valuable", "noise"]
             vec![0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     for content in [
         "valuable candidate one",
@@ -849,7 +850,8 @@ prototypes = ["valuable"]
         env.db_path.clone(),
         config,
         deterministic_factory(&[], vec![0.3, 0.3], &["valuable"]),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "content that bypasses gating entirely").await;
 
@@ -885,7 +887,8 @@ prototypes = ["valuable"]
             vec![0.2, 0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "vector dim stays consistent").await;
     let rows = gating_rows(&env.db());
@@ -1652,7 +1655,8 @@ async fn test_tier1_skips_short_content() {
         env.db_path.clone(),
         config,
         deterministic_factory(&[], vec![0.2, 0.2], &[]),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "tiny").await;
     let rows = gating_rows(&env.db());
@@ -1692,7 +1696,8 @@ prototypes = ["valuable", "noise"]
             vec![0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "above threshold candidate").await;
     let rows = gating_rows(&env.db());
@@ -1732,7 +1737,8 @@ prototypes = ["valuable", "noise"]
             vec![0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "below threshold candidate").await;
     let rows = gating_rows(&env.db());
@@ -1833,7 +1839,8 @@ enabled = false
         env.db_path.clone(),
         config,
         deterministic_factory(&[], vec![0.2, 0.2], &[]),
-    );
+    )
+    .expect("create MCP server");
 
     let mcp_status = server.mempal_status().await.expect("mcp status").0;
     let output = run_mempal(&env.home, &["status"]);
@@ -1879,7 +1886,8 @@ prototypes = ["valuable"]
         env.db_path.clone(),
         config,
         deterministic_factory(&[("valuable", vec![1.0, 0.0])], vec![0.2, 0.2], &[]),
-    );
+    )
+    .expect("create MCP server");
 
     let mcp_status = server.mempal_status().await.expect("mcp status").0;
     let output = run_mempal(&env.home, &["status"]);
@@ -1948,7 +1956,8 @@ enabled = true
             vec![0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     // Case 1: Tier 1 Skip (too short) — no LLM task enqueued.
     let response = ingest_mcp(&server, "tiny").await;
@@ -2026,7 +2035,8 @@ threshold = 0.5
             vec![0.2, 0.2],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     // Content below threshold → Tier 2 unclassified → Tier 3 LLM judge (fail-open).
     let response = ingest_mcp(&server, "ambiguous content to judge").await;
@@ -2105,7 +2115,8 @@ threshold = 0.5
             vec![0.5, 0.5],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
 
     // Content long enough to produce multiple chunks with max_tokens=10.
     let long_content = "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa";
@@ -2220,7 +2231,8 @@ threshold = 0.5
         env.db_path.clone(),
         config,
         deterministic_factory(&[("keep_proto", vec![1.0, 0.0])], vec![0.5, 0.5], &[]),
-    );
+    )
+    .expect("create MCP server");
 
     let response = ingest_mcp(&server, "ambiguous high-score reject content").await;
     assert!(!response.dropped, "tier3 must fail-open before verdict");
@@ -2308,7 +2320,8 @@ enabled = false
             vec![0.5, 0.5],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
     let first_response = ingest_mcp(&server_phase1, "ambiguous dedup content").await;
     assert!(!first_response.dropped, "phase1 must store the drawer");
     assert_eq!(env.db().drawer_count().expect("drawer count phase1"), 1);
@@ -2357,7 +2370,8 @@ threshold = 0.5
             vec![0.5, 0.5],
             &[],
         ),
-    );
+    )
+    .expect("create MCP server");
     let second_response = ingest_mcp(&server_phase2, "ambiguous dedup content").await;
 
     // Fail-open: not dropped (dedup re-ingest keeps the existing drawer).

--- a/tests/knowledge_card_retrieval.rs
+++ b/tests/knowledge_card_retrieval.rs
@@ -355,7 +355,8 @@ async fn test_mcp_knowledge_cards_retrieve_action() {
     let server = MempalMcpServer::new_with_factory(
         db_path,
         Arc::new(StubEmbedderFactory { vector: vector() }),
-    );
+    )
+    .expect("create MCP server");
 
     let response = server
         .knowledge_cards_json_for_test(json!({

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use axum::{Json, Router, routing::post};
 use mempal::core::config::{Config, ConfigHandle, IngestGatingConfig, LlmConfig, LlmJudgeConfig};
 use mempal::core::db::Database;
-use mempal::core::queue::PendingMessageStore;
+use mempal::core::queue::{ClaimedMessage, PendingMessageStore};
 use mempal::llm::client::LlmClient;
 use mempal::llm::status::LlmStatus;
 use mempal::llm::worker::confirm_llm_task;
@@ -23,6 +23,19 @@ static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn make_store(db: &Database) -> PendingMessageStore {
     PendingMessageStore::new(db.path()).expect("open queue")
+}
+
+fn fake_claim(id: &str) -> ClaimedMessage {
+    ClaimedMessage {
+        id: id.to_string(),
+        kind: "llm_task".to_string(),
+        payload: "{}".to_string(),
+        retry_count: 0,
+        claim_token: "worker:claim".to_string(),
+        source_hash: String::new(),
+        created_at: 0,
+        claimed_at: 0,
+    }
 }
 
 fn llm_chat_response_body(content: &str) -> serde_json::Value {
@@ -79,7 +92,7 @@ fn test_release_claim_returns_task_to_pending() {
     assert_eq!(stats_claimed.pending, 0);
 
     // Release back to pending — simulates worker cancellation due to config change.
-    store.release_claim(&id).expect("release_claim");
+    store.release_claim(&msg).expect("release_claim");
     let released_op_state: String = db
         .conn()
         .query_row(
@@ -110,9 +123,10 @@ fn test_release_claim_does_not_increment_retry_count() {
         .claim_next_by_kind("worker", 300, "llm_task")
         .expect("claim_next_by_kind")
         .expect("message");
+    assert_eq!(msg.id, id);
     assert_eq!(msg.retry_count, 0);
 
-    store.release_claim(&id).expect("release_claim");
+    store.release_claim(&msg).expect("release_claim");
 
     // Claim again — retry_count must still be 0.
     let msg2 = store
@@ -131,7 +145,7 @@ fn test_release_claim_returns_error_for_unknown_id() {
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
     let store = make_store(&db);
 
-    let result = store.release_claim("nonexistent-id");
+    let result = store.release_claim(&fake_claim("nonexistent-id"));
     assert!(
         result.is_err(),
         "release_claim on unknown id must return MessageNotFound"
@@ -374,7 +388,7 @@ async fn test_llm_process_refreshes_heartbeat_during_long_judge_call() {
     let (process_result, _) = tokio::join!(process, claim_probe);
     process_result.expect("process llm task");
 
-    confirm_llm_task(&store, &claimed.id).expect("confirm llm task");
+    confirm_llm_task(&store, &claimed).expect("confirm llm task");
 
     let after_confirm = store
         .claim_next_by_kind("worker-c", 1, "llm_task")
@@ -424,7 +438,7 @@ fn test_release_claim_on_already_pending_is_error() {
 
     let id = store.enqueue("llm_task", "{}").expect("enqueue");
     // Task is pending (not claimed) — release_claim should return error.
-    let result = store.release_claim(&id);
+    let result = store.release_claim(&fake_claim(&id));
     assert!(
         result.is_err(),
         "release_claim on a pending (unclaimed) task must fail"

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -132,7 +132,7 @@ async fn test_mcp_status_surfaces_queue_stats() {
         .expect("done");
     store.confirm(&done.id).expect("confirm");
 
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
     assert_eq!(response.queue_stats.pending, 1);
@@ -166,7 +166,7 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
         .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
         .expect("mark terminal failed");
 
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
     assert_eq!(response.queue_stats.failed, 1);
@@ -181,7 +181,7 @@ async fn test_mcp_status_surfaces_source_type_distribution() {
     insert_drawer_with_source_type(&db_path, "drawer-user", SourceType::UserExplicit);
     insert_drawer_with_source_type(&db_path, "drawer-hook", SourceType::SystemGenerated);
 
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
     let user_count = response
@@ -220,7 +220,7 @@ async fn test_mcp_status_surfaces_consolidation_stats() {
     }
     merge_cluster(&db, &ids, CompactionStrategy::RichestContent, false).expect("merge cluster");
 
-    let server = MempalMcpServer::new(db_path, config);
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
     assert_eq!(response.total_compacted_drawers, 2);

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -130,7 +130,7 @@ async fn test_mcp_status_surfaces_queue_stats() {
         .claim_next("worker-done", 60)
         .expect("claim")
         .expect("done");
-    store.confirm(&done.id).expect("confirm");
+    store.confirm(&done).expect("confirm");
 
     let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
@@ -163,7 +163,7 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
         .expect("claim")
         .expect("failed row");
     store
-        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
         .expect("mark terminal failed");
 
     let server = MempalMcpServer::new(db_path, config).expect("create MCP server");

--- a/tests/mcp_timeline.rs
+++ b/tests/mcp_timeline.rs
@@ -73,6 +73,7 @@ impl TimelineEnv {
 
     fn server(&self) -> MempalMcpServer {
         MempalMcpServer::new_with_factory(self.db_path.clone(), Arc::new(PanicEmbedderFactory))
+            .expect("create MCP server")
     }
 }
 

--- a/tests/memory_strata.rs
+++ b/tests/memory_strata.rs
@@ -66,7 +66,8 @@ impl TestEnv {
         Database::open(&db_path).expect("open db");
         ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
         let server =
-            MempalMcpServer::new_with_factory(db_path.clone(), Arc::new(StaticEmbedderFactory));
+            MempalMcpServer::new_with_factory(db_path.clone(), Arc::new(StaticEmbedderFactory))
+                .expect("create MCP server");
         Self {
             _tmp: tmp,
             db_path,

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -143,7 +143,8 @@ fn setup_mcp_server() -> (TempDir, Database, MempalMcpServer) {
         Arc::new(StubEmbedderFactory {
             vector: vec![0.1, 0.2, 0.3],
         }),
-    );
+    )
+    .expect("create MCP server");
     (tmp, db, server)
 }
 
@@ -155,7 +156,8 @@ fn setup_rest_mcp_server() -> (TempDir, Database, MempalMcpServer, mempal::api::
     let factory = Arc::new(StubEmbedderFactory {
         vector: vec![0.1, 0.2, 0.3],
     });
-    let server = MempalMcpServer::new_with_factory(db_path.clone(), factory.clone());
+    let server = MempalMcpServer::new_with_factory(db_path.clone(), factory.clone())
+        .expect("create MCP server");
     let state = mempal::api::ApiState::new(db_path, factory);
     (tmp, db, server, state)
 }

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -896,9 +896,10 @@ async fn test_rest_after_mcp_default_ingest_reuses_existing_bootstrap_drawer() {
 
 #[cfg(feature = "rest")]
 #[tokio::test]
-async fn test_rest_ingest_does_not_claim_typed_field_parity() {
+async fn test_rest_ingest_preserves_typed_fields_on_bootstrap_identity() {
     let (_tmp, db, _server, state) = setup_rest_mcp_server();
-    let content = "REST typed fields remain ignored";
+    let content = "REST typed fields are persisted";
+    let statement = "REST should preserve typed knowledge metadata.";
     let (status, body) = post_rest_ingest(
         state,
         json!({
@@ -906,7 +907,7 @@ async fn test_rest_ingest_does_not_claim_typed_field_parity() {
             "wing": "mempal",
             "room": "identity",
             "memory_kind": "knowledge",
-            "statement": "REST should not accept typed knowledge yet.",
+            "statement": statement,
             "tier": "shu",
             "status": "promoted",
             "supporting_refs": ["drawer_ev_001"]
@@ -926,10 +927,11 @@ async fn test_rest_ingest_does_not_claim_typed_field_parity() {
         .get_drawer(&expected)
         .expect("load rest drawer")
         .expect("rest drawer exists");
-    assert_eq!(drawer.memory_kind, MemoryKind::Evidence);
-    assert_eq!(drawer.statement, None);
-    assert_eq!(drawer.tier, None);
-    assert_eq!(drawer.status, None);
+    assert_eq!(drawer.memory_kind, MemoryKind::Knowledge);
+    assert_eq!(drawer.statement.as_deref(), Some(statement));
+    assert_eq!(drawer.tier, Some(KnowledgeTier::Shu));
+    assert_eq!(drawer.status, Some(KnowledgeStatus::Promoted));
+    assert_eq!(drawer.supporting_refs, vec!["drawer_ev_001"]);
 }
 
 #[tokio::test]

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -364,7 +364,8 @@ fn setup_mcp_server() -> (TempDir, Database, MempalMcpServer) {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     let db = Database::open(&db_path).expect("open db");
-    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory));
+    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory))
+        .expect("create MCP server");
     (tmp, db, server)
 }
 

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use async_trait::async_trait;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::{
-    Database, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
+    Database, DbError, FORK_EXT_META_DDL, FORK_EXT_V1_SCHEMA_SQL, FORK_EXT_V2_SCHEMA_SQL,
     FORK_EXT_V3_SCHEMA_SQL, apply_fork_ext_migrations_to, read_fork_ext_version,
     set_fork_ext_version,
 };
@@ -685,6 +685,55 @@ async fn test_medium_similarity_candidate_merged() {
     assert_eq!(audits.len(), 1);
     assert_eq!(audits[0].decision, "merge");
     assert_eq!(audits[0].near_drawer_id.as_deref(), Some("existing"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_stale_novelty_merge_version_cannot_overwrite_supplement() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(true);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "existing",
+            content: "Decision: keep raw content",
+            wing: DEFAULT_WING,
+            room: DEFAULT_ROOM,
+            project_id: None,
+        },
+        &[1.0, 0.0],
+    );
+
+    let db = env.db();
+    let (original_content, observed_merge_count) = db
+        .drawer_merge_state("existing")
+        .expect("load merge state")
+        .expect("merge target exists");
+    assert_eq!(observed_merge_count, 0);
+
+    let first_content =
+        format!("{original_content}\n---\nSUPPLEMENTARY (first):\nfirst supplement");
+    db.update_drawer_after_merge("existing", &first_content, "1713000001", &[0.9, 0.1], 0)
+        .expect("first merge succeeds");
+
+    let stale_content =
+        format!("{original_content}\n---\nSUPPLEMENTARY (stale):\nstale supplement");
+    let error = db
+        .update_drawer_after_merge("existing", &stale_content, "1713000002", &[0.1, 0.9], 0)
+        .expect_err("stale merge must conflict");
+    assert!(matches!(
+        error,
+        DbError::DrawerMergeConflict {
+            drawer_id,
+            expected_merge_count: 0,
+        } if drawer_id == "existing"
+    ));
+
+    let content = drawer_content(&env.db_path, "existing");
+    assert!(content.contains("first supplement"));
+    assert!(!content.contains("stale supplement"));
+    let (merge_count, updated_at) = merge_state(&env.db_path, "existing");
+    assert_eq!(merge_count, 1);
+    assert_eq!(updated_at.as_deref(), Some("1713000001"));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -13,7 +13,7 @@ use mempal::core::db::{
 };
 use mempal::core::types::{Drawer, SourceType, Triple};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
-use mempal::mcp::{IngestRequest, IngestResponse, MempalMcpServer};
+use mempal::mcp::{IngestOperationState, IngestRequest, IngestResponse, MempalMcpServer};
 use rusqlite::{Connection, OptionalExtension, params};
 use tempfile::TempDir;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
@@ -686,6 +686,60 @@ async fn test_medium_similarity_candidate_merged() {
     assert_eq!(audits.len(), 1);
     assert_eq!(audits[0].decision, "merge");
     assert_eq!(audits[0].near_drawer_id.as_deref(), Some("existing"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_mcp_merge_audit_failure_rolls_back_target_update() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(true);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "existing",
+            content: "Decision: keep atomic MCP merge audits",
+            wing: DEFAULT_WING,
+            room: DEFAULT_ROOM,
+            project_id: None,
+        },
+        &[1.0, 0.0],
+    );
+    Connection::open(&env.db_path)
+        .expect("open sqlite")
+        .execute_batch("DROP TABLE novelty_audit")
+        .expect("drop novelty audit table");
+    let candidate = "Also: audit insert failure must roll back merge";
+    let server = env.server(&[(candidate, vec![0.9, 0.4358899])], &[]);
+
+    let response = server
+        .ingest_json_for_test(
+            serde_json::to_value(IngestRequest {
+                content: candidate.to_string(),
+                wing: DEFAULT_WING.to_string(),
+                room: Some(DEFAULT_ROOM.to_string()),
+                dry_run: Some(false),
+                ..IngestRequest::default()
+            })
+            .expect("serialize ingest request"),
+        )
+        .await
+        .expect("failed operation response");
+
+    assert_eq!(response.state, Some(IngestOperationState::Failed));
+    assert!(
+        response
+            .failure_detail
+            .as_deref()
+            .unwrap_or_default()
+            .contains("novelty_audit"),
+        "failure detail should mention audit write failure: {response:?}"
+    );
+    assert_eq!(
+        drawer_content(&env.db_path, "existing"),
+        "Decision: keep atomic MCP merge audits"
+    );
+    let (merge_count, updated_at) = merge_state(&env.db_path, "existing");
+    assert_eq!(merge_count, 0);
+    assert_eq!(updated_at, None);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -171,6 +171,7 @@ impl TestEnv {
                 ),
             }),
         )
+        .expect("create MCP server")
     }
 }
 

--- a/tests/pattern_induction.rs
+++ b/tests/pattern_induction.rs
@@ -210,6 +210,7 @@ impl TestEnv {
                 default: default_vec,
             }),
         )
+        .expect("create MCP server")
     }
 
     fn db(&self) -> Database {

--- a/tests/privacy_scrubbing.rs
+++ b/tests/privacy_scrubbing.rs
@@ -217,6 +217,7 @@ async fn status_response(db_path: &Path) -> StatusResponse {
             ..Config::default()
         },
     )
+    .expect("create MCP server")
     .mempal_status()
     .await
     .expect("status")

--- a/tests/privacy_scrubbing.rs
+++ b/tests/privacy_scrubbing.rs
@@ -498,13 +498,7 @@ pattern = "("
 #[test]
 fn test_no_new_runtime_dependencies_introduced() {
     let runtime_packages = runtime_dependency_names();
-    let baseline_output = Command::new("git")
-        .args(["show", "main:Cargo.lock"])
-        .output()
-        .expect("read baseline Cargo.lock from main");
-    assert!(baseline_output.status.success(), "{baseline_output:?}");
-    let baseline_lock =
-        String::from_utf8(baseline_output.stdout).expect("baseline Cargo.lock is utf8");
+    let baseline_lock = baseline_cargo_lock();
     let baseline_packages = lockfile_package_names(&baseline_lock);
 
     // Intentional additions approved in feat/integrate-upstream-subcommands:
@@ -521,6 +515,41 @@ fn test_no_new_runtime_dependencies_introduced() {
         new_runtime_packages.is_empty(),
         "new runtime dependencies detected: {new_runtime_packages:?}"
     );
+}
+
+fn baseline_cargo_lock() -> String {
+    let base_ref = std::env::var("GITHUB_BASE_REF").unwrap_or_else(|_| "main".to_string());
+    let direct_refs = [
+        format!("{base_ref}:Cargo.lock"),
+        format!("origin/{base_ref}:Cargo.lock"),
+        "main:Cargo.lock".to_string(),
+        "origin/main:Cargo.lock".to_string(),
+    ];
+
+    for spec in direct_refs {
+        if let Some(lock) = git_show_cargo_lock(&spec) {
+            return lock;
+        }
+    }
+
+    let fetch = Command::new("git")
+        .args(["fetch", "--depth=1", "origin", &base_ref])
+        .output()
+        .expect("fetch baseline Cargo.lock ref");
+    assert!(fetch.status.success(), "{fetch:?}");
+
+    git_show_cargo_lock("FETCH_HEAD:Cargo.lock").expect("baseline Cargo.lock is available")
+}
+
+fn git_show_cargo_lock(spec: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["show", spec])
+        .output()
+        .expect("read baseline Cargo.lock");
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(output.stdout).expect("baseline Cargo.lock is utf8"))
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/progressive_disclosure.rs
+++ b/tests/progressive_disclosure.rs
@@ -112,6 +112,7 @@ impl TestEnv {
                 vector: vec![0.1, 0.2, 0.3],
             }),
         )
+        .expect("create MCP server")
     }
 }
 

--- a/tests/project_vector_isolation.rs
+++ b/tests/project_vector_isolation.rs
@@ -122,6 +122,7 @@ impl SearchEnv {
                 vector: vec![0.1, 0.2, 0.3],
             }),
         )
+        .expect("create MCP server")
     }
 }
 
@@ -775,7 +776,8 @@ async fn test_stale_reindex_preserves_project_id() {
         Arc::new(StaticEmbedderFactory {
             vector: vec![0.0, 0.0, 0.0, 0.0],
         }),
-    );
+    )
+    .expect("create MCP server");
     let project_ids = parse_search_ids(
         &search_response_json_with_request(
             &server,

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mempal::core::db::Database;
 use mempal::core::queue::{
-    LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig, QueueFailureDisposition,
+    ClaimedMessage, LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig, QueueError,
+    QueueFailureDisposition,
 };
 use mempal::llm::worker::confirm_llm_task;
 use rusqlite::Connection;
@@ -26,6 +27,55 @@ fn new_store() -> (TempDir, PathBuf, PendingMessageStore) {
     Database::open(&db_path).expect("open db");
     let store = PendingMessageStore::new(&db_path).expect("create store");
     (tmp, db_path, store)
+}
+
+fn stale_then_reclaimed(
+    store: &PendingMessageStore,
+    db_path: &PathBuf,
+) -> (ClaimedMessage, ClaimedMessage) {
+    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let stale = store
+        .claim_next("worker-a", 60)
+        .expect("claim stale")
+        .expect("stale claim");
+    assert_eq!(stale.id, id);
+
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .execute(
+            "UPDATE pending_messages SET heartbeat_at = ?2, claimed_at = ?2 WHERE id = ?1",
+            rusqlite::params![id, now_secs() - 120],
+        )
+        .expect("age heartbeat");
+    assert_eq!(store.reclaim_stale(60).expect("reclaim stale"), 1);
+
+    let reclaimed = store
+        .claim_next("worker-b", 60)
+        .expect("reclaim claim")
+        .expect("reclaimed claim");
+    assert_eq!(reclaimed.id, stale.id);
+    assert_ne!(reclaimed.claim_token, stale.claim_token);
+    (stale, reclaimed)
+}
+
+fn assert_active_claim(db_path: &PathBuf, claim: &ClaimedMessage) {
+    let (status, claim_token): (String, String) = Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT status, claim_token FROM pending_messages WHERE id = ?1",
+            [&claim.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read active claim");
+    assert_eq!(status, "claimed");
+    assert_eq!(claim_token, claim.claim_token);
+}
+
+fn assert_claim_lost(error: QueueError, expected_id: &str) {
+    match error {
+        QueueError::ClaimLost(id) => assert_eq!(id, expected_id),
+        other => panic!("expected ClaimLost for {expected_id}, got {other:?}"),
+    }
 }
 
 #[test]
@@ -68,7 +118,7 @@ fn test_confirm_deletes_row() {
         .expect("message");
     assert_eq!(claimed.id, id);
 
-    store.confirm(&claimed.id).expect("confirm");
+    store.confirm(&claimed).expect("confirm");
     let stats = store.stats().expect("stats");
 
     assert_eq!(stats.pending, 0);
@@ -116,7 +166,7 @@ fn test_confirm_llm_task_missing_row_is_benign() {
         .expect("delete claimed row");
     drop(conn);
 
-    confirm_llm_task(&store, &id).expect("confirm missing LLM task");
+    confirm_llm_task(&store, &claimed).expect("confirm missing LLM task");
 }
 
 #[test]
@@ -142,7 +192,7 @@ fn test_mark_failed_sets_backoff_next_attempt() {
     assert_eq!(claimed.id, id);
 
     let before = now_secs();
-    store.mark_failed(&id, "timeout").expect("mark failed");
+    store.mark_failed(&claimed, "timeout").expect("mark failed");
 
     let conn = Connection::open(db_path).expect("open sqlite");
     let (retry_count, retry_backoff_ms, next_attempt_at, status, op_state, last_error): (
@@ -182,13 +232,18 @@ fn test_mark_failed_sets_backoff_next_attempt() {
 fn test_retryable_failure_is_retried_not_dead_lettered_first() {
     let (_tmp, db_path, store) = new_store();
     let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
-    store
+    let claimed = store
         .claim_next("worker-a", 60)
         .expect("claim")
         .expect("message");
+    assert_eq!(claimed.id, id);
 
     store
-        .mark_failed_with_disposition(&id, "transport timeout", QueueFailureDisposition::Retryable)
+        .mark_failed_with_disposition(
+            &claimed,
+            "transport timeout",
+            QueueFailureDisposition::Retryable,
+        )
         .expect("mark retryable failure");
 
     let (status, retry_count): (String, i64) = Connection::open(db_path)
@@ -207,14 +262,14 @@ fn test_retryable_failure_is_retried_not_dead_lettered_first() {
 fn test_terminal_failure_dead_letters_immediately() {
     let (_tmp, db_path, store) = new_store();
     let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
-    store
+    let claimed = store
         .claim_next("worker-a", 60)
         .expect("claim")
         .expect("message");
 
     store
         .mark_failed_with_disposition(
-            &id,
+            &claimed,
             "invalid embedding input",
             QueueFailureDisposition::Terminal,
         )
@@ -249,6 +304,43 @@ fn test_terminal_failure_dead_letters_immediately() {
 }
 
 #[test]
+fn test_stale_claim_finalizers_fail_without_touching_reclaimed_claim() {
+    let (_tmp, db_path, store) = new_store();
+
+    let (stale_complete, active_complete) = stale_then_reclaimed(&store, &db_path);
+    let complete_error = store
+        .complete_operation(&stale_complete, "completed", None, None, None, None)
+        .expect_err("stale complete must fail");
+    assert_claim_lost(complete_error, &stale_complete.id);
+    assert_active_claim(&db_path, &active_complete);
+
+    let (stale_confirm, active_confirm) = stale_then_reclaimed(&store, &db_path);
+    let confirm_error = store
+        .confirm(&stale_confirm)
+        .expect_err("stale confirm must fail");
+    assert_claim_lost(confirm_error, &stale_confirm.id);
+    assert_active_claim(&db_path, &active_confirm);
+
+    let (stale_fail, active_fail) = stale_then_reclaimed(&store, &db_path);
+    let fail_error = store
+        .mark_failed_with_disposition(
+            &stale_fail,
+            "stale failure",
+            QueueFailureDisposition::Terminal,
+        )
+        .expect_err("stale failure finalizer must fail");
+    assert_claim_lost(fail_error, &stale_fail.id);
+    assert_active_claim(&db_path, &active_fail);
+
+    let (stale_release, active_release) = stale_then_reclaimed(&store, &db_path);
+    let release_error = store
+        .release_claim(&stale_release)
+        .expect_err("stale release must fail");
+    assert_claim_lost(release_error, &stale_release.id);
+    assert_active_claim(&db_path, &active_release);
+}
+
+#[test]
 fn test_retryable_failure_stays_retryable_past_max_retries() {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
@@ -270,7 +362,7 @@ fn test_retryable_failure_stays_retryable_past_max_retries() {
             .expect("claim")
             .expect("message");
         assert_eq!(claimed.id, id);
-        store.mark_failed(&id, "timeout").expect("mark failed");
+        store.mark_failed(&claimed, "timeout").expect("mark failed");
     }
 
     let conn = Connection::open(&db_path).expect("open sqlite");
@@ -613,7 +705,7 @@ fn test_last_error_is_redacted_and_truncated() {
     let id = store
         .enqueue("hook_event", r#"{"tool":"Bash"}"#)
         .expect("enqueue");
-    store
+    let claimed = store
         .claim_next("worker-a", 60)
         .expect("claim")
         .expect("message");
@@ -621,7 +713,7 @@ fn test_last_error_is_redacted_and_truncated() {
     let secret = "sk-abcdefghijklmnopqrstuvwxyz0123456789SECRETKEY";
     let oversized_error = format!("before {secret} {}", "x".repeat(LAST_ERROR_MAX_BYTES * 2));
     store
-        .mark_failed(&id, &oversized_error)
+        .mark_failed(&claimed, &oversized_error)
         .expect("mark failed with secret");
 
     let stored_error = Connection::open(db_path)

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -230,7 +230,7 @@ fn test_queue_stats_reflects_current_state() {
         .expect("claim")
         .expect("done row");
     assert_eq!(done.id, done_id);
-    store.confirm(&done.id).expect("confirm");
+    store.confirm(&done).expect("confirm");
 
     let failed = store
         .claim_next("worker-failed", 60)
@@ -238,7 +238,7 @@ fn test_queue_stats_reflects_current_state() {
         .expect("failed row");
     assert_eq!(failed.id, failed_id);
     store
-        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
         .expect("mark terminal failed");
 
     let stats = store.stats().expect("stats");
@@ -315,14 +315,14 @@ fn test_status_command_shows_queue_stats() {
         .expect("claim")
         .expect("done");
     assert_eq!(done.id, done_id);
-    store.confirm(&done.id).expect("confirm");
+    store.confirm(&done).expect("confirm");
     let failed = store
         .claim_next("worker-failed", 60)
         .expect("claim")
         .expect("failed");
     assert_eq!(failed.id, failed_id);
     store
-        .mark_failed_with_disposition(&failed.id, "boom", QueueFailureDisposition::Terminal)
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
         .expect("mark terminal failed");
 
     let output = Command::new(mempal_bin())

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -383,7 +383,8 @@ fn active_chunk_indexes(db: &Database, source_file: &str) -> Vec<i64> {
 fn setup_mcp_server() -> (TempDir, std::path::PathBuf, MempalMcpServer) {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
-    let server = MempalMcpServer::new_with_factory(db_path.clone(), Arc::new(StubEmbedderFactory));
+    let server = MempalMcpServer::new_with_factory(db_path.clone(), Arc::new(StubEmbedderFactory))
+        .expect("create MCP server");
     (tmp, db_path, server)
 }
 

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -277,6 +277,7 @@ preview_chars = 48
                 vector: vec![0.9, 0.1, 0.3],
             }),
         )
+        .expect("create MCP server")
     }
 }
 

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
+use mempal::core::AsyncDb;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
@@ -201,7 +202,7 @@ preview_chars = 48
             .store
             .claim_next("worker-session-review", 120)?
             .expect("claimed message");
-        let db = Database::open(&self.db_path)?;
+        let db = AsyncDb::open(&self.db_path, 4)?;
         process_claimed_message_with_embedder(
             &db,
             &self.store,

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use mempal::core::AsyncDb;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
-use mempal::core::queue::PendingMessageStore;
+use mempal::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
 use mempal::core::types::{Drawer, SourceType};
 use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
@@ -203,9 +203,10 @@ preview_chars = 48
             .claim_next("worker-session-review", 120)?
             .expect("claimed message");
         let db = AsyncDb::open(&self.db_path, 4)?;
+        let async_store = AsyncPendingMessageStore::from_store(self.store.clone());
         process_claimed_message_with_embedder(
             &db,
-            &self.store,
+            &async_store,
             "worker-session-review",
             &claimed,
             embedder,

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -45,7 +45,8 @@ fn setup_mcp_server() -> (TempDir, Database, MempalMcpServer) {
     let tmp = TempDir::new().expect("tempdir");
     let db_path = tmp.path().join("palace.db");
     let db = Database::open(&db_path).expect("open db");
-    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory));
+    let server = MempalMcpServer::new_with_factory(db_path, Arc::new(StubEmbedderFactory))
+        .expect("create MCP server");
     (tmp, db, server)
 }
 

--- a/tests/typed_ingest_pinned.rs
+++ b/tests/typed_ingest_pinned.rs
@@ -111,6 +111,7 @@ backend = "model2vec"
             self.config(),
             Arc::new(StaticEmbedderFactory { dim: 4 }),
         )
+        .expect("create MCP server")
     }
 }
 
@@ -200,7 +201,8 @@ async fn test_pinned_facts_no_embedding() {
         env.db_path.clone(),
         env.config(),
         Arc::new(PanicEmbedderFactory),
-    );
+    )
+    .expect("create MCP server");
 
     let response = server
         .mempal_pinned_facts(Parameters(PinnedFactsRequest {

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -959,7 +959,7 @@ async fn test_operation_status_reports_queued_then_completed() {
     let _guard = ConfigOverrideGuard::install(&config_path);
     let config = Config::load_from(&config_path).expect("load config");
     let db_path = home.path().join(".mempal/palace.db");
-    let server = MempalMcpServer::new(db_path.clone(), config);
+    let server = MempalMcpServer::new(db_path.clone(), config).expect("create MCP server");
 
     let operation_id =
         enqueue_prepared_operation(&db_path, "status cli content", "mcp", Some("status"));
@@ -999,7 +999,7 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
     let _guard = ConfigOverrideGuard::install(&config_path);
     let config = Config::load_from(&config_path).expect("load config");
     let db_path = home.path().join(".mempal/palace.db");
-    let server = MempalMcpServer::new(db_path.clone(), config);
+    let server = MempalMcpServer::new(db_path.clone(), config).expect("create MCP server");
 
     let operation_id =
         enqueue_prepared_operation(&db_path, "wait cli content", "mcp", Some("wait"));

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "4eff44276c1a893adc1a737e32650b8295c47812"
+commit = "dca5584e122c7f1075e65a3c0e41c10ebfa8a6d1"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "e636590658b0ff99acb28ac5b34401bc1af6ffd6"
+commit = "4eff44276c1a893adc1a737e32650b8295c47812"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3c1d49e645b0b15db46ee35196b6a67b08cc12c0"
+commit = "c1a4177b6bf3c1038069f404d06a9744423c03d9"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "dca5584e122c7f1075e65a3c0e41c10ebfa8a6d1"
+commit = "a4bc694c2874f9d1047be31f27eb8eaadde4f91a"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "a4bc694c2874f9d1047be31f27eb8eaadde4f91a"
+commit = "c2dbc309b2757d45715f9fcf29ddeebf18041186"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "8576a6c84975151dbf57537ec9cba9e466ddf02b"
+commit = "e636590658b0ff99acb28ac5b34401bc1af6ffd6"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "c1a4177b6bf3c1038069f404d06a9744423c03d9"
+commit = "284004c0c8440a386632d53ce009b9fb978e2870"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "284004c0c8440a386632d53ce009b9fb978e2870"
+commit = "8576a6c84975151dbf57537ec9cba9e466ddf02b"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- move MCP and LLM DB write paths off async runtime workers
- keep hook workers claiming queue work under heartbeat/claim ownership
- bound MCP search/ingest waits while preserving durable operation receipts
- make novelty merge audit writes atomic across daemon and MCP paths
- keep doctor construction read-only and bind queue finalizers to active claims

## Review

- tier-4 CSA review PASS: `01KTJY35AAHXGTD9837NER6WDG`
- check-verdict PASS for `main...HEAD` at `275cf2a`

Closes #345
Closes #346
Closes #348
Closes #349
