### PR TITLE
fix(mcp): check client roots capability before calling list_roots

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -636,7 +636,13 @@ impl MempalMcpServer {
         }
 
         let peer = self.client_peer.lock().ok().and_then(|guard| guard.clone());
+        let client_supports_roots = peer
+            .as_ref()
+            .and_then(|p| p.peer_info())
+            .and_then(|info| info.capabilities.roots.clone())
+            .is_some();
         if let Some(peer) = peer
+            && client_supports_roots
             && let Ok(result) = peer.list_roots().await
             && let Some(project_id) = result
                 .roots


### PR DESCRIPTION
## Summary
- Guard `resolve_mcp_project_id` against MCP clients that do not declare the `roots` capability
- Check `peer_info().capabilities.roots.is_some()` before calling `peer.list_roots()`
- Prevents transport closure when Codex (or other non-roots clients) receives an unsupported reverse request

## Test plan
- [x] Clippy clean, all 450 unit tests pass
- [x] CSA review PASS/CLEAN
- [ ] Verify `mempal_status` works from Codex client without transport closure

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)