### PR TITLE
Fix runtime install and LLM retry policy

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,9 +59,9 @@ test-onnx:
 build:
     cargo build --release --all-features
 
-# Install mempal binary to /usr/local/bin.
+# Install mempal binary to /usr/local/bin with REST enabled.
 install:
-    CARGO_HOME=/usr/local cargo install --path . --force
+    CARGO_INSTALL_ROOT="${CARGO_INSTALL_ROOT:-/usr/local}"; cargo install --path . --locked --features rest --force --root "$CARGO_INSTALL_ROOT"
 
 # Bump patch version (requires cargo-edit).
 bump-patch:

--- a/scripts/hooks/post-merge.sh
+++ b/scripts/hooks/post-merge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Auto-install mempal after merges that change the binary source.
+# Uses `just install` so the post-merge path stays feature-identical to manual installs.
 set -euo pipefail
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
@@ -9,7 +10,7 @@ if ! git rev-parse --verify ORIG_HEAD >/dev/null 2>&1; then
 fi
 
 changed_files=$(git diff-tree -r --name-only ORIG_HEAD HEAD 2>/dev/null || true)
-if ! grep -Eq '^(src/|Cargo\.toml$|crates/)' <<<"$changed_files"; then
+if ! grep -Eq '^(src/|Cargo\.toml$|Cargo\.lock$|justfile$|scripts/hooks/post-merge\.sh$|crates/)' <<<"$changed_files"; then
   exit 0
 fi
 
@@ -28,7 +29,7 @@ repo_root=$1
 
 printf "\n[%s] post-merge install started in %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$repo_root"
 cd "$repo_root"
-CARGO_HOME=/usr/local cargo install --path . --force
+just install
 printf "[%s] post-merge install finished\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ' mempal-post-merge-install "$repo_root" >>"$log_file" 2>&1 </dev/null &
 

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -14,7 +14,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 git pull --ff-only origin main
-CARGO_HOME="${CARGO_HOME:-/usr/local}" cargo install --path crates/mempal-cli --force --locked
+install_root="${CARGO_INSTALL_ROOT:-/usr/local}"
+cargo install --path . --force --locked --features rest --root "$install_root"
 
 echo "--- verifying schema match ---"
-"${CARGO_HOME:-/usr/local}/bin/mempal" status | grep -E "schema_version|fork_ext_version"
+"$install_root/bin/mempal" status | grep -E "schema_version|fork_ext_version"

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -65,7 +65,7 @@ impl LlmRouter {
         request: &LlmRequest,
         heartbeat: Option<&HeartbeatCallback>,
     ) -> Result<RoutedLlmResponse, LlmError> {
-        let mut last_retryable = None;
+        let mut last_non_cooldown_retryable = None;
         let mut earliest_retry_after: Option<Duration> = None;
         for endpoint in self.endpoints.iter() {
             if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
@@ -96,13 +96,14 @@ impl LlmRouter {
                             Some(current) => current.min(retry_after),
                             None => retry_after,
                         });
+                    } else {
+                        last_non_cooldown_retryable = Some(error);
                     }
-                    last_retryable = Some(error);
                 }
                 Err(error) => return Err(error),
             }
         }
-        match (last_retryable, earliest_retry_after) {
+        match (last_non_cooldown_retryable, earliest_retry_after) {
             (Some(error), _) => Err(error),
             (None, Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
                 retry_after,

--- a/tests/llm_router.rs
+++ b/tests/llm_router.rs
@@ -137,7 +137,7 @@ async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
     let primary_mock = primary
         .mock("POST", "/v1/chat/completions")
         .with_status(429)
-        .with_header("retry-after", "2")
+        .with_header("retry-after", "5")
         .with_body("primary rate limited")
         .expect(1)
         .create_async()
@@ -145,7 +145,7 @@ async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
     let secondary_mock = secondary
         .mock("POST", "/v1/chat/completions")
         .with_status(429)
-        .with_header("retry-after", "2")
+        .with_header("retry-after", "60")
         .with_body("secondary rate limited")
         .expect(1)
         .create_async()
@@ -164,15 +164,61 @@ async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
 
     primary_mock.assert_async().await;
     secondary_mock.assert_async().await;
+    assert!(matches!(
+        first,
+        LlmError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after == std::time::Duration::from_secs(5)
+    ));
     assert!(first.is_retryable());
     assert!(matches!(
         second,
         LlmError::TemporarilyUnavailable {
             retry_after,
             ..
-        } if retry_after <= std::time::Duration::from_secs(2)
+        } if retry_after <= std::time::Duration::from_secs(5)
     ));
     assert!(second.is_retryable());
+}
+
+#[tokio::test]
+async fn test_llm_router_mixed_5xx_then_rate_limit_uses_non_cooldown_retry_policy() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("primary server error")
+        .expect(1)
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "60")
+        .with_body("secondary rate limited")
+        .expect(1)
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let error = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("ordinary retryable failure should win over endpoint cooldown");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(matches!(
+        error,
+        LlmError::HttpStatus {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            ..
+        }
+    ));
+    assert!(error.is_retryable());
 }
 
 #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "14b5f3bccc4adcc61bcf42657840cc926e423f11"
+commit = "6d9dd5929c80f187d9141d8d564233136cb75ac7"
 source_kind = "git"


### PR DESCRIPTION
## Summary\n\n- update weave.lock for the cli-sub-agent pin drift\n- keep local mempal installs REST-enabled for Hermes-facing service usage\n- preserve LLM retry policy when endpoint cooldown and ordinary retryable failures are mixed\n\n## Verification\n\n- just clippy\n- just test\n- cargo test --test llm_router\n- bash -n scripts/hooks/post-merge.sh scripts/install-from-source.sh\n- just --dry-run install\n- cargo install --path . --locked --features rest --force --root <tmp> --debug && <tmp>/bin/mempal --version\n- csa review --range main...HEAD: PASS (01KTV8MYCAGZZ6D32825D6MB8D)\n\n## CSA Notes\n\n- gemini quota fallback failure tracked in RyderFreeman4Logos/cli-sub-agent#2037\n- commit skill daemon/result failures tracked in #2048/#2049\n