### PR TITLE
fix(test): replace hardcoded /tmp path with TempDir in operation status test

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -11188,7 +11188,8 @@ enabled = true
 
     #[tokio::test]
     async fn test_mcp_operation_status_tracks_reclaim_and_completion() {
-        let db_path = PathBuf::from("/tmp/mempal-async-status.db");
+        let tmp = TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
         Database::open(&db_path).expect("open db");
 
         let server = MempalMcpServer::new_with_factory(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "abbf958ee78f5f76e2701477c63077d390163a34"
+commit = "28df4de0fc023e9ef3e5a0e0faa73d79ee3495a2"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp/mempal-async-status.db` with `TempDir` in `test_mcp_operation_status_tracks_reclaim_and_completion`
- Fixes intermittent test failures caused by stale state from prior runs

## Test plan
- [x] Test passes in isolation and as part of full suite
- [x] CSA review PASS/CLEAN

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)