### PR TITLE
feat(hook): add short-lived diagnostic log for hook failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1719,7 @@ dependencies = [
  "clap",
  "daemonize",
  "dotenvy",
+ "filetime",
  "hyper 0.14.32",
  "jieba-rs",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ panic = "abort"        # no unwinding — smaller binary, faster panic
 
 [dev-dependencies]
 dotenvy = "0.15"
+filetime = "0.2"
 axum = "0.8"
 hyper = { version = "0.14", features = ["http1", "server", "tcp"] }
 mockito = "1"

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -164,7 +164,20 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
             anyhow::bail!(msg);
         }
     };
-    let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
+    let store = match PendingMessageStore::new(db.path()) {
+        Ok(store) => store,
+        Err(error) => {
+            crate::hook_diagnostics::log_hook_failure(
+                &mempal_home,
+                event_name,
+                &crate::hook_diagnostics::HookOutcome::Dropped {
+                    error: format!("{error:#}"),
+                    stage: "queue_init".to_string(),
+                },
+            );
+            return Err(error).context("failed to open pending queue");
+        }
+    };
     let enqueue_result = match fallback.identity() {
         FallbackEnqueueIdentity::Fresh => store.enqueue(event.queue_kind(), &payload),
         FallbackEnqueueIdentity::Idempotent { key } => {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -132,25 +132,57 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
 
     let payload =
         serde_json::to_string(&envelope).context("failed to serialize hook capture envelope")?;
+    let event_name = event.display_name();
     let fallback = match try_enqueue_via_daemon(&mempal_home, event.queue_kind(), &payload) {
         DaemonEnqueueOutcome::Accepted => return Ok(()),
         DaemonEnqueueOutcome::Fallback(fallback) => fallback,
     };
 
-    let db = Database::open(&db_path).with_context(|| {
-        format!(
-            "failed to open database for hook enqueue after {}",
-            fallback.reason()
-        )
-    })?;
+    crate::hook_diagnostics::log_hook_failure(
+        &mempal_home,
+        event_name,
+        &crate::hook_diagnostics::HookOutcome::FallbackPersisted {
+            reason: fallback.reason().to_string(),
+        },
+    );
+
+    let db = match Database::open(&db_path) {
+        Ok(db) => db,
+        Err(error) => {
+            let msg = format!(
+                "failed to open database for hook enqueue after {}: {error:#}",
+                fallback.reason()
+            );
+            crate::hook_diagnostics::log_hook_failure(
+                &mempal_home,
+                event_name,
+                &crate::hook_diagnostics::HookOutcome::Dropped {
+                    error: format!("{error:#}"),
+                    stage: "db_open".to_string(),
+                },
+            );
+            anyhow::bail!(msg);
+        }
+    };
     let store = PendingMessageStore::new(db.path()).context("failed to open pending queue")?;
-    match fallback.identity() {
+    let enqueue_result = match fallback.identity() {
         FallbackEnqueueIdentity::Fresh => store.enqueue(event.queue_kind(), &payload),
         FallbackEnqueueIdentity::Idempotent { key } => {
             store.enqueue_idempotent_with_key(event.queue_kind(), &payload, key)
         }
+    };
+    if let Err(error) = &enqueue_result {
+        crate::hook_diagnostics::log_hook_failure(
+            &mempal_home,
+            event_name,
+            &crate::hook_diagnostics::HookOutcome::Dropped {
+                error: format!("{error:#}"),
+                stage: "enqueue".to_string(),
+            },
+        );
     }
-    .with_context(|| format!("failed to enqueue hook payload after {}", fallback.reason()))?;
+    enqueue_result
+        .with_context(|| format!("failed to enqueue hook payload after {}", fallback.reason()))?;
     Ok(())
 }
 

--- a/src/hook_diagnostics.rs
+++ b/src/hook_diagnostics.rs
@@ -1,0 +1,161 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_LOG_BYTES: u64 = 64 * 1024;
+const TTL_SECS: u64 = 3600;
+const LOG_FILENAME: &str = "hook-diagnostics.log";
+
+pub enum HookOutcome {
+    DaemonAccepted,
+    FallbackPersisted { reason: String },
+    Dropped { error: String, stage: String },
+}
+
+pub fn log_hook_failure(mempal_home: &Path, event: &str, outcome: &HookOutcome) {
+    if matches!(outcome, HookOutcome::DaemonAccepted) {
+        return;
+    }
+    let path = mempal_home.join(LOG_FILENAME);
+    if let Err(error) = try_log(&path, event, outcome) {
+        eprintln!(
+            "hook diagnostics: failed to write {}: {error}",
+            path.display()
+        );
+    }
+}
+
+fn try_log(path: &Path, event: &str, outcome: &HookOutcome) -> std::io::Result<()> {
+    prune_if_stale(path);
+    truncate_if_oversized(path);
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let line = match outcome {
+        HookOutcome::DaemonAccepted => return Ok(()),
+        HookOutcome::FallbackPersisted { reason } => {
+            format!("{now} FALLBACK event={event} reason={reason}\n")
+        }
+        HookOutcome::Dropped { error, stage } => {
+            format!("{now} DROPPED event={event} stage={stage} error={error}\n")
+        }
+    };
+
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(line.as_bytes())?;
+    Ok(())
+}
+
+fn prune_if_stale(path: &Path) {
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return;
+    };
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default();
+    if age.as_secs() > TTL_SECS {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn truncate_if_oversized(path: &Path) {
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() > MAX_LOG_BYTES {
+        let _ = fs::remove_file(path);
+    }
+}
+
+pub fn diagnostic_log_path(mempal_home: &Path) -> PathBuf {
+    mempal_home.join(LOG_FILENAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_success_does_not_write() {
+        let tmp = TempDir::new().unwrap();
+        log_hook_failure(tmp.path(), "PostToolUse", &HookOutcome::DaemonAccepted);
+        assert!(!tmp.path().join(LOG_FILENAME).exists());
+    }
+
+    #[test]
+    fn test_fallback_writes_entry() {
+        let tmp = TempDir::new().unwrap();
+        log_hook_failure(
+            tmp.path(),
+            "PostToolUse",
+            &HookOutcome::FallbackPersisted {
+                reason: "daemon not running".to_string(),
+            },
+        );
+        let content = fs::read_to_string(tmp.path().join(LOG_FILENAME)).unwrap();
+        assert!(content.contains("FALLBACK"));
+        assert!(content.contains("PostToolUse"));
+        assert!(content.contains("daemon not running"));
+    }
+
+    #[test]
+    fn test_dropped_writes_entry() {
+        let tmp = TempDir::new().unwrap();
+        log_hook_failure(
+            tmp.path(),
+            "SessionEnd",
+            &HookOutcome::Dropped {
+                error: "disk full".to_string(),
+                stage: "db_open".to_string(),
+            },
+        );
+        let content = fs::read_to_string(tmp.path().join(LOG_FILENAME)).unwrap();
+        assert!(content.contains("DROPPED"));
+        assert!(content.contains("SessionEnd"));
+        assert!(content.contains("disk full"));
+        assert!(content.contains("db_open"));
+    }
+
+    #[test]
+    fn test_stale_log_pruned() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(LOG_FILENAME);
+        fs::write(&path, "old data\n").unwrap();
+        filetime::set_file_mtime(&path, filetime::FileTime::from_unix_time(0, 0)).unwrap();
+        log_hook_failure(
+            tmp.path(),
+            "PostToolUse",
+            &HookOutcome::FallbackPersisted {
+                reason: "test".to_string(),
+            },
+        );
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("old data"));
+        assert!(content.contains("FALLBACK"));
+    }
+
+    #[test]
+    fn test_oversized_log_truncated() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(LOG_FILENAME);
+        let big = "x".repeat(MAX_LOG_BYTES as usize + 1);
+        fs::write(&path, &big).unwrap();
+        log_hook_failure(
+            tmp.path(),
+            "PostToolUse",
+            &HookOutcome::FallbackPersisted {
+                reason: "test".to_string(),
+            },
+        );
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.len() < MAX_LOG_BYTES as usize);
+        assert!(content.contains("FALLBACK"));
+    }
+}

