### PR TITLE
Report stale mempal DB holder processes

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -422,6 +422,7 @@ fn spawn_hook_message_heartbeat(
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        ticker.tick().await;
         loop {
             ticker.tick().await;
             if shutdown_requested() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -361,6 +361,7 @@ async fn process_hook_worker_message(
     claim_ttl_secs: i64,
 ) {
     let message_id = message.id.clone();
+    refresh_hook_message_heartbeat(&state.store, &message_id, &state.worker_id).await;
     let heartbeat_handle = spawn_hook_message_heartbeat(
         state.store.clone(),
         message_id.clone(),
@@ -426,18 +427,26 @@ fn spawn_hook_message_heartbeat(
             if shutdown_requested() {
                 break;
             }
-            if let Err(error) = store
-                .refresh_heartbeat(message_id.clone(), worker_id.clone())
-                .await
-            {
-                tracing::warn!(
-                    ?error,
-                    message_id,
-                    "failed to refresh hook message heartbeat"
-                );
-            }
+            refresh_hook_message_heartbeat(&store, &message_id, &worker_id).await;
         }
     })
+}
+
+async fn refresh_hook_message_heartbeat(
+    store: &AsyncPendingMessageStore,
+    message_id: &str,
+    worker_id: &str,
+) {
+    if let Err(error) = store
+        .refresh_heartbeat(message_id.to_string(), worker_id.to_string())
+        .await
+    {
+        tracing::warn!(
+            ?error,
+            message_id,
+            "failed to refresh hook message heartbeat"
+        );
+    }
 }
 
 fn hook_message_heartbeat_interval(claim_ttl_secs: i64) -> Duration {

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -172,7 +172,7 @@ pub fn is_daemon_argv<S: AsRef<str>>(argv: &[S], binary_name: &str) -> bool {
     }
 }
 
-fn first_cli_subcommand<S: AsRef<str>>(argv: &[S]) -> Option<(usize, &str)> {
+pub(crate) fn first_cli_subcommand<S: AsRef<str>>(argv: &[S]) -> Option<(usize, &str)> {
     let mut skip_next = false;
     for (index, arg) in argv.iter().enumerate().skip(1) {
         let arg = arg.as_ref();

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -24,12 +24,13 @@
 //! and is released automatically when the process dies — even on `SIGKILL`,
 //! which is precisely how an orphaned daemon's lock frees up for its successor.
 
-use std::collections::BTreeSet;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 
+#[cfg(target_os = "linux")]
+use crate::db_path_identity::DbPathIdentity;
 use thiserror::Error;
 
 /// Lock file name, written next to `daemon.pid` inside `mempal_home`.
@@ -220,7 +221,7 @@ fn enumerate_daemon_pids_in_proc(
     self_pid: i32,
 ) -> Vec<i32> {
     let mut pids = Vec::new();
-    let Some(db_identity) = DbPathIdentity::from_db_path(db_path) else {
+    let Some(db_identity) = DbPathIdentity::from_existing_db_path(db_path) else {
         return pids;
     };
     let Ok(entries) = std::fs::read_dir(proc_root) else {
@@ -262,50 +263,6 @@ fn process_matches_db_path(proc_pid_dir: &Path, db_identity: &DbPathIdentity) ->
 }
 
 #[cfg(target_os = "linux")]
-#[derive(Debug, Clone)]
-struct DbPathIdentity {
-    db_path: PathBuf,
-    fd_targets: BTreeSet<PathBuf>,
-}
-
-#[cfg(target_os = "linux")]
-impl DbPathIdentity {
-    fn from_db_path(db_path: &Path) -> Option<Self> {
-        let db_path = std::fs::canonicalize(db_path).ok()?;
-        let mut fd_targets = BTreeSet::new();
-        fd_targets.insert(db_path.clone());
-        for suffix in ["-wal", "-shm"] {
-            let sidecar = append_os_suffix(&db_path, suffix);
-            fd_targets.insert(canonicalize_if_present(&sidecar));
-        }
-        Some(Self {
-            db_path,
-            fd_targets,
-        })
-    }
-
-    fn db_path(&self) -> &Path {
-        &self.db_path
-    }
-
-    fn matches_fd_target(&self, fd_target: &Path) -> bool {
-        self.fd_targets.contains(fd_target)
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn append_os_suffix(path: &Path, suffix: &str) -> PathBuf {
-    let mut os = OsString::from(path.as_os_str());
-    os.push(OsStr::new(suffix));
-    PathBuf::from(os)
-}
-
-#[cfg(target_os = "linux")]
-fn canonicalize_if_present(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
-#[cfg(target_os = "linux")]
 fn process_has_db_fd(proc_pid_dir: &Path, db_identity: &DbPathIdentity) -> bool {
     let Ok(entries) = std::fs::read_dir(proc_pid_dir.join("fd")) else {
         return false;
@@ -315,10 +272,7 @@ fn process_has_db_fd(proc_pid_dir: &Path, db_identity: &DbPathIdentity) -> bool 
         let Ok(target) = std::fs::read_link(entry.path()) else {
             return false;
         };
-        let Ok(canonical_target) = std::fs::canonicalize(target) else {
-            return false;
-        };
-        db_identity.matches_fd_target(&canonical_target)
+        db_identity.matches_fd(&entry.path(), &target)
     })
 }
 
@@ -680,6 +634,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_enumerate_proc_scan_matches_non_utf8_db_path() {
+        use std::ffi::OsString;
         use std::os::unix::ffi::OsStringExt;
 
         let temp = tempfile::tempdir().expect("temp dir");

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -63,7 +63,7 @@ impl DbFileIdentity {
             return true;
         }
 
-        let stripped_target = strip_deleted_suffix(fd_target.to_path_buf());
+        let stripped_target = strip_deleted_suffix(fd_path, fd_target);
         let canonical_target = canonicalize_if_present(&stripped_target);
 
         self.fd_targets.contains(&canonical_target) || self.fd_targets.contains(&stripped_target)
@@ -164,12 +164,50 @@ fn file_id_for_path(path: &Path) -> Option<FileId> {
 }
 
 #[cfg(target_os = "linux")]
-fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
+fn strip_deleted_suffix(fd_path: &Path, path: &Path) -> PathBuf {
     const DELETED_SUFFIX: &[u8] = b" (deleted)";
     let bytes = path.as_os_str().as_bytes();
     if bytes.ends_with(DELETED_SUFFIX) {
+        let target_file_id = file_id_for_path(path);
+        let fd_file_id = file_id_for_path(fd_path);
+        if target_file_id.is_some() && target_file_id == fd_file_id {
+            return path.to_path_buf();
+        }
         let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
         return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));
     }
-    path
+    path.to_path_buf()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn test_matches_fd_does_not_strip_literal_deleted_suffix_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let literal_deleted_path = tmp.path().join("palace.db (deleted)");
+        File::create(&db_path).expect("db file");
+        File::create(&literal_deleted_path).expect("literal deleted suffix file");
+        let identity = DbFileIdentity::from_resolved_path(&db_path);
+
+        assert!(
+            !identity.matches_fd(&literal_deleted_path, &literal_deleted_path),
+            "a real file whose name ends with the kernel suffix text is not the DB"
+        );
+    }
+
+    #[test]
+    fn test_matches_fd_strips_kernel_deleted_suffix_when_target_path_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let fd_path = tmp.path().join("fd-3");
+        File::create(&db_path).expect("db file");
+        let identity = DbFileIdentity::from_resolved_path(&db_path);
+        let deleted_target = append_os_suffix(&db_path, " (deleted)");
+
+        assert!(identity.matches_fd(&fd_path, &deleted_target));
+    }
 }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -67,40 +67,27 @@ impl DbFileIdentity {
         }
 
         let target_name_matches = self.target_name_matches(fd_target);
-        let mut fd_file_id = None;
-        if target_name_matches {
-            fd_file_id = file_id_for_path(fd_path);
-            if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
-                return true;
-            }
+        if !target_name_matches {
+            return false;
         }
 
-        let canonical_target =
-            if target_is_symlink(fd_target) || (target_name_matches && fd_file_id.is_none()) {
-                Some(canonicalize_if_present(fd_target))
-            } else {
-                None
-            };
+        let fd_file_id = file_id_for_path(fd_path);
+        if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
+            return true;
+        }
+
+        let canonical_target = if target_is_symlink(fd_target) || fd_file_id.is_none() {
+            Some(canonicalize_if_present(fd_target))
+        } else {
+            None
+        };
         if canonical_target
             .as_ref()
             .is_some_and(|target| self.fd_targets.contains(target))
         {
             return true;
         }
-        if !target_name_matches
-            && !canonical_target
-                .as_ref()
-                .is_some_and(|target| self.target_name_matches(target))
-        {
-            return false;
-        }
 
-        if fd_file_id.is_none() {
-            fd_file_id = file_id_for_path(fd_path);
-        }
-        if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
-            return true;
-        }
         let stripped_target = strip_deleted_suffix(fd_file_id, fd_target);
 
         self.fd_targets.contains(stripped_target.as_ref())
@@ -273,10 +260,26 @@ mod tests {
     }
 
     #[test]
-    fn test_matches_fd_canonical_target_keeps_symlink_path_match() {
+    fn test_matches_fd_rejects_unrelated_absolute_target_before_metadata_fallback() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let real_db_path = tmp.path().join("palace.db");
-        let linked_db_path = tmp.path().join("linked.db");
+        let db_path = tmp.path().join("palace.db");
+        let unrelated_path = tmp.path().join("notes.txt");
+        File::create(&db_path).expect("db file");
+        File::create(&unrelated_path).expect("unrelated file");
+        let identity = DbFileIdentity::from_resolved_path(&db_path);
+
+        assert!(!identity.matches_fd(&tmp.path().join("missing-fd"), &unrelated_path));
+    }
+
+    #[test]
+    fn test_matches_fd_canonical_target_keeps_matching_name_symlink_path_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real");
+        let linked_dir = tmp.path().join("linked");
+        fs::create_dir(&real_dir).expect("real dir");
+        fs::create_dir(&linked_dir).expect("linked dir");
+        let real_db_path = real_dir.join("palace.db");
+        let linked_db_path = linked_dir.join("palace.db");
         File::create(&real_db_path).expect("db file");
         symlink(&real_db_path, &linked_db_path).expect("db symlink");
         let identity = DbFileIdentity::from_resolved_path(&real_db_path);

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -75,11 +75,23 @@ impl DbFileIdentity {
             }
         }
 
-        let canonical_target = canonicalize_if_present(fd_target);
-        if self.fd_targets.contains(&canonical_target) {
+        let canonical_target =
+            if target_is_symlink(fd_target) || (target_name_matches && fd_file_id.is_none()) {
+                Some(canonicalize_if_present(fd_target))
+            } else {
+                None
+            };
+        if canonical_target
+            .as_ref()
+            .is_some_and(|target| self.fd_targets.contains(target))
+        {
             return true;
         }
-        if !target_name_matches && !self.target_name_matches(&canonical_target) {
+        if !target_name_matches
+            && !canonical_target
+                .as_ref()
+                .is_some_and(|target| self.target_name_matches(target))
+        {
             return false;
         }
 
@@ -91,9 +103,11 @@ impl DbFileIdentity {
         }
         let stripped_target = strip_deleted_suffix(fd_file_id, fd_target);
 
-        self.fd_targets
-            .contains(&canonicalize_if_present(&stripped_target))
-            || self.fd_targets.contains(stripped_target.as_ref())
+        self.fd_targets.contains(stripped_target.as_ref())
+            || (matches!(stripped_target, Cow::Owned(_))
+                && self
+                    .fd_targets
+                    .contains(&canonicalize_if_present(&stripped_target)))
     }
 
     fn target_name_matches(&self, path: &Path) -> bool {
@@ -197,6 +211,10 @@ fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
 
 fn canonicalize_if_present(path: &Path) -> PathBuf {
     canonicalize_db_path_or_parent(path.to_path_buf()).unwrap_or_else(|| path.to_path_buf())
+}
+
+fn target_is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
 }
 
 fn file_id_for_path(path: &Path) -> Option<FileId> {

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -222,8 +222,8 @@ fn stripped_deleted_name(file_name: &OsStr) -> Option<OsString> {
 fn strip_deleted_suffix(fd_file_id: Option<FileId>, path: &Path) -> Cow<'_, Path> {
     let bytes = path.as_os_str().as_bytes();
     if bytes.ends_with(DELETED_SUFFIX) {
-        if let Some(target_file_id) = file_id_for_path(path) {
-            if fd_file_id == Some(target_file_id) {
+        if let Some(fd_file_id) = fd_file_id {
+            if file_id_for_path(path).is_some_and(|target_file_id| fd_file_id == target_file_id) {
                 return Cow::Borrowed(path);
             }
         }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -1,4 +1,6 @@
 #[cfg(target_os = "linux")]
+use std::borrow::Cow;
+#[cfg(target_os = "linux")]
 use std::collections::BTreeSet;
 #[cfg(target_os = "linux")]
 use std::ffi::{OsStr, OsString};
@@ -59,14 +61,18 @@ impl DbFileIdentity {
     }
 
     pub(crate) fn matches_fd(&self, fd_path: &Path, fd_target: &Path) -> bool {
-        if file_id_for_path(fd_path).is_some_and(|file_id| self.file_ids.contains(&file_id)) {
-            return true;
+        let fd_file_id = file_id_for_path(fd_path);
+        if let Some(file_id) = fd_file_id {
+            if self.file_ids.contains(&file_id) {
+                return true;
+            }
         }
 
-        let stripped_target = strip_deleted_suffix(fd_path, fd_target);
+        let stripped_target = strip_deleted_suffix(fd_file_id, fd_target);
         let canonical_target = canonicalize_if_present(&stripped_target);
 
-        self.fd_targets.contains(&canonical_target) || self.fd_targets.contains(&stripped_target)
+        self.fd_targets.contains(&canonical_target)
+            || self.fd_targets.contains(stripped_target.as_ref())
     }
 }
 
@@ -164,19 +170,19 @@ fn file_id_for_path(path: &Path) -> Option<FileId> {
 }
 
 #[cfg(target_os = "linux")]
-fn strip_deleted_suffix(fd_path: &Path, path: &Path) -> PathBuf {
+fn strip_deleted_suffix(fd_file_id: Option<FileId>, path: &Path) -> Cow<'_, Path> {
     const DELETED_SUFFIX: &[u8] = b" (deleted)";
     let bytes = path.as_os_str().as_bytes();
     if bytes.ends_with(DELETED_SUFFIX) {
         if let Some(target_file_id) = file_id_for_path(path) {
-            if file_id_for_path(fd_path) == Some(target_file_id) {
-                return path.to_path_buf();
+            if fd_file_id == Some(target_file_id) {
+                return Cow::Borrowed(path);
             }
         }
         let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
-        return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));
+        return Cow::Owned(PathBuf::from(OsString::from_vec(bytes[..keep].to_vec())));
     }
-    path.to_path_buf()
+    Cow::Borrowed(path)
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -166,12 +166,11 @@ fn resolve_configured_path_lossy(path: &Path) -> PathBuf {
 }
 
 fn resolve_path_with_cwd_lossy(path: &Path, cwd: &Path) -> PathBuf {
-    let absolute = if path.is_absolute() {
+    if path.is_absolute() {
         path.to_path_buf()
     } else {
         cwd.join(path)
-    };
-    canonicalize_if_present(&absolute)
+    }
 }
 
 fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
@@ -333,6 +332,20 @@ mod tests {
             std::fs::canonicalize(tmp.path())
                 .expect("canonical tempdir")
                 .join("palace.db")
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_with_cwd_lossy_absolutizes_without_canonicalizing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real");
+        let linked_dir = tmp.path().join("linked");
+        fs::create_dir(&real_dir).expect("real dir");
+        symlink(&real_dir, &linked_dir).expect("dir symlink");
+
+        assert_eq!(
+            resolve_path_with_cwd_lossy(Path::new("palace.db"), &linked_dir),
+            linked_dir.join("palace.db")
         );
     }
 

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -196,7 +196,7 @@ fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
 }
 
 fn canonicalize_if_present(path: &Path) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    canonicalize_db_path_or_parent(path.to_path_buf()).unwrap_or_else(|| path.to_path_buf())
 }
 
 fn file_id_for_path(path: &Path) -> Option<FileId> {
@@ -303,6 +303,24 @@ mod tests {
             identity.db_path(),
             std::fs::canonicalize(tmp.path())
                 .expect("canonical tempdir")
+                .join("palace.db")
+        );
+    }
+
+    #[test]
+    fn test_canonicalize_if_present_uses_canonical_parent_when_file_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real");
+        let linked_dir = tmp.path().join("linked");
+        fs::create_dir(&real_dir).expect("real dir");
+        symlink(&real_dir, &linked_dir).expect("dir symlink");
+
+        let db_path = linked_dir.join("palace.db");
+
+        assert_eq!(
+            canonicalize_if_present(&db_path),
+            std::fs::canonicalize(&real_dir)
+                .expect("canonical real dir")
                 .join("palace.db")
         );
     }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -63,6 +63,9 @@ impl DbFileIdentity {
         if self.fd_targets.contains(fd_target) {
             return true;
         }
+        if !fd_target.is_absolute() {
+            return false;
+        }
 
         let target_name_matches = self.target_name_matches(fd_target);
         let canonical_target = canonicalize_if_present(fd_target);
@@ -230,6 +233,16 @@ mod tests {
         let identity = DbFileIdentity::from_resolved_path(&db_path);
 
         assert!(identity.matches_fd(&tmp.path().join("missing-fd"), &db_path));
+    }
+
+    #[test]
+    fn test_matches_fd_rejects_non_absolute_fd_targets_after_direct_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        File::create(&db_path).expect("db file");
+        let identity = DbFileIdentity::from_resolved_path(&db_path);
+
+        assert!(!identity.matches_fd(&tmp.path().join("fd-3"), Path::new("socket:[12345]")));
     }
 
     #[test]

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -24,6 +24,7 @@ impl FileId {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DbFileIdentity {
     fd_targets: BTreeSet<PathBuf>,
+    target_names: BTreeSet<OsString>,
     file_ids: BTreeSet<FileId>,
 }
 
@@ -38,30 +39,58 @@ impl DbFileIdentity {
         let canonical = canonicalize_if_present(path);
         self.fd_targets.insert(path.to_path_buf());
         self.fd_targets.insert(canonical.clone());
+        self.insert_target_name(path);
+        self.insert_target_name(&canonical);
 
         if let Some(file_id) = file_id_for_path(path).or_else(|| file_id_for_path(&canonical)) {
             self.file_ids.insert(file_id);
         }
     }
 
+    fn insert_target_name(&mut self, path: &Path) {
+        if let Some(file_name) = path.file_name() {
+            self.target_names.insert(file_name.to_os_string());
+        }
+    }
+
     pub(crate) fn merge(&mut self, other: Self) {
         self.fd_targets.extend(other.fd_targets);
+        self.target_names.extend(other.target_names);
         self.file_ids.extend(other.file_ids);
     }
 
     pub(crate) fn matches_fd(&self, fd_path: &Path, fd_target: &Path) -> bool {
-        let fd_file_id = file_id_for_path(fd_path);
-        if let Some(file_id) = fd_file_id {
-            if self.file_ids.contains(&file_id) {
-                return true;
-            }
+        if self.fd_targets.contains(fd_target) {
+            return true;
         }
 
-        let stripped_target = strip_deleted_suffix(fd_file_id, fd_target);
-        let canonical_target = canonicalize_if_present(&stripped_target);
+        let target_name_matches = self.target_name_matches(fd_target);
+        let canonical_target = canonicalize_if_present(fd_target);
+        if self.fd_targets.contains(&canonical_target) {
+            return true;
+        }
+        if !target_name_matches && !self.target_name_matches(&canonical_target) {
+            return false;
+        }
 
-        self.fd_targets.contains(&canonical_target)
+        let fd_file_id = file_id_for_path(fd_path);
+        if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
+            return true;
+        }
+        let stripped_target = strip_deleted_suffix(fd_file_id, fd_target);
+
+        self.fd_targets
+            .contains(&canonicalize_if_present(&stripped_target))
             || self.fd_targets.contains(stripped_target.as_ref())
+    }
+
+    fn target_name_matches(&self, path: &Path) -> bool {
+        let Some(file_name) = path.file_name() else {
+            return false;
+        };
+        self.target_names.contains(file_name)
+            || stripped_deleted_name(file_name)
+                .is_some_and(|stripped| self.target_names.contains(&stripped))
     }
 }
 
@@ -164,8 +193,16 @@ fn file_id_for_path(path: &Path) -> Option<FileId> {
         .map(|metadata| FileId::from_metadata(&metadata))
 }
 
+const DELETED_SUFFIX: &[u8] = b" (deleted)";
+
+fn stripped_deleted_name(file_name: &OsStr) -> Option<OsString> {
+    let bytes = file_name.as_bytes();
+    bytes.ends_with(DELETED_SUFFIX).then(|| {
+        OsString::from_vec(bytes[..bytes.len().saturating_sub(DELETED_SUFFIX.len())].to_vec())
+    })
+}
+
 fn strip_deleted_suffix(fd_file_id: Option<FileId>, path: &Path) -> Cow<'_, Path> {
-    const DELETED_SUFFIX: &[u8] = b" (deleted)";
     let bytes = path.as_os_str().as_bytes();
     if bytes.ends_with(DELETED_SUFFIX) {
         if let Some(target_file_id) = file_id_for_path(path) {
@@ -183,6 +220,29 @@ fn strip_deleted_suffix(fd_file_id: Option<FileId>, path: &Path) -> Cow<'_, Path
 mod tests {
     use super::*;
     use std::fs::File;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn test_matches_fd_direct_target_does_not_require_fd_metadata() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        File::create(&db_path).expect("db file");
+        let identity = DbFileIdentity::from_resolved_path(&db_path);
+
+        assert!(identity.matches_fd(&tmp.path().join("missing-fd"), &db_path));
+    }
+
+    #[test]
+    fn test_matches_fd_canonical_target_keeps_symlink_path_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_db_path = tmp.path().join("palace.db");
+        let linked_db_path = tmp.path().join("linked.db");
+        File::create(&real_db_path).expect("db file");
+        symlink(&real_db_path, &linked_db_path).expect("db symlink");
+        let identity = DbFileIdentity::from_resolved_path(&real_db_path);
+
+        assert!(identity.matches_fd(&tmp.path().join("missing-fd"), &linked_db_path));
+    }
 
     #[test]
     fn test_matches_fd_does_not_strip_literal_deleted_suffix_path() {

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -87,7 +87,7 @@ pub(crate) struct DbPathIdentity {
 impl DbPathIdentity {
     pub(crate) fn from_existing_db_path(db_path: &Path) -> Option<Self> {
         let absolute_db_path = resolve_configured_path_lossy(db_path);
-        let canonical_db_path = fs::canonicalize(absolute_db_path).ok()?;
+        let canonical_db_path = canonicalize_db_path_or_parent(absolute_db_path)?;
         Some(Self::from_resolved_db_path(canonical_db_path))
     }
 
@@ -158,6 +158,22 @@ fn resolve_path_with_cwd_lossy(path: &Path, cwd: &Path) -> PathBuf {
 }
 
 #[cfg(target_os = "linux")]
+fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
+    if let Ok(canonical) = fs::canonicalize(&path) {
+        return Some(canonical);
+    }
+
+    let file_name = path.file_name()?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::canonicalize(parent)
+        .ok()
+        .map(|canonical_parent| canonical_parent.join(file_name))
+}
+
+#[cfg(target_os = "linux")]
 fn canonicalize_if_present(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
@@ -215,5 +231,19 @@ mod tests {
         let deleted_target = append_os_suffix(&db_path, " (deleted)");
 
         assert!(identity.matches_fd(&fd_path, &deleted_target));
+    }
+
+    #[test]
+    fn test_from_existing_db_path_uses_canonical_parent_when_db_is_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let identity = DbPathIdentity::from_existing_db_path(&db_path).expect("db identity");
+
+        assert_eq!(
+            identity.db_path(),
+            std::fs::canonicalize(tmp.path())
+                .expect("canonical tempdir")
+                .join("palace.db")
+        );
     }
 }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -70,6 +70,14 @@ impl DbFileIdentity {
         }
 
         let target_name_matches = self.target_name_matches(fd_target);
+        let mut fd_file_id = None;
+        if target_name_matches {
+            fd_file_id = file_id_for_path(fd_path);
+            if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
+                return true;
+            }
+        }
+
         let canonical_target = canonicalize_if_present(fd_target);
         if self.fd_targets.contains(&canonical_target) {
             return true;
@@ -78,7 +86,9 @@ impl DbFileIdentity {
             return false;
         }
 
-        let fd_file_id = file_id_for_path(fd_path);
+        if fd_file_id.is_none() {
+            fd_file_id = file_id_for_path(fd_path);
+        }
         if fd_file_id.is_some_and(|file_id| self.file_ids.contains(&file_id)) {
             return true;
         }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -38,13 +38,10 @@ impl DbFileIdentity {
     }
 
     fn insert_target(&mut self, path: &Path) {
-        let canonical = canonicalize_if_present(path);
         self.fd_targets.insert(path.to_path_buf());
-        self.fd_targets.insert(canonical.clone());
         self.insert_target_name(path);
-        self.insert_target_name(&canonical);
 
-        if let Some(file_id) = file_id_for_path(path).or_else(|| file_id_for_path(&canonical)) {
+        if let Some(file_id) = file_id_for_path(path) {
             self.file_ids.insert(file_id);
         }
     }

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -1,3 +1,5 @@
+#![cfg(target_os = "linux")]
+
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::ffi::{OsStr, OsString};

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -1,26 +1,17 @@
-#[cfg(target_os = "linux")]
 use std::borrow::Cow;
-#[cfg(target_os = "linux")]
 use std::collections::BTreeSet;
-#[cfg(target_os = "linux")]
 use std::ffi::{OsStr, OsString};
-#[cfg(target_os = "linux")]
 use std::fs;
-#[cfg(target_os = "linux")]
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-#[cfg(target_os = "linux")]
 use std::os::unix::fs::MetadataExt;
-#[cfg(target_os = "linux")]
 use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct FileId {
     dev: u64,
     ino: u64,
 }
 
-#[cfg(target_os = "linux")]
 impl FileId {
     fn from_metadata(metadata: &fs::Metadata) -> Self {
         Self {
@@ -30,14 +21,12 @@ impl FileId {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DbFileIdentity {
     fd_targets: BTreeSet<PathBuf>,
     file_ids: BTreeSet<FileId>,
 }
 
-#[cfg(target_os = "linux")]
 impl DbFileIdentity {
     pub(crate) fn from_resolved_path(path: &Path) -> Self {
         let mut identity = Self::default();
@@ -76,14 +65,12 @@ impl DbFileIdentity {
     }
 }
 
-#[cfg(target_os = "linux")]
 #[derive(Debug, Clone)]
 pub(crate) struct DbPathIdentity {
     db_path: PathBuf,
     files: DbFileIdentity,
 }
 
-#[cfg(target_os = "linux")]
 impl DbPathIdentity {
     pub(crate) fn from_existing_db_path(db_path: &Path) -> Option<Self> {
         let absolute_db_path = resolve_configured_path_lossy(db_path);
@@ -109,7 +96,6 @@ impl DbPathIdentity {
     }
 }
 
-#[cfg(target_os = "linux")]
 pub(crate) fn db_file_targets(db_path: &Path) -> Vec<(&'static str, DbFileIdentity)> {
     db_file_targets_from_resolved_db_path(resolve_configured_path_lossy(db_path))
 }
@@ -122,7 +108,6 @@ pub(crate) fn db_file_targets_with_cwd(
     db_file_targets_from_resolved_db_path(resolve_path_with_cwd_lossy(db_path, cwd))
 }
 
-#[cfg(target_os = "linux")]
 fn db_file_targets_from_resolved_db_path(db_path: PathBuf) -> Vec<(&'static str, DbFileIdentity)> {
     let resolved_db_path = canonicalize_if_present(&db_path);
     let shm_path = append_os_suffix(&resolved_db_path, "-shm");
@@ -134,20 +119,17 @@ fn db_file_targets_from_resolved_db_path(db_path: PathBuf) -> Vec<(&'static str,
     ]
 }
 
-#[cfg(target_os = "linux")]
 pub(crate) fn append_os_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut os = OsString::from(path.as_os_str());
     os.push(OsStr::new(suffix));
     PathBuf::from(os)
 }
 
-#[cfg(target_os = "linux")]
 fn resolve_configured_path_lossy(path: &Path) -> PathBuf {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     resolve_path_with_cwd_lossy(path, &cwd)
 }
 
-#[cfg(target_os = "linux")]
 fn resolve_path_with_cwd_lossy(path: &Path, cwd: &Path) -> PathBuf {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
@@ -157,7 +139,6 @@ fn resolve_path_with_cwd_lossy(path: &Path, cwd: &Path) -> PathBuf {
     canonicalize_if_present(&absolute)
 }
 
-#[cfg(target_os = "linux")]
 fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
     if let Ok(canonical) = fs::canonicalize(&path) {
         return Some(canonical);
@@ -173,19 +154,16 @@ fn canonicalize_db_path_or_parent(path: PathBuf) -> Option<PathBuf> {
         .map(|canonical_parent| canonical_parent.join(file_name))
 }
 
-#[cfg(target_os = "linux")]
 fn canonicalize_if_present(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-#[cfg(target_os = "linux")]
 fn file_id_for_path(path: &Path) -> Option<FileId> {
     fs::metadata(path)
         .ok()
         .map(|metadata| FileId::from_metadata(&metadata))
 }
 
-#[cfg(target_os = "linux")]
 fn strip_deleted_suffix(fd_file_id: Option<FileId>, path: &Path) -> Cow<'_, Path> {
     const DELETED_SUFFIX: &[u8] = b" (deleted)";
     let bytes = path.as_os_str().as_bytes();

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -1,0 +1,175 @@
+#[cfg(target_os = "linux")]
+use std::collections::BTreeSet;
+#[cfg(target_os = "linux")]
+use std::ffi::{OsStr, OsString};
+#[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::MetadataExt;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FileId {
+    dev: u64,
+    ino: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl FileId {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DbFileIdentity {
+    fd_targets: BTreeSet<PathBuf>,
+    file_ids: BTreeSet<FileId>,
+}
+
+#[cfg(target_os = "linux")]
+impl DbFileIdentity {
+    pub(crate) fn from_resolved_path(path: &Path) -> Self {
+        let mut identity = Self::default();
+        identity.insert_target(path);
+        identity
+    }
+
+    fn insert_target(&mut self, path: &Path) {
+        let canonical = canonicalize_if_present(path);
+        self.fd_targets.insert(path.to_path_buf());
+        self.fd_targets.insert(canonical.clone());
+
+        if let Some(file_id) = file_id_for_path(path).or_else(|| file_id_for_path(&canonical)) {
+            self.file_ids.insert(file_id);
+        }
+    }
+
+    pub(crate) fn merge(&mut self, other: Self) {
+        self.fd_targets.extend(other.fd_targets);
+        self.file_ids.extend(other.file_ids);
+    }
+
+    pub(crate) fn matches_fd(&self, fd_path: &Path, fd_target: &Path) -> bool {
+        if file_id_for_path(fd_path).is_some_and(|file_id| self.file_ids.contains(&file_id)) {
+            return true;
+        }
+
+        let stripped_target = strip_deleted_suffix(fd_target.to_path_buf());
+        let canonical_target = canonicalize_if_present(&stripped_target);
+
+        self.fd_targets.contains(&canonical_target) || self.fd_targets.contains(&stripped_target)
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone)]
+pub(crate) struct DbPathIdentity {
+    db_path: PathBuf,
+    files: DbFileIdentity,
+}
+
+#[cfg(target_os = "linux")]
+impl DbPathIdentity {
+    pub(crate) fn from_existing_db_path(db_path: &Path) -> Option<Self> {
+        let absolute_db_path = resolve_configured_path_lossy(db_path);
+        let canonical_db_path = fs::canonicalize(absolute_db_path).ok()?;
+        Some(Self::from_resolved_db_path(canonical_db_path))
+    }
+
+    pub(crate) fn from_resolved_db_path(db_path: PathBuf) -> Self {
+        let mut files = DbFileIdentity::from_resolved_path(&db_path);
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = append_os_suffix(&db_path, suffix);
+            files.merge(DbFileIdentity::from_resolved_path(&sidecar));
+        }
+        Self { db_path, files }
+    }
+
+    pub(crate) fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub(crate) fn matches_fd(&self, fd_path: &Path, fd_target: &Path) -> bool {
+        self.files.matches_fd(fd_path, fd_target)
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn db_file_targets(db_path: &Path) -> Vec<(&'static str, DbFileIdentity)> {
+    db_file_targets_from_resolved_db_path(resolve_configured_path_lossy(db_path))
+}
+
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn db_file_targets_with_cwd(
+    db_path: &Path,
+    cwd: &Path,
+) -> Vec<(&'static str, DbFileIdentity)> {
+    db_file_targets_from_resolved_db_path(resolve_path_with_cwd_lossy(db_path, cwd))
+}
+
+#[cfg(target_os = "linux")]
+fn db_file_targets_from_resolved_db_path(db_path: PathBuf) -> Vec<(&'static str, DbFileIdentity)> {
+    let resolved_db_path = canonicalize_if_present(&db_path);
+    let shm_path = append_os_suffix(&resolved_db_path, "-shm");
+    let wal_path = append_os_suffix(&resolved_db_path, "-wal");
+    vec![
+        ("db", DbFileIdentity::from_resolved_path(&resolved_db_path)),
+        ("shm", DbFileIdentity::from_resolved_path(&shm_path)),
+        ("wal", DbFileIdentity::from_resolved_path(&wal_path)),
+    ]
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn append_os_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut os = OsString::from(path.as_os_str());
+    os.push(OsStr::new(suffix));
+    PathBuf::from(os)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_configured_path_lossy(path: &Path) -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    resolve_path_with_cwd_lossy(path, &cwd)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_path_with_cwd_lossy(path: &Path, cwd: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    canonicalize_if_present(&absolute)
+}
+
+#[cfg(target_os = "linux")]
+fn canonicalize_if_present(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(target_os = "linux")]
+fn file_id_for_path(path: &Path) -> Option<FileId> {
+    fs::metadata(path)
+        .ok()
+        .map(|metadata| FileId::from_metadata(&metadata))
+}
+
+#[cfg(target_os = "linux")]
+fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
+    const DELETED_SUFFIX: &[u8] = b" (deleted)";
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.ends_with(DELETED_SUFFIX) {
+        let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
+        return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));
+    }
+    path
+}

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -168,10 +168,10 @@ fn strip_deleted_suffix(fd_path: &Path, path: &Path) -> PathBuf {
     const DELETED_SUFFIX: &[u8] = b" (deleted)";
     let bytes = path.as_os_str().as_bytes();
     if bytes.ends_with(DELETED_SUFFIX) {
-        let target_file_id = file_id_for_path(path);
-        let fd_file_id = file_id_for_path(fd_path);
-        if target_file_id.is_some() && target_file_id == fd_file_id {
-            return path.to_path_buf();
+        if let Some(target_file_id) = file_id_for_path(path) {
+            if file_id_for_path(fd_path) == Some(target_file_id) {
+                return path.to_path_buf();
+            }
         }
         let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
         return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));

--- a/src/db_path_identity.rs
+++ b/src/db_path_identity.rs
@@ -76,15 +76,8 @@ impl DbFileIdentity {
             return true;
         }
 
-        let canonical_target = if target_is_symlink(fd_target) || fd_file_id.is_none() {
-            Some(canonicalize_if_present(fd_target))
-        } else {
-            None
-        };
-        if canonical_target
-            .as_ref()
-            .is_some_and(|target| self.fd_targets.contains(target))
-        {
+        let canonical_target = canonicalize_if_present(fd_target);
+        if self.fd_targets.contains(&canonical_target) {
             return true;
         }
 
@@ -200,10 +193,6 @@ fn canonicalize_if_present(path: &Path) -> PathBuf {
     canonicalize_db_path_or_parent(path.to_path_buf()).unwrap_or_else(|| path.to_path_buf())
 }
 
-fn target_is_symlink(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink())
-}
-
 fn file_id_for_path(path: &Path) -> Option<FileId> {
     fs::metadata(path)
         .ok()
@@ -285,6 +274,25 @@ mod tests {
         let identity = DbFileIdentity::from_resolved_path(&real_db_path);
 
         assert!(identity.matches_fd(&tmp.path().join("missing-fd"), &linked_db_path));
+    }
+
+    #[test]
+    fn test_matches_fd_canonical_target_matches_parent_symlink_after_recreate() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("real");
+        let linked_dir = tmp.path().join("linked");
+        let stale_dir = tmp.path().join("stale");
+        fs::create_dir(&real_dir).expect("real dir");
+        fs::create_dir(&stale_dir).expect("stale dir");
+        symlink(&real_dir, &linked_dir).expect("dir symlink");
+        let real_db_path = real_dir.join("palace.db");
+        let linked_db_path = linked_dir.join("palace.db");
+        let stale_fd_path = stale_dir.join("palace.db");
+        File::create(&real_db_path).expect("db file");
+        File::create(&stale_fd_path).expect("stale fd file");
+        let identity = DbFileIdentity::from_resolved_path(&real_db_path);
+
+        assert!(identity.matches_fd(&stale_fd_path, &linked_db_path));
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,6 +5,7 @@ use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
 
 use crate::core::db::CURRENT_SCHEMA_VERSION;
+use crate::process_diagnostics::{DbHolderReport, inspect_db_holders};
 
 pub const REQUIRED_MCP_TOOLS: &[&str] = &[
     "mempal_context",
@@ -62,6 +63,7 @@ pub struct DoctorReport {
     pub current_version: String,
     pub supported_schema_version: u32,
     pub db: DoctorDbReport,
+    pub db_holders: DbHolderReport,
     pub install: DoctorInstallReport,
     pub warnings: Vec<String>,
     pub recommendations: Vec<String>,
@@ -85,6 +87,7 @@ pub struct DoctorInstallReport {
 
 pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     let db = inspect_db(db_path);
+    let db_holders = inspect_db_holders(db_path);
     let install = inspect_install();
     let mut warnings = Vec::new();
     let mut recommendations = vec![
@@ -104,6 +107,37 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     if let Some(error) = db.error.as_deref() {
         warnings.push(format!("database schema could not be inspected: {error}"));
     }
+    if let Some(error) = db_holders.error.as_deref() {
+        warnings.push(format!(
+            "database holder processes could not be inspected: {error}"
+        ));
+    }
+    if db_holders.stale_mcp_server_count > 0 {
+        warnings.push(format!(
+            "{} stale mempal MCP server process(es) hold the database open",
+            db_holders.stale_mcp_server_count
+        ));
+        recommendations.push(
+            "Restart stale MCP clients after confirming they are not the active session."
+                .to_string(),
+        );
+    }
+    if db_holders.orphan_daemon_count > 0 {
+        warnings.push(format!(
+            "{} orphan daemon process(es) hold the database open",
+            db_holders.orphan_daemon_count
+        ));
+        recommendations.push("Run `mempal daemon status` and `mempal daemon reap`.".to_string());
+    }
+    if db_holders.extra_holder_count > 0
+        && db_holders.stale_mcp_server_count == 0
+        && db_holders.orphan_daemon_count == 0
+    {
+        warnings.push(format!(
+            "{} extra process(es) hold the database open",
+            db_holders.extra_holder_count
+        ));
+    }
     if install.path_matches_current_exe == Some(false) {
         warnings
             .push("PATH resolves mempal to a different executable than this process".to_string());
@@ -118,6 +152,7 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         current_version: env!("CARGO_PKG_VERSION").to_string(),
         supported_schema_version: CURRENT_SCHEMA_VERSION,
         db,
+        db_holders,
         install,
         warnings,
         recommendations,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -107,6 +107,33 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     if let Some(error) = db.error.as_deref() {
         warnings.push(format!("database schema could not be inspected: {error}"));
     }
+    push_db_holder_warnings(&mut warnings, &mut recommendations, &db_holders);
+    if install.path_matches_current_exe == Some(false) {
+        warnings
+            .push("PATH resolves mempal to a different executable than this process".to_string());
+        recommendations
+            .push("Check `which mempal` and restart long-lived MCP clients.".to_string());
+    }
+    if install.path_mempal.is_none() {
+        warnings.push("PATH does not contain a mempal executable".to_string());
+    }
+
+    DoctorReport {
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        supported_schema_version: CURRENT_SCHEMA_VERSION,
+        db,
+        db_holders,
+        install,
+        warnings,
+        recommendations,
+    }
+}
+
+fn push_db_holder_warnings(
+    warnings: &mut Vec<String>,
+    recommendations: &mut Vec<String>,
+    db_holders: &DbHolderReport,
+) {
     if let Some(error) = db_holders.error.as_deref() {
         warnings.push(format!(
             "database holder processes could not be inspected: {error}"
@@ -129,33 +156,11 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         ));
         recommendations.push("Run `mempal daemon status` and `mempal daemon reap`.".to_string());
     }
-    if db_holders.extra_holder_count > 0
-        && db_holders.stale_mcp_server_count == 0
-        && db_holders.orphan_daemon_count == 0
-    {
+    if db_holders.extra_holder_count > 0 {
         warnings.push(format!(
             "{} extra process(es) hold the database open",
             db_holders.extra_holder_count
         ));
-    }
-    if install.path_matches_current_exe == Some(false) {
-        warnings
-            .push("PATH resolves mempal to a different executable than this process".to_string());
-        recommendations
-            .push("Check `which mempal` and restart long-lived MCP clients.".to_string());
-    }
-    if install.path_mempal.is_none() {
-        warnings.push("PATH does not contain a mempal executable".to_string());
-    }
-
-    DoctorReport {
-        current_version: env!("CARGO_PKG_VERSION").to_string(),
-        supported_schema_version: CURRENT_SCHEMA_VERSION,
-        db,
-        db_holders,
-        install,
-        warnings,
-        recommendations,
     }
 }
 
@@ -222,4 +227,42 @@ fn paths_match(left: &Path, right: &Path) -> bool {
     let left = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
     let right = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
     left == right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_db_holder_warnings_report_extra_holders_alongside_specific_roles() {
+        let report = DbHolderReport {
+            db_path: "/tmp/palace.db".to_string(),
+            holder_count: 3,
+            extra_holder_count: 1,
+            stale_mcp_server_count: 1,
+            orphan_daemon_count: 1,
+            error: None,
+            holders: Vec::new(),
+        };
+        let mut warnings = Vec::new();
+        let mut recommendations = Vec::new();
+
+        push_db_holder_warnings(&mut warnings, &mut recommendations, &report);
+
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("stale mempal MCP server"))
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("orphan daemon"))
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.contains("extra process"))
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod crystallize;
 pub mod daemon;
 pub mod daemon_bootstrap;
 pub mod daemon_singleton;
+#[cfg(target_os = "linux")]
+pub(crate) mod db_path_identity;
 pub mod doctor;
 pub mod embed;
 pub mod endpoint_health;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod knowledge_lifecycle;
 pub mod llm;
 pub mod mcp;
 pub mod observability;
+pub mod process_diagnostics;
 pub mod repair;
 pub mod search;
 pub mod session_review;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9401,6 +9401,8 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         Some(hb) => println!("  last_heartbeat_unix_secs: {hb}"),
         None => println!("  last_heartbeat_unix_secs: none"),
     }
+    let db_holders = mempal::process_diagnostics::inspect_db_holders(db.path());
+    print_db_holder_report("DB Holders", &db_holders, "  ");
     println!("Queue:");
     println!("  pending: {}", queue_stats.pending);
     println!("  claimed: {}", queue_stats.claimed);
@@ -11126,6 +11128,8 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
             siblings.len()
         );
     }
+    let db_holders = mempal::process_diagnostics::inspect_db_holders(db_path);
+    print_db_holder_report("db_holders", &db_holders, "");
     Ok(())
 }
 fn prime_embedder_degraded() -> bool {
@@ -12016,9 +12020,62 @@ fn doctor_command(format: String) -> Result<()> {
             for warning in &report.warnings {
                 println!("warning: {warning}");
             }
+            print_db_holder_report("db_holders", &report.db_holders, "");
         }
     }
     Ok(())
+}
+
+fn print_db_holder_report(
+    heading: &str,
+    report: &mempal::process_diagnostics::DbHolderReport,
+    indent: &str,
+) {
+    println!("{heading}:");
+    println!("{indent}path: {}", report.db_path);
+    println!("{indent}total: {}", report.holder_count);
+    println!("{indent}extra_holders: {}", report.extra_holder_count);
+    println!(
+        "{indent}stale_mcp_servers: {}",
+        report.stale_mcp_server_count
+    );
+    println!("{indent}orphan_daemons: {}", report.orphan_daemon_count);
+    if let Some(error) = report.error.as_deref() {
+        println!("{indent}error: {error}");
+    }
+    if report.holders.is_empty() {
+        println!("{indent}holders: none");
+        return;
+    }
+    println!("{indent}holders:");
+    for holder in &report.holders {
+        let age = holder
+            .age_secs
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let started = holder
+            .started_at_unix_secs
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let files = if holder.opened_files.is_empty() {
+            "none".to_string()
+        } else {
+            holder.opened_files.join(",")
+        };
+        println!(
+            "{indent}- pid={} role={} classification={} current_process={} current_daemon={} current_mcp_server={} age_secs={} started_at_unix_secs={} files={} command={}",
+            holder.pid,
+            holder.role,
+            holder.classification,
+            holder.current_process,
+            holder.current_daemon,
+            holder.current_mcp_server,
+            age,
+            started,
+            files,
+            holder.command
+        );
+    }
 }
 
 async fn brief_command(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1939,6 +1939,7 @@ impl MempalMcpServer {
         let embed_snapshot = global_embed_status().snapshot();
         let intelligence_snapshot = crate::intelligence::global_intelligence_status().snapshot();
         let mut system_warnings = current_system_warnings();
+        let db_holders = crate::process_diagnostics::inspect_db_holders(&self.db_path);
         let vector_search_circuit =
             VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
         if db_snapshot.null_project_backfill_pending > 0 {
@@ -1971,6 +1972,7 @@ impl MempalMcpServer {
                 source: "project_isolation".to_string(),
             });
         }
+        push_db_holder_warnings(&mut system_warnings, &db_holders);
 
         let embed_failure_headline =
             crate::core::queue::failure_headline_count(embed_snapshot.fail_count, &queue_stats);
@@ -2051,6 +2053,7 @@ impl MempalMcpServer {
                 avg_processing_ms: queue_stats.avg_processing_ms,
                 eta_secs: queue_stats.eta_secs,
             },
+            db_holders,
             scrub_stats: ScrubStatsDto::from(ConfigHandle::scrub_stats()),
             chunker_stats: ChunkerStatsDto::from(
                 crate::ingest::chunk::global_chunker_stats().snapshot(),
@@ -7201,6 +7204,52 @@ fn push_mcp_timeout_warning(
         message: warning,
         source: "mcp_timeout".to_string(),
     });
+}
+
+fn push_db_holder_warnings(
+    system_warnings: &mut Vec<SystemWarning>,
+    report: &crate::process_diagnostics::DbHolderReport,
+) {
+    if let Some(error) = report.error.as_deref() {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: format!("database holder process inspection failed: {error}"),
+            source: "db_holders".to_string(),
+        });
+    }
+    if report.stale_mcp_server_count > 0 {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: format!(
+                "{} stale mempal MCP server process(es) hold palace.db open",
+                report.stale_mcp_server_count
+            ),
+            source: "db_holders".to_string(),
+        });
+    }
+    if report.orphan_daemon_count > 0 {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: format!(
+                "{} orphan daemon process(es) hold palace.db open",
+                report.orphan_daemon_count
+            ),
+            source: "db_holders".to_string(),
+        });
+    }
+    if report.extra_holder_count > 0
+        && report.stale_mcp_server_count == 0
+        && report.orphan_daemon_count == 0
+    {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: format!(
+                "{} extra process(es) hold palace.db open",
+                report.extra_holder_count
+            ),
+            source: "db_holders".to_string(),
+        });
+    }
 }
 
 fn stale_index_warning_from_bool(is_stale: bool) -> Option<SystemWarning> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7237,10 +7237,7 @@ fn push_db_holder_warnings(
             source: "db_holders".to_string(),
         });
     }
-    if report.extra_holder_count > 0
-        && report.stale_mcp_server_count == 0
-        && report.orphan_daemon_count == 0
-    {
+    if report.extra_holder_count > 0 {
         system_warnings.push(SystemWarning {
             level: "warn".to_string(),
             message: format!(
@@ -8272,6 +8269,32 @@ mod tests {
             warning.source == "vector_index"
                 && warning.message.contains("reindex --from-config --stale")
         })
+    }
+
+    #[test]
+    fn test_db_holder_system_warnings_report_extra_holders_with_specific_roles() {
+        let report = crate::process_diagnostics::DbHolderReport {
+            db_path: "/tmp/palace.db".to_string(),
+            holder_count: 3,
+            extra_holder_count: 1,
+            stale_mcp_server_count: 1,
+            orphan_daemon_count: 1,
+            error: None,
+            holders: Vec::new(),
+        };
+        let mut warnings = Vec::new();
+
+        push_db_holder_warnings(&mut warnings, &report);
+
+        assert!(warnings.iter().any(|warning| {
+            warning.source == "db_holders" && warning.message.contains("stale mempal MCP server")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.source == "db_holders" && warning.message.contains("orphan daemon")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.source == "db_holders" && warning.message.contains("extra process")
+        }));
     }
 
     fn insert_drawer_with_project(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -29,6 +29,7 @@ use crate::knowledge_card_retrieval::{RetrievedEvidenceCitation, RetrievedKnowle
 use crate::knowledge_distill::DistillOutcome;
 use crate::knowledge_gate::{GateReport, PromotionPolicyEntry};
 use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
+use crate::process_diagnostics::DbHolderReport;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -1920,6 +1921,10 @@ pub struct StatusResponse {
     /// Sticky embedder circuit plus the current vector-search fallback policy.
     pub embedder_circuit: EmbedderCircuitDto,
     pub queue_stats: QueueStatsDto,
+    /// Live processes holding `palace.db`, `palace.db-wal`, or
+    /// `palace.db-shm` open, classified as current daemon/MCP server versus
+    /// stale or extra holders.
+    pub db_holders: DbHolderReport,
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,
@@ -2366,6 +2371,7 @@ pub struct DoctorResponse {
     pub current_version: String,
     pub supported_schema_version: u32,
     pub db: DoctorDbDto,
+    pub db_holders: DbHolderReport,
     pub install: DoctorInstallDto,
     pub warnings: Vec<String>,
     pub recommendations: Vec<String>,
@@ -2378,6 +2384,7 @@ impl DoctorResponse {
             current_version: report.current_version,
             supported_schema_version: report.supported_schema_version,
             db: report.db.into(),
+            db_holders: report.db_holders,
             install: report.install.into(),
             warnings: report.warnings,
             recommendations: report.recommendations,

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -2,10 +2,10 @@
 use std::fs;
 use std::path::Path;
 #[cfg(target_os = "linux")]
-use std::path::PathBuf;
-#[cfg(target_os = "linux")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(target_os = "linux")]
+use crate::db_path_identity::{DbFileIdentity, db_file_targets};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -182,7 +182,7 @@ fn empty_report(db_path: &Path, error: Option<String>) -> DbHolderReport {
 }
 
 #[cfg(target_os = "linux")]
-fn opened_db_files(fd_dir: &Path, targets: &[(String, PathBuf)]) -> Vec<String> {
+fn opened_db_files(fd_dir: &Path, targets: &[(&'static str, DbFileIdentity)]) -> Vec<String> {
     let entries = match fs::read_dir(fd_dir) {
         Ok(entries) => entries,
         Err(_) => return Vec::new(),
@@ -192,45 +192,16 @@ fn opened_db_files(fd_dir: &Path, targets: &[(String, PathBuf)]) -> Vec<String> 
         let Ok(target) = fs::read_link(entry.path()) else {
             continue;
         };
-        let target = strip_deleted_suffix(target);
         for (kind, expected) in targets {
-            if target == *expected && !opened.contains(kind) {
-                opened.push(kind.clone());
+            if expected.matches_fd(&entry.path(), &target)
+                && !opened.iter().any(|opened_kind| opened_kind == kind)
+            {
+                opened.push((*kind).to_string());
             }
         }
     }
     opened.sort();
     opened
-}
-
-#[cfg(target_os = "linux")]
-fn db_file_targets(db_path: &Path) -> Vec<(String, PathBuf)> {
-    vec![
-        ("db".to_string(), db_path.to_path_buf()),
-        ("shm".to_string(), path_with_suffix(db_path, "-shm")),
-        ("wal".to_string(), path_with_suffix(db_path, "-wal")),
-    ]
-}
-
-#[cfg(target_os = "linux")]
-fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
-    let mut value = path.as_os_str().to_os_string();
-    value.push(suffix);
-    PathBuf::from(value)
-}
-
-#[cfg(target_os = "linux")]
-fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
-    use std::ffi::OsString;
-    use std::os::unix::ffi::{OsStrExt, OsStringExt};
-
-    const DELETED_SUFFIX: &[u8] = b" (deleted)";
-    let bytes = path.as_os_str().as_bytes();
-    if bytes.ends_with(DELETED_SUFFIX) {
-        let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
-        return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));
-    }
-    path
 }
 
 #[cfg(target_os = "linux")]
@@ -403,7 +374,9 @@ mod tests {
     #[cfg(target_os = "linux")]
     mod linux {
         use super::super::*;
+        use crate::db_path_identity::{append_os_suffix, db_file_targets_with_cwd};
         use std::fs;
+        use std::fs::File;
         use std::os::unix::fs::symlink;
 
         fn write_process(proc_root: &Path, pid: i32, argv: &[&str], db_files: &[&Path]) {
@@ -452,8 +425,8 @@ mod tests {
             let mempal_home = tmp.path().join(".mempal");
             fs::create_dir_all(&mempal_home).expect("create mempal home");
             let db_path = mempal_home.join("palace.db");
-            let wal_path = path_with_suffix(&db_path, "-wal");
-            let shm_path = path_with_suffix(&db_path, "-shm");
+            let wal_path = append_os_suffix(&db_path, "-wal");
+            let shm_path = append_os_suffix(&db_path, "-shm");
             fs::write(mempal_home.join("daemon.pid"), "42\n").expect("write pidfile");
 
             write_process(
@@ -517,6 +490,69 @@ mod tests {
             assert_eq!(report.holder_count, 1);
             assert_eq!(report.holders[0].role, "other");
             assert_eq!(report.holders[0].classification, "extra_holder");
+        }
+
+        #[test]
+        fn test_opened_db_files_matches_relative_db_path_against_absolute_fd_target() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            let db_path = tmp.path().join("palace.db");
+            File::create(&db_path).expect("db file");
+            write_process(&proc_root, 33, &["mempal", "serve"], &[db_path.as_path()]);
+
+            let targets = db_file_targets_with_cwd(Path::new("palace.db"), tmp.path());
+            let opened = opened_db_files(&proc_root.join("33").join("fd"), &targets);
+
+            assert_eq!(opened, vec!["db"]);
+        }
+
+        #[test]
+        fn test_opened_db_files_matches_symlinked_db_directory() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            let real_home = tmp.path().join("real-mempal");
+            let linked_home = tmp.path().join("linked-mempal");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::create_dir_all(&real_home).expect("create real home");
+            symlink(&real_home, &linked_home).expect("symlink home");
+            let real_db_path = real_home.join("palace.db");
+            File::create(&real_db_path).expect("db file");
+            write_process(
+                &proc_root,
+                44,
+                &["mempal", "serve"],
+                &[real_db_path.as_path()],
+            );
+
+            let targets = db_file_targets(&linked_home.join("palace.db"));
+            let opened = opened_db_files(&proc_root.join("44").join("fd"), &targets);
+
+            assert_eq!(opened, vec!["db"]);
+        }
+
+        #[test]
+        fn test_opened_db_files_matches_symlinked_db_path() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            let real_home = tmp.path().join("real-mempal");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::create_dir_all(&real_home).expect("create real home");
+            let real_db_path = real_home.join("palace.db");
+            let linked_db_path = tmp.path().join("palace-link.db");
+            File::create(&real_db_path).expect("db file");
+            symlink(&real_db_path, &linked_db_path).expect("symlink db");
+            write_process(
+                &proc_root,
+                55,
+                &["mempal", "serve"],
+                &[real_db_path.as_path()],
+            );
+
+            let targets = db_file_targets(&linked_db_path);
+            let opened = opened_db_files(&proc_root.join("55").join("fd"), &targets);
+
+            assert_eq!(opened, vec!["db"]);
         }
     }
 

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "linux")]
-use std::fs;
 use std::path::Path;
 #[cfg(target_os = "linux")]
-use std::path::PathBuf;
-#[cfg(target_os = "linux")]
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[cfg(target_os = "linux")]
 use crate::db_path_identity::{DbFileIdentity, db_file_targets};

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -312,10 +312,10 @@ fn is_mempal_invocation(argv: &[String], binary_name: &str) -> bool {
 
 #[cfg(target_os = "linux")]
 fn is_mcp_server_argv(argv: &[String]) -> bool {
-    let Some((index, subcommand)) = first_cli_subcommand(argv) else {
+    let Some((_, subcommand)) = first_cli_subcommand(argv) else {
         return false;
     };
-    subcommand == "serve" && argv[index + 1..].iter().any(|arg| arg == "--mcp")
+    subcommand == "serve"
 }
 
 #[cfg(target_os = "linux")]
@@ -429,6 +429,10 @@ mod tests {
             );
             assert!(is_mcp_server_argv(&[
                 "/usr/local/bin/mempal".to_string(),
+                "serve".to_string()
+            ]));
+            assert!(is_mcp_server_argv(&[
+                "/usr/local/bin/mempal".to_string(),
                 "--db-path".to_string(),
                 "/tmp/palace.db".to_string(),
                 "serve".to_string(),
@@ -461,7 +465,7 @@ mod tests {
             write_process(
                 &proc_root,
                 77,
-                &["/usr/local/bin/mempal", "serve", "--mcp"],
+                &["/usr/local/bin/mempal", "serve"],
                 &[db_path.as_path(), wal_path.as_path(), shm_path.as_path()],
             );
             write_process(

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -321,18 +321,29 @@ fn read_boot_time(proc_root: &Path) -> Option<u64> {
 
 #[cfg(target_os = "linux")]
 fn read_start_ticks(path: &Path) -> Option<u64> {
-    let content = fs::read_to_string(path).ok()?;
+    let content = fs::read(path).ok()?;
     parse_start_ticks(&content)
 }
 
 #[cfg(target_os = "linux")]
-fn parse_start_ticks(stat: &str) -> Option<u64> {
-    let close = stat.rfind(") ")?;
-    stat[close + 2..]
-        .split_whitespace()
+fn parse_start_ticks(stat: &[u8]) -> Option<u64> {
+    let close = stat.windows(2).rposition(|window| window == b") ")?;
+    let start_ticks = stat[close + 2..]
+        .split(u8::is_ascii_whitespace)
+        .filter(|field| !field.is_empty())
         .nth(19)?
-        .parse::<u64>()
-        .ok()
+        .iter()
+        .try_fold(0_u64, |value, digit| {
+            digit
+                .checked_sub(b'0')
+                .filter(|digit| *digit <= 9)
+                .and_then(|digit| {
+                    value
+                        .checked_mul(10)
+                        .and_then(|value| value.checked_add(u64::from(digit)))
+                })
+        })?;
+    Some(start_ticks)
 }
 
 #[cfg(target_os = "linux")]
@@ -403,8 +414,20 @@ mod tests {
                 "serve".to_string(),
                 "--mcp".to_string()
             ]));
-            let stat = "123 (mempal worker) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765";
+            let stat = b"123 (mempal worker) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765";
             assert_eq!(parse_start_ticks(stat), Some(98765));
+        }
+
+        #[test]
+        fn test_read_start_ticks_handles_non_utf8_process_name() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let stat_path = tmp.path().join("stat");
+            let mut stat = b"123 (mempal ".to_vec();
+            stat.extend_from_slice(&[0xff, 0xfe]);
+            stat.extend_from_slice(b") S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765");
+            fs::write(&stat_path, stat).expect("write stat");
+
+            assert_eq!(read_start_ticks(&stat_path), Some(98765));
         }
 
         #[test]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -41,6 +41,7 @@ pub struct DbHolderProcess {
     pub pid: i32,
     pub role: String,
     pub classification: String,
+    /// Sanitized process label for human diagnostics. This is never raw argv.
     pub command: String,
     pub opened_files: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,7 +133,7 @@ fn inspect_db_holders_in_proc(
             pid,
             role: role.to_string(),
             classification: classification.to_string(),
-            command: command_display(&argv),
+            command: command_display(role),
             opened_files,
             started_at_unix_secs,
             age_secs,
@@ -299,11 +300,14 @@ fn is_mcp_server_argv(argv: &[String]) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn command_display(argv: &[String]) -> String {
-    if argv.is_empty() {
-        return "<unknown>".to_string();
+fn command_display(role: &str) -> String {
+    match role {
+        "mempal_daemon" => "mempal daemon".to_string(),
+        "mempal_mcp_server" => "mempal serve".to_string(),
+        "mempal_cli" => "mempal cli".to_string(),
+        "other" => "other process".to_string(),
+        _ => "<unknown>".to_string(),
     }
-    argv.join(" ")
 }
 
 #[cfg(target_os = "linux")]
@@ -401,6 +405,14 @@ mod tests {
         }
 
         #[test]
+        fn test_command_display_uses_fixed_labels_only() {
+            assert_eq!(command_display("mempal_mcp_server"), "mempal serve");
+            assert_eq!(command_display("mempal_daemon"), "mempal daemon");
+            assert_eq!(command_display("mempal_cli"), "mempal cli");
+            assert_eq!(command_display("other"), "other process");
+        }
+
+        #[test]
         fn test_daemon_pid_path_uses_current_dir_for_bare_relative_db_path() {
             assert_eq!(
                 daemon_pid_path(Path::new("palace.db")),
@@ -494,6 +506,66 @@ mod tests {
             assert_eq!(report.holder_count, 1);
             assert_eq!(report.holders[0].role, "other");
             assert_eq!(report.holders[0].classification, "extra_holder");
+        }
+
+        #[test]
+        fn test_inspect_db_holders_redacts_sensitive_argv_from_diagnostics() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::write(proc_root.join("stat"), "btime 1000\n").expect("write proc stat");
+
+            let db_path = tmp.path().join("palace.db");
+            let private_config = tmp.path().join("private").join("config.toml");
+            write_process(
+                &proc_root,
+                77,
+                &[
+                    "/private/bin/mempal",
+                    "serve",
+                    "--mcp",
+                    "--api-key",
+                    "sk-test-secret",
+                    "--config-path",
+                    private_config.to_str().expect("utf8 path"),
+                    "--token=ghp_test_secret",
+                ],
+                &[db_path.as_path()],
+            );
+            write_process(
+                &proc_root,
+                99,
+                &[
+                    "/private/tools/sqlite3",
+                    db_path.to_str().expect("utf8 path"),
+                    "--password=hunter2",
+                    "OPENAI_API_KEY=sk-hidden",
+                ],
+                &[db_path.as_path()],
+            );
+
+            let report = inspect_db_holders_in_proc(&db_path, &proc_root, 1100, 100);
+            let serialized = serde_json::to_string(&report).expect("serialize report");
+
+            assert_eq!(report.holder_count, 2);
+            assert_eq!(report.holders[0].command, "mempal serve");
+            assert_eq!(report.holders[1].command, "other process");
+            for forbidden in [
+                "--api-key",
+                "sk-test-secret",
+                "--config-path",
+                private_config.to_str().expect("utf8 path"),
+                "--token=ghp_test_secret",
+                "--password=hunter2",
+                "OPENAI_API_KEY=sk-hidden",
+                "/private/bin/mempal",
+                "/private/tools/sqlite3",
+            ] {
+                assert!(
+                    !serialized.contains(forbidden),
+                    "db holder diagnostics leaked raw argv fragment: {forbidden}"
+                );
+            }
         }
 
         #[test]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -104,7 +104,8 @@ fn inspect_db_holders_in_proc(
 
     let mut holders = Vec::new();
     for entry in entries.flatten() {
-        let Some(pid) = parse_pid(entry.file_name().to_string_lossy().as_ref()) else {
+        let file_name = entry.file_name();
+        let Some(pid) = file_name.to_str().and_then(parse_pid) else {
             continue;
         };
         let pid_dir = entry.path();

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -1,0 +1,511 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rmcp::schemars::{self, JsonSchema};
+use serde::{Deserialize, Serialize};
+
+/// Best-effort report of live processes that currently hold the mempal SQLite
+/// database, WAL, or shared-memory file open.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct DbHolderReport {
+    pub db_path: String,
+    pub holder_count: usize,
+    pub extra_holder_count: usize,
+    pub stale_mcp_server_count: usize,
+    pub orphan_daemon_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub holders: Vec<DbHolderProcess>,
+}
+
+impl DbHolderReport {
+    pub fn has_problem(&self) -> bool {
+        self.extra_holder_count > 0
+            || self.stale_mcp_server_count > 0
+            || self.orphan_daemon_count > 0
+            || self.error.is_some()
+    }
+}
+
+/// One live process with an open fd to `palace.db`, `palace.db-wal`, or
+/// `palace.db-shm`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct DbHolderProcess {
+    pub pid: i32,
+    pub role: String,
+    pub classification: String,
+    pub command: String,
+    pub opened_files: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at_unix_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_secs: Option<u64>,
+    pub current_process: bool,
+    pub current_daemon: bool,
+    pub current_mcp_server: bool,
+}
+
+/// Inspect live DB holders. On non-Unix platforms this returns an empty report
+/// because portable process fd enumeration is not available without external
+/// tooling.
+pub fn inspect_db_holders(db_path: &Path) -> DbHolderReport {
+    #[cfg(unix)]
+    {
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0);
+        inspect_db_holders_in_proc(
+            db_path,
+            Path::new("/proc"),
+            now_secs,
+            clock_ticks_per_second(),
+        )
+    }
+
+    #[cfg(not(unix))]
+    {
+        empty_report(
+            db_path,
+            Some("process fd inspection is only supported on Unix".to_string()),
+        )
+    }
+}
+
+#[cfg(unix)]
+fn inspect_db_holders_in_proc(
+    db_path: &Path,
+    proc_root: &Path,
+    now_secs: u64,
+    clock_ticks_per_second: u64,
+) -> DbHolderReport {
+    let current_pid = std::process::id() as i32;
+    let daemon_pid = read_daemon_pid(db_path);
+    let binary_name =
+        crate::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
+    let boot_time = read_boot_time(proc_root);
+    let targets = db_file_targets(db_path);
+    let entries = match fs::read_dir(proc_root) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return empty_report(
+                db_path,
+                Some(format!(
+                    "failed to read process table {}: {error}",
+                    proc_root.display()
+                )),
+            );
+        }
+    };
+
+    let mut holders = Vec::new();
+    for entry in entries.flatten() {
+        let Some(pid) = parse_pid(entry.file_name().to_string_lossy().as_ref()) else {
+            continue;
+        };
+        let pid_dir = entry.path();
+        let opened_files = opened_db_files(&pid_dir.join("fd"), &targets);
+        if opened_files.is_empty() {
+            continue;
+        }
+
+        let argv = read_cmdline(&pid_dir.join("cmdline"));
+        let role = classify_role(&argv, &binary_name);
+        let current_process = pid == current_pid;
+        let current_daemon = daemon_pid == Some(pid) && role == "mempal_daemon";
+        let current_mcp_server = current_process && role == "mempal_mcp_server";
+        let classification =
+            classify_holder(role, current_process, current_daemon, current_mcp_server);
+        let started_at_unix_secs = boot_time.and_then(|btime| {
+            read_start_ticks(&pid_dir.join("stat")).map(|ticks| {
+                btime.saturating_add(ticks.saturating_div(clock_ticks_per_second.max(1)))
+            })
+        });
+        let age_secs = started_at_unix_secs.map(|started| now_secs.saturating_sub(started));
+
+        holders.push(DbHolderProcess {
+            pid,
+            role: role.to_string(),
+            classification: classification.to_string(),
+            command: command_display(&argv),
+            opened_files,
+            started_at_unix_secs,
+            age_secs,
+            current_process,
+            current_daemon,
+            current_mcp_server,
+        });
+    }
+
+    holders.sort_by_key(|holder| holder.pid);
+    build_report(db_path, holders, None)
+}
+
+fn build_report(
+    db_path: &Path,
+    holders: Vec<DbHolderProcess>,
+    error: Option<String>,
+) -> DbHolderReport {
+    let stale_mcp_server_count = holders
+        .iter()
+        .filter(|holder| holder.classification == "stale_mcp_server")
+        .count();
+    let orphan_daemon_count = holders
+        .iter()
+        .filter(|holder| holder.classification == "orphan_daemon")
+        .count();
+    let extra_holder_count = holders
+        .iter()
+        .filter(|holder| {
+            !matches!(
+                holder.classification.as_str(),
+                "current_process" | "current_daemon" | "current_mcp_server"
+            )
+        })
+        .count();
+
+    DbHolderReport {
+        db_path: db_path.display().to_string(),
+        holder_count: holders.len(),
+        extra_holder_count,
+        stale_mcp_server_count,
+        orphan_daemon_count,
+        error,
+        holders,
+    }
+}
+
+fn empty_report(db_path: &Path, error: Option<String>) -> DbHolderReport {
+    build_report(db_path, Vec::new(), error)
+}
+
+#[cfg(unix)]
+fn opened_db_files(fd_dir: &Path, targets: &[(String, PathBuf)]) -> Vec<String> {
+    let entries = match fs::read_dir(fd_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+    let mut opened = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(target) = fs::read_link(entry.path()) else {
+            continue;
+        };
+        let target = strip_deleted_suffix(target);
+        for (kind, expected) in targets {
+            if target == *expected && !opened.contains(kind) {
+                opened.push(kind.clone());
+            }
+        }
+    }
+    opened.sort();
+    opened
+}
+
+#[cfg(unix)]
+fn db_file_targets(db_path: &Path) -> Vec<(String, PathBuf)> {
+    vec![
+        ("db".to_string(), db_path.to_path_buf()),
+        ("shm".to_string(), path_with_suffix(db_path, "-shm")),
+        ("wal".to_string(), path_with_suffix(db_path, "-wal")),
+    ]
+}
+
+#[cfg(unix)]
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
+}
+
+#[cfg(unix)]
+fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    const DELETED_SUFFIX: &[u8] = b" (deleted)";
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.ends_with(DELETED_SUFFIX) {
+        let keep = bytes.len().saturating_sub(DELETED_SUFFIX.len());
+        return PathBuf::from(OsString::from_vec(bytes[..keep].to_vec()));
+    }
+    path
+}
+
+#[cfg(unix)]
+fn read_daemon_pid(db_path: &Path) -> Option<i32> {
+    let pid_path = db_path.parent()?.join("daemon.pid");
+    fs::read_to_string(pid_path)
+        .ok()
+        .and_then(|content| content.trim().parse::<i32>().ok())
+}
+
+#[cfg(unix)]
+fn read_cmdline(path: &Path) -> Vec<String> {
+    let Ok(bytes) = fs::read(path) else {
+        return Vec::new();
+    };
+    parse_cmdline(&bytes)
+}
+
+#[cfg(unix)]
+fn parse_cmdline(bytes: &[u8]) -> Vec<String> {
+    bytes
+        .split(|byte| *byte == b'\0')
+        .filter(|part| !part.is_empty())
+        .map(|part| String::from_utf8_lossy(part).into_owned())
+        .collect()
+}
+
+#[cfg(unix)]
+fn classify_role(argv: &[String], binary_name: &str) -> &'static str {
+    if !is_mempal_invocation(argv, binary_name) {
+        return "other";
+    }
+    if crate::daemon_singleton::is_daemon_argv(argv, binary_name)
+        || crate::daemon_singleton::is_daemon_argv(argv, "mempal")
+    {
+        return "mempal_daemon";
+    }
+    if is_mcp_server_argv(argv) {
+        return "mempal_mcp_server";
+    }
+    "mempal_cli"
+}
+
+#[cfg(unix)]
+fn classify_holder(
+    role: &str,
+    current_process: bool,
+    current_daemon: bool,
+    current_mcp_server: bool,
+) -> &'static str {
+    if current_daemon {
+        "current_daemon"
+    } else if current_mcp_server {
+        "current_mcp_server"
+    } else if current_process {
+        "current_process"
+    } else if role == "mempal_mcp_server" {
+        "stale_mcp_server"
+    } else if role == "mempal_daemon" {
+        "orphan_daemon"
+    } else {
+        "extra_holder"
+    }
+}
+
+#[cfg(unix)]
+fn is_mempal_invocation(argv: &[String], binary_name: &str) -> bool {
+    let Some(program) = argv.first() else {
+        return false;
+    };
+    let Some(name) = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+    name == binary_name || name == "mempal"
+}
+
+#[cfg(unix)]
+fn is_mcp_server_argv(argv: &[String]) -> bool {
+    let Some((index, subcommand)) = first_cli_subcommand(argv) else {
+        return false;
+    };
+    subcommand == "serve" && argv[index + 1..].iter().any(|arg| arg == "--mcp")
+}
+
+#[cfg(unix)]
+fn first_cli_subcommand(argv: &[String]) -> Option<(usize, &str)> {
+    let mut index = 1;
+    while index < argv.len() {
+        let arg = argv[index].as_str();
+        if arg == "--" {
+            return argv.get(index + 1).map(|value| (index + 1, value.as_str()));
+        }
+        if global_flag_takes_value(arg) {
+            index += 2;
+            continue;
+        }
+        if global_flag_has_inline_value(arg) || arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        return Some((index, arg));
+    }
+    None
+}
+
+#[cfg(unix)]
+fn global_flag_takes_value(arg: &str) -> bool {
+    matches!(arg, "--config" | "--db-path")
+}
+
+#[cfg(unix)]
+fn global_flag_has_inline_value(arg: &str) -> bool {
+    arg.starts_with("--config=") || arg.starts_with("--db-path=")
+}
+
+#[cfg(unix)]
+fn command_display(argv: &[String]) -> String {
+    if argv.is_empty() {
+        return "<unknown>".to_string();
+    }
+    argv.join(" ")
+}
+
+#[cfg(unix)]
+fn read_boot_time(proc_root: &Path) -> Option<u64> {
+    let content = fs::read_to_string(proc_root.join("stat")).ok()?;
+    content.lines().find_map(|line| {
+        let value = line.strip_prefix("btime ")?;
+        value.trim().parse::<u64>().ok()
+    })
+}
+
+#[cfg(unix)]
+fn read_start_ticks(path: &Path) -> Option<u64> {
+    let content = fs::read_to_string(path).ok()?;
+    parse_start_ticks(&content)
+}
+
+#[cfg(unix)]
+fn parse_start_ticks(stat: &str) -> Option<u64> {
+    let close = stat.rfind(") ")?;
+    let fields = stat[close + 2..].split_whitespace().collect::<Vec<_>>();
+    fields.get(19)?.parse::<u64>().ok()
+}
+
+#[cfg(unix)]
+fn parse_pid(value: &str) -> Option<i32> {
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<i32>().ok().filter(|pid| *pid > 0)
+}
+
+#[cfg(unix)]
+fn clock_ticks_per_second() -> u64 {
+    // SAFETY: sysconf(_SC_CLK_TCK) is a read-only libc query with no pointer
+    // arguments and no Rust aliasing or lifetime requirements.
+    let ticks = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    u64::try_from(ticks)
+        .ok()
+        .filter(|ticks| *ticks > 0)
+        .unwrap_or(100)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    mod unix {
+        use super::super::*;
+        use std::fs;
+        use std::os::unix::fs::symlink;
+
+        fn write_process(proc_root: &Path, pid: i32, argv: &[&str], db_files: &[&Path]) {
+            let pid_dir = proc_root.join(pid.to_string());
+            let fd_dir = pid_dir.join("fd");
+            fs::create_dir_all(&fd_dir).expect("create fake fd dir");
+            fs::write(pid_dir.join("cmdline"), argv.join("\0")).expect("write cmdline");
+            fs::write(
+                pid_dir.join("stat"),
+                format!("{pid} (mempal) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 250"),
+            )
+            .expect("write stat");
+            for (index, file) in db_files.iter().enumerate() {
+                symlink(file, fd_dir.join((index + 3).to_string())).expect("symlink fd");
+            }
+        }
+
+        #[test]
+        fn test_parse_cmdline_and_start_ticks() {
+            assert_eq!(
+                parse_cmdline(b"/usr/local/bin/mempal\0serve\0--mcp\0"),
+                vec!["/usr/local/bin/mempal", "serve", "--mcp"]
+            );
+            let stat = "123 (mempal worker) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765";
+            assert_eq!(parse_start_ticks(stat), Some(98765));
+        }
+
+        #[test]
+        fn test_inspect_db_holders_classifies_stale_mcp_and_orphan_daemon() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::write(proc_root.join("stat"), "cpu 0 0 0 0\nbtime 1000\n").expect("write stat");
+
+            let mempal_home = tmp.path().join(".mempal");
+            fs::create_dir_all(&mempal_home).expect("create mempal home");
+            let db_path = mempal_home.join("palace.db");
+            let wal_path = path_with_suffix(&db_path, "-wal");
+            let shm_path = path_with_suffix(&db_path, "-shm");
+            fs::write(mempal_home.join("daemon.pid"), "42\n").expect("write pidfile");
+
+            write_process(
+                &proc_root,
+                42,
+                &["mempal", "daemon", "--foreground"],
+                &[db_path.as_path()],
+            );
+            write_process(
+                &proc_root,
+                77,
+                &["/usr/local/bin/mempal", "serve", "--mcp"],
+                &[db_path.as_path(), wal_path.as_path(), shm_path.as_path()],
+            );
+            write_process(
+                &proc_root,
+                88,
+                &["mempal", "daemon", "--foreground"],
+                &[db_path.as_path()],
+            );
+
+            let report = inspect_db_holders_in_proc(&db_path, &proc_root, 1100, 100);
+
+            assert_eq!(report.holder_count, 3);
+            assert_eq!(report.stale_mcp_server_count, 1);
+            assert_eq!(report.orphan_daemon_count, 1);
+            assert_eq!(report.extra_holder_count, 2);
+            assert!(report.has_problem());
+            assert_eq!(report.holders[0].classification, "current_daemon");
+            assert_eq!(report.holders[1].classification, "stale_mcp_server");
+            assert_eq!(report.holders[1].opened_files, vec!["db", "shm", "wal"]);
+            assert_eq!(report.holders[1].started_at_unix_secs, Some(1002));
+            assert_eq!(report.holders[1].age_secs, Some(98));
+            assert_eq!(report.holders[2].classification, "orphan_daemon");
+        }
+
+        #[test]
+        fn test_inspect_db_holders_ignores_non_db_fds_and_quoted_commands() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::write(proc_root.join("stat"), "btime 1000\n").expect("write proc stat");
+
+            let db_path = tmp.path().join("palace.db");
+            let other_path = tmp.path().join("other.db");
+            write_process(
+                &proc_root,
+                11,
+                &["claude", "-p", "mempal serve --mcp"],
+                &[db_path.as_path()],
+            );
+            write_process(
+                &proc_root,
+                22,
+                &["mempal", "serve", "--mcp"],
+                &[other_path.as_path()],
+            );
+
+            let report = inspect_db_holders_in_proc(&db_path, &proc_root, 1100, 100);
+
+            assert_eq!(report.holder_count, 1);
+            assert_eq!(report.holders[0].role, "other");
+            assert_eq!(report.holders[0].classification, "extra_holder");
+        }
+    }
+}

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -328,8 +328,11 @@ fn read_start_ticks(path: &Path) -> Option<u64> {
 #[cfg(target_os = "linux")]
 fn parse_start_ticks(stat: &str) -> Option<u64> {
     let close = stat.rfind(") ")?;
-    let fields = stat[close + 2..].split_whitespace().collect::<Vec<_>>();
-    fields.get(19)?.parse::<u64>().ok()
+    stat[close + 2..]
+        .split_whitespace()
+        .nth(19)?
+        .parse::<u64>()
+        .ok()
 }
 
 #[cfg(target_os = "linux")]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -186,11 +186,12 @@ fn opened_db_files(fd_dir: &Path, targets: &[(&'static str, DbFileIdentity)]) ->
     };
     let mut opened = Vec::new();
     for entry in entries.flatten() {
-        let Ok(target) = fs::read_link(entry.path()) else {
+        let fd_path = entry.path();
+        let Ok(target) = fs::read_link(&fd_path) else {
             continue;
         };
         for (kind, expected) in targets {
-            if expected.matches_fd(&entry.path(), &target)
+            if expected.matches_fd(&fd_path, &target)
                 && !opened.iter().any(|opened_kind| opened_kind == kind)
             {
                 opened.push((*kind).to_string());

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -191,9 +191,10 @@ fn opened_db_files(fd_dir: &Path, targets: &[(&'static str, DbFileIdentity)]) ->
             continue;
         };
         for (kind, expected) in targets {
-            if expected.matches_fd(&fd_path, &target)
-                && !opened.iter().any(|opened_kind| opened_kind == kind)
-            {
+            if opened.iter().any(|opened_kind| opened_kind == kind) {
+                continue;
+            }
+            if expected.matches_fd(&fd_path, &target) {
                 opened.push((*kind).to_string());
             }
         }

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -1,5 +1,9 @@
+#[cfg(target_os = "linux")]
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rmcp::schemars::{self, JsonSchema};
@@ -46,11 +50,10 @@ pub struct DbHolderProcess {
     pub current_mcp_server: bool,
 }
 
-/// Inspect live DB holders. On non-Unix platforms this returns an empty report
-/// because portable process fd enumeration is not available without external
-/// tooling.
+/// Inspect live DB holders. On non-Linux platforms this returns an empty report
+/// because `/proc/<pid>/fd` enumeration is Linux-specific.
 pub fn inspect_db_holders(db_path: &Path) -> DbHolderReport {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -65,16 +68,13 @@ pub fn inspect_db_holders(db_path: &Path) -> DbHolderReport {
         )
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(target_os = "linux"))]
     {
-        empty_report(
-            db_path,
-            Some("process fd inspection is only supported on Unix".to_string()),
-        )
+        empty_report(db_path, None)
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn inspect_db_holders_in_proc(
     db_path: &Path,
     proc_root: &Path,
@@ -181,7 +181,7 @@ fn empty_report(db_path: &Path, error: Option<String>) -> DbHolderReport {
     build_report(db_path, Vec::new(), error)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn opened_db_files(fd_dir: &Path, targets: &[(String, PathBuf)]) -> Vec<String> {
     let entries = match fs::read_dir(fd_dir) {
         Ok(entries) => entries,
@@ -203,7 +203,7 @@ fn opened_db_files(fd_dir: &Path, targets: &[(String, PathBuf)]) -> Vec<String> 
     opened
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn db_file_targets(db_path: &Path) -> Vec<(String, PathBuf)> {
     vec![
         ("db".to_string(), db_path.to_path_buf()),
@@ -212,14 +212,14 @@ fn db_file_targets(db_path: &Path) -> Vec<(String, PathBuf)> {
     ]
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut value = path.as_os_str().to_os_string();
     value.push(suffix);
     PathBuf::from(value)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
     use std::ffi::OsString;
     use std::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -233,7 +233,7 @@ fn strip_deleted_suffix(path: PathBuf) -> PathBuf {
     path
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_daemon_pid(db_path: &Path) -> Option<i32> {
     let pid_path = db_path.parent()?.join("daemon.pid");
     fs::read_to_string(pid_path)
@@ -241,7 +241,7 @@ fn read_daemon_pid(db_path: &Path) -> Option<i32> {
         .and_then(|content| content.trim().parse::<i32>().ok())
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_cmdline(path: &Path) -> Vec<String> {
     let Ok(bytes) = fs::read(path) else {
         return Vec::new();
@@ -249,7 +249,7 @@ fn read_cmdline(path: &Path) -> Vec<String> {
     parse_cmdline(&bytes)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn parse_cmdline(bytes: &[u8]) -> Vec<String> {
     bytes
         .split(|byte| *byte == b'\0')
@@ -258,7 +258,7 @@ fn parse_cmdline(bytes: &[u8]) -> Vec<String> {
         .collect()
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn classify_role(argv: &[String], binary_name: &str) -> &'static str {
     if !is_mempal_invocation(argv, binary_name) {
         return "other";
@@ -274,7 +274,7 @@ fn classify_role(argv: &[String], binary_name: &str) -> &'static str {
     "mempal_cli"
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn classify_holder(
     role: &str,
     current_process: bool,
@@ -296,7 +296,7 @@ fn classify_holder(
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn is_mempal_invocation(argv: &[String], binary_name: &str) -> bool {
     let Some(program) = argv.first() else {
         return false;
@@ -310,7 +310,7 @@ fn is_mempal_invocation(argv: &[String], binary_name: &str) -> bool {
     name == binary_name || name == "mempal"
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn is_mcp_server_argv(argv: &[String]) -> bool {
     let Some((index, subcommand)) = first_cli_subcommand(argv) else {
         return false;
@@ -318,7 +318,7 @@ fn is_mcp_server_argv(argv: &[String]) -> bool {
     subcommand == "serve" && argv[index + 1..].iter().any(|arg| arg == "--mcp")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn first_cli_subcommand(argv: &[String]) -> Option<(usize, &str)> {
     let mut index = 1;
     while index < argv.len() {
@@ -339,17 +339,17 @@ fn first_cli_subcommand(argv: &[String]) -> Option<(usize, &str)> {
     None
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn global_flag_takes_value(arg: &str) -> bool {
     matches!(arg, "--config" | "--db-path")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn global_flag_has_inline_value(arg: &str) -> bool {
     arg.starts_with("--config=") || arg.starts_with("--db-path=")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn command_display(argv: &[String]) -> String {
     if argv.is_empty() {
         return "<unknown>".to_string();
@@ -357,7 +357,7 @@ fn command_display(argv: &[String]) -> String {
     argv.join(" ")
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_boot_time(proc_root: &Path) -> Option<u64> {
     let content = fs::read_to_string(proc_root.join("stat")).ok()?;
     content.lines().find_map(|line| {
@@ -366,20 +366,20 @@ fn read_boot_time(proc_root: &Path) -> Option<u64> {
     })
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn read_start_ticks(path: &Path) -> Option<u64> {
     let content = fs::read_to_string(path).ok()?;
     parse_start_ticks(&content)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn parse_start_ticks(stat: &str) -> Option<u64> {
     let close = stat.rfind(") ")?;
     let fields = stat[close + 2..].split_whitespace().collect::<Vec<_>>();
     fields.get(19)?.parse::<u64>().ok()
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn parse_pid(value: &str) -> Option<i32> {
     if value.is_empty() {
         return None;
@@ -387,7 +387,7 @@ fn parse_pid(value: &str) -> Option<i32> {
     value.parse::<i32>().ok().filter(|pid| *pid > 0)
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn clock_ticks_per_second() -> u64 {
     // SAFETY: sysconf(_SC_CLK_TCK) is a read-only libc query with no pointer
     // arguments and no Rust aliasing or lifetime requirements.
@@ -400,8 +400,8 @@ fn clock_ticks_per_second() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
-    mod unix {
+    #[cfg(target_os = "linux")]
+    mod linux {
         use super::super::*;
         use std::fs;
         use std::os::unix::fs::symlink;
@@ -427,6 +427,13 @@ mod tests {
                 parse_cmdline(b"/usr/local/bin/mempal\0serve\0--mcp\0"),
                 vec!["/usr/local/bin/mempal", "serve", "--mcp"]
             );
+            assert!(is_mcp_server_argv(&[
+                "/usr/local/bin/mempal".to_string(),
+                "--db-path".to_string(),
+                "/tmp/palace.db".to_string(),
+                "serve".to_string(),
+                "--mcp".to_string()
+            ]));
             let stat = "123 (mempal worker) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765";
             assert_eq!(parse_start_ticks(stat), Some(98765));
         }
@@ -506,6 +513,24 @@ mod tests {
             assert_eq!(report.holder_count, 1);
             assert_eq!(report.holders[0].role, "other");
             assert_eq!(report.holders[0].classification, "extra_holder");
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    mod non_linux {
+        use super::super::*;
+        use std::path::Path;
+
+        #[test]
+        fn test_inspect_db_holders_noops_without_error() {
+            let report = inspect_db_holders(Path::new("/tmp/palace.db"));
+
+            assert_eq!(report.holder_count, 0);
+            assert_eq!(report.extra_holder_count, 0);
+            assert_eq!(report.stale_mcp_server_count, 0);
+            assert_eq!(report.orphan_daemon_count, 0);
+            assert!(report.error.is_none());
+            assert!(!report.has_problem());
         }
     }
 }

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -2,6 +2,8 @@
 use std::fs;
 use std::path::Path;
 #[cfg(target_os = "linux")]
+use std::path::PathBuf;
+#[cfg(target_os = "linux")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(target_os = "linux")]
@@ -158,12 +160,7 @@ fn build_report(
         .count();
     let extra_holder_count = holders
         .iter()
-        .filter(|holder| {
-            !matches!(
-                holder.classification.as_str(),
-                "current_process" | "current_daemon" | "current_mcp_server"
-            )
-        })
+        .filter(|holder| holder.classification == "extra_holder")
         .count();
 
     DbHolderReport {
@@ -206,10 +203,19 @@ fn opened_db_files(fd_dir: &Path, targets: &[(&'static str, DbFileIdentity)]) ->
 
 #[cfg(target_os = "linux")]
 fn read_daemon_pid(db_path: &Path) -> Option<i32> {
-    let pid_path = db_path.parent()?.join("daemon.pid");
+    let pid_path = daemon_pid_path(db_path);
     fs::read_to_string(pid_path)
         .ok()
         .and_then(|content| content.trim().parse::<i32>().ok())
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_path(db_path: &Path) -> PathBuf {
+    db_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join("daemon.pid")
 }
 
 #[cfg(target_os = "linux")]
@@ -283,41 +289,10 @@ fn is_mempal_invocation(argv: &[String], binary_name: &str) -> bool {
 
 #[cfg(target_os = "linux")]
 fn is_mcp_server_argv(argv: &[String]) -> bool {
-    let Some((_, subcommand)) = first_cli_subcommand(argv) else {
+    let Some((_, subcommand)) = crate::daemon_singleton::first_cli_subcommand(argv) else {
         return false;
     };
     subcommand == "serve"
-}
-
-#[cfg(target_os = "linux")]
-fn first_cli_subcommand(argv: &[String]) -> Option<(usize, &str)> {
-    let mut index = 1;
-    while index < argv.len() {
-        let arg = argv[index].as_str();
-        if arg == "--" {
-            return argv.get(index + 1).map(|value| (index + 1, value.as_str()));
-        }
-        if global_flag_takes_value(arg) {
-            index += 2;
-            continue;
-        }
-        if global_flag_has_inline_value(arg) || arg.starts_with('-') {
-            index += 1;
-            continue;
-        }
-        return Some((index, arg));
-    }
-    None
-}
-
-#[cfg(target_os = "linux")]
-fn global_flag_takes_value(arg: &str) -> bool {
-    matches!(arg, "--config" | "--db-path")
-}
-
-#[cfg(target_os = "linux")]
-fn global_flag_has_inline_value(arg: &str) -> bool {
-    arg.starts_with("--config=") || arg.starts_with("--db-path=")
 }
 
 #[cfg(target_os = "linux")]
@@ -378,6 +353,7 @@ mod tests {
         use std::fs;
         use std::fs::File;
         use std::os::unix::fs::symlink;
+        use std::path::PathBuf;
 
         fn write_process(proc_root: &Path, pid: i32, argv: &[&str], db_files: &[&Path]) {
             let pid_dir = proc_root.join(pid.to_string());
@@ -406,13 +382,31 @@ mod tests {
             ]));
             assert!(is_mcp_server_argv(&[
                 "/usr/local/bin/mempal".to_string(),
-                "--db-path".to_string(),
-                "/tmp/palace.db".to_string(),
+                "--config-path".to_string(),
+                "/tmp/config.toml".to_string(),
+                "serve".to_string(),
+                "--mcp".to_string()
+            ]));
+            assert!(is_mcp_server_argv(&[
+                "/usr/local/bin/mempal".to_string(),
+                "--config-path=/tmp/config.toml".to_string(),
                 "serve".to_string(),
                 "--mcp".to_string()
             ]));
             let stat = "123 (mempal worker) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 98765";
             assert_eq!(parse_start_ticks(stat), Some(98765));
+        }
+
+        #[test]
+        fn test_daemon_pid_path_uses_current_dir_for_bare_relative_db_path() {
+            assert_eq!(
+                daemon_pid_path(Path::new("palace.db")),
+                PathBuf::from(".").join("daemon.pid")
+            );
+            assert_eq!(
+                daemon_pid_path(Path::new("data/palace.db")),
+                PathBuf::from("data").join("daemon.pid")
+            );
         }
 
         #[test]
@@ -447,13 +441,19 @@ mod tests {
                 &["mempal", "daemon", "--foreground"],
                 &[db_path.as_path()],
             );
+            write_process(
+                &proc_root,
+                99,
+                &["sqlite3", "palace.db"],
+                &[wal_path.as_path()],
+            );
 
             let report = inspect_db_holders_in_proc(&db_path, &proc_root, 1100, 100);
 
-            assert_eq!(report.holder_count, 3);
+            assert_eq!(report.holder_count, 4);
             assert_eq!(report.stale_mcp_server_count, 1);
             assert_eq!(report.orphan_daemon_count, 1);
-            assert_eq!(report.extra_holder_count, 2);
+            assert_eq!(report.extra_holder_count, 1);
             assert!(report.has_problem());
             assert_eq!(report.holders[0].classification, "current_daemon");
             assert_eq!(report.holders[1].classification, "stale_mcp_server");
@@ -461,6 +461,7 @@ mod tests {
             assert_eq!(report.holders[1].started_at_unix_secs, Some(1002));
             assert_eq!(report.holders[1].age_secs, Some(98));
             assert_eq!(report.holders[2].classification, "orphan_daemon");
+            assert_eq!(report.holders[3].classification, "extra_holder");
         }
 
         #[test]

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -135,6 +135,7 @@ async fn test_mcp_status_surfaces_queue_stats() {
     let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
+    assert!(response.db_holders.error.is_none());
     assert_eq!(response.queue_stats.pending, 1);
     assert_eq!(response.queue_stats.claimed, 0);
     assert_eq!(response.queue_stats.failed, 0);

--- a/tests/ops_runtime.rs
+++ b/tests/ops_runtime.rs
@@ -106,6 +106,12 @@ fn test_cli_doctor_json_reports_schema_and_path() {
     assert_eq!(value["supported_schema_version"], CURRENT_SCHEMA_VERSION);
     assert_eq!(value["db"]["exists"], true);
     assert_eq!(value["db"]["schema_version"], CURRENT_SCHEMA_VERSION);
+    let expected_db_path = palace_db_path(&home).display().to_string();
+    assert_eq!(
+        value["db_holders"]["db_path"].as_str(),
+        Some(expected_db_path.as_str())
+    );
+    assert!(value["db_holders"]["holder_count"].as_u64().is_some());
     assert_eq!(value["install"]["path_matches_current_exe"], false);
     assert!(
         value["warnings"]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f8e613fb5ae919e910e8744e0ec38fd72e5da896"
+commit = "d6d2eabf448416b828c4a801b22c18b03d173a39"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "d6d2eabf448416b828c4a801b22c18b03d173a39"
+commit = "551d1cbd75d6513de9aa9ba58990d8413e2b4f9b"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "551d1cbd75d6513de9aa9ba58990d8413e2b4f9b"
+commit = "cc5c74ebc8c59e6d1588a1bce3c19e9e7a43d03c"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "016e200876838dc742a959a6578b3fc3e592be00"
+commit = "f8e613fb5ae919e910e8744e0ec38fd72e5da896"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "c96ebadd4fc633e54edfffd3e838bde9c592e33a"
+commit = "016e200876838dc742a959a6578b3fc3e592be00"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- report stale or extra mempal processes holding palace.db files in status/doctor surfaces
- gate /proc holder inspection to Linux and canonicalize fd path matching
- classify bare `mempal serve` as an MCP holder where applicable
- stabilize hook heartbeat before processing during the related pre-commit path

## Review

- tier-4 CSA review PASS: `01KTKBWFX8YEBF3FT4MBM9XVB4`
- check-verdict PASS for `main...HEAD` at `b7b2467`

Closes #350
