### PR TITLE
fix(mcp): keep initialize independent of workers

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1790,6 +1790,10 @@ fn should_enqueue_llm_gating(
     }
 }
 
+pub(crate) fn llm_worker_claim_enabled(config: &crate::core::config::Config) -> bool {
+    config.llm.enabled && !config.llm.enabled_for.is_empty()
+}
+
 struct DaemonEmbedder {
     primary: Box<dyn Embedder>,
     fallback: Option<Box<dyn Embedder>>,
@@ -1907,8 +1911,8 @@ mod tests {
 
     use super::{
         ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext, HookWorkerState,
-        build_drawer_records, poll_claim_next, process_claimed_message_with_embedder,
-        run_hook_worker, wing_from_cwd,
+        build_drawer_records, llm_worker_claim_enabled, poll_claim_next,
+        process_claimed_message_with_embedder, run_hook_worker, wing_from_cwd,
     };
 
     struct StubClaimSource {
@@ -1921,6 +1925,20 @@ mod tests {
                 responses: Mutex::new(VecDeque::from(responses)),
             }
         }
+    }
+
+    #[test]
+    fn test_llm_worker_spawn_and_claim_gates_are_separate() {
+        let mut config = Config::default();
+        config.llm.enabled = true;
+        config.llm.base_url = Some("http://127.0.0.1:9/v1".to_string());
+        config.llm.enabled_for.clear();
+
+        assert!(config.llm.enabled);
+        assert!(!llm_worker_claim_enabled(&config));
+
+        config.llm.enabled_for.push("gating".to_string());
+        assert!(llm_worker_claim_enabled(&config));
     }
 
     impl ClaimNextSource for StubClaimSource {

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -72,7 +72,7 @@ pub async fn run_llm_worker(
         // Re-read config at the start of each claim cycle so model/timeout
         // changes are picked up without a full daemon restart.
         let config = ConfigHandle::current();
-        if !config.llm.enabled {
+        if !crate::daemon::llm_worker_claim_enabled(config.as_ref()) {
             tokio::time::sleep(Duration::from_secs(5)).await;
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2585,6 +2585,10 @@ fn run() -> Result<()> {
 
     ConfigHandle::bootstrap(&config_path).context("failed to bootstrap config hot reload")?;
     let config = ConfigHandle::current();
+    if let Commands::Serve { mcp } = &cli.command {
+        return block_on_result(serve_command(config.as_ref(), *mcp));
+    }
+
     let db_path = expand_home(&config.db_path);
     let dashboard_mode = is_dashboard_command(&cli.command);
     if dashboard_mode && !db_path.exists() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -239,23 +239,45 @@ impl MempalMcpServer {
         self.gating_runtime
             .validate_config_shape()
             .context("failed to validate ingest gating config")?;
-        match self.reconcile_reindex_progress() {
-            Ok(0) => {}
-            Ok(updated) => {
-                tracing::info!(
-                    db_path = %self.db_path.display(),
-                    updated,
-                    "reconciled orphan reindex progress rows on startup"
-                );
+        let background = self.clone();
+        let service = self
+            .serve(rmcp::transport::stdio())
+            .await
+            .context("failed to initialize MCP stdio transport")?;
+        background.spawn_stdio_background_tasks();
+        Ok(service)
+    }
+
+    fn spawn_stdio_background_tasks(&self) {
+        let reconcile = self.clone();
+        let db_path = self.db_path.clone();
+        tokio::spawn(async move {
+            match tokio::task::spawn_blocking(move || reconcile.reconcile_reindex_progress()).await
+            {
+                Ok(Ok(0)) => {}
+                Ok(Ok(updated)) => {
+                    tracing::info!(
+                        db_path = %db_path.display(),
+                        updated,
+                        "reconciled orphan reindex progress rows after MCP startup"
+                    );
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        db_path = %db_path.display(),
+                        error = %error,
+                        "failed to reconcile orphan reindex progress rows after MCP startup"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        db_path = %db_path.display(),
+                        error = %error,
+                        "reindex progress reconciliation task failed after MCP startup"
+                    );
+                }
             }
-            Err(error) => {
-                tracing::warn!(
-                    db_path = %self.db_path.display(),
-                    error = %error,
-                    "failed to reconcile orphan reindex progress rows on startup"
-                );
-            }
-        }
+        });
         self.spawn_ingest_drain_worker();
         let _gating_init_task =
             self.gating_runtime
@@ -266,9 +288,6 @@ impl MempalMcpServer {
                         .retry
                         .search_deadline_secs,
                 ));
-        self.serve(rmcp::transport::stdio())
-            .await
-            .context("failed to initialize MCP stdio transport")
     }
 
     fn reconcile_reindex_progress(&self) -> anyhow::Result<usize> {

--- a/tests/common/harness/mcp_stdio.rs
+++ b/tests/common/harness/mcp_stdio.rs
@@ -56,6 +56,10 @@ backend = "model2vec"
 "#
             .to_string()
         };
+        let llm_enabled_for = extra_env
+            .get("MEMPAL_TEST_LLM_ENABLED_FOR")
+            .map(|value| format!("enabled_for = {value}\n"))
+            .unwrap_or_default();
         let llm_section = llm_base_url
             .map(|llm_base_url| {
                 format!(
@@ -64,8 +68,9 @@ backend = "model2vec"
 enabled = true
 base_url = "{}"
 model = "test-llm"
+{}
 "#,
-                    llm_base_url
+                    llm_base_url, llm_enabled_for
                 )
             })
             .unwrap_or_default();

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -90,6 +90,35 @@ async fn mcp_stdio_initializes() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn mcp_stdio_initialize_does_not_wait_for_busy_db_or_noop_llm() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path)?;
+
+    let lock_conn = rusqlite::Connection::open(&db_path)?;
+    lock_conn.execute_batch("BEGIN EXCLUSIVE;")?;
+
+    let mut client = McpStdio::start(
+        &db_path,
+        HashMap::from([
+            (
+                "MEMPAL_TEST_LLM_BASE_URL".to_string(),
+                "http://127.0.0.1:9/v1".to_string(),
+            ),
+            ("MEMPAL_TEST_LLM_ENABLED_FOR".to_string(), "[]".to_string()),
+        ]),
+    )
+    .await?;
+    let server_info = tokio::time::timeout(Duration::from_secs(2), client.initialize()).await??;
+    assert!(!server_info.server_info.name.trim().is_empty());
+    client.shutdown().await?;
+    lock_conn.execute_batch("ROLLBACK;")?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn harness_integration_smoke() -> Result<()> {
     let tmp = TempDir::new()?;

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "8f381d7950b1448108c8c949ad5020f394367faf"
+commit = "feb6aa1368c181d2b41748be1a46310ea75bd9c4"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- let `mempal serve --mcp` enter the serve path before the generic CLI database open
- defer MCP startup DB reconciliation until after stdio transport initialization
- separate LLM worker spawning from queue-claim activation so `enabled_for=[]` idles without blocking hot reload activation

## Verification
- `just fmt`
- `just clippy`
- `just test`
- `csa review --diff` PASS via Gemini session `01KTT5D2BKVQ9R93ER5RPBSPG2`
- `csa review --range main...HEAD` PASS via Gemini session `01KTT65NVQP3P38TPX0SE1T65W`

Closes #380