### PR TITLE
Keep mempal hook stdout protocol-safe

### DIFF
--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -137,6 +137,26 @@ fn test_hook_writes_nothing_to_stdout() {
 }
 
 #[test]
+fn test_hook_post_tool_canonical_stdout_is_empty_and_bootstrap_uses_stderr() {
+    let (home, _db_path) = setup_home();
+    let payload = r#"{"event":"PostToolUse","tool_name":"diagnostic","cwd":"/tmp","command":"true","exit_code":0}"#;
+
+    let output = run_hook(&home, "PostToolUse", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout is Codex hook protocol; got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("config hot-reload: bootstrapped version "),
+        "human-readable bootstrap status must be emitted on stderr, got {stderr:?}"
+    );
+}
+
+#[test]
 fn test_hook_envelopes_oversized_payload() {
     let (home, db_path) = setup_home();
     let mut oversized = String::from("{\"payload\":\"");

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "bb0be45988bc65a0e8f88dcbd3e7045f35d6ec4a"
+commit = "c96ebadd4fc633e54edfffd3e838bde9c592e33a"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- add regression coverage that canonical PostToolUse hook capture does not emit non-protocol stdout
- keep hook stdout safe for Codex hook JSON handling

## Review

- tier-4 CSA review PASS: `01KTK4GD0D41WD49876KW0K3FM`
- check-verdict PASS for `main...HEAD` at `786f897`

Closes #354
