### PR TITLE
Fix timed-out stdin ingest wait exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2997,9 +2997,16 @@ fn block_on_result<F, T>(future: F) -> Result<T>
 where
     F: Future<Output = Result<T>>,
 {
-    tokio::runtime::Runtime::new()
-        .context("failed to construct tokio runtime")?
-        .block_on(future)
+    let runtime = tokio::runtime::Runtime::new().context("failed to construct tokio runtime")?;
+    let result = runtime.block_on(future);
+    if result
+        .as_ref()
+        .err()
+        .is_some_and(|error| error.is::<IngestWaitTimedOut>())
+    {
+        runtime.shutdown_timeout(std::time::Duration::from_millis(100));
+    }
+    result
 }
 
 async fn bench_command(config: &Config, command: BenchCommands) -> Result<()> {
@@ -3709,11 +3716,11 @@ async fn ingest_stdin_command(
             .map(|response| response.0)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
         if response.timed_out {
-            print_operation_response(&response)?;
-            bail!(
-                "timed out waiting for ingest operation {}",
-                response.operation_id.as_deref().unwrap_or("")
-            );
+            print_ingest_wait_receipt_response(options.json, &response)?;
+            std::io::stdout()
+                .flush()
+                .context("failed to flush timed-out ingest receipt")?;
+            return Err(IngestWaitTimedOut::new(response.operation_id.as_deref()).into());
         }
 
         let mut wait_stats = ingest_stdin_wait_stats_from_response(&response);
@@ -3740,7 +3747,7 @@ async fn ingest_stdin_command(
                 );
             }
             _ => {
-                print_operation_response(&response)?;
+                print_ingest_wait_receipt_response(options.json, &response)?;
                 return Ok(());
             }
         }
@@ -12876,3 +12883,44 @@ mod tests {
         );
     }
 }
+
+fn print_ingest_wait_receipt_response(json: bool, response: &IngestResponse) -> Result<()> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(response)
+                .context("failed to serialize ingest wait receipt JSON")?
+        );
+        return Ok(());
+    }
+    print_operation_response(response)
+}
+
+#[derive(Debug)]
+struct IngestWaitTimedOut {
+    operation_id: String,
+}
+
+impl IngestWaitTimedOut {
+    fn new(operation_id: Option<&str>) -> Self {
+        Self {
+            operation_id: operation_id.unwrap_or("").to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for IngestWaitTimedOut {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.operation_id.is_empty() {
+            formatter.write_str("timed out waiting for ingest operation")
+        } else {
+            write!(
+                formatter,
+                "timed out waiting for ingest operation {}",
+                self.operation_id
+            )
+        }
+    }
+}
+
+impl std::error::Error for IngestWaitTimedOut {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2999,11 +2999,7 @@ where
 {
     let runtime = tokio::runtime::Runtime::new().context("failed to construct tokio runtime")?;
     let result = runtime.block_on(future);
-    if result
-        .as_ref()
-        .err()
-        .is_some_and(|error| error.is::<IngestWaitTimedOut>())
-    {
+    if result.as_ref().err().is_some_and(is_ingest_wait_timed_out) {
         runtime.shutdown_timeout(std::time::Duration::from_millis(100));
     }
     result
@@ -12924,3 +12920,30 @@ impl std::fmt::Display for IngestWaitTimedOut {
 }
 
 impl std::error::Error for IngestWaitTimedOut {}
+
+fn is_ingest_wait_timed_out(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|source| source.downcast_ref::<IngestWaitTimedOut>().is_some())
+}
+
+#[cfg(test)]
+mod ingest_wait_timeout_error_tests {
+    use super::*;
+
+    #[test]
+    fn detects_context_wrapped_ingest_wait_timeout() {
+        let wrapped = Err::<(), IngestWaitTimedOut>(IngestWaitTimedOut::new(Some("op-1")))
+            .context("wait failed")
+            .expect_err("context-wrapped timeout should remain an error");
+
+        assert!(is_ingest_wait_timed_out(&wrapped));
+    }
+
+    #[test]
+    fn ignores_other_errors_for_ingest_wait_timeout() {
+        let error = anyhow::anyhow!("other error");
+
+        assert!(!is_ingest_wait_timed_out(&error));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12904,7 +12904,7 @@ struct IngestWaitTimedOut {
 impl IngestWaitTimedOut {
     fn new(operation_id: Option<&str>) -> Self {
         Self {
-            operation_id: operation_id.unwrap_or("").to_string(),
+            operation_id: operation_id.unwrap_or_default().to_string(),
         }
     }
 }

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Mutex, MutexGuard};
+use std::thread;
 use std::time::Duration;
 
 use common::harness::embed_mock::start as start_embed_mock;
@@ -110,6 +111,48 @@ fn run_cli_with_stdin(home: &Path, args: &[&str], payload: &[u8]) -> Output {
         stdin.write_all(payload).expect("write stdin payload");
     }
     child.wait_with_output().expect("wait mempal")
+}
+
+fn run_cli_with_stdin_timeout(
+    home: &Path,
+    args: &[&str],
+    payload: &[u8],
+    timeout: Duration,
+) -> Output {
+    use std::io::Write as _;
+
+    let mut child = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal");
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(payload).expect("write stdin payload");
+    }
+
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return child.wait_with_output().expect("wait mempal"),
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let output = child.wait_with_output().expect("wait killed mempal");
+                    panic!(
+                        "mempal command timed out after {:?}: args={args:?} stdout={} stderr={}",
+                        timeout,
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => panic!("poll mempal child failed: {error}"),
+        }
+    }
 }
 
 fn spawn_cli(home: &Path, args: &[&str]) -> Child {
@@ -489,6 +532,58 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
     assert!(
         drawer_ids.iter().all(|value| value.as_str().is_some()),
         "drawer_ids must contain strings"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_json_timeout_exits_after_receipt() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _config = write_config(home.path(), &format!("http://{addr}/v1"));
+    handle.pause();
+
+    let payload = serde_json::json!({
+        "content": "cli wait json timeout content",
+        "wing": "cli-wing"
+    })
+    .to_string();
+
+    let output = run_cli_with_stdin_timeout(
+        home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--project",
+            "mempal",
+            "--source-type",
+            "agent_observation",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            "1",
+            "--json",
+        ],
+        payload.as_bytes(),
+        Duration::from_secs(4),
+    );
+    handle.resume();
+    handle.shutdown().await;
+
+    assert!(
+        !output.status.success(),
+        "timeout must preserve non-zero CLI status: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let receipt: Value =
+        serde_json::from_slice(&output.stdout).expect("timed-out receipt must be JSON");
+    assert!(receipt["operation_id"].as_str().is_some());
+    assert_eq!(receipt["state"], "queued");
+    assert_eq!(receipt["timed_out"], true);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timed out waiting for ingest operation"),
+        "{stderr}"
     );
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "c2dbc309b2757d45715f9fcf29ddeebf18041186"
+commit = "bb0be45988bc65a0e8f88dcbd3e7045f35d6ec4a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- make stdin JSON ingest wait timeout return a timed_out receipt and exit promptly
- keep JSON stdout machine-consumable for CLI automation

## Review

- tier-4 CSA review PASS: `01KTK1HPAC0BBSQSH6XDXMDG7H`
- check-verdict PASS for `main...HEAD` at `6fe7e3d`

Closes #355
