### PR TITLE
Fix passive hook capture through daemon IPC

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -23,6 +23,7 @@ use crate::core::{
         source_file_or_synthetic,
     },
 };
+use crate::embed::global_embed_status;
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
 use crate::search::{
@@ -619,6 +620,12 @@ async fn ingest_handler(
     State(state): State<ApiState>,
     Json(request): Json<IngestRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    if global_embed_status().should_block_writes() {
+        return Err(ApiError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "mempal embed backend degraded; writes are paused until recovery. Read operations remain available.",
+        ));
+    }
     let response = state.write_queue().enqueue(request).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
@@ -628,6 +635,12 @@ async fn process_ingest_request(
     embedder_factory: Arc<dyn crate::embed::EmbedderFactory>,
     request: IngestRequest,
 ) -> Result<IngestResponse, ApiError> {
+    if global_embed_status().should_block_writes() {
+        return Err(ApiError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "mempal embed backend degraded; writes are paused until recovery. Read operations remain available.",
+        ));
+    }
     let embedder: Box<dyn crate::embed::Embedder> =
         embedder_factory.build().await.map_err(internal_error)?;
     let db = Database::open(&db_path).map_err(internal_error)?;

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -146,12 +146,32 @@ impl AsyncPendingMessageStore {
         self.run(move |store| store.enqueue(&kind, &payload)).await
     }
 
+    /// Enqueue a capture once for a deterministic `kind + payload` identity.
+    ///
+    /// This is for retry/fallback paths where two writers may race to persist the
+    /// same already-captured event. Normal queue callers should use `enqueue` so
+    /// repeated logical events remain distinct messages.
+    pub async fn enqueue_idempotent(&self, kind: String, payload: String) -> Result<String> {
+        self.run(move |store| store.enqueue_idempotent(&kind, &payload))
+            .await
+    }
+
     /// Enqueue without waiting on SQLite write locks.
     ///
     /// Use this when the caller owns a stricter fallback deadline than the
     /// queue's normal busy timeout, such as daemon hook IPC ACK handling.
     pub async fn enqueue_fail_fast(&self, kind: String, payload: String) -> Result<String> {
         self.run(move |store| store.enqueue_fail_fast(&kind, &payload))
+            .await
+    }
+
+    /// Idempotent variant of `enqueue_fail_fast`.
+    pub async fn enqueue_idempotent_fail_fast(
+        &self,
+        kind: String,
+        payload: String,
+    ) -> Result<String> {
+        self.run(move |store| store.enqueue_idempotent_fail_fast(&kind, &payload))
             .await
     }
 
@@ -292,12 +312,27 @@ impl PendingMessageStore {
     }
 
     pub fn enqueue(&self, kind: &str, payload: &str) -> Result<String> {
-        self.enqueue_with_busy_timeout(kind, payload, None)
+        self.enqueue_with_busy_timeout(kind, payload, None, EnqueueIdentity::Fresh)
+    }
+
+    /// Enqueue a capture once for a deterministic `kind + payload` identity.
+    pub fn enqueue_idempotent(&self, kind: &str, payload: &str) -> Result<String> {
+        self.enqueue_with_busy_timeout(kind, payload, None, EnqueueIdentity::Idempotent)
     }
 
     /// Enqueue without waiting for SQLite busy locks.
     pub fn enqueue_fail_fast(&self, kind: &str, payload: &str) -> Result<String> {
-        self.enqueue_with_busy_timeout(kind, payload, Some(Duration::ZERO))
+        self.enqueue_with_busy_timeout(kind, payload, Some(Duration::ZERO), EnqueueIdentity::Fresh)
+    }
+
+    /// Idempotent variant of `enqueue_fail_fast`.
+    pub fn enqueue_idempotent_fail_fast(&self, kind: &str, payload: &str) -> Result<String> {
+        self.enqueue_with_busy_timeout(
+            kind,
+            payload,
+            Some(Duration::ZERO),
+            EnqueueIdentity::Idempotent,
+        )
     }
 
     fn enqueue_with_busy_timeout(
@@ -305,27 +340,58 @@ impl PendingMessageStore {
         kind: &str,
         payload: &str,
         busy_timeout: Option<Duration>,
+        identity: EnqueueIdentity,
     ) -> Result<String> {
-        let id = next_id("msg");
         let created_at = now_secs();
         let source_hash = hash_source(kind, payload);
+        let id = match identity {
+            EnqueueIdentity::Fresh => next_id("msg"),
+            EnqueueIdentity::Idempotent => idempotent_message_id(&source_hash),
+        };
 
         let conn = self.open_connection_with_busy_timeout(busy_timeout)?;
-        conn.execute(
-            r#"
-            INSERT INTO pending_messages (
-                id,
-                kind,
-                source_hash,
-                status,
-                payload,
-                created_at,
-                next_attempt_at
-            )
-            VALUES (?1, ?2, ?3, 'pending', ?4, ?5, ?5)
-            "#,
-            params![id, kind, source_hash, payload, created_at],
-        )?;
+        match identity {
+            EnqueueIdentity::Fresh => {
+                conn.execute(
+                    r#"
+                    INSERT INTO pending_messages (
+                        id,
+                        kind,
+                        source_hash,
+                        status,
+                        payload,
+                        created_at,
+                        next_attempt_at
+                    )
+                    VALUES (?1, ?2, ?3, 'pending', ?4, ?5, ?5)
+                    "#,
+                    params![id, kind, source_hash, payload, created_at],
+                )?;
+            }
+            EnqueueIdentity::Idempotent => {
+                conn.execute(
+                    r#"
+                    INSERT INTO pending_messages (
+                        id,
+                        kind,
+                        source_hash,
+                        status,
+                        payload,
+                        created_at,
+                        next_attempt_at
+                    )
+                    SELECT ?1, ?2, ?3, 'pending', ?4, ?5, ?5
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM pending_message_completions
+                        WHERE message_id = ?1
+                    )
+                    ON CONFLICT(id) DO NOTHING
+                    "#,
+                    params![id, kind, source_hash, payload, created_at],
+                )?;
+            }
+        }
 
         Ok(id)
     }
@@ -1097,6 +1163,16 @@ fn hash_source(kind: &str, payload: &str) -> String {
     hasher.update(&[0]);
     hasher.update(payload.as_bytes());
     hasher.finalize().to_hex().to_string()
+}
+
+fn idempotent_message_id(source_hash: &str) -> String {
+    format!("msg-dedup-{source_hash}")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnqueueIdentity {
+    Fresh,
+    Idempotent,
 }
 
 fn now_secs() -> i64 {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -146,6 +146,15 @@ impl AsyncPendingMessageStore {
         self.run(move |store| store.enqueue(&kind, &payload)).await
     }
 
+    /// Enqueue without waiting on SQLite write locks.
+    ///
+    /// Use this when the caller owns a stricter fallback deadline than the
+    /// queue's normal busy timeout, such as daemon hook IPC ACK handling.
+    pub async fn enqueue_fail_fast(&self, kind: String, payload: String) -> Result<String> {
+        self.run(move |store| store.enqueue_fail_fast(&kind, &payload))
+            .await
+    }
+
     pub async fn claim_next(
         &self,
         worker_id: String,
@@ -283,11 +292,25 @@ impl PendingMessageStore {
     }
 
     pub fn enqueue(&self, kind: &str, payload: &str) -> Result<String> {
+        self.enqueue_with_busy_timeout(kind, payload, None)
+    }
+
+    /// Enqueue without waiting for SQLite busy locks.
+    pub fn enqueue_fail_fast(&self, kind: &str, payload: &str) -> Result<String> {
+        self.enqueue_with_busy_timeout(kind, payload, Some(Duration::ZERO))
+    }
+
+    fn enqueue_with_busy_timeout(
+        &self,
+        kind: &str,
+        payload: &str,
+        busy_timeout: Option<Duration>,
+    ) -> Result<String> {
         let id = next_id("msg");
         let created_at = now_secs();
         let source_hash = hash_source(kind, payload);
 
-        let conn = self.open_connection()?;
+        let conn = self.open_connection_with_busy_timeout(busy_timeout)?;
         conn.execute(
             r#"
             INSERT INTO pending_messages (
@@ -703,7 +726,17 @@ impl PendingMessageStore {
     }
 
     fn open_connection(&self) -> Result<Connection> {
+        self.open_connection_with_busy_timeout(None)
+    }
+
+    fn open_connection_with_busy_timeout(
+        &self,
+        busy_timeout: Option<Duration>,
+    ) -> Result<Connection> {
         let conn = Connection::open(&self.db_path)?;
+        if let Some(timeout) = busy_timeout {
+            conn.busy_timeout(timeout)?;
+        }
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         Ok(conn)

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -156,6 +156,22 @@ impl AsyncPendingMessageStore {
             .await
     }
 
+    /// Enqueue a capture once for an explicit producer-owned idempotency key.
+    ///
+    /// Use this when the producer can name one delivery attempt across racing
+    /// writers. Do not use payload-derived idempotency for ordinary captures,
+    /// because repeated logical events with the same payload must remain
+    /// distinct queue messages.
+    pub async fn enqueue_idempotent_with_key(
+        &self,
+        kind: String,
+        payload: String,
+        idempotency_key: String,
+    ) -> Result<String> {
+        self.run(move |store| store.enqueue_idempotent_with_key(&kind, &payload, &idempotency_key))
+            .await
+    }
+
     /// Enqueue without waiting on SQLite write locks.
     ///
     /// Use this when the caller owns a stricter fallback deadline than the
@@ -173,6 +189,19 @@ impl AsyncPendingMessageStore {
     ) -> Result<String> {
         self.run(move |store| store.enqueue_idempotent_fail_fast(&kind, &payload))
             .await
+    }
+
+    /// Idempotent-key variant of `enqueue_fail_fast`.
+    pub async fn enqueue_idempotent_with_key_fail_fast(
+        &self,
+        kind: String,
+        payload: String,
+        idempotency_key: String,
+    ) -> Result<String> {
+        self.run(move |store| {
+            store.enqueue_idempotent_with_key_fail_fast(&kind, &payload, &idempotency_key)
+        })
+        .await
     }
 
     pub async fn claim_next(
@@ -317,7 +346,22 @@ impl PendingMessageStore {
 
     /// Enqueue a capture once for a deterministic `kind + payload` identity.
     pub fn enqueue_idempotent(&self, kind: &str, payload: &str) -> Result<String> {
-        self.enqueue_with_busy_timeout(kind, payload, None, EnqueueIdentity::Idempotent)
+        self.enqueue_with_busy_timeout(kind, payload, None, EnqueueIdentity::SourceHash)
+    }
+
+    /// Enqueue a capture once for a producer-owned idempotency key.
+    pub fn enqueue_idempotent_with_key(
+        &self,
+        kind: &str,
+        payload: &str,
+        idempotency_key: &str,
+    ) -> Result<String> {
+        self.enqueue_with_busy_timeout(
+            kind,
+            payload,
+            None,
+            EnqueueIdentity::ExplicitKey(idempotency_key.to_string()),
+        )
     }
 
     /// Enqueue without waiting for SQLite busy locks.
@@ -331,7 +375,22 @@ impl PendingMessageStore {
             kind,
             payload,
             Some(Duration::ZERO),
-            EnqueueIdentity::Idempotent,
+            EnqueueIdentity::SourceHash,
+        )
+    }
+
+    /// Idempotent-key variant of `enqueue_fail_fast`.
+    pub fn enqueue_idempotent_with_key_fail_fast(
+        &self,
+        kind: &str,
+        payload: &str,
+        idempotency_key: &str,
+    ) -> Result<String> {
+        self.enqueue_with_busy_timeout(
+            kind,
+            payload,
+            Some(Duration::ZERO),
+            EnqueueIdentity::ExplicitKey(idempotency_key.to_string()),
         )
     }
 
@@ -344,9 +403,12 @@ impl PendingMessageStore {
     ) -> Result<String> {
         let created_at = now_secs();
         let source_hash = hash_source(kind, payload);
-        let id = match identity {
+        let id = match &identity {
             EnqueueIdentity::Fresh => next_id("msg"),
-            EnqueueIdentity::Idempotent => idempotent_message_id(&source_hash),
+            EnqueueIdentity::SourceHash => idempotent_source_message_id(&source_hash),
+            EnqueueIdentity::ExplicitKey(idempotency_key) => {
+                idempotent_key_message_id(kind, idempotency_key)
+            }
         };
 
         let conn = self.open_connection_with_busy_timeout(busy_timeout)?;
@@ -368,7 +430,7 @@ impl PendingMessageStore {
                     params![id, kind, source_hash, payload, created_at],
                 )?;
             }
-            EnqueueIdentity::Idempotent => {
+            EnqueueIdentity::SourceHash | EnqueueIdentity::ExplicitKey(_) => {
                 conn.execute(
                     r#"
                     INSERT INTO pending_messages (
@@ -1165,14 +1227,25 @@ fn hash_source(kind: &str, payload: &str) -> String {
     hasher.finalize().to_hex().to_string()
 }
 
-fn idempotent_message_id(source_hash: &str) -> String {
+fn idempotent_source_message_id(source_hash: &str) -> String {
     format!("msg-dedup-{source_hash}")
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+fn idempotent_key_message_id(kind: &str, idempotency_key: &str) -> String {
+    let mut hasher = Hasher::new();
+    hasher.update(b"mempal queue idempotency key v1");
+    hasher.update(&[0]);
+    hasher.update(kind.as_bytes());
+    hasher.update(&[0]);
+    hasher.update(idempotency_key.as_bytes());
+    format!("msg-dedup-{}", hasher.finalize().to_hex())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum EnqueueIdentity {
     Fresh,
-    Idempotent,
+    SourceHash,
+    ExplicitKey(String),
 }
 
 fn now_secs() -> i64 {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1085,8 +1085,9 @@ fn next_id(prefix: &str) -> String {
         Ok(duration) => duration.as_millis(),
         Err(_) => 0,
     };
+    let pid = std::process::id();
     let counter = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{prefix}-{now_ms:016x}-{counter:016x}")
+    format!("{prefix}-{now_ms:016x}-{pid:08x}-{counter:016x}")
 }
 
 fn saturating_cutoff(now: i64, window_secs: i64) -> i64 {
@@ -1135,6 +1136,17 @@ mod tests {
     use super::*;
     use crate::core::db::Database;
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn pending_message_ids_include_process_component() {
+        let id = next_id("msg");
+        let pid_component = format!("{:08x}", std::process::id());
+
+        assert!(
+            id.contains(&pid_component),
+            "pending message id {id} should include process component {pid_component}"
+        );
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn async_claim_confirm_run_off_runtime() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -635,7 +635,7 @@ async fn persist_hook_ipc_request(
     request: crate::hook_ipc::HookIpcEnqueueRequest,
 ) -> crate::hook_ipc::HookIpcEnqueueResponse {
     match store
-        .enqueue_fail_fast(request.kind.clone(), request.payload.clone())
+        .enqueue_idempotent_fail_fast(request.kind.clone(), request.payload.clone())
         .await
     {
         Ok(message_id) => {
@@ -2058,6 +2058,77 @@ mod tests {
         assert_eq!(count_while_locked, 0);
 
         lock_conn.execute_batch("ROLLBACK;").expect("release lock");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_hook_ipc_timeout_fallback_is_idempotent_with_slow_daemon_persist() {
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+
+        let kind = HookEvent::UserPromptSubmit.queue_kind().to_string();
+        let payload =
+            r#"{"event":"UserPromptSubmit","payload":"timeout fallback same capture"}"#.to_string();
+        let request = crate::hook_ipc::HookIpcEnqueueRequest {
+            kind: kind.clone(),
+            payload: payload.clone(),
+        };
+
+        let store = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_blocking_delay(crate::hook_ipc::HOOK_IPC_TIMEOUT + Duration::from_millis(200));
+        let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
+        let (mut client, server) = tokio::net::UnixStream::pair().expect("unix stream pair");
+        let handler = tokio::spawn(super::handle_hook_ipc_connection(server, store, observer));
+
+        let mut frame = serde_json::to_vec(&request).expect("serialize hook IPC request");
+        frame.push(b'\n');
+        tokio::io::AsyncWriteExt::write_all(&mut client, &frame)
+            .await
+            .expect("write request");
+        tokio::io::AsyncWriteExt::flush(&mut client)
+            .await
+            .expect("flush request");
+
+        let timed_out = tokio::time::timeout(crate::hook_ipc::HOOK_IPC_TIMEOUT, async move {
+            let mut reader = tokio::io::BufReader::new(client);
+            let mut line = String::new();
+            tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line).await
+        })
+        .await;
+        assert!(
+            timed_out.is_err(),
+            "client should time out before daemon persist"
+        );
+
+        let fallback_store = PendingMessageStore::new_without_reclaim(&db_path);
+        let fallback_id = fallback_store
+            .enqueue_idempotent(&kind, &payload)
+            .expect("fallback enqueue");
+
+        handler.await.expect("handler task");
+
+        let conn = rusqlite::Connection::open(&db_path).expect("open sqlite");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
+                row.get(0)
+            })
+            .expect("count pending");
+        assert_eq!(
+            count, 1,
+            "daemon and fallback must collapse the same capture"
+        );
+        let (stored_id, stored_kind, stored_payload): (String, String, String) = conn
+            .query_row(
+                "SELECT id, kind, payload FROM pending_messages LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read pending row");
+        assert_eq!(stored_id, fallback_id);
+        assert_eq!(stored_kind, kind);
+        assert_eq!(stored_payload, payload);
     }
 
     #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -147,6 +147,15 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         return Ok(());
     }
 
+    #[cfg(unix)]
+    let hook_ipc_service = spawn_hook_ipc_service(
+        &context.mempal_home,
+        context.store.clone(),
+        context.write_observer.clone(),
+    )
+    .await
+    .context("failed to start daemon hook IPC service")?;
+
     let embedder = Arc::new(
         DaemonEmbedder::from_config(context.config.as_ref())
             .await
@@ -248,6 +257,9 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         );
         wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
     }
+
+    #[cfg(unix)]
+    hook_ipc_service.shutdown(DAEMON_DRAIN_BUDGET).await;
 
     drain_hook_workers_with_budget(&mut hook_workers, DAEMON_DRAIN_BUDGET).await;
 
@@ -520,6 +532,174 @@ fn spawn_stall_watchdog(
             observer.maybe_log_stall(&store).await;
         }
     })
+}
+
+#[cfg(unix)]
+struct HookIpcServiceHandle {
+    listener_task: Option<tokio::task::JoinHandle<()>>,
+    writer_task: Option<tokio::task::JoinHandle<()>>,
+    socket_guard: Option<crate::hook_ipc::SocketFileGuard>,
+}
+
+#[cfg(unix)]
+impl HookIpcServiceHandle {
+    async fn shutdown(mut self, budget: Duration) {
+        if let Some(listener_task) = self.listener_task.take() {
+            listener_task.abort();
+            let _ = listener_task.await;
+        }
+
+        if let Some(writer_task) = self.writer_task.take() {
+            let mut writer_task = writer_task;
+            match tokio::time::timeout(budget, &mut writer_task).await {
+                Ok(_) => {}
+                Err(_) => {
+                    tracing::warn!(
+                        "hook IPC writer did not drain within shutdown budget; in-memory captures may be retried on the next hook fallback"
+                    );
+                    writer_task.abort();
+                    let _ = writer_task.await;
+                }
+            }
+        }
+        self.socket_guard.take();
+    }
+}
+
+#[cfg(unix)]
+impl Drop for HookIpcServiceHandle {
+    fn drop(&mut self) {
+        if let Some(listener_task) = &self.listener_task {
+            listener_task.abort();
+        }
+        if let Some(writer_task) = &self.writer_task {
+            writer_task.abort();
+        }
+        self.socket_guard.take();
+    }
+}
+
+#[cfg(unix)]
+async fn spawn_hook_ipc_service(
+    mempal_home: &Path,
+    store: AsyncPendingMessageStore,
+    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
+) -> Result<HookIpcServiceHandle> {
+    let (listener, socket_guard) = crate::hook_ipc::bind_listener(mempal_home)?;
+    let socket_path = socket_guard.path().to_path_buf();
+    let (tx, rx) = mpsc::channel(crate::hook_ipc::HOOK_IPC_QUEUE_CAPACITY);
+    let listener_task = tokio::spawn(run_hook_ipc_listener(listener, tx));
+    let writer_task = tokio::spawn(run_hook_ipc_writer(rx, store, write_observer));
+    tracing::info!("daemon hook IPC listening on {}", socket_path.display());
+    Ok(HookIpcServiceHandle {
+        listener_task: Some(listener_task),
+        writer_task: Some(writer_task),
+        socket_guard: Some(socket_guard),
+    })
+}
+
+#[cfg(unix)]
+async fn run_hook_ipc_listener(
+    listener: tokio::net::UnixListener,
+    tx: mpsc::Sender<crate::hook_ipc::HookIpcEnqueueRequest>,
+) {
+    loop {
+        if shutdown_requested() {
+            break;
+        }
+
+        tokio::select! {
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _addr)) => {
+                        let tx = tx.clone();
+                        tokio::spawn(async move {
+                            handle_hook_ipc_connection(stream, tx).await;
+                        });
+                    }
+                    Err(error) => {
+                        tracing::warn!(?error, "hook IPC accept failed");
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            }
+            () = tokio::time::sleep(Duration::from_millis(200)) => {}
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn handle_hook_ipc_connection(
+    mut stream: tokio::net::UnixStream,
+    tx: mpsc::Sender<crate::hook_ipc::HookIpcEnqueueRequest>,
+) {
+    let response = match crate::hook_ipc::read_enqueue_request(&mut stream).await {
+        Ok(request) => match tx.try_send(request) {
+            Ok(()) => crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                crate::hook_ipc::HookIpcEnqueueResponse::Error {
+                    message: "daemon hook IPC queue is full".to_string(),
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                crate::hook_ipc::HookIpcEnqueueResponse::Error {
+                    message: "daemon hook IPC writer is stopped".to_string(),
+                }
+            }
+        },
+        Err(error) => crate::hook_ipc::HookIpcEnqueueResponse::Error {
+            message: format!("invalid hook IPC request: {error}"),
+        },
+    };
+
+    if let Err(error) = crate::hook_ipc::write_enqueue_response(&mut stream, &response).await {
+        tracing::warn!(?error, "failed to write hook IPC response");
+    }
+}
+
+#[cfg(unix)]
+async fn run_hook_ipc_writer(
+    mut rx: mpsc::Receiver<crate::hook_ipc::HookIpcEnqueueRequest>,
+    store: AsyncPendingMessageStore,
+    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
+) {
+    while let Some(request) = rx.recv().await {
+        persist_hook_ipc_request(&store, &write_observer, request).await;
+    }
+}
+
+#[cfg(unix)]
+async fn persist_hook_ipc_request(
+    store: &AsyncPendingMessageStore,
+    write_observer: &crate::daemon_bootstrap::DaemonWriteObserver,
+    request: crate::hook_ipc::HookIpcEnqueueRequest,
+) {
+    let mut attempt = 0_u64;
+    loop {
+        attempt = attempt.saturating_add(1);
+        match store
+            .enqueue(request.kind.clone(), request.payload.clone())
+            .await
+        {
+            Ok(message_id) => {
+                tracing::debug!(message_id, kind = %request.kind, "persisted hook IPC capture");
+                write_observer.record_successful_write();
+                return;
+            }
+            Err(error) => {
+                write_observer.record_error(format!("failed to persist hook IPC capture: {error}"));
+                if attempt == 1 || attempt % 20 == 0 {
+                    tracing::warn!(
+                        ?error,
+                        attempt,
+                        kind = %request.kind,
+                        "failed to persist hook IPC capture; retrying"
+                    );
+                }
+                tokio::time::sleep(crate::hook_ipc::HOOK_IPC_RETRY_DELAY).await;
+            }
+        }
+    }
 }
 
 trait ClaimNextSource {
@@ -1826,6 +2006,57 @@ mod tests {
                 panic!("expected claimed message on retry")
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_hook_ipc_writer_retries_until_sqlite_lock_releases() {
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let lock_conn = rusqlite::Connection::open(&db_path).expect("open lock connection");
+        lock_conn
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold SQLite write lock");
+
+        let store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
+        let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
+        let request = crate::hook_ipc::HookIpcEnqueueRequest {
+            kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
+            payload: r#"{"event":"UserPromptSubmit","payload":"durable after lock"}"#.to_string(),
+        };
+        let writer = tokio::spawn(async move {
+            super::persist_hook_ipc_request(&store, &observer, request).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let count_while_locked: i64 = rusqlite::Connection::open(&db_path)
+            .expect("open read connection")
+            .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
+                row.get(0)
+            })
+            .expect("count pending while locked");
+        assert_eq!(
+            count_while_locked, 0,
+            "writer must keep the accepted IPC payload in memory while SQLite is locked"
+        );
+
+        lock_conn.execute_batch("ROLLBACK;").expect("release lock");
+        tokio::time::timeout(Duration::from_secs(2), writer)
+            .await
+            .expect("writer should persist after lock release")
+            .expect("writer task should not panic");
+        let (kind, payload): (String, String) = rusqlite::Connection::open(&db_path)
+            .expect("open sqlite")
+            .query_row(
+                "SELECT kind, payload FROM pending_messages ORDER BY created_at DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("query persisted IPC message");
+        assert_eq!(kind, HookEvent::UserPromptSubmit.queue_kind());
+        assert!(payload.contains("durable after lock"), "{payload}");
     }
 
     #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -635,7 +635,11 @@ async fn persist_hook_ipc_request(
     request: crate::hook_ipc::HookIpcEnqueueRequest,
 ) -> crate::hook_ipc::HookIpcEnqueueResponse {
     match store
-        .enqueue_idempotent_fail_fast(request.kind.clone(), request.payload.clone())
+        .enqueue_idempotent_with_key_fail_fast(
+            request.kind.clone(),
+            request.payload.clone(),
+            request.idempotency_key.clone(),
+        )
         .await
     {
         Ok(message_id) => {
@@ -1994,10 +1998,10 @@ mod tests {
 
         let store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
         let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
-        let request = crate::hook_ipc::HookIpcEnqueueRequest {
-            kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
-            payload: r#"{"event":"UserPromptSubmit","payload":"durable before ack"}"#.to_string(),
-        };
+        let request = crate::hook_ipc::HookIpcEnqueueRequest::new(
+            HookEvent::UserPromptSubmit.queue_kind(),
+            r#"{"event":"UserPromptSubmit","payload":"durable before ack"}"#,
+        );
 
         let response = send_hook_ipc_request(store, observer, request).await;
         assert_eq!(response, crate::hook_ipc::HookIpcEnqueueResponse::Accepted);
@@ -2027,10 +2031,10 @@ mod tests {
 
         let store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
         let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
-        let request = crate::hook_ipc::HookIpcEnqueueRequest {
-            kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
-            payload: r#"{"event":"UserPromptSubmit","payload":"not durable"}"#.to_string(),
-        };
+        let request = crate::hook_ipc::HookIpcEnqueueRequest::new(
+            HookEvent::UserPromptSubmit.queue_kind(),
+            r#"{"event":"UserPromptSubmit","payload":"not durable"}"#,
+        );
 
         let response = tokio::time::timeout(
             crate::hook_ipc::HOOK_IPC_TIMEOUT,
@@ -2071,10 +2075,8 @@ mod tests {
         let kind = HookEvent::UserPromptSubmit.queue_kind().to_string();
         let payload =
             r#"{"event":"UserPromptSubmit","payload":"timeout fallback same capture"}"#.to_string();
-        let request = crate::hook_ipc::HookIpcEnqueueRequest {
-            kind: kind.clone(),
-            payload: payload.clone(),
-        };
+        let request = crate::hook_ipc::HookIpcEnqueueRequest::new(&kind, &payload);
+        let idempotency_key = request.idempotency_key.clone();
 
         let store = AsyncPendingMessageStore::new_without_reclaim(&db_path)
             .with_blocking_delay(crate::hook_ipc::HOOK_IPC_TIMEOUT + Duration::from_millis(200));
@@ -2104,7 +2106,7 @@ mod tests {
 
         let fallback_store = PendingMessageStore::new_without_reclaim(&db_path);
         let fallback_id = fallback_store
-            .enqueue_idempotent(&kind, &payload)
+            .enqueue_idempotent_with_key(&kind, &payload, &idempotency_key)
             .expect("fallback enqueue");
 
         handler.await.expect("handler task");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -259,7 +259,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     }
 
     #[cfg(unix)]
-    hook_ipc_service.shutdown(DAEMON_DRAIN_BUDGET).await;
+    hook_ipc_service.shutdown().await;
 
     drain_hook_workers_with_budget(&mut hook_workers, DAEMON_DRAIN_BUDGET).await;
 
@@ -537,31 +537,17 @@ fn spawn_stall_watchdog(
 #[cfg(unix)]
 struct HookIpcServiceHandle {
     listener_task: Option<tokio::task::JoinHandle<()>>,
-    writer_task: Option<tokio::task::JoinHandle<()>>,
     socket_guard: Option<crate::hook_ipc::SocketFileGuard>,
 }
 
 #[cfg(unix)]
 impl HookIpcServiceHandle {
-    async fn shutdown(mut self, budget: Duration) {
+    async fn shutdown(mut self) {
         if let Some(listener_task) = self.listener_task.take() {
             listener_task.abort();
             let _ = listener_task.await;
         }
 
-        if let Some(writer_task) = self.writer_task.take() {
-            let mut writer_task = writer_task;
-            match tokio::time::timeout(budget, &mut writer_task).await {
-                Ok(_) => {}
-                Err(_) => {
-                    tracing::warn!(
-                        "hook IPC writer did not drain within shutdown budget; in-memory captures may be retried on the next hook fallback"
-                    );
-                    writer_task.abort();
-                    let _ = writer_task.await;
-                }
-            }
-        }
         self.socket_guard.take();
     }
 }
@@ -571,9 +557,6 @@ impl Drop for HookIpcServiceHandle {
     fn drop(&mut self) {
         if let Some(listener_task) = &self.listener_task {
             listener_task.abort();
-        }
-        if let Some(writer_task) = &self.writer_task {
-            writer_task.abort();
         }
         self.socket_guard.take();
     }
@@ -587,13 +570,10 @@ async fn spawn_hook_ipc_service(
 ) -> Result<HookIpcServiceHandle> {
     let (listener, socket_guard) = crate::hook_ipc::bind_listener(mempal_home)?;
     let socket_path = socket_guard.path().to_path_buf();
-    let (tx, rx) = mpsc::channel(crate::hook_ipc::HOOK_IPC_QUEUE_CAPACITY);
-    let listener_task = tokio::spawn(run_hook_ipc_listener(listener, tx));
-    let writer_task = tokio::spawn(run_hook_ipc_writer(rx, store, write_observer));
+    let listener_task = tokio::spawn(run_hook_ipc_listener(listener, store, write_observer));
     tracing::info!("daemon hook IPC listening on {}", socket_path.display());
     Ok(HookIpcServiceHandle {
         listener_task: Some(listener_task),
-        writer_task: Some(writer_task),
         socket_guard: Some(socket_guard),
     })
 }
@@ -601,7 +581,8 @@ async fn spawn_hook_ipc_service(
 #[cfg(unix)]
 async fn run_hook_ipc_listener(
     listener: tokio::net::UnixListener,
-    tx: mpsc::Sender<crate::hook_ipc::HookIpcEnqueueRequest>,
+    store: AsyncPendingMessageStore,
+    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
 ) {
     loop {
         if shutdown_requested() {
@@ -612,9 +593,10 @@ async fn run_hook_ipc_listener(
             accepted = listener.accept() => {
                 match accepted {
                     Ok((stream, _addr)) => {
-                        let tx = tx.clone();
+                        let store = store.clone();
+                        let write_observer = write_observer.clone();
                         tokio::spawn(async move {
-                            handle_hook_ipc_connection(stream, tx).await;
+                            handle_hook_ipc_connection(stream, store, write_observer).await;
                         });
                     }
                     Err(error) => {
@@ -631,22 +613,11 @@ async fn run_hook_ipc_listener(
 #[cfg(unix)]
 async fn handle_hook_ipc_connection(
     mut stream: tokio::net::UnixStream,
-    tx: mpsc::Sender<crate::hook_ipc::HookIpcEnqueueRequest>,
+    store: AsyncPendingMessageStore,
+    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
 ) {
     let response = match crate::hook_ipc::read_enqueue_request(&mut stream).await {
-        Ok(request) => match tx.try_send(request) {
-            Ok(()) => crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                crate::hook_ipc::HookIpcEnqueueResponse::Error {
-                    message: "daemon hook IPC queue is full".to_string(),
-                }
-            }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                crate::hook_ipc::HookIpcEnqueueResponse::Error {
-                    message: "daemon hook IPC writer is stopped".to_string(),
-                }
-            }
-        },
+        Ok(request) => persist_hook_ipc_request(&store, &write_observer, request).await,
         Err(error) => crate::hook_ipc::HookIpcEnqueueResponse::Error {
             message: format!("invalid hook IPC request: {error}"),
         },
@@ -658,46 +629,25 @@ async fn handle_hook_ipc_connection(
 }
 
 #[cfg(unix)]
-async fn run_hook_ipc_writer(
-    mut rx: mpsc::Receiver<crate::hook_ipc::HookIpcEnqueueRequest>,
-    store: AsyncPendingMessageStore,
-    write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
-) {
-    while let Some(request) = rx.recv().await {
-        persist_hook_ipc_request(&store, &write_observer, request).await;
-    }
-}
-
-#[cfg(unix)]
 async fn persist_hook_ipc_request(
     store: &AsyncPendingMessageStore,
     write_observer: &crate::daemon_bootstrap::DaemonWriteObserver,
     request: crate::hook_ipc::HookIpcEnqueueRequest,
-) {
-    let mut attempt = 0_u64;
-    loop {
-        attempt = attempt.saturating_add(1);
-        match store
-            .enqueue(request.kind.clone(), request.payload.clone())
-            .await
-        {
-            Ok(message_id) => {
-                tracing::debug!(message_id, kind = %request.kind, "persisted hook IPC capture");
-                write_observer.record_successful_write();
-                return;
-            }
-            Err(error) => {
-                write_observer.record_error(format!("failed to persist hook IPC capture: {error}"));
-                if attempt == 1 || attempt % 20 == 0 {
-                    tracing::warn!(
-                        ?error,
-                        attempt,
-                        kind = %request.kind,
-                        "failed to persist hook IPC capture; retrying"
-                    );
-                }
-                tokio::time::sleep(crate::hook_ipc::HOOK_IPC_RETRY_DELAY).await;
-            }
+) -> crate::hook_ipc::HookIpcEnqueueResponse {
+    match store
+        .enqueue_fail_fast(request.kind.clone(), request.payload.clone())
+        .await
+    {
+        Ok(message_id) => {
+            tracing::debug!(message_id, kind = %request.kind, "persisted hook IPC capture");
+            write_observer.record_successful_write();
+            crate::hook_ipc::HookIpcEnqueueResponse::Accepted
+        }
+        Err(error) => {
+            let message = format!("failed to persist hook IPC capture: {error}");
+            write_observer.record_error(message.clone());
+            tracing::warn!(?error, kind = %request.kind, "failed to persist hook IPC capture");
+            crate::hook_ipc::HookIpcEnqueueResponse::Error { message }
         }
     }
 }
@@ -2009,8 +1959,63 @@ mod tests {
     }
 
     #[cfg(unix)]
+    async fn send_hook_ipc_request(
+        store: AsyncPendingMessageStore,
+        observer: crate::daemon_bootstrap::DaemonWriteObserver,
+        request: crate::hook_ipc::HookIpcEnqueueRequest,
+    ) -> crate::hook_ipc::HookIpcEnqueueResponse {
+        let (mut client, server) = tokio::net::UnixStream::pair().expect("unix stream pair");
+        let handler = tokio::spawn(super::handle_hook_ipc_connection(server, store, observer));
+        let mut frame = serde_json::to_vec(&request).expect("serialize hook IPC request");
+        frame.push(b'\n');
+        tokio::io::AsyncWriteExt::write_all(&mut client, &frame)
+            .await
+            .expect("write request");
+        tokio::io::AsyncWriteExt::flush(&mut client)
+            .await
+            .expect("flush request");
+
+        let mut reader = tokio::io::BufReader::new(client);
+        let mut line = String::new();
+        tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line)
+            .await
+            .expect("read response");
+        handler.await.expect("handler task");
+        serde_json::from_str(line.trim()).expect("hook IPC response")
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
-    async fn test_hook_ipc_writer_retries_until_sqlite_lock_releases() {
+    async fn test_hook_ipc_ack_requires_sqlite_persistence() {
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+
+        let store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
+        let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
+        let request = crate::hook_ipc::HookIpcEnqueueRequest {
+            kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
+            payload: r#"{"event":"UserPromptSubmit","payload":"durable before ack"}"#.to_string(),
+        };
+
+        let response = send_hook_ipc_request(store, observer, request).await;
+        assert_eq!(response, crate::hook_ipc::HookIpcEnqueueResponse::Accepted);
+        let (kind, payload): (String, String) = rusqlite::Connection::open(&db_path)
+            .expect("open sqlite")
+            .query_row(
+                "SELECT kind, payload FROM pending_messages ORDER BY created_at DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("query persisted IPC message");
+        assert_eq!(kind, HookEvent::UserPromptSubmit.queue_kind());
+        assert!(payload.contains("durable before ack"), "{payload}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_hook_ipc_rejects_when_sqlite_persistence_fails() {
         super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
@@ -2024,39 +2029,35 @@ mod tests {
         let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
         let request = crate::hook_ipc::HookIpcEnqueueRequest {
             kind: HookEvent::UserPromptSubmit.queue_kind().to_string(),
-            payload: r#"{"event":"UserPromptSubmit","payload":"durable after lock"}"#.to_string(),
+            payload: r#"{"event":"UserPromptSubmit","payload":"not durable"}"#.to_string(),
         };
-        let writer = tokio::spawn(async move {
-            super::persist_hook_ipc_request(&store, &observer, request).await;
-        });
 
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        let response = tokio::time::timeout(
+            crate::hook_ipc::HOOK_IPC_TIMEOUT,
+            send_hook_ipc_request(store, observer, request),
+        )
+        .await
+        .expect("locked SQLite persistence must reject before hook IPC timeout");
+        match response {
+            crate::hook_ipc::HookIpcEnqueueResponse::Accepted => {
+                panic!("IPC must not ACK before pending_messages persistence")
+            }
+            crate::hook_ipc::HookIpcEnqueueResponse::Error { message } => {
+                assert!(
+                    message.contains("failed to persist hook IPC capture"),
+                    "{message}"
+                );
+            }
+        }
         let count_while_locked: i64 = rusqlite::Connection::open(&db_path)
             .expect("open read connection")
             .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
                 row.get(0)
             })
             .expect("count pending while locked");
-        assert_eq!(
-            count_while_locked, 0,
-            "writer must keep the accepted IPC payload in memory while SQLite is locked"
-        );
+        assert_eq!(count_while_locked, 0);
 
         lock_conn.execute_batch("ROLLBACK;").expect("release lock");
-        tokio::time::timeout(Duration::from_secs(2), writer)
-            .await
-            .expect("writer should persist after lock release")
-            .expect("writer task should not panic");
-        let (kind, payload): (String, String) = rusqlite::Connection::open(&db_path)
-            .expect("open sqlite")
-            .query_row(
-                "SELECT kind, payload FROM pending_messages ORDER BY created_at DESC LIMIT 1",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .expect("query persisted IPC message");
-        assert_eq!(kind, HookEvent::UserPromptSubmit.queue_kind());
-        assert!(payload.contains("durable after lock"), "{payload}");
     }
 
     #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -616,10 +616,18 @@ async fn handle_hook_ipc_connection(
     store: AsyncPendingMessageStore,
     write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
 ) {
-    let response = match crate::hook_ipc::read_enqueue_request(&mut stream).await {
-        Ok(request) => persist_hook_ipc_request(&store, &write_observer, request).await,
-        Err(error) => crate::hook_ipc::HookIpcEnqueueResponse::Error {
+    let request_result = tokio::time::timeout(
+        crate::hook_ipc::HOOK_IPC_READ_TIMEOUT,
+        crate::hook_ipc::read_enqueue_request(&mut stream),
+    )
+    .await;
+    let response = match request_result {
+        Ok(Ok(request)) => persist_hook_ipc_request(&store, &write_observer, request).await,
+        Ok(Err(error)) => crate::hook_ipc::HookIpcEnqueueResponse::Error {
             message: format!("invalid hook IPC request: {error}"),
+        },
+        Err(_) => crate::hook_ipc::HookIpcEnqueueResponse::Error {
+            message: "invalid hook IPC request: timed out reading frame".to_string(),
         },
     };
 
@@ -2062,6 +2070,51 @@ mod tests {
         assert_eq!(count_while_locked, 0);
 
         lock_conn.execute_batch("ROLLBACK;").expect("release lock");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_hook_ipc_stalled_request_times_out_without_persisting() {
+        super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+
+        let store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
+        let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
+        let (client, server) = tokio::net::UnixStream::pair().expect("unix stream pair");
+        let handler = tokio::spawn(super::handle_hook_ipc_connection(server, store, observer));
+
+        let mut reader = tokio::io::BufReader::new(client);
+        let mut line = String::new();
+        let bytes_read = tokio::time::timeout(
+            crate::hook_ipc::HOOK_IPC_READ_TIMEOUT + Duration::from_secs(1),
+            tokio::io::AsyncBufReadExt::read_line(&mut reader, &mut line),
+        )
+        .await
+        .expect("stalled request must receive timeout response")
+        .expect("read response");
+        assert!(bytes_read > 0, "daemon should write an error response");
+
+        handler.await.expect("handler task");
+        match serde_json::from_str::<crate::hook_ipc::HookIpcEnqueueResponse>(line.trim())
+            .expect("hook IPC response")
+        {
+            crate::hook_ipc::HookIpcEnqueueResponse::Accepted => {
+                panic!("stalled IPC request must not be accepted")
+            }
+            crate::hook_ipc::HookIpcEnqueueResponse::Error { message } => {
+                assert!(message.contains("timed out reading frame"), "{message}");
+            }
+        }
+
+        let count: i64 = rusqlite::Connection::open(&db_path)
+            .expect("open sqlite")
+            .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
+                row.get(0)
+            })
+            .expect("count pending");
+        assert_eq!(count, 0);
     }
 
     #[cfg(unix)]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -146,7 +146,7 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
     })?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     store
-        .enqueue(event.queue_kind(), &payload)
+        .enqueue_idempotent(event.queue_kind(), &payload)
         .with_context(|| {
             let reason = fallback_reason
                 .as_ref()

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -132,46 +132,85 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
 
     let payload =
         serde_json::to_string(&envelope).context("failed to serialize hook capture envelope")?;
-    let fallback_reason = try_enqueue_via_daemon(&mempal_home, event.queue_kind(), &payload);
-    if fallback_reason.is_none() {
-        return Ok(());
-    }
+    let fallback = match try_enqueue_via_daemon(&mempal_home, event.queue_kind(), &payload) {
+        DaemonEnqueueOutcome::Accepted => return Ok(()),
+        DaemonEnqueueOutcome::Fallback(fallback) => fallback,
+    };
 
     let db = Database::open(&db_path).with_context(|| {
-        let reason = fallback_reason
-            .as_ref()
-            .map(ToString::to_string)
-            .unwrap_or_else(|| "daemon IPC unavailable".to_string());
-        format!("failed to open database for hook enqueue after {reason}")
+        format!(
+            "failed to open database for hook enqueue after {}",
+            fallback.reason()
+        )
     })?;
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
-    store
-        .enqueue_idempotent(event.queue_kind(), &payload)
-        .with_context(|| {
-            let reason = fallback_reason
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_else(|| "daemon IPC unavailable".to_string());
-            format!("failed to enqueue hook payload after {reason}")
-        })?;
+    match fallback.identity() {
+        FallbackEnqueueIdentity::Fresh => store.enqueue(event.queue_kind(), &payload),
+        FallbackEnqueueIdentity::Idempotent { key } => {
+            store.enqueue_idempotent_with_key(event.queue_kind(), &payload, key)
+        }
+    }
+    .with_context(|| format!("failed to enqueue hook payload after {}", fallback.reason()))?;
     Ok(())
 }
 
+enum DaemonEnqueueOutcome {
+    Accepted,
+    Fallback(DaemonFallback),
+}
+
+enum DaemonFallback {
+    Fresh(String),
+    Idempotent { reason: String, key: String },
+}
+
+enum FallbackEnqueueIdentity<'a> {
+    Fresh,
+    Idempotent { key: &'a str },
+}
+
+impl DaemonFallback {
+    fn reason(&self) -> &str {
+        match self {
+            Self::Fresh(reason) | Self::Idempotent { reason, .. } => reason,
+        }
+    }
+
+    fn identity(&self) -> FallbackEnqueueIdentity<'_> {
+        match self {
+            Self::Fresh(_) => FallbackEnqueueIdentity::Fresh,
+            Self::Idempotent { key, .. } => FallbackEnqueueIdentity::Idempotent { key },
+        }
+    }
+}
+
 #[cfg(unix)]
-fn try_enqueue_via_daemon(
-    mempal_home: &Path,
-    kind: &str,
-    payload: &str,
-) -> Option<crate::hook_ipc::HookIpcFallbackReason> {
-    match crate::hook_ipc::enqueue_with_default_timeout(mempal_home, kind, payload) {
-        crate::hook_ipc::HookIpcClientOutcome::Accepted => None,
-        crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => Some(reason),
+fn try_enqueue_via_daemon(mempal_home: &Path, kind: &str, payload: &str) -> DaemonEnqueueOutcome {
+    let request = crate::hook_ipc::HookIpcEnqueueRequest::new(kind, payload);
+    let idempotency_key = request.idempotency_key.clone();
+    match crate::hook_ipc::enqueue_with_default_timeout(mempal_home, request) {
+        crate::hook_ipc::HookIpcClientOutcome::Accepted => DaemonEnqueueOutcome::Accepted,
+        crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => match reason {
+            crate::hook_ipc::HookIpcFallbackReason::Timeout => {
+                DaemonEnqueueOutcome::Fallback(DaemonFallback::Idempotent {
+                    reason: reason.to_string(),
+                    key: idempotency_key,
+                })
+            }
+            reason => DaemonEnqueueOutcome::Fallback(DaemonFallback::Fresh(reason.to_string())),
+        },
     }
 }
 
 #[cfg(not(unix))]
-fn try_enqueue_via_daemon(_mempal_home: &Path, _kind: &str, _payload: &str) -> Option<String> {
-    Some("daemon IPC unsupported on this platform".to_string())
+fn try_enqueue_via_daemon(
+    _mempal_home: &Path,
+    _kind: &str,
+    _payload: &str,
+) -> DaemonEnqueueOutcome {
+    DaemonEnqueueOutcome::Fallback(DaemonFallback::Fresh(
+        "daemon IPC unsupported on this platform".to_string(),
+    ))
 }
 
 fn should_drop_hook_capture(event: HookEvent, bytes: &[u8], config: &Config) -> bool {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -100,9 +100,7 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
     }
 
     let db_path = expand_home_path(&config.db_path);
-    let db = Database::open(&db_path).context("failed to open database for hook enqueue")?;
-    let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
-    let mempal_home = mempal_home_from_db(db.path());
+    let mempal_home = mempal_home_from_db(&db_path);
 
     let captured = capture_stdin_payload(stdin, &mempal_home)?;
     let envelope = CapturedHookEnvelope {
@@ -134,10 +132,46 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
 
     let payload =
         serde_json::to_string(&envelope).context("failed to serialize hook capture envelope")?;
+    let fallback_reason = try_enqueue_via_daemon(&mempal_home, event.queue_kind(), &payload);
+    if fallback_reason.is_none() {
+        return Ok(());
+    }
+
+    let db = Database::open(&db_path).with_context(|| {
+        let reason = fallback_reason
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "daemon IPC unavailable".to_string());
+        format!("failed to open database for hook enqueue after {reason}")
+    })?;
+    let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     store
         .enqueue(event.queue_kind(), &payload)
-        .context("failed to enqueue hook payload")?;
+        .with_context(|| {
+            let reason = fallback_reason
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "daemon IPC unavailable".to_string());
+            format!("failed to enqueue hook payload after {reason}")
+        })?;
     Ok(())
+}
+
+#[cfg(unix)]
+fn try_enqueue_via_daemon(
+    mempal_home: &Path,
+    kind: &str,
+    payload: &str,
+) -> Option<crate::hook_ipc::HookIpcFallbackReason> {
+    match crate::hook_ipc::enqueue_with_default_timeout(mempal_home, kind, payload) {
+        crate::hook_ipc::HookIpcClientOutcome::Accepted => None,
+        crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => Some(reason),
+    }
+}
+
+#[cfg(not(unix))]
+fn try_enqueue_via_daemon(_mempal_home: &Path, _kind: &str, _payload: &str) -> Option<String> {
+    Some("daemon IPC unsupported on this platform".to_string())
 }
 
 fn should_drop_hook_capture(event: HookEvent, bytes: &[u8], config: &Config) -> bool {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -190,15 +190,17 @@ fn try_enqueue_via_daemon(mempal_home: &Path, kind: &str, payload: &str) -> Daem
     let idempotency_key = request.idempotency_key.clone();
     match crate::hook_ipc::enqueue_with_default_timeout(mempal_home, request) {
         crate::hook_ipc::HookIpcClientOutcome::Accepted => DaemonEnqueueOutcome::Accepted,
-        crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => match reason {
-            crate::hook_ipc::HookIpcFallbackReason::Timeout => {
+        crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => {
+            let reason_text = reason.to_string();
+            if reason.may_have_reached_daemon() {
                 DaemonEnqueueOutcome::Fallback(DaemonFallback::Idempotent {
-                    reason: reason.to_string(),
+                    reason: reason_text,
                     key: idempotency_key,
                 })
+            } else {
+                DaemonEnqueueOutcome::Fallback(DaemonFallback::Fresh(reason_text))
             }
-            reason => DaemonEnqueueOutcome::Fallback(DaemonFallback::Fresh(reason.to_string())),
-        },
+        }
     }
 }
 

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -9,8 +9,6 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
 pub(crate) const HOOK_IPC_TIMEOUT: Duration = Duration::from_millis(250);
-pub(crate) const HOOK_IPC_QUEUE_CAPACITY: usize = 1024;
-pub(crate) const HOOK_IPC_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 const SOCKET_FILE_NAME: &str = "daemon-hook.sock";
 const MAX_IPC_FRAME_BYTES: usize = 12 * 1024 * 1024;

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use blake3::Hasher;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -12,11 +14,15 @@ pub(crate) const HOOK_IPC_TIMEOUT: Duration = Duration::from_millis(250);
 
 const SOCKET_FILE_NAME: &str = "daemon-hook.sock";
 const MAX_IPC_FRAME_BYTES: usize = 12 * 1024 * 1024;
+const MAX_IDEMPOTENCY_KEY_BYTES: usize = 128;
+
+static ATTEMPT_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct HookIpcEnqueueRequest {
     pub kind: String,
     pub payload: String,
+    pub idempotency_key: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -65,6 +71,16 @@ impl SocketFileGuard {
     }
 }
 
+impl HookIpcEnqueueRequest {
+    pub(crate) fn new(kind: &str, payload: &str) -> Self {
+        Self {
+            kind: kind.to_string(),
+            payload: payload.to_string(),
+            idempotency_key: new_idempotency_key(),
+        }
+    }
+}
+
 impl Drop for SocketFileGuard {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
@@ -88,8 +104,7 @@ pub(crate) fn bind_listener(mempal_home: &Path) -> Result<(UnixListener, SocketF
 
 pub(crate) fn enqueue_with_default_timeout(
     mempal_home: &Path,
-    kind: &str,
-    payload: &str,
+    request: HookIpcEnqueueRequest,
 ) -> HookIpcClientOutcome {
     let path = socket_path(mempal_home);
     if !path.exists() {
@@ -109,10 +124,6 @@ pub(crate) fn enqueue_with_default_timeout(
         }
     };
 
-    let request = HookIpcEnqueueRequest {
-        kind: kind.to_string(),
-        payload: payload.to_string(),
-    };
     runtime.block_on(async move {
         match tokio::time::timeout(HOOK_IPC_TIMEOUT, enqueue_once(&path, request)).await {
             Ok(outcome) => outcome,
@@ -165,6 +176,15 @@ pub(crate) async fn read_enqueue_request(stream: &mut UnixStream) -> Result<Hook
     if request.payload.is_empty() {
         bail!("hook IPC request payload must not be empty");
     }
+    if request.idempotency_key.trim().is_empty() {
+        bail!("hook IPC request idempotency_key must not be empty");
+    }
+    if request.idempotency_key.len() > MAX_IDEMPOTENCY_KEY_BYTES {
+        bail!(
+            "hook IPC request idempotency_key exceeds {} bytes",
+            MAX_IDEMPOTENCY_KEY_BYTES
+        );
+    }
     Ok(request)
 }
 
@@ -213,4 +233,18 @@ fn trim_line_ending(frame: &[u8]) -> &[u8] {
         .unwrap_or(frame)
         .strip_suffix(b"\r")
         .unwrap_or_else(|| frame.strip_suffix(b"\n").unwrap_or(frame))
+}
+
+fn new_idempotency_key() -> String {
+    let now_ns = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    };
+    let pid = std::process::id();
+    let counter = ATTEMPT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut hasher = Hasher::new();
+    hasher.update(&now_ns.to_le_bytes());
+    hasher.update(&pid.to_le_bytes());
+    hasher.update(&counter.to_le_bytes());
+    format!("hook-ipc-{}", hasher.finalize().to_hex())
 }

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+
+pub(crate) const HOOK_IPC_TIMEOUT: Duration = Duration::from_millis(250);
+pub(crate) const HOOK_IPC_QUEUE_CAPACITY: usize = 1024;
+pub(crate) const HOOK_IPC_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+const SOCKET_FILE_NAME: &str = "daemon-hook.sock";
+const MAX_IPC_FRAME_BYTES: usize = 12 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct HookIpcEnqueueRequest {
+    pub kind: String,
+    pub payload: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(crate) enum HookIpcEnqueueResponse {
+    Accepted,
+    Error { message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HookIpcClientOutcome {
+    Accepted,
+    Fallback(HookIpcFallbackReason),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HookIpcFallbackReason {
+    SocketUnavailable,
+    RuntimeInitFailed(String),
+    Timeout,
+    Io(String),
+    Rejected(String),
+    Protocol(String),
+}
+
+pub(crate) struct SocketFileGuard {
+    path: PathBuf,
+}
+
+impl fmt::Display for HookIpcFallbackReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SocketUnavailable => write!(f, "daemon IPC socket unavailable"),
+            Self::RuntimeInitFailed(error) => write!(f, "daemon IPC runtime init failed: {error}"),
+            Self::Timeout => write!(f, "daemon IPC timed out"),
+            Self::Io(error) => write!(f, "daemon IPC I/O failed: {error}"),
+            Self::Rejected(message) => write!(f, "daemon IPC rejected payload: {message}"),
+            Self::Protocol(error) => write!(f, "daemon IPC protocol failed: {error}"),
+        }
+    }
+}
+
+impl SocketFileGuard {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for SocketFileGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub(crate) fn socket_path(mempal_home: &Path) -> PathBuf {
+    mempal_home.join(SOCKET_FILE_NAME)
+}
+
+pub(crate) fn bind_listener(mempal_home: &Path) -> Result<(UnixListener, SocketFileGuard)> {
+    let path = socket_path(mempal_home);
+    if path.exists() {
+        fs::remove_file(&path)
+            .with_context(|| format!("failed to remove stale {}", path.display()))?;
+    }
+    let listener =
+        UnixListener::bind(&path).with_context(|| format!("failed to bind {}", path.display()))?;
+    Ok((listener, SocketFileGuard { path }))
+}
+
+pub(crate) fn enqueue_with_default_timeout(
+    mempal_home: &Path,
+    kind: &str,
+    payload: &str,
+) -> HookIpcClientOutcome {
+    let path = socket_path(mempal_home);
+    if !path.exists() {
+        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::SocketUnavailable);
+    }
+
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::RuntimeInitFailed(
+                error.to_string(),
+            ));
+        }
+    };
+
+    let request = HookIpcEnqueueRequest {
+        kind: kind.to_string(),
+        payload: payload.to_string(),
+    };
+    runtime.block_on(async move {
+        match tokio::time::timeout(HOOK_IPC_TIMEOUT, enqueue_once(&path, request)).await {
+            Ok(outcome) => outcome,
+            Err(_) => HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Timeout),
+        }
+    })
+}
+
+async fn enqueue_once(path: &Path, request: HookIpcEnqueueRequest) -> HookIpcClientOutcome {
+    let mut stream = match UnixStream::connect(path).await {
+        Ok(stream) => stream,
+        Err(error) => {
+            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+        }
+    };
+    let mut frame = match serde_json::to_vec(&request) {
+        Ok(frame) => frame,
+        Err(error) => {
+            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Protocol(
+                error.to_string(),
+            ));
+        }
+    };
+    frame.push(b'\n');
+    if let Err(error) = stream.write_all(&frame).await {
+        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+    }
+    if let Err(error) = stream.flush().await {
+        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+    }
+
+    match read_enqueue_response(&mut stream).await {
+        Ok(HookIpcEnqueueResponse::Accepted) => HookIpcClientOutcome::Accepted,
+        Ok(HookIpcEnqueueResponse::Error { message }) => {
+            HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Rejected(message))
+        }
+        Err(error) => {
+            HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Protocol(error.to_string()))
+        }
+    }
+}
+
+pub(crate) async fn read_enqueue_request(stream: &mut UnixStream) -> Result<HookIpcEnqueueRequest> {
+    let frame = read_frame(stream).await?;
+    let request: HookIpcEnqueueRequest = serde_json::from_slice(trim_line_ending(&frame))
+        .context("invalid hook IPC request JSON")?;
+    if request.kind.trim().is_empty() {
+        bail!("hook IPC request kind must not be empty");
+    }
+    if request.payload.is_empty() {
+        bail!("hook IPC request payload must not be empty");
+    }
+    Ok(request)
+}
+
+pub(crate) async fn write_enqueue_response(
+    stream: &mut UnixStream,
+    response: &HookIpcEnqueueResponse,
+) -> Result<()> {
+    let mut frame =
+        serde_json::to_vec(response).context("failed to serialize hook IPC response")?;
+    frame.push(b'\n');
+    stream
+        .write_all(&frame)
+        .await
+        .context("failed to write hook IPC response")?;
+    stream
+        .flush()
+        .await
+        .context("failed to flush hook IPC response")?;
+    Ok(())
+}
+
+async fn read_enqueue_response(stream: &mut UnixStream) -> Result<HookIpcEnqueueResponse> {
+    let frame = read_frame(stream).await?;
+    serde_json::from_slice(trim_line_ending(&frame)).context("invalid hook IPC response JSON")
+}
+
+async fn read_frame(stream: &mut UnixStream) -> Result<Vec<u8>> {
+    let mut reader = BufReader::new(stream);
+    let mut frame = Vec::new();
+    let bytes = reader
+        .read_until(b'\n', &mut frame)
+        .await
+        .context("failed to read hook IPC frame")?;
+    if bytes == 0 {
+        bail!("empty hook IPC frame");
+    }
+    if frame.len() > MAX_IPC_FRAME_BYTES {
+        bail!("hook IPC frame exceeds {} bytes", MAX_IPC_FRAME_BYTES);
+    }
+    Ok(frame)
+}
+
+fn trim_line_ending(frame: &[u8]) -> &[u8] {
+    frame
+        .strip_suffix(b"\n")
+        .unwrap_or(frame)
+        .strip_suffix(b"\r")
+        .unwrap_or_else(|| frame.strip_suffix(b"\n").unwrap_or(frame))
+}

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -7,14 +7,16 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use blake3::Hasher;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 
 pub(crate) const HOOK_IPC_TIMEOUT: Duration = Duration::from_millis(250);
+pub(crate) const HOOK_IPC_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
 const SOCKET_FILE_NAME: &str = "daemon-hook.sock";
 const MAX_IPC_FRAME_BYTES: usize = 12 * 1024 * 1024;
 const MAX_IDEMPOTENCY_KEY_BYTES: usize = 128;
+const IPC_READ_CHUNK_BYTES: usize = 8 * 1024;
 
 static ATTEMPT_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -212,19 +214,43 @@ async fn read_enqueue_response(stream: &mut UnixStream) -> Result<HookIpcEnqueue
 }
 
 async fn read_frame(stream: &mut UnixStream) -> Result<Vec<u8>> {
-    let mut reader = BufReader::new(stream);
+    read_frame_with_limit(stream, MAX_IPC_FRAME_BYTES).await
+}
+
+async fn read_frame_with_limit(stream: &mut UnixStream, max_frame_bytes: usize) -> Result<Vec<u8>> {
+    if max_frame_bytes == 0 {
+        bail!("hook IPC frame limit must be greater than zero");
+    }
+
     let mut frame = Vec::new();
-    let bytes = reader
-        .read_until(b'\n', &mut frame)
-        .await
-        .context("failed to read hook IPC frame")?;
-    if bytes == 0 {
-        bail!("empty hook IPC frame");
+    let mut chunk = [0_u8; IPC_READ_CHUNK_BYTES];
+
+    loop {
+        let bytes = stream
+            .read(&mut chunk)
+            .await
+            .context("failed to read hook IPC frame")?;
+        if bytes == 0 {
+            if frame.is_empty() {
+                bail!("empty hook IPC frame");
+            }
+            bail!("unterminated hook IPC frame");
+        }
+
+        let received = &chunk[..bytes];
+        let frame_part_len = received
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(received.len(), |delimiter_index| delimiter_index + 1);
+        if frame.len() + frame_part_len > max_frame_bytes {
+            bail!("hook IPC frame exceeds {} bytes", max_frame_bytes);
+        }
+
+        frame.extend_from_slice(&received[..frame_part_len]);
+        if frame.ends_with(b"\n") {
+            return Ok(frame);
+        }
     }
-    if frame.len() > MAX_IPC_FRAME_BYTES {
-        bail!("hook IPC frame exceeds {} bytes", MAX_IPC_FRAME_BYTES);
-    }
-    Ok(frame)
 }
 
 fn trim_line_ending(frame: &[u8]) -> &[u8] {
@@ -247,4 +273,66 @@ fn new_idempotency_key() -> String {
     hasher.update(&pid.to_le_bytes());
     hasher.update(&counter.to_le_bytes());
     format!("hook-ipc-{}", hasher.finalize().to_hex())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_read_frame_rejects_oversized_frame_before_extending_past_limit() {
+        let (mut client, mut server) = UnixStream::pair().expect("unix stream pair");
+        let reader = tokio::spawn(async move { read_frame_with_limit(&mut server, 32).await });
+
+        let oversized = vec![b'a'; 33];
+        let _ = client.write_all(&oversized).await;
+
+        let error = reader
+            .await
+            .expect("reader task")
+            .expect_err("oversized frame must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("hook IPC frame exceeds 32 bytes"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_read_frame_rejects_unterminated_frame() {
+        let (mut client, mut server) = UnixStream::pair().expect("unix stream pair");
+        let reader = tokio::spawn(async move { read_frame_with_limit(&mut server, 32).await });
+
+        client
+            .write_all(b"{\"status\":\"accepted\"}")
+            .await
+            .expect("write frame");
+        client.shutdown().await.expect("shutdown client");
+
+        let error = reader
+            .await
+            .expect("reader task")
+            .expect_err("unterminated frame must fail");
+        assert!(
+            error.to_string().contains("unterminated hook IPC frame"),
+            "{error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_read_frame_accepts_delimited_frame_at_limit() {
+        let (mut client, mut server) = UnixStream::pair().expect("unix stream pair");
+        let reader = tokio::spawn(async move { read_frame_with_limit(&mut server, 32).await });
+
+        let mut frame = vec![b'a'; 31];
+        frame.push(b'\n');
+        client.write_all(&frame).await.expect("write frame");
+
+        let read = reader.await.expect("reader task").expect("frame at limit");
+        assert_eq!(read, frame);
+    }
 }

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -44,10 +44,12 @@ pub(crate) enum HookIpcClientOutcome {
 pub(crate) enum HookIpcFallbackReason {
     SocketUnavailable,
     RuntimeInitFailed(String),
+    ConnectFailed(String),
     Timeout,
-    Io(String),
+    RequestEncodeFailed(String),
+    RequestWriteFailed(String),
     Rejected(String),
-    Protocol(String),
+    ResponseReadFailed(String),
 }
 
 pub(crate) struct SocketFileGuard {
@@ -59,11 +61,28 @@ impl fmt::Display for HookIpcFallbackReason {
         match self {
             Self::SocketUnavailable => write!(f, "daemon IPC socket unavailable"),
             Self::RuntimeInitFailed(error) => write!(f, "daemon IPC runtime init failed: {error}"),
+            Self::ConnectFailed(error) => write!(f, "daemon IPC connect failed: {error}"),
             Self::Timeout => write!(f, "daemon IPC timed out"),
-            Self::Io(error) => write!(f, "daemon IPC I/O failed: {error}"),
+            Self::RequestEncodeFailed(error) => {
+                write!(f, "daemon IPC request encode failed: {error}")
+            }
+            Self::RequestWriteFailed(error) => {
+                write!(f, "daemon IPC request write failed: {error}")
+            }
             Self::Rejected(message) => write!(f, "daemon IPC rejected payload: {message}"),
-            Self::Protocol(error) => write!(f, "daemon IPC protocol failed: {error}"),
+            Self::ResponseReadFailed(error) => {
+                write!(f, "daemon IPC response read failed: {error}")
+            }
         }
+    }
+}
+
+impl HookIpcFallbackReason {
+    pub(crate) fn may_have_reached_daemon(&self) -> bool {
+        matches!(
+            self,
+            Self::Timeout | Self::RequestWriteFailed(_) | Self::ResponseReadFailed(_)
+        )
     }
 }
 
@@ -138,23 +157,29 @@ async fn enqueue_once(path: &Path, request: HookIpcEnqueueRequest) -> HookIpcCli
     let mut stream = match UnixStream::connect(path).await {
         Ok(stream) => stream,
         Err(error) => {
-            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::ConnectFailed(
+                error.to_string(),
+            ));
         }
     };
     let mut frame = match serde_json::to_vec(&request) {
         Ok(frame) => frame,
         Err(error) => {
-            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Protocol(
+            return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::RequestEncodeFailed(
                 error.to_string(),
             ));
         }
     };
     frame.push(b'\n');
     if let Err(error) = stream.write_all(&frame).await {
-        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::RequestWriteFailed(
+            error.to_string(),
+        ));
     }
     if let Err(error) = stream.flush().await {
-        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Io(error.to_string()));
+        return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::RequestWriteFailed(
+            error.to_string(),
+        ));
     }
 
     match read_enqueue_response(&mut stream).await {
@@ -162,9 +187,9 @@ async fn enqueue_once(path: &Path, request: HookIpcEnqueueRequest) -> HookIpcCli
         Ok(HookIpcEnqueueResponse::Error { message }) => {
             HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Rejected(message))
         }
-        Err(error) => {
-            HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Protocol(error.to_string()))
-        }
+        Err(error) => HookIpcClientOutcome::Fallback(HookIpcFallbackReason::ResponseReadFailed(
+            error.to_string(),
+        )),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod factcheck;
 pub mod field_taxonomy;
 pub mod hook;
 pub mod hook_install;
+#[cfg(unix)]
+pub(crate) mod hook_ipc;
 pub mod hotpatch;
 pub mod importance;
 pub mod ingest;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3148,6 +3148,10 @@ impl MempalMcpServer {
         controls: IngestControls,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         self.spawn_ingest_drain_worker();
+        let dry_run = request.dry_run.unwrap_or(false);
+        if !dry_run && global_embed_status().should_block_writes() {
+            return Err(degraded_write_error());
+        }
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let room = request.room.as_deref();
         // Snapshot the request-wide warnings once so every early-return path reports a
@@ -3158,7 +3162,6 @@ impl MempalMcpServer {
         let request_system_warnings = self
             .system_warnings_with_stale_index_bounded(self.ingest_admission_deadline)
             .await?;
-        let dry_run = request.dry_run.unwrap_or(false);
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
@@ -3209,9 +3212,6 @@ impl MempalMcpServer {
                 }
             };
             return Ok(Json(response));
-        }
-        if global_embed_status().should_block_writes() {
-            return Err(degraded_write_error());
         }
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
@@ -3386,6 +3386,10 @@ impl MempalMcpServer {
         request: IngestRequest,
         controls: IngestControls,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        let dry_run = request.dry_run.unwrap_or(false);
+        if !dry_run && global_embed_status().should_block_writes() {
+            return Err(degraded_write_error());
+        }
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
@@ -3400,7 +3404,6 @@ impl MempalMcpServer {
         // (`should_block_writes`) re-reads fresh status via `degraded_write_error()` and
         // rejects before any success response that would carry this snapshot is built.
         let request_system_warnings = system_warnings_with_stale_index(&db);
-        let dry_run = request.dry_run.unwrap_or(false);
         let no_gate = controls.no_gate;
         let bypass_novelty = controls.bypass_novelty;
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
@@ -3433,10 +3436,6 @@ impl MempalMcpServer {
         let confidence = resolve_confidence_param(source_type, request.confidence)?;
         let metadata = validate_ingest_request(&request, &source_type)?;
         let mut timings = BTreeMap::new();
-
-        if !dry_run && global_embed_status().should_block_writes() {
-            return Err(degraded_write_error());
-        }
 
         let embedder = self.embedder_factory.build().await.map_err(|error| {
             ErrorData::internal_error(format!("failed to build embedder: {error}"), None)

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -9,7 +9,7 @@ use std::thread;
 #[cfg(unix)]
 use std::time::Duration;
 
-use mempal::core::db::Database;
+use mempal::core::{db::Database, queue::PendingMessageStore};
 use rusqlite::Connection;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -96,6 +96,41 @@ fn spawn_fake_daemon_ipc(
     })
 }
 
+#[cfg(unix)]
+fn spawn_fake_persisting_daemon_ipc(
+    home: &TempDir,
+    db_path: PathBuf,
+    response_delay: Duration,
+) -> thread::JoinHandle<String> {
+    let socket_path = home.path().join(".mempal").join("daemon-hook.sock");
+    let _ = fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).expect("bind fake daemon IPC socket");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept hook IPC connection");
+        let mut request = String::new();
+        let mut reader = BufReader::new(stream.try_clone().expect("clone IPC stream"));
+        reader
+            .read_line(&mut request)
+            .expect("read hook IPC request");
+        thread::sleep(response_delay);
+
+        let request_json: Value = serde_json::from_str(request.trim()).expect("request json");
+        let kind = request_json["kind"].as_str().expect("kind");
+        let payload = request_json["payload"].as_str().expect("payload");
+        let idempotency_key = request_json["idempotency_key"]
+            .as_str()
+            .expect("idempotency key");
+        PendingMessageStore::new_without_reclaim(&db_path)
+            .enqueue_idempotent_with_key(kind, payload, idempotency_key)
+            .expect("fake daemon persist");
+
+        let _ = stream.write_all(br#"{"status":"accepted"}"#);
+        let _ = stream.write_all(b"\n");
+        let _ = stream.flush();
+        request
+    })
+}
+
 #[test]
 fn test_hook_post_tool_enqueues_to_queue() {
     let (home, db_path) = setup_home();
@@ -177,6 +212,12 @@ fn test_hook_daemon_ipc_success_does_not_open_sqlite_when_db_locked() {
     let request = ipc.join().expect("fake daemon IPC thread");
     let request_json: Value = serde_json::from_str(request.trim()).expect("request json");
     assert_eq!(request_json["kind"], "hook_post_tool");
+    assert!(
+        request_json["idempotency_key"]
+            .as_str()
+            .is_some_and(|key| !key.is_empty()),
+        "daemon IPC request must carry a per-attempt idempotency key"
+    );
     let envelope: Value =
         serde_json::from_str(request_json["payload"].as_str().expect("payload string"))
             .expect("envelope json");
@@ -186,13 +227,9 @@ fn test_hook_daemon_ipc_success_does_not_open_sqlite_when_db_locked() {
 
 #[cfg(unix)]
 #[test]
-fn test_hook_ipc_timeout_falls_back_to_sqlite_enqueue() {
+fn test_hook_ipc_timeout_fallback_dedupes_with_slow_daemon_persist() {
     let (home, db_path) = setup_home();
-    let ipc = spawn_fake_daemon_ipc(
-        &home,
-        r#"{"status":"accepted"}"#,
-        Some(Duration::from_millis(700)),
-    );
+    let ipc = spawn_fake_persisting_daemon_ipc(&home, db_path.clone(), Duration::from_millis(700));
     let payload = r#"{"prompt":"timeout fallback persists"}"#;
 
     let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
@@ -208,8 +245,50 @@ fn test_hook_ipc_timeout_falls_back_to_sqlite_enqueue() {
         "fallback success must stay quiet, got {:?}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(pending_message_count(&db_path), 1);
     let _ = ipc.join().expect("fake daemon IPC thread");
+    assert_eq!(
+        pending_message_count(&db_path),
+        1,
+        "slow daemon persist and timeout fallback must share the same attempt key"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_no_daemon_direct_fallback_preserves_repeated_identical_captures() {
+    let (home, db_path) = setup_home();
+    let payload = r#"{"prompt":"same prompt repeated while daemon is down"}"#;
+
+    let first = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+    let second = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    for output in [first, second] {
+        assert_eq!(output.status.code(), Some(0));
+        assert!(
+            output.stdout.is_empty(),
+            "stdout must stay empty, got {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "direct fallback success must stay quiet, got {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let conn = Connection::open(db_path).expect("open sqlite");
+    let ids = conn
+        .prepare("SELECT id FROM pending_messages ORDER BY id")
+        .expect("prepare id query")
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query ids")
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .expect("collect ids");
+    assert_eq!(ids.len(), 2, "direct fallback must keep both hook events");
+    assert!(
+        ids.iter().all(|id| !id.starts_with("msg-dedup-")),
+        "direct fallback must use fresh queue IDs, got {ids:?}"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -105,6 +105,21 @@ fn spawn_fake_persisting_daemon_ipc(
     db_path: PathBuf,
     response_delay: Duration,
 ) -> thread::JoinHandle<String> {
+    spawn_fake_persisting_daemon_ipc_with_response(
+        home,
+        db_path,
+        response_delay,
+        Some(r#"{"status":"accepted"}"#),
+    )
+}
+
+#[cfg(unix)]
+fn spawn_fake_persisting_daemon_ipc_with_response(
+    home: &TempDir,
+    db_path: PathBuf,
+    response_delay: Duration,
+    response: Option<&'static str>,
+) -> thread::JoinHandle<String> {
     let socket_path = home.path().join(".mempal").join("daemon-hook.sock");
     let _ = fs::remove_file(&socket_path);
     let listener = UnixListener::bind(&socket_path).expect("bind fake daemon IPC socket");
@@ -127,9 +142,13 @@ fn spawn_fake_persisting_daemon_ipc(
             .enqueue_idempotent_with_key(kind, payload, idempotency_key)
             .expect("fake daemon persist");
 
-        let _ = stream.write_all(br#"{"status":"accepted"}"#);
-        let _ = stream.write_all(b"\n");
-        let _ = stream.flush();
+        if let Some(response) = response {
+            let _ = stream.write_all(response.as_bytes());
+            if !response.as_bytes().ends_with(b"\n") {
+                let _ = stream.write_all(b"\n");
+            }
+            let _ = stream.flush();
+        }
         request
     })
 }
@@ -254,6 +273,46 @@ fn test_hook_ipc_timeout_fallback_dedupes_with_slow_daemon_persist() {
         1,
         "slow daemon persist and timeout fallback must share the same attempt key"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_ipc_lost_or_malformed_ack_fallback_dedupes_after_daemon_persist() {
+    let cases = [
+        ("lost response", None),
+        ("malformed response", Some("not-json")),
+    ];
+
+    for (label, response) in cases {
+        let (home, db_path) = setup_home();
+        let ipc = spawn_fake_persisting_daemon_ipc_with_response(
+            &home,
+            db_path.clone(),
+            Duration::from_millis(0),
+            response,
+        );
+        let payload = format!(r#"{{"prompt":"{label} fallback persists once"}}"#);
+
+        let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+        assert_eq!(output.status.code(), Some(0), "{label}");
+        assert!(
+            output.stdout.is_empty(),
+            "{label}: stdout must stay empty, got {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "{label}: fallback success must stay quiet, got {:?}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let _ = ipc.join().expect("fake daemon IPC thread");
+        assert_eq!(
+            pending_message_count(&db_path),
+            1,
+            "{label}: daemon persist and fallback must share the same attempt key"
+        );
+    }
 }
 
 #[cfg(unix)]

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -214,14 +214,14 @@ fn test_hook_ipc_timeout_falls_back_to_sqlite_enqueue() {
 
 #[cfg(unix)]
 #[test]
-fn test_hook_ipc_rejection_falls_back_to_sqlite_enqueue() {
+fn test_hook_ipc_persistence_error_falls_back_to_sqlite_enqueue() {
     let (home, db_path) = setup_home();
     let ipc = spawn_fake_daemon_ipc(
         &home,
-        r#"{"status":"error","message":"daemon hook IPC queue is full"}"#,
+        r#"{"status":"error","message":"failed to persist hook IPC capture: database is locked"}"#,
         None,
     );
-    let payload = r#"{"prompt":"queue full fallback persists"}"#;
+    let payload = r#"{"prompt":"persistence error fallback persists"}"#;
 
     let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
 

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -1,7 +1,13 @@
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
+use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::thread;
+#[cfg(unix)]
+use std::time::Duration;
 
 use mempal::core::db::Database;
 use rusqlite::Connection;
@@ -65,6 +71,31 @@ fn pending_message_count(db_path: &PathBuf) -> i64 {
     .expect("query pending count")
 }
 
+#[cfg(unix)]
+fn spawn_fake_daemon_ipc(
+    home: &TempDir,
+    response: &'static str,
+    response_delay: Option<Duration>,
+) -> thread::JoinHandle<String> {
+    let socket_path = home.path().join(".mempal").join("daemon-hook.sock");
+    let _ = fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).expect("bind fake daemon IPC socket");
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept hook IPC connection");
+        let mut request = String::new();
+        let mut reader = BufReader::new(stream.try_clone().expect("clone IPC stream"));
+        reader
+            .read_line(&mut request)
+            .expect("read hook IPC request");
+        if let Some(delay) = response_delay {
+            thread::sleep(delay);
+        }
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+        request
+    })
+}
+
 #[test]
 fn test_hook_post_tool_enqueues_to_queue() {
     let (home, db_path) = setup_home();
@@ -110,6 +141,98 @@ fn test_hook_post_tool_enqueues_to_queue() {
     let envelope_json: Value = serde_json::from_str(&envelope).expect("envelope json");
     assert_eq!(envelope_json["event"], "PostToolUse");
     assert_eq!(envelope_json["payload"], payload);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_daemon_ipc_success_does_not_open_sqlite_when_db_locked() {
+    let (home, db_path) = setup_home();
+    let lock_conn = Connection::open(&db_path).expect("open lock connection");
+    lock_conn
+        .execute_batch("BEGIN IMMEDIATE;")
+        .expect("hold SQLite write lock");
+    let ipc = spawn_fake_daemon_ipc(&home, r#"{"status":"accepted"}"#, None);
+    let payload = r#"{"tool_name":"Bash","input":"printf ok","exit_code":0,"output":"ok"}"#;
+
+    let output = run_hook(&home, "hook_post_tool", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "successful hook stderr must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    lock_conn.execute_batch("ROLLBACK;").expect("release lock");
+    assert_eq!(
+        pending_message_count(&db_path),
+        0,
+        "fake daemon ACK means hook must not fall back to direct SQLite enqueue"
+    );
+
+    let request = ipc.join().expect("fake daemon IPC thread");
+    let request_json: Value = serde_json::from_str(request.trim()).expect("request json");
+    assert_eq!(request_json["kind"], "hook_post_tool");
+    let envelope: Value =
+        serde_json::from_str(request_json["payload"].as_str().expect("payload string"))
+            .expect("envelope json");
+    assert_eq!(envelope["event"], "PostToolUse");
+    assert_eq!(envelope["payload"], payload);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_ipc_timeout_falls_back_to_sqlite_enqueue() {
+    let (home, db_path) = setup_home();
+    let ipc = spawn_fake_daemon_ipc(
+        &home,
+        r#"{"status":"accepted"}"#,
+        Some(Duration::from_millis(700)),
+    );
+    let payload = r#"{"prompt":"timeout fallback persists"}"#;
+
+    let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "fallback success must stay quiet, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(pending_message_count(&db_path), 1);
+    let _ = ipc.join().expect("fake daemon IPC thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_ipc_rejection_falls_back_to_sqlite_enqueue() {
+    let (home, db_path) = setup_home();
+    let ipc = spawn_fake_daemon_ipc(
+        &home,
+        r#"{"status":"error","message":"daemon hook IPC queue is full"}"#,
+        None,
+    );
+    let payload = r#"{"prompt":"queue full fallback persists"}"#;
+
+    let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stderr.is_empty(),
+        "fallback success must stay quiet, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(pending_message_count(&db_path), 1);
+    let _ = ipc.join().expect("fake daemon IPC thread");
 }
 
 #[test]

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -91,6 +91,9 @@ fn spawn_fake_daemon_ipc(
             thread::sleep(delay);
         }
         let _ = stream.write_all(response.as_bytes());
+        if !response.as_bytes().ends_with(b"\n") {
+            let _ = stream.write_all(b"\n");
+        }
         let _ = stream.flush();
         request
     })

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -147,6 +147,61 @@ fn test_confirm_deletes_row() {
 }
 
 #[test]
+fn test_idempotent_enqueue_collapses_pending_and_completed_capture() {
+    let (_tmp, db_path, store) = new_store();
+    let payload = r#"{"tool":"Bash"}"#;
+
+    let first_id = store
+        .enqueue_idempotent("hook_event", payload)
+        .expect("first idempotent enqueue");
+    let duplicate_id = store
+        .enqueue_idempotent("hook_event", payload)
+        .expect("duplicate idempotent enqueue");
+    assert_eq!(duplicate_id, first_id);
+
+    let pending_count: i64 = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
+            row.get(0)
+        })
+        .expect("count pending rows");
+    assert_eq!(pending_count, 1);
+
+    let claimed = store
+        .claim_next("worker-1", 60)
+        .expect("claim")
+        .expect("message");
+    assert_eq!(claimed.id, first_id);
+    store.confirm(&claimed).expect("confirm");
+
+    let completed_duplicate_id = store
+        .enqueue_idempotent("hook_event", payload)
+        .expect("idempotent enqueue after completion");
+    assert_eq!(completed_duplicate_id, first_id);
+
+    let (pending_count, completion_count): (i64, i64) = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            r#"
+            SELECT
+                (SELECT COUNT(*) FROM pending_messages),
+                (SELECT COUNT(*) FROM pending_message_completions)
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("count queue rows");
+    assert_eq!(pending_count, 0);
+    assert_eq!(completion_count, 1);
+
+    let fresh_id = store.enqueue("hook_event", payload).expect("fresh enqueue");
+    let second_fresh_id = store
+        .enqueue("hook_event", payload)
+        .expect("second fresh enqueue");
+    assert_ne!(fresh_id, second_fresh_id);
+}
+
+#[test]
 fn test_confirm_llm_task_missing_row_is_benign() {
     let (_tmp, db_path, store) = new_store();
     let id = store

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -202,6 +202,39 @@ fn test_idempotent_enqueue_collapses_pending_and_completed_capture() {
 }
 
 #[test]
+fn test_explicit_idempotency_key_scopes_one_delivery_attempt() {
+    let (_tmp, db_path, store) = new_store();
+    let payload = r#"{"tool":"Bash"}"#;
+
+    let first_id = store
+        .enqueue_idempotent_with_key("hook_event", payload, "attempt-1")
+        .expect("first attempt enqueue");
+    let duplicate_id = store
+        .enqueue_idempotent_with_key("hook_event", payload, "attempt-1")
+        .expect("duplicate attempt enqueue");
+    assert_eq!(duplicate_id, first_id);
+
+    let second_attempt_id = store
+        .enqueue_idempotent_with_key("hook_event", payload, "attempt-2")
+        .expect("second attempt enqueue");
+    assert_ne!(second_attempt_id, first_id);
+
+    let (pending_count, distinct_source_hashes): (i64, i64) = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT source_hash) FROM pending_messages",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("count pending rows");
+    assert_eq!(pending_count, 2);
+    assert_eq!(
+        distinct_source_hashes, 1,
+        "attempt key, not payload hash, must define the idempotency boundary"
+    );
+}
+
+#[test]
 fn test_confirm_llm_task_missing_row_is_benign() {
     let (_tmp, db_path, store) = new_store();
     let id = store

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "62b316505652166f19a3c6ac9a726538a0eeb5c3"
+commit = "03d16cc6d6798a5334c5bb82f9af2c0a6c73b052"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "03d16cc6d6798a5334c5bb82f9af2c0a6c73b052"
+commit = "abbf958ee78f5f76e2701477c63077d390163a34"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- route passive hook captures through daemon IPC when available
- make daemon IPC ACK require durable `pending_messages` persistence
- scope idempotency so fallback races do not duplicate captures while no-daemon direct captures still preserve legitimate repeats
- bound daemon IPC frame reads before oversized attacker-controlled input can allocate unbounded memory
- include `weave.lock` update from CSA tooling

Closes #370.

## Verification

- CSA writer: `01KTMYZ0QZK9NFKEDM0HF1VK0X`
- Review/fix rounds: `01KTN0AG4K5DJ35R5GY6113K9A`, `01KTN1DQ3TPP7DKVPVC8QA1JHV`, `01KTN2A6NJ03JY6SYAB53F9GPT`, `01KTN3DW79YXHR0EZVVC8VMPJV`, `01KTN3ZJ936BX52ECFJ859VH22`, `01KTN5E84B95XAJD3EFF0W7W4P`, `01KTN6MBTVC83YY8X62M6ZJ9KJ`, `01KTN70R6HMFS48AEVMYZ3MDYM`, `01KTN7VBSXP5C3MWR0C20S0M57`
- Final cumulative review: `01KTN8BGRHAK1TFSG7C2PKR2GW`, PASS/CLEAN for `main...HEAD` at `bf8111efbf1`
- Pre-push hook verified the same PASS/CLEAN marker