--- a/src/hook_diagnostics.rs
+++ b/src/hook_diagnostics.rs
@@ -27,9 +27,6 @@ pub fn log_hook_failure(mempal_home: &Path, event: &str, outcome: &HookOutcome) 
 }
 
 fn try_log(path: &Path, event: &str, outcome: &HookOutcome) -> std::io::Result<()> {
-    prune_if_stale(path);
-    truncate_if_oversized(path);
-
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -44,33 +41,36 @@ fn try_log(path: &Path, event: &str, outcome: &HookOutcome) -> std::io::Result<(
         }
     };
 
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let should_reset = should_reset_log(path);
+    let mut file = if should_reset {
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?
+    } else {
+        OpenOptions::new().create(true).append(true).open(path)?
+    };
     file.write_all(line.as_bytes())?;
     Ok(())
 }
 
-fn prune_if_stale(path: &Path) {
+fn should_reset_log(path: &Path) -> bool {
     let Ok(metadata) = fs::metadata(path) else {
-        return;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return;
-    };
-    let age = SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or_default();
-    if age.as_secs() > TTL_SECS {
-        let _ = fs::remove_file(path);
-    }
-}
-
-fn truncate_if_oversized(path: &Path) {
-    let Ok(metadata) = fs::metadata(path) else {
-        return;
+        return false;
     };
     if metadata.len() > MAX_LOG_BYTES {
-        let _ = fs::remove_file(path);
+        return true;
     }
+    if let Ok(modified) = metadata.modified() {
+        let age = SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default();
+        if age.as_secs() > TTL_SECS {
+            return true;
+        }
+    }
+    false
 }
 
 pub fn diagnostic_log_path(mempal_home: &Path) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod endpoint_health;
 pub mod factcheck;
 pub mod field_taxonomy;
 pub mod hook;
+pub mod hook_diagnostics;
 pub mod hook_install;
 #[cfg(unix)]
 pub(crate) mod hook_ipc;

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "28df4de0fc023e9ef3e5a0e0faa73d79ee3495a2"
+commit = "8f381d7950b1448108c8c949ad5020f394367faf"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add `hook_diagnostics` module writing bounded entries to `~/.mempal/hook-diagnostics.log`
- Log IPC fallback, database open failure, queue init failure, and enqueue failure paths
- Auto-reset log when older than 1h or exceeding 64KB (truncate-mode open, no TOCTOU)
- Successful hooks remain silent; diagnostic logging failure never blocks hook execution

## Test plan
- [x] 5 unit tests (success silent, fallback writes, dropped writes, stale pruned, oversized truncated)
- [x] Clippy clean, full test suite passes
- [x] CSA review PASS (round 1 FAIL: missing queue_init log + TOCTOU; round 2 PASS after fixes)

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)