### PR TITLE
Keep passive capture hooks quiet on success

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1633,6 +1633,10 @@ impl ConfigHandle {
         super::hot_reload::global_hot_reload_state().bootstrap(path.as_ref())
     }
 
+    pub fn bootstrap_quiet(path: impl AsRef<Path>) -> Result<(), ConfigError> {
+        super::hot_reload::global_hot_reload_state().bootstrap_quiet(path.as_ref())
+    }
+
     pub fn current() -> Arc<Config> {
         super::hot_reload::global_hot_reload_state().current()
     }

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -136,6 +136,18 @@ impl HotReloadState {
     }
 
     pub fn bootstrap(&self, path: &Path) -> Result<(), ConfigError> {
+        self.bootstrap_with_bootstrap_stderr(path, true)
+    }
+
+    pub fn bootstrap_quiet(&self, path: &Path) -> Result<(), ConfigError> {
+        self.bootstrap_with_bootstrap_stderr(path, false)
+    }
+
+    fn bootstrap_with_bootstrap_stderr(
+        &self,
+        path: &Path,
+        emit_bootstrap_event_to_stderr: bool,
+    ) -> Result<(), ConfigError> {
         let config = Config::load_from(path)?;
         let snapshot = ConfigSnapshot::from_config(config.clone())?;
         self.snapshot.store(Arc::new(snapshot));
@@ -154,10 +166,13 @@ impl HotReloadState {
         self.runtime_prototypes.store(Arc::new(
             config.ingest_gating.embedding_classifier.prototypes.clone(),
         ));
-        self.push_event(format!(
-            "config hot-reload: bootstrapped version {}",
-            self.snapshot_meta().version
-        ));
+        self.record_event(
+            format!(
+                "config hot-reload: bootstrapped version {}",
+                self.snapshot_meta().version
+            ),
+            emit_bootstrap_event_to_stderr,
+        );
 
         let mut runtime = self.runtime.lock().expect("runtime mutex poisoned");
         if let Some(existing) = runtime.take() {
@@ -490,7 +505,13 @@ impl HotReloadState {
     }
 
     fn push_event(&self, event: String) {
-        eprintln!("{event}");
+        self.record_event(event, true);
+    }
+
+    fn record_event(&self, event: String, emit_stderr: bool) {
+        if emit_stderr {
+            eprintln!("{event}");
+        }
         self.persist_event(&event);
         let mut events = self.event_log.lock().expect("event log mutex poisoned");
         if events.len() == MAX_EVENT_LOG {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -88,7 +88,7 @@ pub fn run_command(command: HookCommands) -> Result<()> {
 }
 
 fn run_capture_command(event: HookEvent) -> Result<()> {
-    ConfigHandle::bootstrap(default_config_path()).context("failed to bootstrap config")?;
+    ConfigHandle::bootstrap_quiet(default_config_path()).context("failed to bootstrap config")?;
     enqueue_from_stdin(event)
 }
 

--- a/tests/embedder_degraded_state.rs
+++ b/tests/embedder_degraded_state.rs
@@ -64,7 +64,7 @@ search_deadline_secs = 5
 "#,
     )
     .expect("write config");
-    ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+    ConfigHandle::bootstrap_quiet(&config_path).expect("bootstrap config");
     config_path
 }
 

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -92,6 +92,11 @@ fn test_hook_post_tool_enqueues_to_queue() {
         "stdout must stay empty, got {:?}",
         String::from_utf8_lossy(&output.stdout)
     );
+    assert!(
+        output.stderr.is_empty(),
+        "successful hook stderr must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let conn = Connection::open(db_path).expect("open sqlite");
     let (kind, envelope): (String, String) = conn
@@ -137,23 +142,33 @@ fn test_hook_writes_nothing_to_stdout() {
 }
 
 #[test]
-fn test_hook_post_tool_canonical_stdout_is_empty_and_bootstrap_uses_stderr() {
-    let (home, _db_path) = setup_home();
-    let payload = r#"{"event":"PostToolUse","tool_name":"diagnostic","cwd":"/tmp","command":"true","exit_code":0}"#;
+fn test_passive_hook_success_paths_are_quiet() {
+    let cases = [
+        (
+            "PostToolUse",
+            r#"{"tool_name":"shell","tool_input":{"command":"true"},"tool_response":{"exit_code":0,"stdout":"","stderr":""}}"#,
+        ),
+        ("UserPromptSubmit", r#"{"prompt":"remember the decision"}"#),
+        ("SessionStart", r#"{"session_id":"sess-quiet"}"#),
+        ("SessionEnd", r#"{"session_id":"sess-quiet"}"#),
+    ];
 
-    let output = run_hook(&home, "PostToolUse", payload.as_bytes());
+    for (command, payload) in cases {
+        let (home, _db_path) = setup_home();
+        let output = run_hook(&home, command, payload.as_bytes());
 
-    assert_eq!(output.status.code(), Some(0));
-    assert!(
-        output.stdout.is_empty(),
-        "stdout is Codex hook protocol; got {:?}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("config hot-reload: bootstrapped version "),
-        "human-readable bootstrap status must be emitted on stderr, got {stderr:?}"
-    );
+        assert_eq!(output.status.code(), Some(0), "{command} failed");
+        assert!(
+            output.stdout.is_empty(),
+            "{command} stdout is Codex hook protocol; got {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "{command} successful stderr must stay empty; got {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "cff6be3467c85b399d1e47e750e69b5984031ba0"
+commit = "62b316505652166f19a3c6ac9a726538a0eeb5c3"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Keeps successful passive capture hook execution quiet on stdout/stderr.
- Routes operational hot-reload diagnostics away from successful hook stderr.
- Adds regression coverage for quiet successful PostToolUse capture.

Closes #367.

## Local Review

- CSA implementation: 01KTMV7PXE7PYFJ8EKTPKT8DB1
- CSA cumulative review PASS/CLEAN: 01KTMVYWY5WE32JM8P8ZWE789D
- Pre-push review gate passed for HEAD c3e98276d2e.
