### PR TITLE
fix(config): hot-reload LLM client endpoints

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -601,20 +601,12 @@ impl Config {
         if self.llm.enabled != other.llm.enabled {
             fields.push("llm.enabled");
         }
-        if self.llm.base_url != other.llm.base_url {
-            fields.push("llm.base_url");
+        if self.llm.backend != other.llm.backend {
+            fields.push("llm.backend");
         }
-        // llm.model is just a request parameter — safe to hot-reload
-
-        if self.llm.api_key != other.llm.api_key {
-            fields.push("llm.api_key");
-        }
-        if self.llm.api_key_env != other.llm.api_key_env {
-            fields.push("llm.api_key_env");
-        }
-        if self.llm.extra_body != other.llm.extra_body {
-            fields.push("llm.extra_body");
-        }
+        // LLM endpoint/client request fields are safe to hot-reload: workers
+        // cancel in-flight tasks on generation bump and rebuild the client for
+        // the next claim cycle.
         if self.daemon.log_path != other.daemon.log_path {
             fields.push("daemon.log_path");
         }
@@ -633,11 +625,14 @@ impl Config {
         effective.embed.base_url = self.embed.base_url.clone();
         effective.embed.api_model = self.embed.api_model.clone();
         effective.embed.openai_compat = self.embed.openai_compat.clone();
-        effective.llm.base_url = self.llm.base_url.clone();
-        // llm.model is hot-reloadable — don't pin it
-        effective.llm.api_key = self.llm.api_key.clone();
-        effective.llm.api_key_env = self.llm.api_key_env.clone();
-        effective.llm.extra_body = self.llm.extra_body.clone();
+        if self.llm.enabled != candidate.llm.enabled || self.llm.backend != candidate.llm.backend {
+            effective.llm = self.llm.clone();
+        } else {
+            effective.llm.enabled = self.llm.enabled;
+            effective.llm.backend = self.llm.backend.clone();
+            // LLM endpoint/client request fields are hot-reloadable; keep the
+            // candidate values so new workers/requests use the latest endpoint.
+        }
         effective.daemon.log_path = self.daemon.log_path.clone();
         effective.mcp.log_path = self.mcp.log_path.clone();
         effective
@@ -1626,6 +1621,12 @@ pub struct ConfigSnapshotMeta {
     pub loaded_at_unix_ms: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct LlmRuntimeSnapshot {
+    pub config: Arc<Config>,
+    pub generation: u64,
+}
+
 pub struct ConfigHandle;
 
 impl ConfigHandle {
@@ -1647,6 +1648,13 @@ impl ConfigHandle {
 
     pub fn current_privacy_snapshot() -> (Arc<Config>, Arc<CompiledPrivacyConfig>) {
         super::hot_reload::global_hot_reload_state().current_privacy_snapshot()
+    }
+
+    pub fn current_llm_runtime_snapshot() -> LlmRuntimeSnapshot {
+        let state = super::hot_reload::global_hot_reload_state();
+        let generation = state.current_llm_generation();
+        let config = state.current();
+        LlmRuntimeSnapshot { config, generation }
     }
 
     pub fn scrub_content(input: &str) -> String {
@@ -1718,8 +1726,9 @@ impl ConfigHandle {
 
     /// Subscribe to LLM config generation changes.
     ///
-    /// The counter increments whenever a hot-reloadable LLM field (model,
-    /// retry_interval_secs, enabled_for, max_concurrent) changes via hot-reload.
+    /// The counter increments whenever a hot-reloadable LLM field (endpoint,
+    /// credentials, model, retry_interval_secs, enabled_for, max_concurrent)
+    /// changes via hot-reload.
     /// LLM workers subscribe here to cancel in-flight requests on config change.
     pub fn subscribe_llm_gen() -> tokio::sync::watch::Receiver<u64> {
         super::hot_reload::global_hot_reload_state().subscribe_llm_gen()
@@ -1741,6 +1750,12 @@ impl ConfigHandle {
 fn global_scrub_stats() -> &'static Mutex<ScrubStats> {
     static SCRUB_STATS: OnceLock<Mutex<ScrubStats>> = OnceLock::new();
     SCRUB_STATS.get_or_init(|| Mutex::new(ScrubStats::default()))
+}
+
+#[cfg(test)]
+pub(crate) fn global_config_test_lock() -> Arc<tokio::sync::Mutex<()>> {
+    static LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    Arc::clone(LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(()))))
 }
 
 /// Parameters for time-decay and retrieval-boost of `effective_importance`.

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -109,9 +109,10 @@ pub struct HotReloadState {
     // harness-point: PR0 — counts successful reload applications (version changes)
     reload_count: Arc<AtomicUsize>,
     runtime_prototypes: ArcSwap<Vec<String>>,
-    /// Incremented whenever a hot-reloadable LLM field changes (model,
-    /// retry_interval_secs, enabled_for, max_concurrent). LLM workers subscribe
-    /// to this to cancel in-flight requests and restart with the new config.
+    /// Incremented whenever a hot-reloadable LLM field changes (endpoint,
+    /// credentials, model, extra body, timeout, retry_interval_secs,
+    /// enabled_for, max_concurrent). LLM workers subscribe to this to cancel
+    /// in-flight requests and restart with the new config.
     llm_gen_tx: tokio::sync::watch::Sender<u64>,
 }
 
@@ -272,11 +273,14 @@ impl HotReloadState {
     /// Subscribe to LLM generation changes.
     ///
     /// The channel value is a monotonically-increasing counter that is bumped
-    /// whenever a hot-reloadable LLM field (model, retry_interval_secs,
-    /// enabled_for, max_concurrent) changes. LLM workers use this to detect
-    /// config changes and cancel in-flight requests.
+    /// whenever a hot-reloadable LLM field changes. LLM workers use this to
+    /// detect config changes and cancel in-flight requests.
     pub fn subscribe_llm_gen(&self) -> tokio::sync::watch::Receiver<u64> {
         self.llm_gen_tx.subscribe()
+    }
+
+    pub fn current_llm_generation(&self) -> u64 {
+        *self.llm_gen_tx.borrow()
     }
 
     /// Trigger a reload from the given path without going through the watcher.
@@ -469,7 +473,12 @@ impl HotReloadState {
         }
 
         // Compute LLM gen change before `effective` is consumed by from_config.
-        let llm_hot_changed = previous.config.llm.model != effective.llm.model
+        let llm_hot_changed = previous.config.llm.base_url != effective.llm.base_url
+            || previous.config.llm.model != effective.llm.model
+            || previous.config.llm.api_key != effective.llm.api_key
+            || previous.config.llm.api_key_env != effective.llm.api_key_env
+            || previous.config.llm.extra_body != effective.llm.extra_body
+            || previous.config.llm.request_timeout_secs != effective.llm.request_timeout_secs
             || previous.config.llm.max_concurrent != effective.llm.max_concurrent
             || previous.config.llm.retry_interval_secs != effective.llm.retry_interval_secs
             || previous.config.llm.enabled_for != effective.llm.enabled_for;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,9 +1,9 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{future::Future, pin::Pin};
 
@@ -205,40 +205,37 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     );
 
     let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
-        match crate::llm::LlmClient::from_config(&context.config.llm) {
-            Ok(llm_client) => {
-                let num_workers = context.config.llm.max_concurrent.max(1);
-                let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
-                let llm_store = std::sync::Arc::new(context.store.clone());
-                let llm_client = std::sync::Arc::new(llm_client);
-                let async_db = context.async_db.clone();
-                let write_observer = context.write_observer.clone();
-                tracing::info!("spawning {num_workers} LLM worker tasks");
-                (0..num_workers)
-                    .map(|i| {
-                        let store = llm_store.clone();
-                        let client = llm_client.clone();
-                        let status = llm_status.clone();
-                        let db = async_db.clone();
-                        let observer = write_observer.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = crate::llm::worker::run_llm_worker(
-                                store, client, status, db, observer,
-                            )
-                            .await
-                            {
-                                tracing::error!("LLM worker {i} fatal error: {e:#}");
-                            }
-                            Ok::<(), anyhow::Error>(())
-                        })
-                    })
-                    .collect()
-            }
-            Err(error) => {
-                tracing::warn!("LLM client init failed, skipping LLM worker: {error}");
-                vec![]
-            }
-        }
+        let llm_client_runtime = crate::llm::worker::LlmClientRuntime::new(&context.config.llm);
+        let num_workers = context.config.llm.max_concurrent.max(1);
+        let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
+        let llm_store = std::sync::Arc::new(context.store.clone());
+        let llm_client_runtime = std::sync::Arc::new(Mutex::new(llm_client_runtime));
+        let async_db = context.async_db.clone();
+        let write_observer = context.write_observer.clone();
+        tracing::info!("spawning {num_workers} LLM worker tasks");
+        (0..num_workers)
+            .map(|i| {
+                let store = llm_store.clone();
+                let client_runtime = llm_client_runtime.clone();
+                let status = llm_status.clone();
+                let db = async_db.clone();
+                let observer = write_observer.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = crate::llm::worker::run_llm_worker(
+                        store,
+                        client_runtime,
+                        status,
+                        db,
+                        observer,
+                    )
+                    .await
+                    {
+                        tracing::error!("LLM worker {i} fatal error: {e:#}");
+                    }
+                    Ok::<(), anyhow::Error>(())
+                })
+            })
+            .collect()
     } else {
         vec![]
     };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -207,9 +207,9 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
         let llm_client_runtime = crate::llm::worker::LlmClientRuntime::new(&context.config.llm);
         let num_workers = context.config.llm.max_concurrent.max(1);
-        let llm_status = std::sync::Arc::new(crate::llm::LlmStatus::new(10));
-        let llm_store = std::sync::Arc::new(context.store.clone());
-        let llm_client_runtime = std::sync::Arc::new(Mutex::new(llm_client_runtime));
+        let llm_status = Arc::new(crate::llm::LlmStatus::new(10));
+        let llm_store = Arc::new(context.store.clone());
+        let llm_client_runtime = Arc::new(Mutex::new(llm_client_runtime));
         let async_db = context.async_db.clone();
         let write_observer = context.write_observer.clone();
         tracing::info!("spawning {num_workers} LLM worker tasks");

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -8,7 +8,7 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex, Semaphore};
 
 use crate::core::config::LlmConfig;
 
@@ -73,7 +73,7 @@ impl LlmError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LlmClient {
     http: reqwest::Client,
     base_url: String,
@@ -81,6 +81,7 @@ pub struct LlmClient {
     extra_body: Option<Value>,
     semaphore: Arc<Semaphore>,
     current_max: Arc<AtomicUsize>,
+    concurrency_update_lock: Mutex<()>,
 }
 
 impl LlmClient {
@@ -133,10 +134,12 @@ impl LlmClient {
             extra_body: config.extra_body.clone(),
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
             current_max: Arc::new(AtomicUsize::new(max_concurrent)),
+            concurrency_update_lock: Mutex::new(()),
         })
     }
 
     pub async fn update_concurrency(&self, new_max: usize) {
+        let _guard = self.concurrency_update_lock.lock().await;
         let new_max = new_max.max(1);
         let old_max = self.current_max.load(Ordering::SeqCst);
         if new_max == old_max {

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -211,7 +211,7 @@ pub async fn run_llm_worker(
                         message_id,
                         "LLM client unavailable after claim; releasing task for retry"
                     );
-                    if let Err(release_error) = store.release_claim(message.clone()).await {
+                    if let Err(release_error) = store.release_claim(message).await {
                         tracing::warn!(
                             ?release_error,
                             message_id,
@@ -763,7 +763,7 @@ threshold = 0.5
             DaemonWriteObserver::for_test(),
         ));
 
-        tokio::time::sleep(Duration::from_millis(650)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
         std::fs::write(&config_path, worker_test_config(&new_base_url)).expect("write new config");
         ConfigHandle::harness_reload_from_path(&config_path);
 

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -1,16 +1,17 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::core::AsyncDb;
-use crate::core::config::ConfigHandle;
+use crate::core::config::{Config, ConfigHandle, LlmConfig};
 use crate::core::db::Database;
 use crate::core::queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore};
 use crate::daemon_bootstrap::DaemonWriteObserver;
 
-use super::client::{LlmClient, LlmMessage, LlmRequest};
+use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest};
 use super::retry::{self, HeartbeatCallback};
 use super::status::LlmStatus;
 
@@ -21,6 +22,106 @@ const LLM_VERDICT_KEEP: &str = "keep";
 const LLM_VERDICT_REJECT: &str = "reject";
 
 pub const DEFAULT_GATING_JUDGE_PROMPT: &str = "You are a memory importance judge for a software engineering project memory system.\n\nGiven a piece of content captured from a coding session, determine if it contains IMPORTANT information worth storing long-term. Score from 0.0 to 1.0.\n\nIMPORTANT (score >= 0.7):\n- Architecture or design decisions and their rationale\n- Bug root cause analysis and fix strategies\n- User preferences, workflow choices, or explicit feedback\n- Configuration decisions and why they were made\n- Trade-off evaluations between approaches\n- Security concerns or mitigation strategies\n- Project milestones, status changes, or completion records\n- Integration decisions (which tools, which APIs, why)\n\nNOT IMPORTANT (score < 0.4):\n- Raw tool output (file listings, grep results, git status)\n- Routine code edits without design rationale\n- Build/test output logs\n- Boilerplate file content\n- Simple command execution without decision context\n- Repetitive status checks\n\nRespond with ONLY a JSON object: {\"score\": 0.0-1.0, \"reason\": \"brief explanation\"}";
+
+#[derive(Debug, Clone, PartialEq)]
+struct LlmClientConfigSignature {
+    backend: String,
+    base_url: Option<String>,
+    model: Option<String>,
+    api_key: Option<String>,
+    api_key_env: Option<String>,
+    extra_body: Option<Value>,
+    request_timeout_secs: u64,
+}
+
+impl From<&LlmConfig> for LlmClientConfigSignature {
+    fn from(config: &LlmConfig) -> Self {
+        Self {
+            backend: config.backend.clone(),
+            base_url: config.base_url.clone(),
+            model: config.model.clone(),
+            api_key: config.api_key.clone(),
+            api_key_env: config.api_key_env.clone(),
+            extra_body: config.extra_body.clone(),
+            request_timeout_secs: config.request_timeout_secs,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct LlmClientRuntime {
+    client: Option<Arc<LlmClient>>,
+    signature: LlmClientConfigSignature,
+}
+
+impl LlmClientRuntime {
+    pub fn new(config: &LlmConfig) -> Self {
+        let client = match LlmClient::from_config(config) {
+            Ok(client) => Some(Arc::new(client)),
+            Err(error) => {
+                tracing::warn!(%error, "LLM client unavailable at startup; worker will retry");
+                None
+            }
+        };
+        Self {
+            client,
+            signature: LlmClientConfigSignature::from(config),
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn client_for_config(&mut self, config: &LlmConfig) -> Result<Arc<LlmClient>, LlmError> {
+        let signature = LlmClientConfigSignature::from(config);
+        if self.client.is_none() || self.signature != signature {
+            self.client = Some(Arc::new(LlmClient::from_config(config)?));
+            self.signature = signature;
+            tracing::info!("LLM client rebuilt after config hot-reload");
+        }
+        self.client.as_ref().map(Arc::clone).ok_or_else(|| {
+            LlmError::MissingConfiguration("LLM client unavailable after rebuild".to_string())
+        })
+    }
+}
+
+pub type SharedLlmClientRuntime = Arc<Mutex<LlmClientRuntime>>;
+
+async fn client_for_claimed_generation(
+    client_runtime: &SharedLlmClientRuntime,
+    llm_gen_rx: &mut tokio::sync::watch::Receiver<u64>,
+) -> Result<(Arc<LlmClient>, Arc<Config>), LlmError> {
+    loop {
+        let snapshot = ConfigHandle::current_llm_runtime_snapshot();
+        if !crate::daemon::llm_worker_claim_enabled(snapshot.config.as_ref()) {
+            return Err(LlmError::MissingConfiguration(
+                "LLM worker claim disabled by current config".to_string(),
+            ));
+        }
+
+        let client = {
+            let mut runtime = client_runtime
+                .lock()
+                .expect("LLM client runtime mutex poisoned");
+            runtime.client_for_config(&snapshot.config.llm)
+        }?;
+
+        let new_max = snapshot.config.llm.max_concurrent.max(1);
+        if client.current_max_concurrent() != new_max {
+            client.update_concurrency(new_max).await;
+            tracing::info!("LLM worker: concurrency updated to {new_max}");
+        }
+
+        let observed_generation = *llm_gen_rx.borrow_and_update();
+        if observed_generation == snapshot.generation {
+            return Ok((client, snapshot.config));
+        }
+
+        tracing::info!(
+            from_generation = snapshot.generation,
+            to_generation = observed_generation,
+            "LLM config changed while preparing claimed task; rebuilding client"
+        );
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmTaskPayload {
@@ -37,7 +138,7 @@ pub struct LlmTaskPayload {
 
 pub async fn run_llm_worker(
     store: Arc<AsyncPendingMessageStore>,
-    client: Arc<LlmClient>,
+    client_runtime: SharedLlmClientRuntime,
     status: Arc<LlmStatus>,
     db: AsyncDb,
     write_observer: DaemonWriteObserver,
@@ -59,8 +160,9 @@ pub async fn run_llm_worker(
     }
 
     // Subscribe to LLM config generation changes. When a hot-reloadable LLM
-    // field changes (e.g. model), the receiver value is bumped and any
-    // in-flight task is cancelled so the worker restarts with the new config.
+    // field changes (endpoint, credentials, model, etc.), the receiver value
+    // is bumped and any in-flight task is cancelled so the worker restarts
+    // with the new config.
     let mut llm_gen_rx = ConfigHandle::subscribe_llm_gen();
 
     loop {
@@ -69,18 +171,13 @@ pub async fn run_llm_worker(
             break;
         }
 
-        // Re-read config at the start of each claim cycle so model/timeout
-        // changes are picked up without a full daemon restart.
+        // Re-read config at the start of each claim cycle so runtime-disabled
+        // subsystems stop claiming promptly. The LLM client itself is prepared
+        // only after a task is claimed, using the then-current LLM generation.
         let config = ConfigHandle::current();
         if !crate::daemon::llm_worker_claim_enabled(config.as_ref()) {
             tokio::time::sleep(Duration::from_secs(5)).await;
             continue;
-        }
-
-        let new_max = config.llm.max_concurrent.max(1);
-        if client.current_max_concurrent() != new_max {
-            client.update_concurrency(new_max).await;
-            tracing::info!("LLM worker: concurrency updated to {new_max}");
         }
 
         let message = match store
@@ -103,9 +200,30 @@ pub async fn run_llm_worker(
             }
         };
 
-        // Mark the current generation as seen AFTER claiming so that `changed()`
-        // only fires for changes that happen while THIS task is in-flight.
-        let _ = llm_gen_rx.borrow_and_update();
+        let (client, config) =
+            match client_for_claimed_generation(&client_runtime, &mut llm_gen_rx).await {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    status.record_failure(&error);
+                    let message_id = message.id.clone();
+                    tracing::warn!(
+                        %error,
+                        message_id,
+                        "LLM client unavailable after claim; releasing task for retry"
+                    );
+                    if let Err(release_error) = store.release_claim(message.clone()).await {
+                        tracing::warn!(
+                            ?release_error,
+                            message_id,
+                            "failed to release claimed LLM task after client preparation failure; \
+                             task will be reclaimed by TTL or next startup"
+                        );
+                    }
+                    let retry_interval = ConfigHandle::current().llm.retry_interval_secs.max(1);
+                    tokio::time::sleep(Duration::from_secs(retry_interval)).await;
+                    continue;
+                }
+            };
 
         let message_id = message.id.clone();
         tracing::info!("LLM worker claimed task {message_id}");
@@ -133,11 +251,11 @@ pub async fn run_llm_worker(
         // with the fresh config snapshot.
         let task_result = tokio::select! {
             result = process_llm_task_shared(
-                &client,
+                client.as_ref(),
                 &status,
                 &db,
                 &message.payload,
-                &config,
+                config.as_ref(),
                 Some(heartbeat.as_ref()),
             ) => Some(result),
             _ = llm_gen_rx.changed() => None,
@@ -432,12 +550,15 @@ fn parse_gating_verdict(content: &str) -> (String, f64) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::config::{Config, IngestGatingConfig, LlmJudgeConfig};
+    use crate::core::config::{Config, ConfigHandle, IngestGatingConfig, LlmJudgeConfig};
+    use crate::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
     use crate::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
+    use crate::daemon_bootstrap::DaemonWriteObserver;
     use crate::ingest::gating::GatingDecision;
     use rusqlite::params;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use tokio::sync::Notify;
 
     fn spawn_runtime_ticker() -> (Arc<AtomicU64>, tokio::task::JoinHandle<()>) {
         let ticks = Arc::new(AtomicU64::new(0));
@@ -504,6 +625,73 @@ mod tests {
         }
     }
 
+    fn worker_test_config(base_url: &str) -> String {
+        format!(
+            r#"
+[config_hot_reload]
+enabled = false
+
+[llm]
+enabled = true
+base_url = "{base_url}"
+model = "test-model"
+enabled_for = ["gating"]
+max_concurrent = 1
+retry_interval_secs = 1
+request_timeout_secs = 5
+
+[ingest_gating.llm_judge]
+enabled = true
+threshold = 0.5
+"#
+        )
+    }
+
+    async fn spawn_counting_llm_server(
+        count: Arc<AtomicUsize>,
+        notify: Arc<Notify>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{Json, Router, routing::post};
+
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || {
+                let count = Arc::clone(&count);
+                let notify = Arc::clone(&notify);
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    notify.notify_waiters();
+                    Json(serde_json::json!({
+                        "id": "test",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "{\"verdict\":\"keep\",\"score\":0.9}"
+                            },
+                            "finish_reason": "stop"
+                        }],
+                        "model": "test-model",
+                        "usage": {
+                            "prompt_tokens": 1,
+                            "completion_tokens": 1,
+                            "total_tokens": 2
+                        }
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test LLM server");
+        let addr = listener.local_addr().expect("test LLM server address");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test LLM server");
+        });
+        (format!("http://{addr}/v1"), handle)
+    }
+
     fn gating_task(id: &str) -> LlmTaskPayload {
         LlmTaskPayload {
             task_type: "gating".to_string(),
@@ -522,6 +710,86 @@ mod tests {
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)),
             )
             .expect("read LLM audit verdict")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_worker_uses_reloaded_client_when_generation_changes_before_claim_returns() {
+        let _guard = crate::core::config::global_config_test_lock()
+            .lock_owned()
+            .await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        let db_path = tmp.path().join("palace.db");
+
+        let old_count = Arc::new(AtomicUsize::new(0));
+        let new_count = Arc::new(AtomicUsize::new(0));
+        let old_notify = Arc::new(Notify::new());
+        let new_notify = Arc::new(Notify::new());
+        let (old_base_url, old_server) =
+            spawn_counting_llm_server(Arc::clone(&old_count), Arc::clone(&old_notify)).await;
+        let (new_base_url, new_server) =
+            spawn_counting_llm_server(Arc::clone(&new_count), Arc::clone(&new_notify)).await;
+
+        std::fs::write(&config_path, worker_test_config(&old_base_url)).expect("write old config");
+        ConfigHandle::bootstrap_quiet(&config_path).expect("bootstrap old config");
+
+        let db = Database::open(&db_path).expect("open db");
+        let store = PendingMessageStore::new(db.path()).expect("open queue");
+        let task = LlmTaskPayload {
+            task_type: "gating".to_string(),
+            drawer_id: "claim-after-reload-drawer".to_string(),
+            drawer_ids: vec![],
+            content: "claim-after-reload content".to_string(),
+            system_prompt: None,
+        };
+        store
+            .enqueue(
+                LLM_TASK_KIND,
+                &serde_json::to_string(&task).expect("serialize task"),
+            )
+            .expect("enqueue LLM task");
+
+        let async_store = AsyncPendingMessageStore::from_store(store)
+            .with_blocking_delay(Duration::from_millis(500));
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let client_runtime = Arc::new(Mutex::new(LlmClientRuntime::new(
+            &ConfigHandle::current().llm,
+        )));
+        let worker = tokio::spawn(run_llm_worker(
+            Arc::new(async_store),
+            client_runtime,
+            Arc::new(LlmStatus::new(5)),
+            async_db,
+            DaemonWriteObserver::for_test(),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(650)).await;
+        std::fs::write(&config_path, worker_test_config(&new_base_url)).expect("write new config");
+        ConfigHandle::harness_reload_from_path(&config_path);
+
+        let observed_endpoint = tokio::select! {
+            _ = new_notify.notified() => "new",
+            _ = old_notify.notified() => "old",
+            _ = tokio::time::sleep(Duration::from_secs(5)) => "timeout",
+        };
+
+        worker.abort();
+        let _ = worker.await;
+        old_server.abort();
+        new_server.abort();
+        let _ = old_server.await;
+        let _ = new_server.await;
+
+        assert_eq!(
+            observed_endpoint, "new",
+            "task claimed after LLM generation reload must use the fresh client"
+        );
+        assert_eq!(
+            old_count.load(Ordering::SeqCst),
+            0,
+            "stale pre-reload client must not process a claim returned after reload"
+        );
+        assert_eq!(new_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7836,14 +7836,15 @@ mod tests {
     /// resets it to defaults on Drop so other parallel tests do not see leaked
     /// overrides.
     struct ConfigOverrideGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
+        _lock: tokio::sync::OwnedMutexGuard<()>,
         _tempdir: TempDir,
     }
 
     impl ConfigOverrideGuard {
-        fn install(toml_contents: &str) -> Self {
-            static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-            let lock = LOCK.lock().expect("config override lock poisoned");
+        async fn install(toml_contents: &str) -> Self {
+            let lock = crate::core::config::global_config_test_lock()
+                .lock_owned()
+                .await;
             let tempdir = tempfile::tempdir().expect("config override tempdir");
             let path = tempdir.path().join("override.toml");
             fs::write(&path, toml_contents).expect("write config override");
@@ -9043,7 +9044,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_mcp_context_include_cards_omitted_uses_config_default() {
-        let _guard = ConfigOverrideGuard::install("[context]\ninclude_cards_default = true\n");
+        let _guard =
+            ConfigOverrideGuard::install("[context]\ninclude_cards_default = true\n").await;
         let (_tempdir, db_path, server) = setup_server();
         insert_drawer(
             &db_path,
@@ -11136,7 +11138,8 @@ db_path = "{}"
 enabled = true
 "#,
             config_db_path.display()
-        ));
+        ))
+        .await;
 
         let (_tempdir, db_path, server) = setup_server();
         let raw_secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD";
@@ -11330,7 +11333,8 @@ enabled = true
 reject_on_contradiction = true
 "#,
             db_path.display()
-        ));
+        ))
+        .await;
         insert_triple(
             &db_path,
             "Bob",
@@ -11446,7 +11450,8 @@ enabled = false
 enabled = false
 "#,
             db_path.display()
-        ));
+        ))
+        .await;
         let gate = Arc::new(Notify::new());
         let call_count = Arc::new(AtomicUsize::new(0));
         let server = MempalMcpServer::new_with_factory(

--- a/tests/llm_concurrency.rs
+++ b/tests/llm_concurrency.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use mempal::core::config::LlmConfig;
 use mempal::llm::client::LlmClient;
+use tokio::sync::Barrier;
 
 fn test_config(max_concurrent: usize) -> LlmConfig {
     LlmConfig {
@@ -45,6 +46,31 @@ async fn test_update_concurrency_noop_same_value() {
     client.update_concurrency(3).await;
     assert_eq!(client.current_max_concurrent(), 3);
     assert_eq!(client.available_permits(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn test_concurrent_update_concurrency_increase_is_serialized() {
+    let client = Arc::new(LlmClient::from_config(&test_config(2)).unwrap());
+    let workers = 32;
+    let barrier = Arc::new(Barrier::new(workers + 1));
+    let mut handles = Vec::new();
+
+    for _ in 0..workers {
+        let client = client.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            client.update_concurrency(4).await;
+        }));
+    }
+
+    barrier.wait().await;
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    assert_eq!(client.current_max_concurrent(), 4);
+    assert_eq!(client.available_permits(), 4);
 }
 
 #[tokio::test]

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -163,41 +163,84 @@ enabled = true
 fn test_llm_restart_required_fields() {
     let config = Config::default();
     let mut changed = config.clone();
+    changed.llm.enabled = true;
+    changed.llm.backend = "other_backend".to_string();
     changed.llm.base_url = Some("http://localhost:8317/v1".to_string());
     changed.llm.model = Some("qwen35-35b-a3b".to_string());
+    changed.llm.api_key = Some("direct-key".to_string());
     changed.llm.api_key_env = Some("LOCAL_ROUTER_API_KEY".to_string());
+    changed.llm.extra_body = Some(serde_json::json!({"foo": "bar"}));
 
     let fields = config.restart_required_fields_changed(&changed);
 
-    assert!(fields.contains(&"llm.base_url"));
-    // llm.model is now hot-reloadable
+    assert!(fields.contains(&"llm.enabled"));
+    assert!(fields.contains(&"llm.backend"));
+    // LLM endpoint/client request fields are hot-reloadable.
+    assert!(!fields.contains(&"llm.base_url"));
     assert!(!fields.contains(&"llm.model"));
-    assert!(fields.contains(&"llm.api_key_env"));
+    assert!(!fields.contains(&"llm.api_key"));
+    assert!(!fields.contains(&"llm.api_key_env"));
+    assert!(!fields.contains(&"llm.extra_body"));
 }
 
 #[test]
 fn test_llm_runtime_allowed_fields_hot_reload() {
     let mut current = Config::default();
+    current.llm.enabled = true;
+    current.llm.backend = "openai_compat".to_string();
     current.llm.base_url = Some("http://localhost:8317/v1".to_string());
     current.llm.model = Some("qwen35-35b-a3b".to_string());
+    current.llm.api_key = Some("direct-key".to_string());
     current.llm.api_key_env = Some("LOCAL_ROUTER_API_KEY".to_string());
 
     let mut candidate = current.clone();
     candidate.llm.base_url = Some("http://localhost:9000/v1".to_string());
     candidate.llm.model = Some("other-model".to_string());
+    candidate.llm.api_key = Some("other-direct-key".to_string());
     candidate.llm.api_key_env = Some("OTHER_KEY".to_string());
+    candidate.llm.extra_body =
+        Some(serde_json::json!({"chat_template_kwargs": {"enable_thinking": false}}));
     candidate.llm.max_concurrent = 4;
     candidate.llm.enabled_for = vec!["gating".to_string(), "distill".to_string()];
 
     let effective = current.merge_runtime_allowed(&candidate);
 
-    assert_eq!(effective.llm.base_url, current.llm.base_url);
-    // llm.model is hot-reloadable — candidate value takes effect
+    assert_eq!(effective.llm.enabled, current.llm.enabled);
+    assert_eq!(effective.llm.backend, current.llm.backend);
+    assert_eq!(effective.llm.base_url, candidate.llm.base_url);
     assert_eq!(effective.llm.model, candidate.llm.model);
-    assert_eq!(effective.llm.api_key_env, current.llm.api_key_env);
+    assert_eq!(effective.llm.api_key, candidate.llm.api_key);
+    assert_eq!(effective.llm.api_key_env, candidate.llm.api_key_env);
+    assert_eq!(effective.llm.extra_body, candidate.llm.extra_body);
     assert_eq!(effective.llm.max_concurrent, 4);
     assert_eq!(
         effective.llm.enabled_for,
         vec!["gating".to_string(), "distill".to_string()]
     );
+}
+
+#[test]
+fn test_llm_lifecycle_change_preserves_live_client_config() {
+    let mut current = Config::default();
+    current.llm.enabled = true;
+    current.llm.backend = "openai_compat".to_string();
+    current.llm.base_url = Some("http://localhost:8317/v1".to_string());
+    current.llm.model = Some("qwen35-35b-a3b".to_string());
+    current.llm.api_key = Some("direct-key".to_string());
+    current.llm.api_key_env = Some("LOCAL_ROUTER_API_KEY".to_string());
+    current.llm.max_concurrent = 2;
+
+    let mut candidate = current.clone();
+    candidate.llm.enabled = false;
+    candidate.llm.base_url = None;
+    candidate.llm.model = None;
+    candidate.llm.api_key = None;
+    candidate.llm.api_key_env = None;
+    candidate.llm.extra_body = None;
+    candidate.llm.max_concurrent = 4;
+    candidate.llm.enabled_for = vec!["distill".to_string()];
+
+    let effective = current.merge_runtime_allowed(&candidate);
+
+    assert_eq!(effective.llm, current.llm);
 }

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -11,7 +11,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::{ClaimedMessage, PendingMessageStore};
 use mempal::llm::client::LlmClient;
 use mempal::llm::status::LlmStatus;
-use mempal::llm::worker::confirm_llm_task;
+use mempal::llm::worker::{LlmClientRuntime, confirm_llm_task};
 use mempal::llm::{LlmError, LlmTaskPayload};
 use tokio::sync::Notify;
 
@@ -197,6 +197,50 @@ model = "model-b"
 }
 
 #[test]
+fn test_llm_gen_increments_on_endpoint_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-stable"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_llm_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:20000/v1"
+model = "model-stable"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert!(
+        gen_after > gen_before,
+        "generation must increment when llm.base_url changes (before={gen_before}, after={gen_after})"
+    );
+    assert_eq!(
+        ConfigHandle::current().llm.base_url.as_deref(),
+        Some("http://127.0.0.1:20000/v1")
+    );
+}
+
+#[test]
 fn test_llm_gen_does_not_increment_on_unrelated_change() {
     let _guard = TEST_LOCK.lock().expect("test lock");
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -238,6 +282,54 @@ preview_chars = 200
         gen_after, gen_before,
         "generation must NOT change for non-LLM config changes"
     );
+}
+
+#[test]
+fn test_llm_client_runtime_rebuilds_on_endpoint_change() {
+    let config = LlmConfig {
+        enabled: true,
+        base_url: Some("http://127.0.0.1:19999/v1".to_string()),
+        model: Some("model-stable".to_string()),
+        ..Default::default()
+    };
+    let mut runtime = LlmClientRuntime::new(&config);
+    let first = runtime
+        .client_for_config(&config)
+        .expect("load initial client");
+
+    let mut changed = config.clone();
+    changed.base_url = Some("http://127.0.0.1:20000/v1".to_string());
+    let second = runtime
+        .client_for_config(&changed)
+        .expect("rebuild changed client");
+
+    assert!(
+        !Arc::ptr_eq(&first, &second),
+        "endpoint changes must rebuild LLM client"
+    );
+}
+
+#[test]
+fn test_llm_client_runtime_recovers_after_invalid_initial_config() {
+    let invalid = LlmConfig {
+        enabled: true,
+        base_url: None,
+        model: Some("model-stable".to_string()),
+        ..Default::default()
+    };
+    let mut runtime = LlmClientRuntime::new(&invalid);
+    assert!(
+        runtime.client_for_config(&invalid).is_err(),
+        "invalid initial config should be retried from the worker loop"
+    );
+
+    let mut fixed = invalid.clone();
+    fixed.base_url = Some("http://127.0.0.1:19999/v1".to_string());
+    let client = runtime
+        .client_for_config(&fixed)
+        .expect("fixed config should build a client");
+
+    assert_eq!(client.current_max_concurrent(), fixed.max_concurrent.max(1));
 }
 
 // ── tokio::select! cancellation ───────────────────────────────────────────────

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "feb6aa1368c181d2b41748be1a46310ea75bd9c4"
+commit = "00540c784d704692484dd63a762df7792bb63874"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #366.

- Hot-reload LLM endpoint/client request fields: endpoint, model, credentials, extra body, timeout, retry interval, concurrency, and enabled_for.
- Keep `llm.enabled` and `llm.backend` restart-required lifecycle fields.
- Rebuild the shared LLM client after claim using the current LLM generation, so tasks claimed after reload do not use stale endpoint/credential clients.
- Keep LLM workers alive when startup LLM config is temporarily invalid so later hot reload can recover.
- Preserve live LLM config as a group when restart-required lifecycle fields change.
- Serialize lib tests that override the global ConfigHandle snapshot to avoid cross-test contamination.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --lib llm::worker::tests::test_worker_uses_reloaded_client_when_generation_changes_before_claim_returns -- --nocapture`
- `cargo test --lib`
- pre-commit hook: `just clippy`
- pre-commit hook: `just test`
- pre-push review gate passed for `ea9281c8f54`

## Review

- CSA tier4 full-diff review PASS: `01KTTEWTPBF2A70N09T9RVVXH3`
- Gemini hit rate-limit 429; CSA fallback to Codex completed the review successfully.
