### PR TITLE
feat(llm): add endpoint pool fallback

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -178,6 +178,7 @@ impl Config {
 
     pub fn parse(contents: &str) -> Result<Self, ConfigError> {
         let root: toml::Value = toml::from_str(contents)?;
+        validate_llm_endpoint_pool_toml(&root)?;
         let mut config: Self = toml::from_str(contents)?;
         if root.get("embed").is_none() && root.get("embedder").is_none() {
             config.embed.backend = "model2vec".to_string();
@@ -297,13 +298,8 @@ impl Config {
                 "embed.retry.search_deadline_secs must be greater than 0".to_string(),
             ));
         }
-        if self.llm.enabled
-            && self
-                .llm
-                .base_url
-                .as_deref()
-                .is_none_or(|base_url| base_url.trim().is_empty())
-        {
+        self.llm.validate_endpoint_pool()?;
+        if self.llm.enabled && self.llm.effective_endpoints()?.is_empty() {
             return Err(ConfigError::Validation(
                 "llm.base_url must be set when llm.enabled is true".to_string(),
             ));
@@ -666,32 +662,58 @@ impl Config {
     }
 
     fn llm_base_url_locality_warnings(&self) -> Vec<RuntimeWarning> {
-        [
-            ("llm.base_url", self.llm.base_url.as_deref()),
-            (
-                "memory_intelligence.llm.base_url",
-                self.memory_intelligence.llm.base_url.as_deref(),
-            ),
-        ]
-        .into_iter()
-        .filter_map(|(setting, base_url)| {
-            let base_url = base_url?.trim();
+        let mut warnings = Vec::new();
+        warnings.extend(llm_endpoint_locality_warnings(
+            "llm",
+            self.llm
+                .effective_endpoints()
+                .ok()
+                .as_deref()
+                .unwrap_or(&[]),
+        ));
+        if self.memory_intelligence.llm.defines_endpoint() {
+            let effective = self.memory_intelligence.effective_llm_config(&self.llm);
+            warnings.extend(llm_endpoint_locality_warnings(
+                "memory_intelligence.llm",
+                effective
+                    .effective_endpoints()
+                    .ok()
+                    .as_deref()
+                    .unwrap_or(&[]),
+            ));
+        }
+        warnings
+    }
+}
+
+fn llm_endpoint_locality_warnings(
+    setting: &str,
+    endpoints: &[EffectiveLlmEndpoint],
+) -> Vec<RuntimeWarning> {
+    endpoints
+        .iter()
+        .filter_map(|endpoint| {
+            let base_url = endpoint.base_url.trim();
             if base_url.is_empty() || llm_base_url_is_local_or_lan(base_url) {
                 return None;
             }
             let host = llm_base_url_host(base_url)
                 .map(|host| format!(" host `{host}`"))
                 .unwrap_or_default();
+            let field = if endpoint.id == "legacy" {
+                format!("{setting}.base_url")
+            } else {
+                format!("{setting}.endpoints[{}].base_url", endpoint.id)
+            };
             Some(RuntimeWarning {
                 level: "warn",
                 source: "llm",
                 message: format!(
-                    "{setting}{host} appears outside localhost/LAN; mempal assumes user-configured LLM endpoints are local or private network and does not block operation"
+                    "{field}{host} appears outside localhost/LAN; mempal assumes user-configured LLM endpoints are local or private network and does not block operation"
                 ),
             })
         })
         .collect()
-    }
 }
 
 fn llm_base_url_is_local_or_lan(base_url: &str) -> bool {
@@ -716,6 +738,97 @@ fn llm_base_url_host(base_url: &str) -> Option<String> {
     Url::parse(base_url)
         .ok()
         .and_then(|url| url.host_str().map(str::to_string))
+}
+
+fn validate_llm_endpoint_pool_toml(root: &toml::Value) -> Result<(), ConfigError> {
+    let Some(llm) = root.get("llm").and_then(toml::Value::as_table) else {
+        return Ok(());
+    };
+    if !llm.contains_key("endpoints") {
+        return Ok(());
+    }
+    let scalar_keys = ["base_url", "model", "api_key", "api_key_env", "extra_body"];
+    let conflicts = scalar_keys
+        .into_iter()
+        .filter(|key| llm.contains_key(*key))
+        .collect::<Vec<_>>();
+    if conflicts.is_empty() {
+        return Ok(());
+    }
+    Err(ConfigError::Validation(format!(
+        "llm endpoint list cannot be combined with legacy scalar endpoint fields: {}",
+        conflicts.join(", ")
+    )))
+}
+
+fn normalize_llm_endpoint_id(
+    configured: Option<&str>,
+    index: usize,
+) -> Result<String, ConfigError> {
+    let id = configured
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("endpoint-{}", index + 1));
+    if id.len() > 64
+        || !id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+    {
+        return Err(ConfigError::Validation(format!(
+            "llm endpoint id `{id}` must match [A-Za-z0-9_.-]{{1,64}}"
+        )));
+    }
+    Ok(id)
+}
+
+fn normalize_llm_endpoint_base_url(
+    base_url: Option<&str>,
+    field: &str,
+) -> Result<String, ConfigError> {
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .ok_or_else(|| ConfigError::Validation(format!("{field} must not be empty")))?
+        .trim_end_matches('/')
+        .to_string();
+    validate_llm_base_url(&base_url).map_err(ConfigError::Validation)?;
+    Ok(base_url)
+}
+
+fn normalize_llm_endpoint_model(model: Option<&str>, field: &str) -> Result<String, ConfigError> {
+    model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| ConfigError::Validation(format!("{field} must not be empty")))
+}
+
+pub fn validate_llm_base_url(base_url: &str) -> Result<(), String> {
+    let parsed = Url::parse(base_url)
+        .map_err(|error| format!("invalid llm.base_url `{base_url}`: {error}"))?;
+    if parsed.scheme().is_empty() {
+        return Err("llm.base_url must include a URL scheme".to_string());
+    }
+    if parsed.host_str().is_none() {
+        return Err("llm.base_url must include a host".to_string());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(
+            "llm.base_url must not include userinfo credentials; use api_key_env instead"
+                .to_string(),
+        );
+    }
+    if parsed.query().is_some() {
+        return Err(
+            "llm.base_url must not include query parameters; move secrets to api_key_env"
+                .to_string(),
+        );
+    }
+    if parsed.fragment().is_some() {
+        return Err("llm.base_url must not include URL fragments".to_string());
+    }
+    Ok(())
 }
 
 pub(crate) fn scrub_sensitive_text(input: &str) -> String {
@@ -963,6 +1076,7 @@ pub struct LlmConfig {
     pub api_key: Option<String>,
     pub api_key_env: Option<String>,
     pub extra_body: Option<serde_json::Value>,
+    pub endpoints: Vec<LlmEndpointConfig>,
     #[serde(alias = "timeout_secs")]
     pub request_timeout_secs: u64,
     pub retry_interval_secs: u64,
@@ -980,12 +1094,210 @@ impl Default for LlmConfig {
             api_key: None,
             api_key_env: None,
             extra_body: None,
+            endpoints: Vec::new(),
             request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
             retry_interval_secs: DEFAULT_LLM_RETRY_INTERVAL_SECS,
             max_concurrent: DEFAULT_LLM_MAX_CONCURRENT,
             enabled_for: vec!["gating".to_string()],
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct LlmEndpointConfig {
+    pub id: Option<String>,
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+    pub api_key: Option<String>,
+    pub api_key_env: Option<String>,
+    pub extra_body: Option<serde_json::Value>,
+    #[serde(alias = "timeout_secs")]
+    pub request_timeout_secs: Option<u64>,
+    pub max_concurrent: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveLlmEndpoint {
+    pub id: String,
+    pub base_url: String,
+    pub model: String,
+    pub api_key: Option<String>,
+    pub api_key_env: Option<String>,
+    pub extra_body: Option<serde_json::Value>,
+    pub request_timeout_secs: u64,
+    pub max_concurrent: usize,
+}
+
+impl EffectiveLlmEndpoint {
+    pub fn model_label(&self) -> String {
+        format!("{}={}", self.id, self.model)
+    }
+
+    pub fn base_url_label(&self) -> String {
+        format!("{}={}", self.id, self.base_url)
+    }
+}
+
+impl LlmConfig {
+    pub fn effective_endpoints(&self) -> Result<Vec<EffectiveLlmEndpoint>, ConfigError> {
+        self.validate_endpoint_pool()?;
+        if self.endpoints.is_empty() {
+            return self
+                .legacy_effective_endpoint()
+                .map(|endpoint| endpoint.into_iter().collect::<Vec<EffectiveLlmEndpoint>>());
+        }
+
+        let mut seen = std::collections::BTreeSet::new();
+        self.endpoints
+            .iter()
+            .enumerate()
+            .map(|(index, endpoint)| {
+                let id = normalize_llm_endpoint_id(endpoint.id.as_deref(), index)?;
+                if !seen.insert(id.clone()) {
+                    return Err(ConfigError::Validation(format!(
+                        "llm.endpoints id `{id}` must be unique"
+                    )));
+                }
+                let base_url = normalize_llm_endpoint_base_url(
+                    endpoint.base_url.as_deref(),
+                    format!("llm.endpoints[{index}].base_url").as_str(),
+                )?;
+                let model = normalize_llm_endpoint_model(
+                    endpoint.model.as_deref(),
+                    format!("llm.endpoints[{index}].model").as_str(),
+                )?;
+                Ok(EffectiveLlmEndpoint {
+                    id,
+                    base_url,
+                    model,
+                    api_key: endpoint.api_key.clone(),
+                    api_key_env: endpoint.api_key_env.clone(),
+                    extra_body: endpoint.extra_body.clone(),
+                    request_timeout_secs: endpoint
+                        .request_timeout_secs
+                        .unwrap_or(self.request_timeout_secs),
+                    max_concurrent: endpoint
+                        .max_concurrent
+                        .unwrap_or(self.max_concurrent)
+                        .max(1),
+                })
+            })
+            .collect()
+    }
+
+    pub fn validate_endpoint_pool(&self) -> Result<(), ConfigError> {
+        if self.endpoints.is_empty() {
+            return Ok(());
+        }
+        if self.has_legacy_endpoint_definition() {
+            return Err(ConfigError::Validation(
+                "llm endpoint list cannot be combined with legacy scalar endpoint fields"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn effective_model_summary(&self) -> Option<String> {
+        summarize_effective_endpoints(
+            self,
+            |endpoint| endpoint.model.clone(),
+            EffectiveLlmEndpoint::model_label,
+        )
+    }
+
+    pub fn effective_base_url_summary(&self) -> Option<String> {
+        summarize_effective_endpoints(
+            self,
+            |endpoint| endpoint.base_url.clone(),
+            EffectiveLlmEndpoint::base_url_label,
+        )
+    }
+
+    pub fn effective_endpoint_fingerprints(&self) -> Vec<serde_json::Value> {
+        self.effective_endpoints()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|endpoint| {
+                serde_json::json!({
+                    "id": endpoint.id,
+                    "base_url": endpoint.base_url,
+                    "model": endpoint.model,
+                    "api_key_env": endpoint.api_key_env,
+                    "extra_body": endpoint.extra_body,
+                    "request_timeout_secs": endpoint.request_timeout_secs,
+                    "max_concurrent": endpoint.max_concurrent,
+                })
+            })
+            .collect()
+    }
+
+    fn legacy_effective_endpoint(&self) -> Result<Option<EffectiveLlmEndpoint>, ConfigError> {
+        let has_base_url = self
+            .base_url
+            .as_deref()
+            .is_some_and(|base_url| !base_url.trim().is_empty());
+        let has_model = self
+            .model
+            .as_deref()
+            .is_some_and(|model| !model.trim().is_empty());
+        if !has_base_url && !has_model {
+            return Ok(None);
+        }
+        let base_url = normalize_llm_endpoint_base_url(self.base_url.as_deref(), "llm.base_url")?;
+        let model = normalize_llm_endpoint_model(self.model.as_deref(), "llm.model")?;
+        Ok(Some(EffectiveLlmEndpoint {
+            id: "legacy".to_string(),
+            base_url,
+            model,
+            api_key: self.api_key.clone(),
+            api_key_env: self.api_key_env.clone(),
+            extra_body: self.extra_body.clone(),
+            request_timeout_secs: self.request_timeout_secs,
+            max_concurrent: self.max_concurrent.max(1),
+        }))
+    }
+
+    fn has_legacy_endpoint_definition(&self) -> bool {
+        self.base_url
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .model
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .api_key
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .api_key_env
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self.extra_body.is_some()
+    }
+}
+
+fn summarize_effective_endpoints(
+    config: &LlmConfig,
+    single_label: fn(&EffectiveLlmEndpoint) -> String,
+    multi_label: fn(&EffectiveLlmEndpoint) -> String,
+) -> Option<String> {
+    let endpoints = config.effective_endpoints().ok()?;
+    if endpoints.is_empty() {
+        return None;
+    }
+    if endpoints.len() == 1 {
+        return endpoints.first().map(single_label);
+    }
+    Some(
+        endpoints
+            .iter()
+            .map(multi_label)
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -1008,39 +1320,55 @@ impl MemoryIntelligenceConfig {
     pub fn effective_llm_config(&self, base: &LlmConfig) -> LlmConfig {
         let mut config = base.clone();
         config.enabled = self.mode.uses_llm();
+        let overlay_defines_endpoint_identity = self.llm.defines_endpoint_identity();
+        if overlay_defines_endpoint_identity {
+            config.endpoints.clear();
+        }
         if self.llm.base_url.is_some() {
             config.base_url = self.llm.base_url.clone();
         }
         if self.llm.model.is_some() {
             config.model = self.llm.model.clone();
         }
-        if self.llm.api_key.is_some() {
-            config.api_key = self.llm.api_key.clone();
-        }
-        if self.llm.api_key_env.is_some() {
-            config.api_key_env = self.llm.api_key_env.clone();
-        }
-        if self.llm.extra_body.is_some() {
-            config.extra_body = self.llm.extra_body.clone();
-        }
         config.request_timeout_secs = self.llm.timeout_secs;
+        if !overlay_defines_endpoint_identity && !config.endpoints.is_empty() {
+            for endpoint in &mut config.endpoints {
+                if self.llm.api_key.is_some() {
+                    endpoint.api_key = self.llm.api_key.clone();
+                }
+                if self.llm.api_key_env.is_some() {
+                    if self.llm.api_key.is_none() {
+                        endpoint.api_key = None;
+                    }
+                    endpoint.api_key_env = self.llm.api_key_env.clone();
+                }
+                if self.llm.extra_body.is_some() {
+                    endpoint.extra_body = self.llm.extra_body.clone();
+                }
+            }
+        } else {
+            if self.llm.api_key.is_some() {
+                config.api_key = self.llm.api_key.clone();
+            }
+            if self.llm.api_key_env.is_some() {
+                if self.llm.api_key.is_none() {
+                    config.api_key = None;
+                }
+                config.api_key_env = self.llm.api_key_env.clone();
+            }
+            if self.llm.extra_body.is_some() {
+                config.extra_body = self.llm.extra_body.clone();
+            }
+        }
         config
     }
 
     pub fn has_effective_llm_endpoint(&self, base: &LlmConfig) -> bool {
+        let effective = self.effective_llm_config(base);
         self.mode.uses_llm()
-            && self
-                .llm
-                .base_url
-                .as_deref()
-                .or(base.base_url.as_deref())
-                .is_some_and(|value| !value.trim().is_empty())
-            && self
-                .llm
-                .model
-                .as_deref()
-                .or(base.model.as_deref())
-                .is_some_and(|value| !value.trim().is_empty())
+            && effective
+                .effective_endpoints()
+                .is_ok_and(|endpoints| !endpoints.is_empty())
     }
 }
 
@@ -1053,6 +1381,37 @@ pub struct MemoryIntelligenceLlmConfig {
     pub api_key_env: Option<String>,
     pub timeout_secs: u64,
     pub extra_body: Option<serde_json::Value>,
+}
+
+impl MemoryIntelligenceLlmConfig {
+    fn defines_endpoint_identity(&self) -> bool {
+        self.base_url
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .model
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    pub fn defines_endpoint(&self) -> bool {
+        self.base_url
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .model
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .api_key
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .api_key_env
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self.extra_body.is_some()
+    }
 }
 
 impl Default for MemoryIntelligenceLlmConfig {

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -478,6 +478,7 @@ impl HotReloadState {
             || previous.config.llm.api_key != effective.llm.api_key
             || previous.config.llm.api_key_env != effective.llm.api_key_env
             || previous.config.llm.extra_body != effective.llm.extra_body
+            || previous.config.llm.endpoints != effective.llm.endpoints
             || previous.config.llm.request_timeout_secs != effective.llm.request_timeout_secs
             || previous.config.llm.max_concurrent != effective.llm.max_concurrent
             || previous.config.llm.retry_interval_secs != effective.llm.retry_interval_secs

--- a/src/crystallize.rs
+++ b/src/crystallize.rs
@@ -14,7 +14,7 @@ use crate::core::types::{
 };
 use crate::core::utils::current_timestamp;
 use crate::intelligence::global_intelligence_status;
-use crate::llm::{LlmClient, LlmMessage, LlmRequest};
+use crate::llm::{LlmMessage, LlmRequest, LlmRouter};
 
 #[derive(Debug, Error)]
 pub enum CrystallizeError {
@@ -140,7 +140,7 @@ async fn run_crystallization_inner(
             .has_effective_llm_endpoint(&config.llm)
             .then(|| {
                 let llm_config = config.memory_intelligence.effective_llm_config(&config.llm);
-                LlmClient::from_config(&llm_config)
+                LlmRouter::from_config(&llm_config)
             })
             .transpose()?
     } else {
@@ -504,7 +504,7 @@ fn stable_card_id(source_drawer_ids: &[String]) -> String {
 }
 
 async fn enhance_candidate_with_llm(
-    client: &LlmClient,
+    router: &LlmRouter,
     candidate: &CrystallizeCandidate,
 ) -> Result<CardDraft> {
     let payload = serde_json::json!({
@@ -513,7 +513,7 @@ async fn enhance_candidate_with_llm(
         "deterministic_statement": candidate.card.statement,
         "deterministic_content": candidate.card.content,
     });
-    let response = client
+    let response = router
         .chat_completion(&LlmRequest {
             messages: vec![
                 LlmMessage {
@@ -528,8 +528,9 @@ async fn enhance_candidate_with_llm(
             model: None,
             temperature: Some(0.0),
             max_tokens: Some(1024),
-        })
+        }, None)
         .await?;
+    let response = response.response;
     let decoded: LlmCardDraft = serde_json::from_str(response.content.trim())?;
     validate_llm_draft(candidate, decoded)
 }
@@ -614,7 +615,8 @@ fn stable_prefixed_id(prefix: &str, parts: &[&str]) -> String {
 mod tests {
     use super::*;
     use crate::core::config::Config;
-    use crate::core::types::{BootstrapEvidenceArgs, SourceType};
+    use crate::core::types::{BootstrapEvidenceArgs, IntelligenceMode, SourceType};
+    use mockito::Server;
     use tempfile::TempDir;
 
     fn new_db() -> (TempDir, Database) {
@@ -775,5 +777,85 @@ mod tests {
 
         assert_eq!(summary.cards_created, 0);
         assert_eq!(db.knowledge_card_count().expect("card count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_crystallize_uses_endpoint_pool_fallback() {
+        let (_tmp, db) = new_db();
+        seed_related_drawers(&db);
+        let mut primary = Server::new_async().await;
+        let mut secondary = Server::new_async().await;
+        let primary_mock = primary
+            .mock("POST", "/v1/chat/completions")
+            .with_status(500)
+            .with_body("primary unavailable")
+            .create_async()
+            .await;
+        let draft = serde_json::json!({
+            "statement": "Rust memory cards preserve citations.",
+            "content": "LLM-drafted card that still preserves all source ids.",
+            "source_drawer_ids": ["drawer_1", "drawer_2", "drawer_3", "drawer_4", "drawer_5"]
+        });
+        let secondary_mock = secondary
+            .mock("POST", "/v1/chat/completions")
+            .with_status(200)
+            .with_body(
+                serde_json::json!({
+                    "model": "secondary-model",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": draft.to_string()
+                            }
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let mut config = config();
+        config.memory_intelligence.mode = IntelligenceMode::LocalLlm;
+        config.llm = Config::parse(&format!(
+            r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "{}/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "{}/v1"
+model = "secondary-model"
+"#,
+            primary.url(),
+            secondary.url()
+        ))
+        .expect("parse endpoint pool")
+        .llm;
+
+        let summary = run_crystallization(
+            &db,
+            &config,
+            CrystallizeOptions {
+                dry_run: true,
+                project_id: None,
+                use_llm: true,
+            },
+        )
+        .await
+        .expect("crystallize");
+
+        primary_mock.assert_async().await;
+        secondary_mock.assert_async().await;
+        assert!(summary.used_llm);
+        assert_eq!(
+            summary.candidates[0].card.statement,
+            "Rust memory cards preserve citations."
+        );
     }
 }

--- a/src/endpoint_health.rs
+++ b/src/endpoint_health.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use tokio::time::timeout;
 
-use crate::core::config::Config;
+use crate::core::config::{Config, EffectiveLlmEndpoint};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -88,19 +88,32 @@ async fn probe_llm(config: &Config) -> ProbeStatus {
     if !effective_llm.enabled {
         return ProbeStatus::unreachable("disabled".to_string());
     }
-    let Some(base_url) = effective_llm
-        .base_url
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    else {
-        return ProbeStatus::unreachable("missing base_url".to_string());
+    let endpoints = match effective_llm.effective_endpoints() {
+        Ok(endpoints) if !endpoints.is_empty() => endpoints,
+        Ok(_) => return ProbeStatus::unreachable("missing base_url".to_string()),
+        Err(error) => return ProbeStatus::unreachable(error.to_string()),
     };
-    probe_models_endpoint(
-        base_url,
-        effective_llm.api_key_env.as_deref(),
-        effective_llm.api_key.as_deref(),
-    )
-    .await
+    probe_llm_endpoints(&endpoints).await
+}
+
+async fn probe_llm_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> ProbeStatus {
+    let mut failures = Vec::new();
+    for endpoint in endpoints {
+        let status = probe_models_endpoint(
+            &endpoint.base_url,
+            endpoint.api_key_env.as_deref(),
+            endpoint.api_key.as_deref(),
+        )
+        .await;
+        if status.reachable {
+            return ProbeStatus::reachable(
+                status.latency_ms,
+                format!("http probe via {}", endpoint.id),
+            );
+        }
+        failures.push(format!("{}: {}", endpoint.id, status.detail));
+    }
+    ProbeStatus::unreachable(failures.join("; "))
 }
 
 async fn probe_models_endpoint(

--- a/src/intelligence.rs
+++ b/src/intelligence.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::core::config::Config;
 use crate::core::types::{IntelligenceMode, SearchResult, Triple};
 use crate::core::utils::{build_triple_id, current_timestamp};
-use crate::llm::{LlmClient, LlmMessage, LlmRequest};
+use crate::llm::{LlmMessage, LlmRequest, LlmRouter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnhancedContent {
@@ -125,7 +125,7 @@ impl IntelligenceRouter {
             .has_effective_llm_endpoint(&config.llm)
         {
             let llm_config = config.memory_intelligence.effective_llm_config(&config.llm);
-            LlmClient::from_config(&llm_config)
+            LlmRouter::from_config(&llm_config)
                 .ok()
                 .map(LlmIntelligenceEnhancer::new)
         } else {
@@ -252,12 +252,12 @@ impl IntelligenceEnhancer for DeterministicIntelligenceEnhancer {
 }
 
 pub struct LlmIntelligenceEnhancer {
-    client: LlmClient,
+    router: LlmRouter,
 }
 
 impl LlmIntelligenceEnhancer {
-    pub fn new(client: LlmClient) -> Self {
-        Self { client }
+    pub fn new(router: LlmRouter) -> Self {
+        Self { router }
     }
 }
 
@@ -265,7 +265,7 @@ impl LlmIntelligenceEnhancer {
 impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
     async fn enhance_ingest(&self, raw_content: &str) -> Result<EnhancedContent> {
         let response = self
-            .client
+            .router
             .chat_completion(&LlmRequest {
                 messages: vec![
                     LlmMessage {
@@ -280,8 +280,9 @@ impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
                 model: None,
                 temperature: Some(0.0),
                 max_tokens: Some(512),
-            })
+            }, None)
             .await?;
+        let response = response.response;
         let decoded: LlmEnhancedContent = parse_llm_json(&response.content)?;
         validate_enhanced_content(raw_content, decoded)
     }
@@ -298,7 +299,7 @@ impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
             .collect::<Vec<_>>()
             .join("\n---\n");
         let response = self
-            .client
+            .router
             .chat_completion(&LlmRequest {
                 messages: vec![
                     LlmMessage {
@@ -313,15 +314,16 @@ impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
                 model: None,
                 temperature: Some(0.0),
                 max_tokens: Some(1024),
-            })
+            }, None)
             .await?;
+        let response = response.response;
         let decoded: LlmEnhancedResults = parse_llm_json(&response.content)?;
         validate_search_results(results, decoded)
     }
 
     async fn extract_kg_triples(&self, content: &str) -> Result<Vec<Triple>> {
         let response = self
-            .client
+            .router
             .chat_completion(&LlmRequest {
                 messages: vec![
                     LlmMessage {
@@ -336,15 +338,16 @@ impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
                 model: None,
                 temperature: Some(0.0),
                 max_tokens: Some(512),
-            })
+            }, None)
             .await?;
+        let response = response.response;
         let decoded: LlmTriples = parse_llm_json(&response.content)?;
         validate_triples(content, decoded)
     }
 
     async fn explain_contradiction(&self, a: &str, b: &str) -> Result<String> {
         let response = self
-            .client
+            .router
             .chat_completion(&LlmRequest {
                 messages: vec![
                     LlmMessage {
@@ -359,8 +362,9 @@ impl IntelligenceEnhancer for LlmIntelligenceEnhancer {
                 model: None,
                 temperature: Some(0.0),
                 max_tokens: Some(256),
-            })
+            }, None)
             .await?;
+        let response = response.response;
         let decoded: LlmExplanation = parse_llm_json(&response.content)?;
         let explanation = decoded.explanation.trim();
         if explanation.is_empty() {

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -3,14 +3,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use reqwest::StatusCode;
-use reqwest::Url;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use tokio::sync::{Mutex, Semaphore};
 
-use crate::core::config::LlmConfig;
+use crate::core::config::{EffectiveLlmEndpoint, LlmConfig, validate_llm_base_url};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LlmMessage {
@@ -58,6 +57,11 @@ pub enum LlmError {
     },
     #[error("LLM request timed out")]
     Timeout,
+    #[error("all LLM endpoints are temporarily unavailable: {reason}")]
+    TemporarilyUnavailable {
+        retry_after: Duration,
+        reason: String,
+    },
     #[error("missing LLM configuration: {0}")]
     MissingConfiguration(String),
 }
@@ -65,7 +69,7 @@ pub enum LlmError {
 impl LlmError {
     pub fn is_retryable(&self) -> bool {
         match self {
-            Self::HttpRequest { .. } | Self::Timeout => true,
+            Self::HttpRequest { .. } | Self::Timeout | Self::TemporarilyUnavailable { .. } => true,
             Self::HttpStatus { status, .. } => status.is_server_error(),
             Self::ClientError { status, .. } => *status == StatusCode::TOO_MANY_REQUESTS,
             Self::DecodeResponse(_) | Self::MissingConfiguration(_) => false,
@@ -86,30 +90,26 @@ pub struct LlmClient {
 
 impl LlmClient {
     pub fn from_config(config: &LlmConfig) -> Result<Self, LlmError> {
-        let base_url = config
-            .base_url
-            .as_deref()
-            .filter(|base_url| !base_url.trim().is_empty())
-            .ok_or_else(|| {
-                LlmError::MissingConfiguration(
-                    "llm.base_url is required for backend=openai_compat; example: http://127.0.0.1:8317/v1"
-                        .to_string(),
-                )
-            })?
-            .trim_end_matches('/')
-            .to_string();
-        validate_base_url(&base_url)?;
+        let mut endpoints = config
+            .effective_endpoints()
+            .map_err(|error| LlmError::MissingConfiguration(error.to_string()))?;
+        let endpoint = if endpoints.is_empty() {
+            return Err(LlmError::MissingConfiguration(
+                "llm.base_url is required for backend=openai_compat; example: http://127.0.0.1:8317/v1"
+                    .to_string(),
+            ));
+        } else {
+            endpoints.remove(0)
+        };
+        Self::from_endpoint(&endpoint)
+    }
 
-        let model = config
-            .model
-            .as_deref()
-            .filter(|model| !model.trim().is_empty())
-            .ok_or_else(|| LlmError::MissingConfiguration("llm.model".to_string()))?
-            .to_string();
+    pub fn from_endpoint(endpoint: &EffectiveLlmEndpoint) -> Result<Self, LlmError> {
+        validate_base_url(&endpoint.base_url)?;
 
         let mut headers = HeaderMap::new();
         let resolved_key =
-            resolve_api_key(config.api_key.as_deref(), config.api_key_env.as_deref())?;
+            resolve_api_key(endpoint.api_key.as_deref(), endpoint.api_key_env.as_deref())?;
         if let Some(api_key) = resolved_key {
             let header_value =
                 HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|error| {
@@ -122,16 +122,16 @@ impl LlmClient {
 
         let http = reqwest::Client::builder()
             .default_headers(headers)
-            .timeout(Duration::from_secs(config.request_timeout_secs))
+            .timeout(Duration::from_secs(endpoint.request_timeout_secs))
             .build()
             .map_err(|source| LlmError::HttpRequest { source })?;
 
-        let max_concurrent = config.max_concurrent.max(1);
+        let max_concurrent = endpoint.max_concurrent.max(1);
         Ok(Self {
             http,
-            base_url,
-            model,
-            extra_body: config.extra_body.clone(),
+            base_url: endpoint.base_url.clone(),
+            model: endpoint.model.clone(),
+            extra_body: endpoint.extra_body.clone(),
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
             current_max: Arc::new(AtomicUsize::new(max_concurrent)),
             concurrency_update_lock: Mutex::new(()),
@@ -285,27 +285,7 @@ fn read_api_key(api_key_env: Option<&str>) -> Result<Option<String>, LlmError> {
 }
 
 fn validate_base_url(base_url: &str) -> Result<(), LlmError> {
-    let parsed = Url::parse(base_url).map_err(|error| {
-        LlmError::MissingConfiguration(format!("invalid llm.base_url `{base_url}`: {error}"))
-    })?;
-    if !parsed.username().is_empty() || parsed.password().is_some() {
-        return Err(LlmError::MissingConfiguration(
-            "llm.base_url must not include userinfo credentials; use api_key_env instead"
-                .to_string(),
-        ));
-    }
-    if parsed.query().is_some() {
-        return Err(LlmError::MissingConfiguration(
-            "llm.base_url must not include query parameters; move secrets to api_key_env"
-                .to_string(),
-        ));
-    }
-    if parsed.fragment().is_some() {
-        return Err(LlmError::MissingConfiguration(
-            "llm.base_url must not include URL fragments".to_string(),
-        ));
-    }
-    Ok(())
+    validate_llm_base_url(base_url).map_err(LlmError::MissingConfiguration)
 }
 
 fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,9 +1,11 @@
 pub mod client;
 pub mod retry;
+pub mod router;
 pub mod status;
 pub mod worker;
 
 pub use client::{LlmClient, LlmError, LlmMessage, LlmRequest, LlmResponse, Usage};
 pub use retry::retry_llm_operation;
+pub use router::{LlmRouter, RoutedLlmResponse};
 pub use status::{LlmStatus, LlmWarning};
 pub use worker::{DEFAULT_GATING_JUDGE_PROMPT, LlmTaskPayload, process_llm_task};

--- a/src/llm/retry.rs
+++ b/src/llm/retry.rs
@@ -58,6 +58,10 @@ where
 }
 
 fn retry_after_from_error(error: &LlmError, default_secs: u64) -> Duration {
+    if let LlmError::TemporarilyUnavailable { retry_after, .. } = error {
+        let capped = retry_after.as_secs().min(MAX_RETRY_AFTER_SECS);
+        return Duration::from_secs(capped);
+    }
     if let LlmError::ClientError {
         retry_after: Some(header_duration),
         ..

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -1,0 +1,166 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use reqwest::StatusCode;
+use tokio::sync::Mutex;
+
+use crate::core::config::{EffectiveLlmEndpoint, LlmConfig};
+
+use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse};
+use super::retry::HeartbeatCallback;
+
+const MAX_RETRY_AFTER_SECS: u64 = 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutedLlmResponse {
+    pub endpoint_id: String,
+    pub endpoint_model: String,
+    pub response: LlmResponse,
+}
+
+#[derive(Debug)]
+struct RoutedEndpoint {
+    config: EffectiveLlmEndpoint,
+    client: LlmClient,
+    unavailable_until: Mutex<Option<Instant>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LlmRouter {
+    endpoints: Arc<Vec<Arc<RoutedEndpoint>>>,
+}
+
+impl LlmRouter {
+    pub fn from_config(config: &LlmConfig) -> Result<Self, LlmError> {
+        let endpoints = config
+            .effective_endpoints()
+            .map_err(|error| LlmError::MissingConfiguration(error.to_string()))?;
+        Self::from_endpoints(endpoints)
+    }
+
+    pub fn from_endpoints(endpoints: Vec<EffectiveLlmEndpoint>) -> Result<Self, LlmError> {
+        if endpoints.is_empty() {
+            return Err(LlmError::MissingConfiguration(
+                "llm endpoints must not be empty".to_string(),
+            ));
+        }
+        let routed = endpoints
+            .into_iter()
+            .map(|config| {
+                let client = LlmClient::from_endpoint(&config)?;
+                Ok(Arc::new(RoutedEndpoint {
+                    config,
+                    client,
+                    unavailable_until: Mutex::new(None),
+                }))
+            })
+            .collect::<Result<Vec<_>, LlmError>>()?;
+        Ok(Self {
+            endpoints: Arc::new(routed),
+        })
+    }
+
+    pub async fn chat_completion(
+        &self,
+        request: &LlmRequest,
+        heartbeat: Option<&HeartbeatCallback>,
+    ) -> Result<RoutedLlmResponse, LlmError> {
+        let mut last_retryable = None;
+        let mut earliest_retry_after: Option<Duration> = None;
+        for endpoint in self.endpoints.iter() {
+            if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
+                earliest_retry_after = Some(match earliest_retry_after {
+                    Some(current) => current.min(retry_after),
+                    None => retry_after,
+                });
+                continue;
+            }
+            refresh_heartbeat(heartbeat)?;
+            match endpoint.client.chat_completion(request).await {
+                Ok(response) => {
+                    return Ok(RoutedLlmResponse {
+                        endpoint_id: endpoint.config.id.clone(),
+                        endpoint_model: endpoint.config.model.clone(),
+                        response,
+                    });
+                }
+                Err(error) if should_try_next_endpoint(&error) => {
+                    if let LlmError::ClientError {
+                        status: StatusCode::TOO_MANY_REQUESTS,
+                        retry_after,
+                        ..
+                    } = &error
+                    {
+                        let retry_after = endpoint.mark_temporarily_unavailable(*retry_after).await;
+                        earliest_retry_after = Some(match earliest_retry_after {
+                            Some(current) => current.min(retry_after),
+                            None => retry_after,
+                        });
+                    }
+                    last_retryable = Some(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        match (last_retryable, earliest_retry_after) {
+            (Some(error), _) => Err(error),
+            (None, Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
+                retry_after,
+                reason: format!(
+                    "{} endpoint(s) are cooling down after retryable failures",
+                    self.endpoints.len()
+                ),
+            }),
+            (None, None) => Err(LlmError::MissingConfiguration(
+                "no LLM endpoint is currently available".to_string(),
+            )),
+        }
+    }
+
+    pub fn endpoint_count(&self) -> usize {
+        self.endpoints.len()
+    }
+}
+
+impl RoutedEndpoint {
+    async fn temporary_unavailable_remaining(&self) -> Option<Duration> {
+        let mut guard = self.unavailable_until.lock().await;
+        match *guard {
+            Some(until) if until > Instant::now() => {
+                Some(until.saturating_duration_since(Instant::now()))
+            }
+            Some(_) => {
+                *guard = None;
+                None
+            }
+            None => None,
+        }
+    }
+
+    async fn mark_temporarily_unavailable(&self, retry_after: Option<Duration>) -> Duration {
+        let retry_after = retry_after
+            .unwrap_or_else(|| Duration::from_secs(MAX_RETRY_AFTER_SECS))
+            .min(Duration::from_secs(MAX_RETRY_AFTER_SECS));
+        let mut guard = self.unavailable_until.lock().await;
+        *guard = Some(Instant::now() + retry_after);
+        retry_after
+    }
+}
+
+fn should_try_next_endpoint(error: &LlmError) -> bool {
+    match error {
+        LlmError::HttpRequest { .. }
+        | LlmError::Timeout
+        | LlmError::TemporarilyUnavailable { .. } => true,
+        LlmError::HttpStatus { status, .. } => status.is_server_error(),
+        LlmError::ClientError { status, .. } => *status == StatusCode::TOO_MANY_REQUESTS,
+        LlmError::DecodeResponse(_) | LlmError::MissingConfiguration(_) => false,
+    }
+}
+
+fn refresh_heartbeat(heartbeat: Option<&HeartbeatCallback>) -> Result<(), LlmError> {
+    if let Some(callback) = heartbeat {
+        callback()?;
+    }
+    Ok(())
+}

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -11,8 +11,9 @@ use crate::core::db::Database;
 use crate::core::queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore};
 use crate::daemon_bootstrap::DaemonWriteObserver;
 
-use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest};
+use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest, LlmResponse};
 use super::retry::{self, HeartbeatCallback};
+use super::router::LlmRouter;
 use super::status::LlmStatus;
 
 const LLM_TASK_KIND: &str = "llm_task";
@@ -31,7 +32,9 @@ struct LlmClientConfigSignature {
     api_key: Option<String>,
     api_key_env: Option<String>,
     extra_body: Option<Value>,
+    endpoints: Vec<crate::core::config::LlmEndpointConfig>,
     request_timeout_secs: u64,
+    max_concurrent: usize,
 }
 
 impl From<&LlmConfig> for LlmClientConfigSignature {
@@ -43,42 +46,44 @@ impl From<&LlmConfig> for LlmClientConfigSignature {
             api_key: config.api_key.clone(),
             api_key_env: config.api_key_env.clone(),
             extra_body: config.extra_body.clone(),
+            endpoints: config.endpoints.clone(),
             request_timeout_secs: config.request_timeout_secs,
+            max_concurrent: config.max_concurrent,
         }
     }
 }
 
 #[doc(hidden)]
 pub struct LlmClientRuntime {
-    client: Option<Arc<LlmClient>>,
+    router: Option<Arc<LlmRouter>>,
     signature: LlmClientConfigSignature,
 }
 
 impl LlmClientRuntime {
     pub fn new(config: &LlmConfig) -> Self {
-        let client = match LlmClient::from_config(config) {
-            Ok(client) => Some(Arc::new(client)),
+        let router = match LlmRouter::from_config(config) {
+            Ok(router) => Some(Arc::new(router)),
             Err(error) => {
-                tracing::warn!(%error, "LLM client unavailable at startup; worker will retry");
+                tracing::warn!(%error, "LLM router unavailable at startup; worker will retry");
                 None
             }
         };
         Self {
-            client,
+            router,
             signature: LlmClientConfigSignature::from(config),
         }
     }
 
     #[doc(hidden)]
-    pub fn client_for_config(&mut self, config: &LlmConfig) -> Result<Arc<LlmClient>, LlmError> {
+    pub fn router_for_config(&mut self, config: &LlmConfig) -> Result<Arc<LlmRouter>, LlmError> {
         let signature = LlmClientConfigSignature::from(config);
-        if self.client.is_none() || self.signature != signature {
-            self.client = Some(Arc::new(LlmClient::from_config(config)?));
+        if self.router.is_none() || self.signature != signature {
+            self.router = Some(Arc::new(LlmRouter::from_config(config)?));
             self.signature = signature;
-            tracing::info!("LLM client rebuilt after config hot-reload");
+            tracing::info!("LLM router rebuilt after config hot-reload");
         }
-        self.client.as_ref().map(Arc::clone).ok_or_else(|| {
-            LlmError::MissingConfiguration("LLM client unavailable after rebuild".to_string())
+        self.router.as_ref().map(Arc::clone).ok_or_else(|| {
+            LlmError::MissingConfiguration("LLM router unavailable after rebuild".to_string())
         })
     }
 }
@@ -88,7 +93,7 @@ pub type SharedLlmClientRuntime = Arc<Mutex<LlmClientRuntime>>;
 async fn client_for_claimed_generation(
     client_runtime: &SharedLlmClientRuntime,
     llm_gen_rx: &mut tokio::sync::watch::Receiver<u64>,
-) -> Result<(Arc<LlmClient>, Arc<Config>), LlmError> {
+) -> Result<(Arc<LlmRouter>, Arc<Config>), LlmError> {
     loop {
         let snapshot = ConfigHandle::current_llm_runtime_snapshot();
         if !crate::daemon::llm_worker_claim_enabled(snapshot.config.as_ref()) {
@@ -97,22 +102,16 @@ async fn client_for_claimed_generation(
             ));
         }
 
-        let client = {
+        let router = {
             let mut runtime = client_runtime
                 .lock()
                 .expect("LLM client runtime mutex poisoned");
-            runtime.client_for_config(&snapshot.config.llm)
+            runtime.router_for_config(&snapshot.config.llm)
         }?;
-
-        let new_max = snapshot.config.llm.max_concurrent.max(1);
-        if client.current_max_concurrent() != new_max {
-            client.update_concurrency(new_max).await;
-            tracing::info!("LLM worker: concurrency updated to {new_max}");
-        }
 
         let observed_generation = *llm_gen_rx.borrow_and_update();
         if observed_generation == snapshot.generation {
-            return Ok((client, snapshot.config));
+            return Ok((router, snapshot.config));
         }
 
         tracing::info!(
@@ -200,7 +199,7 @@ pub async fn run_llm_worker(
             }
         };
 
-        let (client, config) =
+        let (router, config) =
             match client_for_claimed_generation(&client_runtime, &mut llm_gen_rx).await {
                 Ok(prepared) => prepared,
                 Err(error) => {
@@ -251,7 +250,7 @@ pub async fn run_llm_worker(
         // with the fresh config snapshot.
         let task_result = tokio::select! {
             result = process_llm_task_shared(
-                client.as_ref(),
+                router.as_ref(),
                 &status,
                 &db,
                 &message.payload,
@@ -341,7 +340,7 @@ pub fn confirm_llm_task(store: &PendingMessageStore, claim: &ClaimedMessage) -> 
 }
 
 async fn process_llm_task_shared(
-    client: &LlmClient,
+    router: &LlmRouter,
     status: &LlmStatus,
     db: &AsyncDb,
     payload: &str,
@@ -352,20 +351,20 @@ async fn process_llm_task_shared(
         serde_json::from_str(payload).context("failed to decode LLM task payload")?;
 
     match task.task_type.as_str() {
-        "gating" => process_gating_task(client, status, db, &task, config, heartbeat).await,
+        "gating" => process_gating_task(router, status, db, &task, config, heartbeat).await,
         other => anyhow::bail!("unknown LLM task type: {other}"),
     }
 }
 
 async fn process_gating_task(
-    client: &LlmClient,
+    router: &LlmRouter,
     status: &LlmStatus,
     db: &AsyncDb,
     task: &LlmTaskPayload,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<()> {
-    let (verdict, score) = request_gating_verdict(client, status, task, config, heartbeat).await?;
+    let (verdict, score) = request_gating_verdict(router, status, task, config, heartbeat).await?;
     apply_gating_verdict_async(db, task.clone(), config.clone(), verdict, score).await
 }
 
@@ -394,7 +393,8 @@ pub async fn process_llm_task(
     match task.task_type.as_str() {
         "gating" => {
             let (verdict, score) =
-                request_gating_verdict(client, status, &task, config, heartbeat).await?;
+                request_gating_verdict_with_client(client, status, &task, config, heartbeat)
+                    .await?;
             apply_gating_verdict(db, &task, config, &verdict, score)
         }
         other => anyhow::bail!("unknown LLM task type: {other}"),
@@ -402,18 +402,49 @@ pub async fn process_llm_task(
 }
 
 async fn request_gating_verdict(
+    router: &LlmRouter,
+    status: &LlmStatus,
+    task: &LlmTaskPayload,
+    config: &crate::core::config::Config,
+    heartbeat: Option<&HeartbeatCallback>,
+) -> Result<(String, f64)> {
+    let request = gating_request(task);
+    let retry_interval = config.llm.retry_interval_secs;
+    let response = retry::retry_llm_operation(retry_interval, heartbeat, || async {
+        router
+            .chat_completion(&request, heartbeat)
+            .await
+            .map(|routed| routed.response)
+    })
+    .await;
+
+    record_gating_response(status, response)
+}
+
+async fn request_gating_verdict_with_client(
     client: &LlmClient,
     status: &LlmStatus,
     task: &LlmTaskPayload,
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<(String, f64)> {
+    let request = gating_request(task);
+    let retry_interval = config.llm.retry_interval_secs;
+    let response = retry::retry_llm_operation(retry_interval, heartbeat, || {
+        client.chat_completion(&request)
+    })
+    .await;
+
+    record_gating_response(status, response)
+}
+
+fn gating_request(task: &LlmTaskPayload) -> LlmRequest {
     let system_prompt = task
         .system_prompt
         .as_deref()
         .unwrap_or(DEFAULT_GATING_JUDGE_PROMPT);
 
-    let request = LlmRequest {
+    LlmRequest {
         messages: vec![
             LlmMessage {
                 role: "system".to_string(),
@@ -427,14 +458,13 @@ async fn request_gating_verdict(
         model: None,
         temperature: Some(0.0),
         max_tokens: Some(1024),
-    };
+    }
+}
 
-    let retry_interval = config.llm.retry_interval_secs;
-    let response = retry::retry_llm_operation(retry_interval, heartbeat, || {
-        client.chat_completion(&request)
-    })
-    .await;
-
+fn record_gating_response(
+    status: &LlmStatus,
+    response: Result<LlmResponse, LlmError>,
+) -> Result<(String, f64)> {
     match response {
         Ok(response) => {
             status.record_success();
@@ -647,6 +677,36 @@ threshold = 0.5
         )
     }
 
+    fn worker_endpoint_pool_config(primary_base_url: &str, secondary_base_url: &str) -> String {
+        format!(
+            r#"
+[config_hot_reload]
+enabled = false
+
+[llm]
+enabled = true
+enabled_for = ["gating"]
+max_concurrent = 1
+retry_interval_secs = 1
+request_timeout_secs = 5
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "{primary_base_url}"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "{secondary_base_url}"
+model = "secondary-model"
+
+[ingest_gating.llm_judge]
+enabled = true
+threshold = 0.5
+"#
+        )
+    }
+
     async fn spawn_counting_llm_server(
         count: Arc<AtomicUsize>,
         notify: Arc<Notify>,
@@ -692,6 +752,38 @@ threshold = 0.5
         (format!("http://{addr}/v1"), handle)
     }
 
+    async fn spawn_failing_llm_server(
+        count: Arc<AtomicUsize>,
+        notify: Arc<Notify>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{Router, http::StatusCode, routing::post};
+
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || {
+                let count = Arc::clone(&count);
+                let notify = Arc::clone(&notify);
+                async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    notify.notify_waiters();
+                    (StatusCode::INTERNAL_SERVER_ERROR, "server error")
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind failing test LLM server");
+        let addr = listener
+            .local_addr()
+            .expect("failing test LLM server address");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve failing test LLM server");
+        });
+        (format!("http://{addr}/v1"), handle)
+    }
+
     fn gating_task(id: &str) -> LlmTaskPayload {
         LlmTaskPayload {
             task_type: "gating".to_string(),
@@ -710,6 +802,23 @@ threshold = 0.5
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?)),
             )
             .expect("read LLM audit verdict")
+    }
+
+    fn maybe_llm_audit_verdict(db: &Database, id: &str) -> Option<(String, f64)> {
+        let (verdict, score) = db
+            .conn()
+            .query_row(
+                "SELECT llm_verdict, llm_score FROM gating_audit WHERE drawer_id = ?1",
+                params![id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<f64>>(1)?,
+                    ))
+                },
+            )
+            .expect("read optional LLM audit verdict");
+        verdict.zip(score)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -790,6 +899,105 @@ threshold = 0.5
             "stale pre-reload client must not process a claim returned after reload"
         );
         assert_eq!(new_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_worker_gating_uses_endpoint_pool_fallback() {
+        let _guard = crate::core::config::global_config_test_lock()
+            .lock_owned()
+            .await;
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let config_path = tmp.path().join("config.toml");
+        let db_path = tmp.path().join("palace.db");
+
+        let primary_count = Arc::new(AtomicUsize::new(0));
+        let secondary_count = Arc::new(AtomicUsize::new(0));
+        let primary_notify = Arc::new(Notify::new());
+        let secondary_notify = Arc::new(Notify::new());
+        let (primary_base_url, primary_server) =
+            spawn_failing_llm_server(Arc::clone(&primary_count), Arc::clone(&primary_notify)).await;
+        let (secondary_base_url, secondary_server) =
+            spawn_counting_llm_server(Arc::clone(&secondary_count), Arc::clone(&secondary_notify))
+                .await;
+
+        std::fs::write(
+            &config_path,
+            worker_endpoint_pool_config(&primary_base_url, &secondary_base_url),
+        )
+        .expect("write endpoint pool config");
+        ConfigHandle::bootstrap_quiet(&config_path).expect("bootstrap endpoint pool config");
+
+        let db = Database::open(&db_path).expect("open db");
+        let drawer_id = "endpoint-pool-fallback-drawer";
+        insert_drawer(&db, drawer_id);
+        record_pending_llm_audit(&db, drawer_id);
+        let store = PendingMessageStore::new(db.path()).expect("open queue");
+        let task = gating_task(drawer_id);
+        store
+            .enqueue(
+                LLM_TASK_KIND,
+                &serde_json::to_string(&task).expect("serialize task"),
+            )
+            .expect("enqueue LLM task");
+
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let client_runtime = Arc::new(Mutex::new(LlmClientRuntime::new(
+            &ConfigHandle::current().llm,
+        )));
+        let worker = tokio::spawn(run_llm_worker(
+            Arc::new(async_store),
+            client_runtime,
+            Arc::new(LlmStatus::new(5)),
+            async_db,
+            DaemonWriteObserver::for_test(),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(5), secondary_notify.notified())
+            .await
+            .expect("secondary endpoint should be used");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some((verdict, score)) = maybe_llm_audit_verdict(&db, drawer_id)
+                    && verdict == LLM_VERDICT_KEEP
+                    && score >= 0.9
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("LLM audit should be updated by worker");
+
+        worker.abort();
+        let _ = worker.await;
+        primary_server.abort();
+        secondary_server.abort();
+        let _ = primary_server.await;
+        let _ = secondary_server.await;
+
+        assert_eq!(
+            primary_count.load(Ordering::SeqCst),
+            1,
+            "production worker should try the primary endpoint first"
+        );
+        assert_eq!(
+            secondary_count.load(Ordering::SeqCst),
+            1,
+            "production worker should fall back to the secondary endpoint"
+        );
+        assert!(
+            !drawer_is_deleted(&db, drawer_id),
+            "keep verdict from fallback endpoint must retain the drawer"
+        );
+        assert!(
+            store
+                .claim_next_by_kind("after-fallback-worker", 1, LLM_TASK_KIND)
+                .expect("claim after worker fallback")
+                .is_none(),
+            "completed fallback task must be confirmed"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ use mempal::knowledge_gate::{
 use mempal::knowledge_lifecycle::{
     DemoteRequest, PromoteRequest, demote_knowledge, promote_knowledge,
 };
-use mempal::llm::{DEFAULT_GATING_JUDGE_PROMPT, LlmClient, LlmMessage, LlmRequest};
+use mempal::llm::{DEFAULT_GATING_JUDGE_PROMPT, LlmMessage, LlmRequest, LlmRouter};
 use mempal::mcp::{
     IngestControls, IngestOperationState, IngestRequest, IngestResponse, MempalMcpServer,
     OperationStatusRequest,
@@ -9422,11 +9422,11 @@ fn config_intelligence_command(config: &Config) -> Result<()> {
     println!("  mode: {}", config.memory_intelligence.mode);
     println!("  llm_state: {llm_state}");
     println!("  llm_backend: {}", effective_llm.backend);
-    match effective_llm.model.as_deref() {
+    match effective_llm.effective_model_summary().as_deref() {
         Some(model) => println!("  llm_model: {model}"),
         None => println!("  llm_model: none"),
     }
-    match effective_llm.base_url.as_deref() {
+    match effective_llm.effective_base_url_summary().as_deref() {
         Some(base_url) => println!("  llm_base_url: {base_url}"),
         None => println!("  llm_base_url: none"),
     }
@@ -9803,8 +9803,11 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     println!("  enabled: {}", config.llm.enabled);
     if config.llm.enabled {
         println!("  backend: {}", config.llm.backend);
-        if let Some(model) = config.llm.model.as_deref() {
+        if let Some(model) = config.llm.effective_model_summary().as_deref() {
             println!("  model: {model}");
+        }
+        if let Some(base_url) = config.llm.effective_base_url_summary().as_deref() {
+            println!("  base_url: {base_url}");
         }
         println!("  max_concurrent: {}", config.llm.max_concurrent);
         let llm_pending = queue_stats.pending;
@@ -12311,15 +12314,15 @@ async fn maintenance_rejudge_command(
         )
         .context("failed to load historical rejudge candidates")?;
     let config_version = historical_rejudge_config_version(config);
-    let llm_client = historical_rejudge_llm_client(config);
-    let judge_model = llm_client
+    let llm_router = historical_rejudge_llm_router(config);
+    let judge_model = llm_router
         .as_ref()
-        .and(config.llm.model.clone())
-        .or_else(|| Some("deterministic".to_string()).filter(|_| llm_client.is_none()));
+        .and_then(|_| config.llm.effective_model_summary())
+        .or_else(|| Some("deterministic".to_string()).filter(|_| llm_router.is_none()));
 
     let mut decisions = Vec::with_capacity(rows.len());
     for row in &rows {
-        let decision = evaluate_historical_drawer(row, config, llm_client.as_ref()).await;
+        let decision = evaluate_historical_drawer(row, config, llm_router.as_ref()).await;
         decisions.push((row, decision));
     }
 
@@ -13409,7 +13412,7 @@ fn print_historical_rejudge_restore_report(
 async fn evaluate_historical_drawer(
     row: &mempal::core::db::HistoricalRejudgeCandidate,
     config: &Config,
-    llm_client: Option<&LlmClient>,
+    llm_router: Option<&LlmRouter>,
 ) -> HistoricalRejudgeDecision {
     let drawer = &row.drawer;
     if let Some(reason) = historical_protection_reason(drawer) {
@@ -13434,8 +13437,8 @@ async fn evaluate_historical_drawer(
         };
     }
 
-    if let Some(client) = llm_client {
-        match request_historical_llm_score(client, drawer, config).await {
+    if let Some(router) = llm_router {
+        match request_historical_llm_score(router, drawer, config).await {
             Ok((score, reason)) => {
                 let threshold = config
                     .ingest_gating
@@ -13584,7 +13587,7 @@ fn protected_historical_decision(reason: String) -> HistoricalRejudgeDecision {
     }
 }
 
-fn historical_rejudge_llm_client(config: &Config) -> Option<LlmClient> {
+fn historical_rejudge_llm_router(config: &Config) -> Option<LlmRouter> {
     if !config.llm.enabled || !config.llm.enabled_for.iter().any(|item| item == "gating") {
         return None;
     }
@@ -13592,11 +13595,11 @@ fn historical_rejudge_llm_client(config: &Config) -> Option<LlmClient> {
     if !judge.enabled {
         return None;
     }
-    LlmClient::from_config(&config.llm).ok()
+    LlmRouter::from_config(&config.llm).ok()
 }
 
 async fn request_historical_llm_score(
-    client: &LlmClient,
+    router: &LlmRouter,
     drawer: &Drawer,
     config: &Config,
 ) -> Result<(f64, String)> {
@@ -13621,10 +13624,11 @@ async fn request_historical_llm_score(
         temperature: Some(0.0),
         max_tokens: Some(512),
     };
-    let response = client
-        .chat_completion(&request)
+    let response = router
+        .chat_completion(&request, None)
         .await
         .context("historical rejudge LLM request failed")?;
+    let response = response.response;
     Ok(parse_historical_llm_score(&response.content))
 }
 
@@ -13680,9 +13684,12 @@ fn historical_rejudge_config_version(config: &Config) -> String {
         "gating": config.ingest_gating,
         "llm": {
             "enabled": config.llm.enabled,
-            "model": config.llm.model,
-            "enabled_for": config.llm.enabled_for,
+            "backend": config.llm.backend.clone(),
+            "endpoints": config.llm.effective_endpoint_fingerprints(),
+            "enabled_for": config.llm.enabled_for.clone(),
             "max_concurrent": config.llm.max_concurrent,
+            "request_timeout_secs": config.llm.request_timeout_secs,
+            "retry_interval_secs": config.llm.retry_interval_secs,
         }
     });
     let bytes = serde_json::to_vec(&relevant).unwrap_or_default();
@@ -14895,6 +14902,59 @@ mod historical_rejudge_tests {
 
     fn test_config() -> Config {
         Config::parse("[gating]\nenabled = true\n").expect("parse config")
+    }
+
+    #[test]
+    fn historical_rejudge_config_version_includes_endpoint_pool_identity() {
+        let primary = Config::parse(
+            r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "judge-a"
+base_url = "http://judge-a.local:8317/v1"
+model = "judge-model-a"
+
+[[llm.endpoints]]
+id = "judge-b"
+base_url = "http://judge-b.local:8317/v1"
+model = "judge-model-b"
+
+[gating]
+enabled = true
+"#,
+        )
+        .expect("parse primary config");
+        let changed = Config::parse(
+            r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "judge-a"
+base_url = "http://judge-a.local:8317/v1"
+model = "judge-model-a"
+
+[[llm.endpoints]]
+id = "judge-b"
+base_url = "http://judge-b.local:8317/v1"
+model = "judge-model-c"
+
+[gating]
+enabled = true
+"#,
+        )
+        .expect("parse changed config");
+
+        assert_ne!(
+            historical_rejudge_config_version(&primary),
+            historical_rejudge_config_version(&changed)
+        );
+        assert_eq!(
+            primary.llm.effective_model_summary().as_deref(),
+            Some("judge-a=judge-model-a, judge-b=judge-model-b")
+        );
     }
 
     fn insert_drawer(db: &Database, id: &str, content: &str, wing: &str, room: Option<&str>) {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,7 +10,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     AsyncDb,
     anchor::{self, DerivedAnchor},
-    config::ConfigHandle,
+    config::{Config, ConfigHandle},
     db::{
         CURRENT_VECTOR_INDEX_VERSION, Database, NoveltyAuditInsert, VECTOR_DISTANCE_METRIC,
         read_fork_ext_version,
@@ -36,8 +36,8 @@ use crate::core::{
         SearchResult, SourceType, TriggerHints, Triple, default_confidence,
     },
     utils::{
-        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, iso_timestamp,
-        knowledge_source_file, link_superseded_drawer, normalize_rfc3339_timestamp,
+        build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, expand_home,
+        iso_timestamp, knowledge_source_file, link_superseded_drawer, normalize_rfc3339_timestamp,
         source_file_or_synthetic,
     },
 };
@@ -108,18 +108,29 @@ use super::tools::{
     KnowledgeDistillRequest, KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse,
     KnowledgePolicyResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
     KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest,
-    LeaseResponse, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
-    OperationStatusRequest, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto,
-    Phase3Request, Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
-    PinnedFactsResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
-    ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto,
-    RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto,
-    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto,
-    SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest,
-    StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto, TaxonomyRequest,
-    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
-    TunnelsResponse, TurnStorageStatusDto,
+    LeaseResponse, LlmEndpointStatusDto, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
+    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PeekMessageDto, PeekPartnerRequest,
+    PeekPartnerResponse, Phase3GateDto, Phase3Request, Phase3Response, PinnedFactDto,
+    PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse, QueueStatsDto,
+    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
+    RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
+    SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
+    SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest, StatusResponse, StatusScope,
+    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
+    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
+
+fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool {
+    let config_db_path = expand_home(&config.db_path);
+    if config_db_path == server_db_path {
+        return true;
+    }
+    match (config_db_path.canonicalize(), server_db_path.canonicalize()) {
+        (Ok(config_db_path), Ok(server_db_path)) => config_db_path == server_db_path,
+        _ => false,
+    }
+}
 
 const MCP_SEARCH_ROUTE_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
@@ -130,6 +141,7 @@ const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
 #[derive(Clone)]
 pub struct MempalMcpServer {
     db_path: PathBuf,
+    initial_config: Arc<Config>,
     async_db: Arc<OnceCell<AsyncDb>>,
     async_queue: AsyncPendingMessageStore,
     gating_runtime: Arc<GatingRuntime>,
@@ -175,12 +187,14 @@ impl MempalMcpServer {
 
     pub fn new_with_factory_and_config(
         db_path: PathBuf,
-        config: crate::core::config::Config,
+        config: Config,
         embedder_factory: Arc<dyn EmbedderFactory>,
     ) -> anyhow::Result<Self> {
         let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path);
+        let initial_config = Arc::new(config.clone());
         Ok(Self {
             db_path,
+            initial_config,
             async_db: Arc::new(OnceCell::new()),
             async_queue,
             gating_runtime: Arc::new(GatingRuntime::new(config, Arc::clone(&embedder_factory))),
@@ -199,6 +213,15 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
         })
+    }
+
+    fn status_config_snapshot(&self) -> Arc<Config> {
+        let current = ConfigHandle::current();
+        if config_db_path_matches_server(current.as_ref(), &self.db_path) {
+            current
+        } else {
+            Arc::clone(&self.initial_config)
+        }
     }
 
     #[cfg(any(test, feature = "db-test-seam"))]
@@ -2070,7 +2093,7 @@ impl MempalMcpServer {
             StatusDetail::Full => StatusScope::All,
         });
         let cfg_meta = ConfigHandle::snapshot_meta();
-        let config = ConfigHandle::current();
+        let config = self.status_config_snapshot();
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await?;
@@ -2290,7 +2313,19 @@ impl MempalMcpServer {
             llm_status: LlmStatusDto {
                 enabled: config.llm.enabled,
                 backend: Some(config.llm.backend.clone()),
-                model: config.llm.model.clone(),
+                model: config.llm.effective_model_summary(),
+                endpoints: config
+                    .llm
+                    .effective_endpoints()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|endpoint| LlmEndpointStatusDto {
+                        id: endpoint.id,
+                        base_url: endpoint.base_url,
+                        model: endpoint.model,
+                        max_concurrent: endpoint.max_concurrent,
+                    })
+                    .collect(),
                 max_concurrent: config.llm.max_concurrent,
             },
             intelligence_status: IntelligenceStatusDto {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1998,6 +1998,16 @@ pub struct LlmStatusDto {
     pub backend: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub endpoints: Vec<LlmEndpointStatusDto>,
+    pub max_concurrent: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct LlmEndpointStatusDto {
+    pub id: String,
+    pub base_url: String,
+    pub model: String,
     pub max_concurrent: usize,
 }
 

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -226,7 +226,7 @@ pub fn gating_runtime_status(
                 .llm_judge
                 .as_ref()
                 .is_some_and(|judge| judge.enabled),
-        llm_model: config.llm.model.clone(),
+        llm_model: config.llm.effective_model_summary(),
         tier2_threshold: config.ingest_gating.embedding_classifier.threshold,
         llm_threshold: config
             .ingest_gating

--- a/tests/endpoint_health.rs
+++ b/tests/endpoint_health.rs
@@ -1,0 +1,47 @@
+use mempal::core::config::Config;
+use mempal::endpoint_health::probe_endpoints;
+use mockito::Server;
+
+#[tokio::test]
+async fn test_endpoint_health_probes_llm_endpoint_pool() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("GET", "/v1/models")
+        .with_status(500)
+        .with_body("primary unavailable")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("GET", "/v1/models")
+        .with_status(200)
+        .with_body(r#"{"object":"list","data":[]}"#)
+        .create_async()
+        .await;
+    let config = Config::parse(&format!(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "{}/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "{}/v1"
+model = "secondary-model"
+"#,
+        primary.url(),
+        secondary.url()
+    ))
+    .expect("parse endpoint pool");
+
+    let health = probe_endpoints(&config).await;
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(health.llm.reachable, "{health:#?}");
+    assert_eq!(health.llm.detail, "http probe via secondary");
+}

--- a/tests/intelligence.rs
+++ b/tests/intelligence.rs
@@ -35,6 +35,34 @@ extra_body = {{ chat_template_kwargs = {{ enable_thinking = false }} }}
     .expect("parse config")
 }
 
+fn endpoint_pool_config_for(primary: &Server, secondary: &Server, mode: &str) -> Config {
+    Config::parse(&format!(
+        r#"
+[memory_intelligence]
+mode = "{mode}"
+
+[memory_intelligence.llm]
+timeout_secs = 1
+
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "{}/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "{}/v1"
+model = "secondary-model"
+"#,
+        primary.url(),
+        secondary.url()
+    ))
+    .expect("parse endpoint pool config")
+}
+
 #[test]
 fn test_intelligence_mode_config_parsing() {
     for (raw, expected) in [
@@ -94,6 +122,40 @@ async fn test_auto_mode_fallback() {
     assert_eq!(enhanced.raw_content, "Alice works at Acme");
     assert!(enhanced.candidate_facts.is_empty());
     assert!(enhanced.fallback_reason.is_some());
+}
+
+#[tokio::test]
+async fn test_memory_intelligence_uses_endpoint_pool_fallback() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("primary unavailable")
+        .create_async()
+        .await;
+    let supported = serde_json::json!({
+        "candidate_facts": ["Alice works at Acme"],
+        "tags": ["employment"],
+        "contradiction": false,
+        "correction": false
+    })
+    .to_string();
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(llm_response(&supported))
+        .create_async()
+        .await;
+    let config = endpoint_pool_config_for(&primary, &secondary, "local_llm");
+    let router = IntelligenceRouter::from_config(&config);
+
+    let enhanced = router.enhance_ingest("Alice works at Acme").await;
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(enhanced.used_llm);
+    assert_eq!(enhanced.candidate_facts, vec!["Alice works at Acme"]);
 }
 
 #[tokio::test]

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -62,6 +62,165 @@ enabled_for = ["gating", "distill", "compress"]
 }
 
 #[test]
+fn test_llm_config_legacy_scalar_config_yields_one_effective_endpoint() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+base_url = "http://localhost:8317/v1"
+model = "qwen35-35b-a3b"
+api_key_env = "LOCAL_ROUTER_API_KEY"
+request_timeout_secs = 45
+max_concurrent = 8
+"#,
+    )
+    .expect("legacy llm config should parse");
+
+    let endpoints = config
+        .llm
+        .effective_endpoints()
+        .expect("legacy endpoint should normalize");
+
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(endpoints[0].id, "legacy");
+    assert_eq!(endpoints[0].base_url, "http://localhost:8317/v1");
+    assert_eq!(endpoints[0].model, "qwen35-35b-a3b");
+    assert_eq!(
+        endpoints[0].api_key_env.as_deref(),
+        Some("LOCAL_ROUTER_API_KEY")
+    );
+    assert_eq!(endpoints[0].request_timeout_secs, 45);
+    assert_eq!(endpoints[0].max_concurrent, 8);
+}
+
+#[test]
+fn test_llm_config_endpoint_list_yields_stable_effective_endpoint_ids() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+base_url = "http://primary.local:8317/v1/"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "lan.backup-1"
+base_url = "http://backup.local:8317/v1"
+model = "backup-model"
+request_timeout_secs = 12
+max_concurrent = 3
+"#,
+    )
+    .expect("endpoint list should parse");
+
+    let endpoints = config
+        .llm
+        .effective_endpoints()
+        .expect("endpoint list should normalize");
+
+    assert_eq!(endpoints.len(), 2);
+    assert_eq!(endpoints[0].id, "endpoint-1");
+    assert_eq!(endpoints[0].base_url, "http://primary.local:8317/v1");
+    assert_eq!(endpoints[0].model, "primary-model");
+    assert_eq!(endpoints[0].request_timeout_secs, 30);
+    assert_eq!(endpoints[0].max_concurrent, 16);
+    assert_eq!(endpoints[1].id, "lan.backup-1");
+    assert_eq!(endpoints[1].request_timeout_secs, 12);
+    assert_eq!(endpoints[1].max_concurrent, 3);
+}
+
+#[test]
+fn test_llm_config_endpoint_list_reports_effective_status_summaries() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://primary.local:8317/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "http://secondary.local:8317/v1"
+model = "secondary-model"
+"#,
+    )
+    .expect("endpoint list should parse");
+
+    assert_eq!(
+        config.llm.effective_model_summary().as_deref(),
+        Some("primary=primary-model, secondary=secondary-model")
+    );
+    assert_eq!(
+        config.llm.effective_base_url_summary().as_deref(),
+        Some("primary=http://primary.local:8317/v1, secondary=http://secondary.local:8317/v1")
+    );
+}
+
+#[test]
+fn test_endpoint_pool_external_llm_base_url_warns_but_does_not_block_config() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "local"
+base_url = "http://localhost:8317/v1"
+model = "local-model"
+
+[[llm.endpoints]]
+id = "cloud"
+base_url = "https://api.example.com/v1"
+model = "operator-owned-model"
+"#,
+    )
+    .expect("external endpoint pool warning must not block config parsing");
+
+    let warnings = config.collect_runtime_warnings();
+    assert!(
+        warnings.iter().any(|warning| {
+            warning.source == "llm"
+                && warning.message.contains("llm.endpoints[cloud].base_url")
+                && warning.message.contains("api.example.com")
+        }),
+        "{warnings:?}"
+    );
+}
+
+#[test]
+fn test_llm_config_scalar_and_endpoint_list_conflict_fails_validation() {
+    let err = Config::parse(
+        r#"
+[llm]
+enabled = true
+base_url = "http://localhost:8317/v1"
+model = "legacy-model"
+
+[[llm.endpoints]]
+base_url = "http://backup.local:8317/v1"
+model = "backup-model"
+"#,
+    )
+    .expect_err("scalar endpoint and endpoint list must conflict");
+
+    match err {
+        ConfigError::Validation(message) => {
+            assert!(
+                message.contains("legacy scalar endpoint fields"),
+                "{message}"
+            );
+            assert!(message.contains("base_url"), "{message}");
+            assert!(message.contains("model"), "{message}");
+        }
+        other => panic!("expected ConfigError::Validation, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_memory_intelligence_config_parse_full() {
     let config = Config::parse(
         r#"
@@ -96,6 +255,133 @@ extra_body = { chat_template_kwargs = { enable_thinking = false } }
             .and_then(|value| value.as_bool()),
         Some(false)
     );
+}
+
+#[test]
+fn test_llm_config_memory_intelligence_inherits_endpoint_pool_with_request_overrides() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+request_timeout_secs = 30
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://primary.local:8317/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "http://secondary.local:8317/v1"
+model = "secondary-model"
+
+[memory_intelligence]
+mode = "local_llm"
+
+[memory_intelligence.llm]
+api_key = "mi-direct-key"
+api_key_env = "MI_LLM_API_KEY"
+timeout_secs = 7
+extra_body = { chat_template_kwargs = { enable_thinking = false } }
+"#,
+    )
+    .expect("memory intelligence endpoint-pool overlay should parse");
+
+    assert!(
+        config
+            .memory_intelligence
+            .has_effective_llm_endpoint(&config.llm)
+    );
+    let effective = config.memory_intelligence.effective_llm_config(&config.llm);
+    let endpoints = effective
+        .effective_endpoints()
+        .expect("memory intelligence endpoint pool should normalize");
+
+    assert_eq!(endpoints.len(), 2);
+    assert_eq!(endpoints[0].id, "primary");
+    assert_eq!(endpoints[0].base_url, "http://primary.local:8317/v1");
+    assert_eq!(endpoints[0].model, "primary-model");
+    assert_eq!(endpoints[1].id, "secondary");
+    assert_eq!(endpoints[1].base_url, "http://secondary.local:8317/v1");
+    assert_eq!(endpoints[1].model, "secondary-model");
+    for endpoint in endpoints {
+        assert_eq!(endpoint.api_key.as_deref(), Some("mi-direct-key"));
+        assert_eq!(endpoint.api_key_env.as_deref(), Some("MI_LLM_API_KEY"));
+        assert_eq!(endpoint.request_timeout_secs, 7);
+        assert_eq!(
+            endpoint
+                .extra_body
+                .as_ref()
+                .and_then(|body| body.pointer("/chat_template_kwargs/enable_thinking"))
+                .and_then(|value| value.as_bool()),
+            Some(false)
+        );
+    }
+}
+
+#[test]
+fn test_llm_config_memory_intelligence_api_key_env_override_replaces_inherited_direct_key() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://primary.local:8317/v1"
+model = "primary-model"
+api_key = "base-direct-key"
+
+[memory_intelligence]
+mode = "local_llm"
+
+[memory_intelligence.llm]
+api_key_env = "MI_LLM_API_KEY"
+"#,
+    )
+    .expect("memory intelligence api_key_env overlay should parse");
+
+    let effective = config.memory_intelligence.effective_llm_config(&config.llm);
+    let endpoints = effective
+        .effective_endpoints()
+        .expect("memory intelligence endpoint pool should normalize");
+
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(endpoints[0].api_key, None);
+    assert_eq!(endpoints[0].api_key_env.as_deref(), Some("MI_LLM_API_KEY"));
+}
+
+#[test]
+fn test_llm_config_memory_intelligence_endpoint_identity_override_replaces_base_endpoint_pool() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "base"
+base_url = "http://base.local:8317/v1"
+model = "base-model"
+
+[memory_intelligence]
+mode = "local_llm"
+
+[memory_intelligence.llm]
+base_url = "http://mi.local:18009/v1"
+model = "mi-model"
+"#,
+    )
+    .expect("memory intelligence endpoint identity override should parse");
+
+    let effective = config.memory_intelligence.effective_llm_config(&config.llm);
+    let endpoints = effective
+        .effective_endpoints()
+        .expect("memory intelligence identity endpoint should normalize");
+
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(endpoints[0].id, "legacy");
+    assert_eq!(endpoints[0].base_url, "http://mi.local:18009/v1");
+    assert_eq!(endpoints[0].model, "mi-model");
 }
 
 #[test]

--- a/tests/llm_router.rs
+++ b/tests/llm_router.rs
@@ -1,0 +1,251 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use mempal::core::config::Config;
+use mempal::llm::{LlmError, LlmMessage, LlmRequest, LlmRouter};
+use mockito::{Matcher, Server};
+
+fn request() -> LlmRequest {
+    LlmRequest {
+        messages: vec![LlmMessage {
+            role: "user".to_string(),
+            content: "hello".to_string(),
+        }],
+        model: None,
+        temperature: Some(0.0),
+        max_tokens: Some(16),
+    }
+}
+
+fn success_body(model: &str, content: &str) -> String {
+    serde_json::json!({
+        "model": model,
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content
+                }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+            "total_tokens": 10
+        }
+    })
+    .to_string()
+}
+
+fn endpoint_pool_config(primary: &Server, secondary: &Server) -> mempal::core::config::LlmConfig {
+    Config::parse(&format!(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "{}/v1"
+model = "primary-model"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "{}/v1"
+model = "secondary-model"
+"#,
+        primary.url(),
+        secondary.url()
+    ))
+    .expect("parse endpoint pool")
+    .llm
+}
+
+#[tokio::test]
+async fn test_llm_router_primary_5xx_falls_back_to_secondary_success() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("server error")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "model": "secondary-model"
+        })))
+        .with_status(200)
+        .with_body(success_body("secondary-model", "ok"))
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let response = router
+        .chat_completion(&request(), None)
+        .await
+        .expect("fallback response");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert_eq!(response.endpoint_id, "secondary");
+    assert_eq!(response.endpoint_model, "secondary-model");
+    assert_eq!(response.response.content, "ok");
+}
+
+#[tokio::test]
+async fn test_llm_router_429_marks_endpoint_and_falls_back() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "2")
+        .with_body("rate limited")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(success_body("secondary-model", "fallback"))
+        .expect(2)
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let first = router
+        .chat_completion(&request(), None)
+        .await
+        .expect("first fallback");
+    let second = router
+        .chat_completion(&request(), None)
+        .await
+        .expect("second fallback");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert_eq!(first.endpoint_id, "secondary");
+    assert_eq!(second.endpoint_id, "secondary");
+}
+
+#[tokio::test]
+async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "2")
+        .with_body("primary rate limited")
+        .expect(1)
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "2")
+        .with_body("secondary rate limited")
+        .expect(1)
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let first = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("all endpoints rate limited");
+    let second = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("cooling down endpoints should remain retryable");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(first.is_retryable());
+    assert!(matches!(
+        second,
+        LlmError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after <= std::time::Duration::from_secs(2)
+    ));
+    assert!(second.is_retryable());
+}
+
+#[tokio::test]
+async fn test_llm_router_nonretryable_4xx_stops_without_secondary() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(400)
+        .with_body("bad request")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(success_body("secondary-model", "should not be used"))
+        .expect(0)
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let error = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("4xx must stop");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(matches!(
+        error,
+        LlmError::ClientError {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn test_llm_router_heartbeat_fires_during_routed_attempts() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("server error")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(success_body("secondary-model", "ok"))
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+    let heartbeat_count = Arc::new(AtomicUsize::new(0));
+    let heartbeat_count_for_callback = Arc::clone(&heartbeat_count);
+    let heartbeat: Box<mempal::llm::retry::HeartbeatCallback> = Box::new(move || {
+        heartbeat_count_for_callback.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+
+    let response = router
+        .chat_completion(&request(), Some(heartbeat.as_ref()))
+        .await
+        .expect("fallback response");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert_eq!(response.endpoint_id, "secondary");
+    assert!(
+        heartbeat_count.load(Ordering::SeqCst) >= 2,
+        "heartbeat should fire before each routed endpoint attempt"
+    );
+}

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -241,6 +241,62 @@ model = "model-stable"
 }
 
 #[test]
+fn test_llm_gen_increments_on_endpoint_list_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_llm_gen();
+    let gen_before = *rx.borrow_and_update();
+    let version_before = ConfigHandle::version();
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+
+[[llm.endpoints]]
+base_url = "http://127.0.0.1:20000/v1"
+model = "model-b"
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    let version_after = ConfigHandle::version();
+    assert!(
+        gen_after > gen_before,
+        "generation must increment when llm.endpoints changes (before={gen_before}, after={gen_after})"
+    );
+    assert_ne!(
+        version_after, version_before,
+        "config hash must change when llm.endpoints changes"
+    );
+    assert_eq!(version_after.len(), 12);
+    assert_eq!(ConfigHandle::current().llm.endpoints.len(), 2);
+}
+
+#[test]
 fn test_llm_gen_does_not_increment_on_unrelated_change() {
     let _guard = TEST_LOCK.lock().expect("test lock");
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -294,18 +350,66 @@ fn test_llm_client_runtime_rebuilds_on_endpoint_change() {
     };
     let mut runtime = LlmClientRuntime::new(&config);
     let first = runtime
-        .client_for_config(&config)
-        .expect("load initial client");
+        .router_for_config(&config)
+        .expect("load initial router");
 
     let mut changed = config.clone();
     changed.base_url = Some("http://127.0.0.1:20000/v1".to_string());
     let second = runtime
-        .client_for_config(&changed)
-        .expect("rebuild changed client");
+        .router_for_config(&changed)
+        .expect("rebuild changed router");
 
     assert!(
         !Arc::ptr_eq(&first, &second),
-        "endpoint changes must rebuild LLM client"
+        "endpoint changes must rebuild LLM router"
+    );
+}
+
+#[test]
+fn test_llm_client_runtime_rebuilds_on_endpoint_list_change() {
+    let config = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+"#,
+    )
+    .expect("parse initial endpoint list")
+    .llm;
+    let mut runtime = LlmClientRuntime::new(&config);
+    let first = runtime
+        .router_for_config(&config)
+        .expect("load initial router");
+
+    let changed = Config::parse(
+        r#"
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "http://127.0.0.1:20000/v1"
+model = "model-b"
+"#,
+    )
+    .expect("parse changed endpoint list")
+    .llm;
+    let second = runtime
+        .router_for_config(&changed)
+        .expect("rebuild changed endpoint list router");
+
+    assert!(
+        !Arc::ptr_eq(&first, &second),
+        "endpoint list changes must rebuild LLM router runtime"
     );
 }
 
@@ -319,17 +423,17 @@ fn test_llm_client_runtime_recovers_after_invalid_initial_config() {
     };
     let mut runtime = LlmClientRuntime::new(&invalid);
     assert!(
-        runtime.client_for_config(&invalid).is_err(),
+        runtime.router_for_config(&invalid).is_err(),
         "invalid initial config should be retried from the worker loop"
     );
 
     let mut fixed = invalid.clone();
     fixed.base_url = Some("http://127.0.0.1:19999/v1".to_string());
-    let client = runtime
-        .client_for_config(&fixed)
-        .expect("fixed config should build a client");
+    let router = runtime
+        .router_for_config(&fixed)
+        .expect("fixed config should build a router");
 
-    assert_eq!(client.current_max_concurrent(), fixed.max_concurrent.max(1));
+    assert_eq!(router.endpoint_count(), 1);
 }
 
 // ── tokio::select! cancellation ───────────────────────────────────────────────

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -68,6 +68,65 @@ fn insert_drawer_with_source_type(db_path: &Path, id: &str, source_type: SourceT
     db.insert_drawer(&drawer).expect("insert drawer");
 }
 
+#[tokio::test]
+async fn test_mcp_status_reports_llm_endpoint_pool() {
+    let (tmp, db_path) = setup_home();
+    let mempal_home = tmp.path().join(".mempal");
+    let config_path = mempal_home.join("config.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[llm]
+enabled = true
+
+[[llm.endpoints]]
+id = "primary"
+base_url = "http://primary.local:8317/v1"
+model = "primary-model"
+max_concurrent = 2
+
+[[llm.endpoints]]
+id = "secondary"
+base_url = "http://secondary.local:8317/v1"
+model = "secondary-model"
+max_concurrent = 3
+
+[gating]
+enabled = true
+
+[gating.llm_judge]
+enabled = true
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write endpoint-pool config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap endpoint-pool config");
+    let config = Config::load_from(&config_path).expect("load endpoint-pool config");
+
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(
+        response.llm_status.model.as_deref(),
+        Some("primary=primary-model, secondary=secondary-model")
+    );
+    assert_eq!(
+        response.ingest_gating_status.llm_model.as_deref(),
+        Some("primary=primary-model, secondary=secondary-model")
+    );
+    assert_eq!(response.llm_status.endpoints.len(), 2);
+    assert_eq!(response.llm_status.endpoints[0].id, "primary");
+    assert_eq!(
+        response.llm_status.endpoints[0].base_url,
+        "http://primary.local:8317/v1"
+    );
+    assert_eq!(response.llm_status.endpoints[1].model, "secondary-model");
+}
+
 #[cfg(feature = "integration")]
 async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let app = Router::new().route(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "2bcba4aea27cd40b5149cc2b1e6509657ed4ebe1"
+commit = "14b5f3bccc4adcc61bcf42657840cc926e423f11"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add effective text LLM endpoint pools with legacy scalar `[llm]` compatibility.
- Route gating, rejudge, endpoint health, status/MCP surfaces, and observability through effective endpoint semantics.
- Add fallback/cooldown behavior, endpoint-pool warnings, hot-reload generation handling, and regression coverage.

Closes #364

## Verification

- Commit workflow completed via CSA commit skill.
- Local diff review PASS: `01KTV07F7VH68ASCJE58Z0ER44`.
- Full range review PASS for `main...HEAD`: `01KTV38H8FNW152Z6D96FF4H8H`.
- Commit: `6ce0b43 feat(llm): add endpoint pool fallback`.

## Notes

- `weave.lock` was committed with the related CSA/tooling change as required by repo policy.
- Gemini review was unavailable due quota; codex CSA review was used as fallback.
