### PR TITLE
Harden LLM salience gate observability

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1679,17 +1679,29 @@ impl ConfigHandle {
 
     pub fn collect_runtime_warnings() -> Vec<RuntimeWarning> {
         let mut warnings = Self::current().collect_runtime_warnings();
-        let mut seen = std::collections::BTreeSet::new();
-        for event in Self::recent_events() {
-            if event.contains("requires restart, change ignored") && seen.insert(event.clone()) {
-                warnings.push(RuntimeWarning {
-                    level: "warn",
-                    source: "config",
-                    message: event,
-                });
-            }
+        for event in Self::restart_required_pending() {
+            warnings.push(RuntimeWarning {
+                level: "warn",
+                source: "config",
+                message: event,
+            });
         }
         warnings
+    }
+
+    pub fn restart_required_pending() -> Vec<String> {
+        let mut events =
+            super::hot_reload::global_hot_reload_state().restart_required_pending_events();
+        events.extend(
+            super::hot_reload::restart_required_pending_events_from_config_path(
+                &default_config_path(),
+            ),
+        );
+        let mut seen = std::collections::BTreeSet::new();
+        events
+            .into_iter()
+            .filter(|event| seen.insert(event.clone()))
+            .collect()
     }
 
     pub fn runtime_prototypes() -> Vec<String> {

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 use std::ffi::{OsStr, OsString};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
@@ -12,6 +14,8 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use super::config::{CompiledPrivacyConfig, Config, ConfigError, ConfigSnapshotMeta};
 
 const MAX_EVENT_LOG: usize = 64;
+const MAX_PERSISTED_EVENT_LOG_BYTES: u64 = 64 * 1024;
+const HOT_RELOAD_EVENT_LOG_FILE: &str = "hot-reload-events.log";
 const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 #[derive(Debug)]
@@ -90,6 +94,7 @@ pub struct HotReloadState {
     snapshot: ArcSwap<ConfigSnapshot>,
     runtime: Mutex<Option<RuntimeControl>>,
     event_log: Mutex<VecDeque<String>>,
+    event_log_path: Mutex<Option<PathBuf>>,
     parse_attempts: AtomicUsize,
     // harness-point: PR0 — counts successful reload applications (version changes)
     reload_count: Arc<AtomicUsize>,
@@ -110,6 +115,7 @@ impl HotReloadState {
             snapshot: ArcSwap::from_pointee(snapshot),
             runtime: Mutex::new(None),
             event_log: Mutex::new(VecDeque::new()),
+            event_log_path: Mutex::new(None),
             parse_attempts: AtomicUsize::new(0),
             reload_count: Arc::new(AtomicUsize::new(0)),
             runtime_prototypes: ArcSwap::from_pointee(
@@ -123,6 +129,10 @@ impl HotReloadState {
         let config = Config::load_from(path)?;
         let snapshot = ConfigSnapshot::from_config(config.clone())?;
         self.snapshot.store(Arc::new(snapshot));
+        *self
+            .event_log_path
+            .lock()
+            .expect("event log path mutex poisoned") = Some(hot_reload_event_log_path(path));
         self.runtime_prototypes.store(Arc::new(
             config.ingest_gating.embedding_classifier.prototypes.clone(),
         ));
@@ -195,6 +205,20 @@ impl HotReloadState {
             .iter()
             .cloned()
             .collect()
+    }
+
+    pub fn restart_required_pending_events(&self) -> Vec<String> {
+        let mut events = Vec::new();
+        events.extend(self.recent_events());
+        if let Some(path) = self
+            .event_log_path
+            .lock()
+            .expect("event log path mutex poisoned")
+            .clone()
+        {
+            events.extend(read_restart_required_events_from_path(&path));
+        }
+        dedupe_restart_required_events(events)
     }
 
     pub fn runtime_prototypes(&self) -> Vec<String> {
@@ -449,12 +473,73 @@ impl HotReloadState {
 
     fn push_event(&self, event: String) {
         eprintln!("{event}");
+        self.persist_event(&event);
         let mut events = self.event_log.lock().expect("event log mutex poisoned");
         if events.len() == MAX_EVENT_LOG {
             let _ = events.pop_front();
         }
         events.push_back(event);
     }
+
+    fn persist_event(&self, event: &str) {
+        let Some(path) = self
+            .event_log_path
+            .lock()
+            .expect("event log path mutex poisoned")
+            .clone()
+        else {
+            return;
+        };
+        if std::fs::metadata(&path)
+            .map(|metadata| metadata.len() > MAX_PERSISTED_EVENT_LOG_BYTES)
+            .unwrap_or(false)
+        {
+            let _ = std::fs::write(&path, "");
+        }
+        match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(mut file) => {
+                let _ = writeln!(file, "{event}");
+            }
+            Err(error) => {
+                eprintln!(
+                    "config hot-reload: failed to persist event to {}: {error}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+pub fn hot_reload_event_log_path(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(HOT_RELOAD_EVENT_LOG_FILE)
+}
+
+pub fn restart_required_pending_events_from_config_path(config_path: &Path) -> Vec<String> {
+    read_restart_required_events_from_path(&hot_reload_event_log_path(config_path))
+}
+
+fn read_restart_required_events_from_path(path: &Path) -> Vec<String> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    dedupe_restart_required_events(contents.lines().map(ToOwned::to_owned))
+}
+
+fn dedupe_restart_required_events(events: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    events
+        .into_iter()
+        .filter(|event| is_restart_required_event(event))
+        .filter(|event| seen.insert(event.clone()))
+        .collect()
+}
+
+fn is_restart_required_event(event: &str) -> bool {
+    event.contains("requires restart, change ignored")
+        || event.contains("effective after daemon restart")
 }
 
 fn create_watcher(

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use arc_swap::ArcSwap;
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::{Deserialize, Serialize};
 
 use super::config::{CompiledPrivacyConfig, Config, ConfigError, ConfigSnapshotMeta};
 
@@ -17,6 +18,15 @@ const MAX_EVENT_LOG: usize = 64;
 const MAX_PERSISTED_EVENT_LOG_BYTES: u64 = 64 * 1024;
 const HOT_RELOAD_EVENT_LOG_FILE: &str = "hot-reload-events.log";
 const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const HOT_RELOAD_EVENT_KIND_RESTART_REQUIRED: &str = "restart_required";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PersistedHotReloadEvent {
+    mempal_hot_reload_event: String,
+    schema_version: u8,
+    pid: u32,
+    message: String,
+}
 
 #[derive(Debug)]
 struct ConfigSnapshot {
@@ -133,6 +143,14 @@ impl HotReloadState {
             .event_log_path
             .lock()
             .expect("event log path mutex poisoned") = Some(hot_reload_event_log_path(path));
+        clear_persisted_restart_events_for_pid(
+            &hot_reload_event_log_path(path),
+            std::process::id(),
+        );
+        self.event_log
+            .lock()
+            .expect("event log mutex poisoned")
+            .clear();
         self.runtime_prototypes.store(Arc::new(
             config.ingest_gating.embedding_classifier.prototypes.clone(),
         ));
@@ -498,7 +516,7 @@ impl HotReloadState {
         }
         match OpenOptions::new().create(true).append(true).open(&path) {
             Ok(mut file) => {
-                let _ = writeln!(file, "{event}");
+                let _ = writeln!(file, "{}", persisted_event_line(event));
             }
             Err(error) => {
                 eprintln!(
@@ -525,7 +543,11 @@ fn read_restart_required_events_from_path(path: &Path) -> Vec<String> {
     let Ok(contents) = std::fs::read_to_string(path) else {
         return Vec::new();
     };
-    dedupe_restart_required_events(contents.lines().map(ToOwned::to_owned))
+    dedupe_restart_required_events(
+        contents
+            .lines()
+            .filter_map(restart_required_message_from_persisted_line),
+    )
 }
 
 fn dedupe_restart_required_events(events: impl IntoIterator<Item = String>) -> Vec<String> {
@@ -540,6 +562,84 @@ fn dedupe_restart_required_events(events: impl IntoIterator<Item = String>) -> V
 fn is_restart_required_event(event: &str) -> bool {
     event.contains("requires restart, change ignored")
         || event.contains("effective after daemon restart")
+}
+
+fn persisted_event_line(event: &str) -> String {
+    if !is_restart_required_event(event) {
+        return event.to_string();
+    }
+
+    let record = PersistedHotReloadEvent {
+        mempal_hot_reload_event: HOT_RELOAD_EVENT_KIND_RESTART_REQUIRED.to_string(),
+        schema_version: 1,
+        pid: std::process::id(),
+        message: event.to_string(),
+    };
+    serde_json::to_string(&record).unwrap_or_else(|_| event.to_string())
+}
+
+fn restart_required_message_from_persisted_line(line: &str) -> Option<String> {
+    let record = serde_json::from_str::<PersistedHotReloadEvent>(line).ok()?;
+    if record.mempal_hot_reload_event != HOT_RELOAD_EVENT_KIND_RESTART_REQUIRED {
+        return None;
+    }
+    if !is_restart_required_event(&record.message) || !process_is_running(record.pid) {
+        return None;
+    }
+    Some(record.message)
+}
+
+fn clear_persisted_restart_events_for_pid(path: &Path, pid: u32) {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+
+    let mut changed = false;
+    let retained = contents
+        .lines()
+        .filter(
+            |line| match serde_json::from_str::<PersistedHotReloadEvent>(line) {
+                Ok(record)
+                    if record.mempal_hot_reload_event == HOT_RELOAD_EVENT_KIND_RESTART_REQUIRED
+                        && record.pid == pid =>
+                {
+                    changed = true;
+                    false
+                }
+                _ => true,
+            },
+        )
+        .collect::<Vec<_>>();
+
+    if changed {
+        let next = if retained.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n", retained.join("\n"))
+        };
+        let _ = std::fs::write(path, next);
+    }
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return false;
+    };
+    if pid <= 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) does not send a signal; it only checks whether a
+    // process exists and whether this process may signal it.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_running(pid: u32) -> bool {
+    pid == std::process::id()
 }
 
 fn create_watcher(

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
 
+use crate::core::config::ConfigHandle;
 use crate::core::db::CURRENT_SCHEMA_VERSION;
 use crate::process_diagnostics::{DbHolderReport, inspect_db_holders};
 
@@ -65,6 +66,7 @@ pub struct DoctorReport {
     pub db: DoctorDbReport,
     pub db_holders: DbHolderReport,
     pub install: DoctorInstallReport,
+    pub restart_required_config_changes: Vec<String>,
     pub warnings: Vec<String>,
     pub recommendations: Vec<String>,
 }
@@ -89,6 +91,7 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     let db = inspect_db(db_path);
     let db_holders = inspect_db_holders(db_path);
     let install = inspect_install();
+    let restart_required_config_changes = ConfigHandle::restart_required_pending();
     let mut warnings = Vec::new();
     let mut recommendations = vec![
         "Run `mempal doctor --format json` after installing or upgrading mempal.".to_string(),
@@ -107,6 +110,9 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     if let Some(error) = db.error.as_deref() {
         warnings.push(format!("database schema could not be inspected: {error}"));
     }
+    for change in &restart_required_config_changes {
+        warnings.push(format!("config change pending restart: {change}"));
+    }
     push_db_holder_warnings(&mut warnings, &mut recommendations, &db_holders);
     if install.path_matches_current_exe == Some(false) {
         warnings
@@ -124,6 +130,7 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         db,
         db_holders,
         install,
+        restart_required_config_changes,
         warnings,
         recommendations,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9222,6 +9222,16 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         .context("failed to read gating counters")?;
     let gating_stats =
         observability::gating_stats(db, config, None).context("failed to read gating stats")?;
+    let dropped_total = gating_drop_counts
+        .total
+        .unwrap_or_else(|| gating_drop_counts.by_reason.values().copied().sum::<u64>());
+    let ingest_gating_status = observability::gating_runtime_status(
+        db,
+        config,
+        dropped_total,
+        ConfigHandle::restart_required_pending(),
+    )
+    .context("failed to build ingest gating status")?;
     let db_size_bytes = db
         .database_size_bytes()
         .context("failed to compute database size")?;
@@ -9438,6 +9448,27 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("  redactions_per_pattern: {per}");
     }
     println!("Gating:");
+    println!("  enabled: {}", ingest_gating_status.enabled);
+    println!("  tier1_active: {}", ingest_gating_status.tier1_active);
+    println!("  tier2_active: {}", ingest_gating_status.tier2_active);
+    println!("  llm_active: {}", ingest_gating_status.llm_active);
+    match ingest_gating_status.llm_model.as_deref() {
+        Some(model) => println!("  llm_model: {model}"),
+        None => println!("  llm_model: none"),
+    }
+    println!(
+        "  tier2_threshold: {}",
+        ingest_gating_status.tier2_threshold
+    );
+    match ingest_gating_status.llm_threshold {
+        Some(threshold) => println!("  llm_threshold: {threshold}"),
+        None => println!("  llm_threshold: none"),
+    }
+    println!("  rules_count: {}", ingest_gating_status.rules_count);
+    println!(
+        "  tier1_skip_events: {}",
+        display_list_or_none(&ingest_gating_status.tier1_skip_events)
+    );
     println!("  kept: {}", gating_stats.kept);
     println!("  skipped: {}", gating_stats.skipped);
     println!("  tier1_kept: {}", gating_stats.tier1_kept);
@@ -9450,10 +9481,44 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         .iter()
         .filter_map(|(r, c)| (*c > 0).then_some(format!("{r}={c}")))
         .collect::<Vec<_>>();
-    let dropped_total = gating_drop_counts
-        .total
-        .unwrap_or_else(|| gating_drop_counts.by_reason.values().copied().sum::<u64>());
     println!("  dropped_total: {dropped_total}");
+    println!(
+        "  quarantined_total: {}",
+        ingest_gating_status.quarantined_total
+    );
+    println!(
+        "  soft_deleted_total: {}",
+        ingest_gating_status.soft_deleted_total
+    );
+    match ingest_gating_status.last_keep_at {
+        Some(timestamp) => println!("  last_keep_at: {timestamp}"),
+        None => println!("  last_keep_at: none"),
+    }
+    match ingest_gating_status.last_skip_at {
+        Some(timestamp) => println!("  last_skip_at: {timestamp}"),
+        None => println!("  last_skip_at: none"),
+    }
+    match ingest_gating_status.last_llm_success_at {
+        Some(timestamp) => println!("  last_llm_success_at: {timestamp}"),
+        None => println!("  last_llm_success_at: none"),
+    }
+    match ingest_gating_status.last_llm_failure_at {
+        Some(timestamp) => println!("  last_llm_failure_at: {timestamp}"),
+        None => println!("  last_llm_failure_at: none"),
+    }
+    if ingest_gating_status
+        .restart_required_config_changes
+        .is_empty()
+    {
+        println!("  restart_required_config_changes: none");
+    } else {
+        println!(
+            "  restart_required_config_changes: {}",
+            ingest_gating_status
+                .restart_required_config_changes
+                .join(" | ")
+        );
+    }
     if nonzero.is_empty() {
         println!("  dropped_by_reason: none");
     } else {
@@ -12017,6 +12082,14 @@ fn doctor_command(format: String) -> Result<()> {
                 "path_matches_current_exe={:?}",
                 report.install.path_matches_current_exe
             );
+            if report.restart_required_config_changes.is_empty() {
+                println!("restart_required_config_changes=none");
+            } else {
+                println!(
+                    "restart_required_config_changes={}",
+                    report.restart_required_config_changes.join(" | ")
+                );
+            }
             for warning in &report.warnings {
                 println!("warning: {warning}");
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -101,23 +101,24 @@ use super::tools::{
     CoworkPushRequest, CoworkPushResponse, DeleteRequest, DeleteResponse, DoctorMcpDto,
     DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning, EmbedStatusDto,
     EmbedderCircuitDto, EndpointHealthDto, FactCheckRequest, FactCheckResponse,
-    FieldTaxonomyEntryDto, FieldTaxonomyResponse, IngestControls, IngestOperationState,
-    IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto,
-    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
-    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
-    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
-    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
-    KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest, LeaseResponse, LlmStatusDto,
-    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
-    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
-    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
-    ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
-    RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
-    SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
-    SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest, StatusResponse, StatusScope,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
-    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    FieldTaxonomyEntryDto, FieldTaxonomyResponse, GatingRuntimeStatusDto, IngestControls,
+    IngestOperationState, IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest,
+    KgResponse, KgStatsDto, KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest,
+    KnowledgeCardsResponse, KnowledgeDemoteRequest, KnowledgeDemoteResponse,
+    KnowledgeDistillRequest, KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse,
+    KnowledgePolicyResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
+    KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest,
+    LeaseResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
+    OperationStatusRequest, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto,
+    Phase3Request, Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
+    PinnedFactsResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
+    ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto,
+    RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto,
+    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto,
+    SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest,
+    StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
+    TunnelsResponse, TurnStorageStatusDto,
 };
 
 const MCP_SEARCH_ROUTE_DEADLINE: Duration = Duration::from_secs(5);
@@ -1976,6 +1977,30 @@ impl MempalMcpServer {
 
         let embed_failure_headline =
             crate::core::queue::failure_headline_count(embed_snapshot.fail_count, &queue_stats);
+        let config_for_gating_status = Arc::clone(&config);
+        let restart_required_config_changes = ConfigHandle::restart_required_pending();
+        let async_db = self.async_db().await.map_err(|error| {
+            ErrorData::internal_error(format!("async db init failed: {error}"), None)
+        })?;
+        let ingest_gating_status = async_db
+            .run_read_anyhow(move |db| {
+                let gating_drop_counts = db
+                    .gating_drop_counts()
+                    .context("gating drop counts failed")?;
+                let dropped_total = gating_drop_counts
+                    .total
+                    .unwrap_or_else(|| gating_drop_counts.by_reason.values().copied().sum::<u64>());
+                crate::observability::gating_runtime_status(
+                    db,
+                    config_for_gating_status.as_ref(),
+                    dropped_total,
+                    restart_required_config_changes,
+                )
+            })
+            .await
+            .map_err(|error| {
+                ErrorData::internal_error(format!("ingest gating status failed: {error}"), None)
+            })?;
 
         Ok(Json(StatusResponse {
             schema_version: db_snapshot.schema_version,
@@ -2044,6 +2069,7 @@ impl MempalMcpServer {
                     .as_str()
                     .to_string(),
             },
+            ingest_gating_status: GatingRuntimeStatusDto::from(ingest_gating_status),
             queue_stats: QueueStatsDto {
                 pending: queue_stats.pending,
                 claimed: queue_stats.claimed,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1920,6 +1920,8 @@ pub struct StatusResponse {
     pub embed_status: EmbedStatusDto,
     /// Sticky embedder circuit plus the current vector-search fallback policy.
     pub embedder_circuit: EmbedderCircuitDto,
+    /// Runtime write-admission gate state for passive ingest and explicit writes.
+    pub ingest_gating_status: GatingRuntimeStatusDto,
     pub queue_stats: QueueStatsDto,
     /// Live processes holding `palace.db`, `palace.db-wal`, or
     /// `palace.db-shm` open, classified as current daemon/MCP server versus
@@ -1993,6 +1995,61 @@ pub struct LlmStatusDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     pub max_concurrent: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct GatingRuntimeStatusDto {
+    pub enabled: bool,
+    pub tier1_active: bool,
+    pub tier2_active: bool,
+    pub llm_active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_model: Option<String>,
+    pub tier2_threshold: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_threshold: Option<f64>,
+    pub tier1_skip_events: Vec<String>,
+    pub rules_count: usize,
+    pub kept_total: usize,
+    pub skipped_total: usize,
+    pub dropped_total: u64,
+    pub quarantined_total: u64,
+    pub soft_deleted_total: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_keep_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_skip_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_llm_success_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_llm_failure_at: Option<i64>,
+    pub restart_required_config_changes: Vec<String>,
+}
+
+impl From<crate::observability::GatingRuntimeStatus> for GatingRuntimeStatusDto {
+    fn from(value: crate::observability::GatingRuntimeStatus) -> Self {
+        Self {
+            enabled: value.enabled,
+            tier1_active: value.tier1_active,
+            tier2_active: value.tier2_active,
+            llm_active: value.llm_active,
+            llm_model: value.llm_model,
+            tier2_threshold: value.tier2_threshold,
+            llm_threshold: value.llm_threshold,
+            tier1_skip_events: value.tier1_skip_events,
+            rules_count: value.rules_count,
+            kept_total: value.kept_total,
+            skipped_total: value.skipped_total,
+            dropped_total: value.dropped_total,
+            quarantined_total: value.quarantined_total,
+            soft_deleted_total: value.soft_deleted_total,
+            last_keep_at: value.last_keep_at,
+            last_skip_at: value.last_skip_at,
+            last_llm_success_at: value.last_llm_success_at,
+            last_llm_failure_at: value.last_llm_failure_at,
+            restart_required_config_changes: value.restart_required_config_changes,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -239,12 +239,10 @@ pub fn gating_runtime_status(
         skipped_total,
         dropped_total: dropped_total.max(skipped_total as u64),
         quarantined_total: 0,
-        soft_deleted_total: db
-            .deleted_drawer_count()
-            .context("failed to count soft-deleted drawers for gating status")?,
+        soft_deleted_total: gating_soft_deleted_count(db)?,
         last_keep_at: last_gating_decision_at(db, "keep")?,
         last_skip_at: last_gating_decision_at(db, "skip")?,
-        last_llm_success_at: last_llm_verdict_at(db)?,
+        last_llm_success_at: last_completed_llm_task_at(db)?,
         last_llm_failure_at: last_failed_llm_task_at(db)?,
         restart_required_config_changes,
     })
@@ -274,34 +272,102 @@ fn last_gating_decision_at(db: &Database, decision: &str) -> Result<Option<i64>>
         .context("failed to read last gating decision timestamp")
 }
 
-fn last_llm_verdict_at(db: &Database) -> Result<Option<i64>> {
-    if !table_has_column(db, "gating_audit", "llm_verdict")? {
-        return Ok(None);
+fn gating_soft_deleted_count(db: &Database) -> Result<i64> {
+    if !table_has_column(db, "gating_audit", "drawer_id")?
+        || !table_has_column(db, "gating_audit", "llm_verdict")?
+    {
+        return Ok(0);
     }
+
     db.conn()
         .query_row(
-            "SELECT MAX(created_at) FROM gating_audit WHERE llm_verdict IS NOT NULL",
+            r#"
+            SELECT COUNT(DISTINCT drawers.id)
+            FROM drawers
+            INNER JOIN gating_audit ON gating_audit.drawer_id = drawers.id
+            WHERE drawers.deleted_at IS NOT NULL
+              AND gating_audit.llm_verdict = 'reject'
+            "#,
             [],
-            |row| row.get::<_, Option<i64>>(0),
+            |row| row.get::<_, i64>(0),
         )
+        .context("failed to count gate soft-deleted drawers")
+}
+
+fn last_completed_llm_task_at(db: &Database) -> Result<Option<i64>> {
+    if !table_has_column(db, "pending_message_completions", "completed_at")? {
+        return Ok(None);
+    }
+
+    let sql = if table_has_column(db, "pending_message_completions", "op_state")? {
+        r#"
+        SELECT MAX(completed_at)
+        FROM pending_message_completions
+        WHERE kind = 'llm_task' AND op_state IN ('completed', 'rejected')
+        "#
+    } else {
+        r#"
+        SELECT MAX(completed_at)
+        FROM pending_message_completions
+        WHERE kind = 'llm_task'
+        "#
+    };
+
+    db.conn()
+        .query_row(sql, [], |row| row.get::<_, Option<i64>>(0))
         .optional()
         .map(Option::flatten)
-        .context("failed to read last LLM gating verdict timestamp")
+        .context("failed to read last completed LLM task timestamp")
 }
 
 fn last_failed_llm_task_at(db: &Database) -> Result<Option<i64>> {
-    if !table_has_column(db, "pending_messages", "kind")? {
-        return Ok(None);
+    let completion_failure_at =
+        if table_has_column(db, "pending_message_completions", "completed_at")?
+            && table_has_column(db, "pending_message_completions", "op_state")?
+        {
+            db.conn()
+                .query_row(
+                    r#"
+                    SELECT MAX(completed_at)
+                    FROM pending_message_completions
+                    WHERE kind = 'llm_task' AND op_state = 'failed'
+                    "#,
+                    [],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .optional()
+                .map(Option::flatten)
+                .context("failed to read completed failed LLM task timestamp")?
+        } else {
+            None
+        };
+
+    let dead_letter_failure_at = if table_has_column(db, "pending_messages", "kind")?
+        && table_has_column(db, "pending_messages", "next_attempt_at")?
+    {
+        db.conn()
+            .query_row(
+                r#"
+                SELECT MAX(next_attempt_at * 1000)
+                FROM pending_messages
+                WHERE kind = 'llm_task' AND status = 'failed'
+                "#,
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .map(Option::flatten)
+            .context("failed to read dead-lettered LLM task timestamp")?
+    } else {
+        None
+    };
+
+    match (completion_failure_at, dead_letter_failure_at) {
+        (Some(completion), Some(dead_letter)) => Ok(Some(completion.max(dead_letter))),
+        (Some(completion), None) => Ok(Some(completion)),
+        (None, Some(dead_letter)) => Ok(Some(dead_letter)),
+        (None, None) => Ok(None),
     }
-    db.conn()
-        .query_row(
-            "SELECT MAX(created_at) FROM pending_messages WHERE kind = 'llm_task' AND status = 'failed'",
-            [],
-            |row| row.get::<_, Option<i64>>(0),
-        )
-        .optional()
-        .map(Option::flatten)
-        .context("failed to read last failed LLM task timestamp")
 }
 
 fn table_has_column(db: &Database, table: &str, column: &str) -> Result<bool> {

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -11,7 +11,7 @@ use crate::core::project::{ProjectFilterMode, ProjectSearchScope, resolve_projec
 use crate::cowork::peek::{format_rfc3339, parse_rfc3339};
 use anyhow::{Context, Result, bail};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 use serde::Serialize;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
@@ -175,6 +175,145 @@ pub struct GatingStatsSummary {
     pub unclassified: usize,
     pub kept_by_label: std::collections::BTreeMap<String, usize>,
     pub skipped_by_reason: std::collections::BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GatingRuntimeStatus {
+    pub enabled: bool,
+    pub tier1_active: bool,
+    pub tier2_active: bool,
+    pub llm_active: bool,
+    pub llm_model: Option<String>,
+    pub tier2_threshold: f32,
+    pub llm_threshold: Option<f64>,
+    pub tier1_skip_events: Vec<String>,
+    pub rules_count: usize,
+    pub kept_total: usize,
+    pub skipped_total: usize,
+    pub dropped_total: u64,
+    pub quarantined_total: u64,
+    pub soft_deleted_total: i64,
+    pub last_keep_at: Option<i64>,
+    pub last_skip_at: Option<i64>,
+    pub last_llm_success_at: Option<i64>,
+    pub last_llm_failure_at: Option<i64>,
+    pub restart_required_config_changes: Vec<String>,
+}
+
+pub fn gating_runtime_status(
+    db: &Database,
+    config: &Config,
+    dropped_total: u64,
+    restart_required_config_changes: Vec<String>,
+) -> Result<GatingRuntimeStatus> {
+    let kept_total = gating_decision_count(db, "keep")?;
+    let skipped_total = gating_decision_count(db, "skip")?;
+    Ok(GatingRuntimeStatus {
+        enabled: config.ingest_gating.enabled,
+        tier1_active: config.ingest_gating.enabled,
+        tier2_active: config.ingest_gating.enabled
+            && config.ingest_gating.embedding_classifier.enabled
+            && !config
+                .ingest_gating
+                .embedding_classifier
+                .prototypes
+                .is_empty(),
+        llm_active: config.ingest_gating.enabled
+            && config.llm.enabled
+            && config.llm.enabled_for.iter().any(|item| item == "gating")
+            && config
+                .ingest_gating
+                .llm_judge
+                .as_ref()
+                .is_some_and(|judge| judge.enabled),
+        llm_model: config.llm.model.clone(),
+        tier2_threshold: config.ingest_gating.embedding_classifier.threshold,
+        llm_threshold: config
+            .ingest_gating
+            .llm_judge
+            .as_ref()
+            .map(|judge| judge.threshold),
+        tier1_skip_events: config.ingest_gating.tier1_skip_events.clone(),
+        rules_count: config.ingest_gating.rules.len(),
+        kept_total,
+        skipped_total,
+        dropped_total: dropped_total.max(skipped_total as u64),
+        quarantined_total: 0,
+        soft_deleted_total: db
+            .deleted_drawer_count()
+            .context("failed to count soft-deleted drawers for gating status")?,
+        last_keep_at: last_gating_decision_at(db, "keep")?,
+        last_skip_at: last_gating_decision_at(db, "skip")?,
+        last_llm_success_at: last_llm_verdict_at(db)?,
+        last_llm_failure_at: last_failed_llm_task_at(db)?,
+        restart_required_config_changes,
+    })
+}
+
+fn gating_decision_count(db: &Database, decision: &str) -> Result<usize> {
+    let count = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM gating_audit WHERE decision = ?1",
+            [decision],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to count gating decisions")?;
+    usize::try_from(count).context("gating decision count was negative or too large")
+}
+
+fn last_gating_decision_at(db: &Database, decision: &str) -> Result<Option<i64>> {
+    db.conn()
+        .query_row(
+            "SELECT MAX(created_at) FROM gating_audit WHERE decision = ?1",
+            [decision],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+        .map(Option::flatten)
+        .context("failed to read last gating decision timestamp")
+}
+
+fn last_llm_verdict_at(db: &Database) -> Result<Option<i64>> {
+    if !table_has_column(db, "gating_audit", "llm_verdict")? {
+        return Ok(None);
+    }
+    db.conn()
+        .query_row(
+            "SELECT MAX(created_at) FROM gating_audit WHERE llm_verdict IS NOT NULL",
+            [],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+        .map(Option::flatten)
+        .context("failed to read last LLM gating verdict timestamp")
+}
+
+fn last_failed_llm_task_at(db: &Database) -> Result<Option<i64>> {
+    if !table_has_column(db, "pending_messages", "kind")? {
+        return Ok(None);
+    }
+    db.conn()
+        .query_row(
+            "SELECT MAX(created_at) FROM pending_messages WHERE kind = 'llm_task' AND status = 'failed'",
+            [],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+        .map(Option::flatten)
+        .context("failed to read last failed LLM task timestamp")
+}
+
+fn table_has_column(db: &Database, table: &str, column: &str) -> Result<bool> {
+    let mut statement = db
+        .conn()
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .with_context(|| format!("failed to inspect {table} columns"))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to read {table} columns"))?;
+    Ok(columns.iter().any(|candidate| candidate == column))
 }
 
 pub fn tail_command(db: &Database, config: &Config, options: TailOptions<'_>) -> Result<()> {

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -538,6 +538,67 @@ async fn test_embedder_backend_change_warns_and_ignores() {
     wait_for_version_change(&stable_version);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_restart_required_hot_reload_event_expires_after_restart_bootstrap() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let changed = config.replace("http://gb10:18002/v1/", "http://localhost:9000/v1/");
+    write_config_atomic(&env.config_path, &changed);
+    std::thread::sleep(Duration::from_millis(500));
+
+    let pending = ConfigHandle::restart_required_pending();
+    assert!(
+        pending
+            .iter()
+            .any(|event| event.contains("embedder.base_url requires restart")),
+        "pending restart-required changes missing before restart: {pending:?}"
+    );
+
+    let event_log_path = env
+        .config_path
+        .parent()
+        .expect("config path has parent")
+        .join("hot-reload-events.log");
+    let persisted = fs::read_to_string(&event_log_path).expect("read hot reload event log");
+    assert!(
+        persisted.contains("\"mempal_hot_reload_event\":\"restart_required\""),
+        "restart-required event should be persisted with structured metadata: {persisted}"
+    );
+
+    ConfigHandle::bootstrap(&env.config_path).expect("restart bootstrap");
+    assert_eq!(
+        ConfigHandle::current().embed.base_url.as_deref(),
+        Some("http://localhost:9000/v1/")
+    );
+
+    let pending_after_restart = ConfigHandle::restart_required_pending();
+    assert!(
+        pending_after_restart
+            .iter()
+            .all(|event| !event.contains("embedder.base_url requires restart")),
+        "stale restart-required change survived restart: {pending_after_restart:?}"
+    );
+
+    #[cfg(feature = "integration")]
+    {
+        let output = Command::new(mempal_bin())
+            .arg("status")
+            .env("HOME", env._tmp.path())
+            .output()
+            .expect("run mempal status after restart");
+        assert!(output.status.success(), "status failed: {output:?}");
+        let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+        assert!(
+            stdout.contains("restart_required_config_changes: none"),
+            "status still reported stale restart-required changes: {stdout}"
+        );
+    }
+}
+
 #[cfg(feature = "integration")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_restart_required_hot_reload_changes_surface_in_status_and_doctor() {

--- a/tests/config_hot_reload.rs
+++ b/tests/config_hot_reload.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use mempal::core::config::ConfigHandle;
 use mempal::core::db::{CURRENT_FORK_EXT_VERSION, Database};
+use mempal::doctor::build_doctor_report;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::ingest::gating::{IngestCandidate, evaluate_tier1};
 use mempal::mcp::{IngestRequest, MempalMcpServer};
@@ -535,6 +536,60 @@ async fn test_embedder_backend_change_warns_and_ignores() {
     );
     write_config_atomic(&env.config_path, &allowed);
     wait_for_version_change(&stable_version);
+}
+
+#[cfg(feature = "integration")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_restart_required_hot_reload_changes_surface_in_status_and_doctor() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(&base_config(&PathBuf::from("/tmp/placeholder")));
+    let config = base_config(&env.db_path);
+    write_config_atomic(&env.config_path, &config);
+    ConfigHandle::bootstrap(&env.config_path).expect("rebootstrap config");
+
+    let changed = config.replace("http://gb10:18002/v1/", "http://localhost:9000/v1/");
+    write_config_atomic(&env.config_path, &changed);
+    std::thread::sleep(Duration::from_millis(500));
+
+    let pending = ConfigHandle::restart_required_pending();
+    assert!(
+        pending
+            .iter()
+            .any(|event| event.contains("embedder.base_url requires restart")),
+        "pending restart-required changes missing: {pending:?}"
+    );
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", env._tmp.path())
+        .output()
+        .expect("run mempal status");
+    assert!(output.status.success(), "status failed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(
+        stdout.contains("restart_required_config_changes:"),
+        "status did not print restart-required changes: {stdout}"
+    );
+    assert!(
+        stdout.contains("embedder.base_url requires restart"),
+        "status did not include ignored change: {stdout}"
+    );
+
+    let report = build_doctor_report(&env.db_path);
+    assert!(
+        report
+            .restart_required_config_changes
+            .iter()
+            .any(|event| event.contains("embedder.base_url requires restart")),
+        "doctor report missing restart-required changes: {report:#?}"
+    );
+    assert!(
+        report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("config change pending restart")),
+        "doctor warnings missing restart-required warning: {report:#?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -154,6 +154,28 @@ fn drawer_content_contains(db_path: &Path, marker: &str) -> bool {
         != 0
 }
 
+fn active_queue_count(db_path: &Path) -> i64 {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status IN ('pending', 'claimed')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query active queue count")
+}
+
+fn gating_skip_count(db_path: &Path) -> i64 {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM gating_audit WHERE decision = 'skip'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("query gating skip count")
+}
+
 fn message_status(db_path: &Path, id: &str) -> Option<(String, i64)> {
     Connection::open(db_path)
         .expect("open sqlite")
@@ -403,6 +425,127 @@ async fn test_daemon_processes_hook_post_tool_to_drawer() {
         "privacy scrub must affect stored preview: {body}"
     );
     assert!(!body.contains(raw_secret), "raw secret leaked into drawer");
+
+    daemon.sigterm();
+    let status = daemon.wait().await.expect("wait daemon");
+    assert!(status.success(), "daemon exited with {status:?}");
+    handle.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_gating_drops_low_value_hook_and_keeps_high_signal_prompt() {
+    let _guard = test_guard().await;
+    let (tmp, _mempal_home, db_path, config_path) = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "http://{addr}/v1"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 2
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 50
+daemon_claim_ttl_secs = 60
+
+[privacy]
+enabled = true
+
+[gating]
+enabled = true
+
+[daemon]
+log_path = "{}"
+"#,
+            db_path.display(),
+            db_path
+                .parent()
+                .expect("mempal home")
+                .join("daemon.log")
+                .display()
+        ),
+    )
+    .expect("write gated config");
+
+    enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "123".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                serde_json::json!({
+                    "session_id": "sess-low-value-read",
+                    "tool_name": "Read",
+                    "input": "README.md",
+                    "output": "LOW_VALUE_READ_SENTINEL",
+                    "exit_code": 0
+                })
+                .to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 128,
+            truncated: false,
+        },
+    );
+    enqueue_envelope(
+        &db_path,
+        &CapturedHookEnvelope {
+            event: HookEvent::UserPromptSubmit.display_name().to_string(),
+            kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
+            agent: "claude".to_string(),
+            captured_at: "124".to_string(),
+            claude_cwd: tmp.path().display().to_string(),
+            payload: Some(
+                serde_json::json!({
+                    "session_id": "sess-high-signal-prompt",
+                    "prompt": "HIGH_SIGNAL_DECISION_SENTINEL We decided the LLM salience gate must stay active for passive hooks while preserving root causes and architecture decisions."
+                })
+                .to_string(),
+            ),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: 256,
+            truncated: false,
+        },
+    );
+
+    let mut daemon = DaemonSupervisor::spawn(
+        HashMap::from([("HOME".to_string(), tmp.path().display().to_string())]),
+        vec!["--foreground".to_string()],
+    )
+    .await
+    .expect("spawn daemon");
+    daemon
+        .wait_ready(Duration::from_secs(5))
+        .await
+        .expect("wait ready");
+    wait_for_condition(Duration::from_secs(10), || {
+        active_queue_count(&db_path) == 0
+    })
+    .await;
+
+    assert!(
+        !drawer_content_contains(&db_path, "LOW_VALUE_READ_SENTINEL"),
+        "low-value Read hook should not become durable drawer content"
+    );
+    assert!(
+        drawer_content_contains(&db_path, "HIGH_SIGNAL_DECISION_SENTINEL"),
+        "high-signal user prompt should be retained as durable drawer content"
+    );
+    assert_eq!(gating_skip_count(&db_path), 1);
 
     daemon.sigterm();
     let status = daemon.wait().await.expect("wait daemon");

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -19,6 +19,7 @@ use mempal::core::db::{
     read_fork_ext_version, set_fork_ext_version,
 };
 use mempal::core::queue::PendingMessageStore;
+use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory};
 use mempal::ingest::gating::{
     GatingDecision, GatingRuntime, IngestCandidate, compile_classifier_from_config,
@@ -436,6 +437,21 @@ fn insert_gating_audit_row(db: &Database, seed: GatingAuditSeed) {
             ],
         )
         .expect("insert gating audit row");
+}
+
+fn insert_status_drawer(db: &Database, id: &str) {
+    let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: id.to_string(),
+        content: format!("status fixture drawer {id}"),
+        wing: "code-memory".to_string(),
+        room: Some("gating".to_string()),
+        source_file: Some(format!("{id}.md")),
+        source_type: SourceType::UserExplicit,
+        added_at: "2026-06-08T00:00:00Z".to_string(),
+        chunk_index: Some(0),
+        importance: 3,
+    });
+    db.insert_drawer(&drawer).expect("insert status drawer");
 }
 
 fn now_unix_secs() -> i64 {
@@ -2117,6 +2133,109 @@ threshold = 0.42
     assert_eq!(gate.quarantined_total, 0);
     assert!(gate.last_keep_at.is_some());
     assert!(gate.last_skip_at.is_some());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_uses_llm_task_and_gate_delete_sources() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[llm]
+enabled = true
+base_url = "http://localhost:18317/v1"
+model = "test-model"
+
+[gating]
+enabled = true
+
+[gating.llm_judge]
+enabled = true
+threshold = 0.42
+"#,
+    );
+    let db = env.db();
+
+    let audit_created_at = 1_700_000_000;
+    let llm_completed_at = 1_800_000_123_456;
+    let llm_failed_at = 1_900_000_654_000;
+
+    insert_gating_audit_row(
+        &db,
+        GatingAuditSeed {
+            candidate_hash: "llm-keep-candidate".to_string(),
+            drawer_id: Some("llm-keep-drawer".to_string()),
+            decision: "keep",
+            tier: 3,
+            label: Some("llm_pending".to_string()),
+            reason: None,
+            score: Some(0.9),
+            created_at: audit_created_at,
+        },
+    );
+    db.upsert_llm_verdict("llm-keep-drawer", "keep", Some(0.9))
+        .expect("upsert keep verdict");
+
+    insert_status_drawer(&db, "llm-rejected-drawer");
+    insert_gating_audit_row(
+        &db,
+        GatingAuditSeed {
+            candidate_hash: "llm-reject-candidate".to_string(),
+            drawer_id: Some("llm-rejected-drawer".to_string()),
+            decision: "keep",
+            tier: 3,
+            label: Some("llm_pending".to_string()),
+            reason: None,
+            score: Some(0.1),
+            created_at: audit_created_at + 1,
+        },
+    );
+    db.upsert_llm_verdict("llm-rejected-drawer", "reject", Some(0.1))
+        .expect("upsert reject verdict");
+    db.soft_delete_drawer("llm-rejected-drawer")
+        .expect("soft delete rejected drawer");
+
+    insert_status_drawer(&db, "manual-delete-drawer");
+    db.soft_delete_drawer("manual-delete-drawer")
+        .expect("soft delete unrelated drawer");
+
+    db.conn()
+        .execute(
+            r#"
+            INSERT INTO pending_message_completions (
+                message_id, kind, created_at, claimed_at, completed_at, processing_ms,
+                result_drawer_id, op_state, rejected_reason, failure_detail, result_json
+            )
+            VALUES (
+                'llm-success', 'llm_task', ?1, ?1, ?2, 123,
+                'llm-keep-drawer', 'completed', NULL, NULL, NULL
+            )
+            "#,
+            rusqlite::params![audit_created_at * 1000, llm_completed_at],
+        )
+        .expect("insert LLM completion");
+    db.conn()
+        .execute(
+            r#"
+            INSERT INTO pending_messages (
+                id, kind, source_hash, status, payload, created_at,
+                next_attempt_at, retry_count, last_error
+            )
+            VALUES (
+                'llm-failed', 'llm_task', 'failed-source', 'failed', '{}',
+                ?1, ?2, 1, 'boom'
+            )
+            "#,
+            rusqlite::params![audit_created_at, llm_failed_at / 1000],
+        )
+        .expect("insert failed LLM task");
+
+    let server = MempalMcpServer::new(env.db_path.clone(), env.config()).expect("create server");
+    let status = server.mempal_status().await.expect("status").0;
+    let gate = status.ingest_gating_status;
+
+    assert_eq!(gate.last_llm_success_at, Some(llm_completed_at));
+    assert_eq!(gate.last_llm_failure_at, Some(llm_failed_at));
+    assert_eq!(gate.soft_deleted_total, 1);
 }
 
 #[test]

--- a/tests/judge_gating.rs
+++ b/tests/judge_gating.rs
@@ -2058,6 +2058,105 @@ threshold = 0.5
     assert_eq!(rows[0].label.as_deref(), Some("llm_pending"));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_reports_active_llm_gate_and_metrics() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(
+        r#"
+[llm]
+enabled = true
+base_url = "http://localhost:18317/v1"
+model = "test-model"
+max_concurrent = 8
+
+[gating]
+enabled = true
+
+[gating.embedding_classifier]
+enabled = true
+threshold = 0.8
+prototypes = ["valuable"]
+
+[gating.llm_judge]
+enabled = true
+threshold = 0.42
+"#,
+    );
+    let config = env.config();
+    let server = MempalMcpServer::new_with_factory_and_config(
+        env.db_path.clone(),
+        config,
+        deterministic_factory(
+            &[
+                ("valuable", vec![1.0, 0.0]),
+                ("durable architecture decision root cause", vec![0.99, 0.01]),
+            ],
+            vec![0.2, 0.2],
+            &[],
+        ),
+    )
+    .expect("create MCP server");
+
+    let skipped = ingest_mcp(&server, "tiny").await;
+    assert!(skipped.dropped, "short content should be skipped");
+    let kept = ingest_mcp(&server, "durable architecture decision root cause").await;
+    assert!(!kept.dropped, "high-signal content should be retained");
+
+    let status = server.mempal_status().await.expect("status").0;
+    let gate = status.ingest_gating_status;
+    assert!(gate.enabled);
+    assert!(gate.tier1_active);
+    assert!(gate.tier2_active);
+    assert!(gate.llm_active);
+    assert_eq!(gate.llm_model.as_deref(), Some("test-model"));
+    assert_eq!(gate.llm_threshold, Some(0.42));
+    assert_eq!(gate.tier2_threshold, 0.8);
+    assert_eq!(gate.kept_total, 1);
+    assert_eq!(gate.skipped_total, 1);
+    assert_eq!(gate.dropped_total, 1);
+    assert_eq!(gate.quarantined_total, 0);
+    assert!(gate.last_keep_at.is_some());
+    assert!(gate.last_skip_at.is_some());
+}
+
+#[test]
+fn test_tier1_rejects_low_value_hook_and_keeps_high_signal_prompt() {
+    let _guard = test_guard_blocking();
+    let config = Config::parse(
+        r#"
+[gating]
+enabled = true
+"#,
+    )
+    .expect("parse config");
+
+    let read_decision = evaluate_tier1(
+        &IngestCandidate {
+            content: "Read output that should not become durable evidence".to_string(),
+            event: Some("PostToolUse".to_string()),
+            tool_name: Some("Read".to_string()),
+            exit_code: Some(0),
+        },
+        &config.ingest_gating,
+    )
+    .expect("read tool decision");
+    assert!(read_decision.is_rejected());
+    assert_eq!(read_decision.gating_reason.as_deref(), Some("read_tool"));
+
+    let prompt_decision = evaluate_tier1(
+        &IngestCandidate {
+            content: "We decided to keep the local LLM salience gate because it prevents passive hook flood while preserving architecture decisions.".to_string(),
+            event: Some("UserPromptSubmit".to_string()),
+            tool_name: None,
+            exit_code: None,
+        },
+        &config.ingest_gating,
+    )
+    .expect("user prompt decision");
+    assert!(!prompt_decision.is_rejected());
+    assert_eq!(prompt_decision.label.as_deref(), Some("user_prompt_submit"));
+}
+
 /// Multi-chunk ingest with Tier 3 LLM reject must soft-delete every chunk drawer,
 /// not just the first one.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "cc5c74ebc8c59e6d1588a1bce3c19e9e7a43d03c"
+commit = "92533aac4a60244d2cfece840fe1f9518d1a3177"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "92533aac4a60244d2cfece840fe1f9518d1a3177"
+commit = "8dd0dd9ebccbe99ac995d423e4f3011f5bd5fff9"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Exposes runtime ingest-gating status for the LLM salience gate, including active state, model/threshold information, runtime outcomes, and status surfaces.
- Surfaces restart-required hot-reload state through status/doctor/MCP and clears stale pending restart signals after a restart loads the new config.
- Adds coverage for low-value passive capture handling, high-signal retention, restart-required status behavior, and metrics/status consistency.

Closes #351.

## Local Review

- CSA implementation: 01KTKZZWXS3TWNTDZ0KDHC3HGG
- CSA review round 1: 01KTM1E662FW91E5DSR4HEV6TK, FAIL, fixed by 8c88ea9
- CSA review round 2: 01KTM2MPC26QEYNDRA27ES4NQM, FAIL, fixed by 04483fc
- CSA review round 3: 01KTM3PSABS95DSY1VJCMN464F, PASS/CLEAN
- Pre-push review gate passed for HEAD 04483fc7ef1.
