### PR TITLE
Fix stale MCP holder daemon restart loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,10 @@ jobs:
         with:
           components: rustfmt
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
 
       - name: cargo fmt --all --check
         run: cargo fmt --all --check
@@ -31,6 +33,8 @@ jobs:
     name: ${{ matrix.label }}
     needs: fmt
     runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_JOBS: 2
     strategy:
       fail-fast: false
       matrix:
@@ -47,14 +51,22 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache cargo registry and target
+      - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "false"
 
       - name: cargo clippy --workspace --all-targets ${{ matrix.cargo_args }} -- -D warnings
         run: cargo clippy --workspace --all-targets ${{ matrix.cargo_args }} -- -D warnings
 
+      - name: Clear clippy artifacts before tests
+        run: cargo clean
+
       - name: cargo test --workspace ${{ matrix.cargo_args }}
         run: cargo test --workspace ${{ matrix.cargo_args }}
+
+      - name: Clear test artifacts before release build
+        run: cargo clean
 
       - name: cargo build --workspace --release ${{ matrix.cargo_args }}
         run: cargo build --workspace --release ${{ matrix.cargo_args }}

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicU64, Ordering},
 };
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
@@ -19,6 +19,10 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 
 const DAEMON_STALL_SECONDS: u64 = 5 * 60;
 const DAEMON_STALL_LOG_THROTTLE_SECONDS: u64 = 60;
+#[cfg(target_os = "linux")]
+const DB_HOLDER_TERM_GRACE: Duration = Duration::from_secs(2);
+#[cfg(target_os = "linux")]
+const DB_HOLDER_TERM_POLL: Duration = Duration::from_millis(100);
 
 pub type SharedDatabase = Arc<AsyncMutex<Database>>;
 
@@ -240,9 +244,7 @@ fn bootstrap_inner(
 
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::DbOpen);
-    let db = Database::open(&db_path).context("failed to open daemon database")?;
-    let async_db = AsyncDb::open(&db_path, 4).context("failed to open daemon async database")?;
-    let store = AsyncPendingMessageStore::new(db.path()).context("failed to open pending queue")?;
+    let (db, async_db, store) = open_daemon_storage_with_remediation(&db_path)?;
     let db = Arc::new(AsyncMutex::new(db));
     let write_observer = DaemonWriteObserver::new();
 
@@ -266,6 +268,172 @@ fn bootstrap_inner(
         _pid_guard: pid_guard,
         _lock_guard: lock_guard,
     })
+}
+
+fn open_daemon_storage_with_remediation(
+    db_path: &Path,
+) -> Result<(Database, AsyncDb, AsyncPendingMessageStore)> {
+    match open_daemon_storage_once(db_path) {
+        Ok(handles) => Ok(handles),
+        Err(error) if is_sqlite_lock_error(&error) => {
+            #[cfg(target_os = "linux")]
+            {
+                open_daemon_storage_after_stale_holder_cleanup(db_path, error)
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(error)
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn open_daemon_storage_once(
+    db_path: &Path,
+) -> Result<(Database, AsyncDb, AsyncPendingMessageStore)> {
+    let db = Database::open(db_path).context("failed to open daemon database")?;
+    let async_db = AsyncDb::open(db_path, 4).context("failed to open daemon async database")?;
+    let store = AsyncPendingMessageStore::new(db.path()).context("failed to open pending queue")?;
+    Ok((db, async_db, store))
+}
+
+fn is_sqlite_lock_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains("database is locked")
+            || message.contains("database file is locked")
+            || message.contains("database is busy")
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn open_daemon_storage_after_stale_holder_cleanup(
+    db_path: &Path,
+    first_error: anyhow::Error,
+) -> Result<(Database, AsyncDb, AsyncPendingMessageStore)> {
+    let before = crate::process_diagnostics::inspect_db_holders(db_path);
+    let plan = crate::process_diagnostics::plan_stale_db_holder_remediation(&before);
+    let mut remediation_errors = Vec::new();
+
+    if !plan.terminate_pids.is_empty() {
+        if let Err(error) = terminate_db_holder_pids(
+            &plan.terminate_pids,
+            DB_HOLDER_TERM_GRACE,
+            DB_HOLDER_TERM_POLL,
+        ) {
+            remediation_errors.push(error.to_string());
+        }
+    }
+
+    match open_daemon_storage_once(db_path) {
+        Ok(handles) => Ok(handles),
+        Err(error) if is_sqlite_lock_error(&error) => {
+            let after = crate::process_diagnostics::inspect_db_holders(db_path);
+            let terminated_pids = plan.terminate_pids;
+            Err(anyhow::anyhow!(
+                "{}",
+                crate::process_diagnostics::format_db_lock_remediation_hint(
+                    db_path,
+                    &format!(
+                        "{}; initial error: {}",
+                        format_error_chain(&error),
+                        format_error_chain(&first_error)
+                    ),
+                    &after,
+                    &terminated_pids,
+                    &remediation_errors,
+                )
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn format_error_chain(error: &anyhow::Error) -> String {
+    error
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(": ")
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_db_holder_pids(pids: &[i32], grace: Duration, poll: Duration) -> Result<()> {
+    let mut remaining = pids.to_vec();
+    let mut errors = Vec::new();
+
+    for pid in &remaining {
+        if let Err(error) = signal_pid(*pid, libc::SIGTERM) {
+            errors.push(format!("SIGTERM pid {pid} failed: {error}"));
+        }
+    }
+
+    let deadline = Instant::now() + grace;
+    while Instant::now() < deadline {
+        remaining.retain(|pid| match process_is_running(*pid) {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(error) => {
+                errors.push(format!("status pid {pid} failed: {error}"));
+                false
+            }
+        });
+        if remaining.is_empty() {
+            break;
+        }
+        std::thread::sleep(poll);
+    }
+
+    for pid in remaining {
+        match process_is_running(pid) {
+            Ok(true) => {
+                if let Err(error) = signal_pid(pid, libc::SIGKILL) {
+                    errors.push(format!("SIGKILL pid {pid} failed: {error}"));
+                }
+            }
+            Ok(false) => {}
+            Err(error) => errors.push(format!("status pid {pid} failed: {error}")),
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("{}", errors.join("; ")))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn signal_pid(pid: i32, signal: i32) -> Result<()> {
+    // SAFETY: the PID list comes from exact DB-holder classification for this
+    // database. ESRCH means the process exited between planning and signal.
+    let rc = unsafe { libc::kill(pid, signal) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    Err(error).with_context(|| format!("failed to signal pid {pid}"))
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_running(pid: i32) -> Result<bool> {
+    // SAFETY: kill(pid, 0) performs a kernel liveness/permission check without
+    // delivering a signal or dereferencing Rust memory.
+    let rc = unsafe { libc::kill(pid, 0) };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH) => Ok(false),
+        Some(libc::EPERM) => Ok(true),
+        _ => Err(error).with_context(|| format!("failed to inspect pid {pid}")),
+    }
 }
 
 fn unix_secs() -> u64 {
@@ -465,6 +633,14 @@ mod tests {
         observer.force_last_successful_write_for_test(now.saturating_sub(DAEMON_STALL_SECONDS));
 
         assert_eq!(observer.stall_diagnostic(&store, now).await, None);
+    }
+
+    #[test]
+    fn test_sqlite_lock_detection_checks_context_chain() {
+        let error = anyhow::anyhow!("database is locked: Error code 5")
+            .context("failed to open daemon database");
+
+        assert!(is_sqlite_lock_error(&error));
     }
 
     #[test]

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -18,7 +18,9 @@ use anyhow::{Context, Result};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
 
 #[cfg(target_os = "linux")]
-use crate::process_diagnostics::{DbHolderRemediationTarget, DbHolderReport, inspect_db_holders};
+use crate::process_diagnostics::{
+    DbHolderRemediationTarget, DbHolderReport, inspect_db_holders_for_startup_remediation,
+};
 
 const DAEMON_STALL_SECONDS: u64 = 5 * 60;
 const DAEMON_STALL_LOG_THROTTLE_SECONDS: u64 = 60;
@@ -315,7 +317,7 @@ fn open_daemon_storage_after_stale_holder_cleanup(
     db_path: &Path,
     first_error: anyhow::Error,
 ) -> Result<(Database, AsyncDb, AsyncPendingMessageStore)> {
-    let before = crate::process_diagnostics::inspect_db_holders(db_path);
+    let before = inspect_db_holders_for_startup_remediation(db_path);
     let plan = crate::process_diagnostics::plan_stale_db_holder_remediation(&before);
     let mut remediation_errors = Vec::new();
 
@@ -333,7 +335,7 @@ fn open_daemon_storage_after_stale_holder_cleanup(
     match open_daemon_storage_once(db_path) {
         Ok(handles) => Ok(handles),
         Err(error) if is_sqlite_lock_error(&error) => {
-            let after = crate::process_diagnostics::inspect_db_holders(db_path);
+            let after = inspect_db_holders_for_startup_remediation(db_path);
             let terminated_pids = termination_outcome.signaled;
             Err(anyhow::anyhow!(
                 "{}",
@@ -395,7 +397,7 @@ struct RealDbHolderProcessOps<'a> {
 #[cfg(target_os = "linux")]
 impl DbHolderProcessOps for RealDbHolderProcessOps<'_> {
     fn inspect_holders(&mut self) -> DbHolderReport {
-        inspect_db_holders(self.db_path)
+        inspect_db_holders_for_startup_remediation(self.db_path)
     }
 
     fn signal(&mut self, pid: i32, signal: i32) -> Result<()> {

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -17,6 +17,9 @@ use crate::core::{
 use anyhow::{Context, Result};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
 
+#[cfg(target_os = "linux")]
+use crate::process_diagnostics::{DbHolderRemediationTarget, DbHolderReport, inspect_db_holders};
+
 const DAEMON_STALL_SECONDS: u64 = 5 * 60;
 const DAEMON_STALL_LOG_THROTTLE_SECONDS: u64 = 60;
 #[cfg(target_os = "linux")]
@@ -316,21 +319,22 @@ fn open_daemon_storage_after_stale_holder_cleanup(
     let plan = crate::process_diagnostics::plan_stale_db_holder_remediation(&before);
     let mut remediation_errors = Vec::new();
 
-    if !plan.terminate_pids.is_empty() {
-        if let Err(error) = terminate_db_holder_pids(
-            &plan.terminate_pids,
+    let mut termination_outcome = DbHolderTerminationOutcome::default();
+    if !plan.terminate_targets.is_empty() {
+        termination_outcome = terminate_db_holder_targets(
+            db_path,
+            &plan.terminate_targets,
             DB_HOLDER_TERM_GRACE,
             DB_HOLDER_TERM_POLL,
-        ) {
-            remediation_errors.push(error.to_string());
-        }
+        );
+        remediation_errors.extend(termination_outcome.errors.clone());
     }
 
     match open_daemon_storage_once(db_path) {
         Ok(handles) => Ok(handles),
         Err(error) if is_sqlite_lock_error(&error) => {
             let after = crate::process_diagnostics::inspect_db_holders(db_path);
-            let terminated_pids = plan.terminate_pids;
+            let terminated_pids = termination_outcome.signaled;
             Err(anyhow::anyhow!(
                 "{}",
                 crate::process_diagnostics::format_db_lock_remediation_hint(
@@ -360,49 +364,189 @@ fn format_error_chain(error: &anyhow::Error) -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn terminate_db_holder_pids(pids: &[i32], grace: Duration, poll: Duration) -> Result<()> {
-    let mut remaining = pids.to_vec();
-    let mut errors = Vec::new();
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct DbHolderTerminationOutcome {
+    signaled: Vec<i32>,
+    killed: Vec<i32>,
+    errors: Vec<String>,
+}
 
-    for pid in &remaining {
-        if let Err(error) = signal_pid(*pid, libc::SIGTERM) {
-            errors.push(format!("SIGTERM pid {pid} failed: {error}"));
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DbHolderSignalAttempt {
+    Signaled,
+    IdentityMismatch(String),
+    SignalFailed(String),
+}
+
+#[cfg(target_os = "linux")]
+trait DbHolderProcessOps {
+    fn inspect_holders(&mut self) -> DbHolderReport;
+    fn signal(&mut self, pid: i32, signal: i32) -> Result<()>;
+    fn is_running(&mut self, pid: i32) -> Result<bool>;
+    fn sleep(&mut self, duration: Duration);
+}
+
+#[cfg(target_os = "linux")]
+struct RealDbHolderProcessOps<'a> {
+    db_path: &'a Path,
+}
+
+#[cfg(target_os = "linux")]
+impl DbHolderProcessOps for RealDbHolderProcessOps<'_> {
+    fn inspect_holders(&mut self) -> DbHolderReport {
+        inspect_db_holders(self.db_path)
+    }
+
+    fn signal(&mut self, pid: i32, signal: i32) -> Result<()> {
+        signal_pid(pid, signal)
+    }
+
+    fn is_running(&mut self, pid: i32) -> Result<bool> {
+        process_is_running(pid)
+    }
+
+    fn sleep(&mut self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_db_holder_targets(
+    db_path: &Path,
+    targets: &[DbHolderRemediationTarget],
+    grace: Duration,
+    poll: Duration,
+) -> DbHolderTerminationOutcome {
+    let mut ops = RealDbHolderProcessOps { db_path };
+    terminate_db_holder_targets_with_ops(targets, &mut ops, grace, poll)
+}
+
+#[cfg(target_os = "linux")]
+fn terminate_db_holder_targets_with_ops(
+    targets: &[DbHolderRemediationTarget],
+    ops: &mut impl DbHolderProcessOps,
+    grace: Duration,
+    poll: Duration,
+) -> DbHolderTerminationOutcome {
+    let mut outcome = DbHolderTerminationOutcome::default();
+    let mut remaining = Vec::new();
+
+    for target in targets {
+        match signal_matching_db_holder(target, libc::SIGTERM, ops, "SIGTERM") {
+            DbHolderSignalAttempt::Signaled => {
+                outcome.signaled.push(target.pid);
+                remaining.push(target.clone());
+            }
+            DbHolderSignalAttempt::IdentityMismatch(error) => {
+                outcome.errors.push(error);
+            }
+            DbHolderSignalAttempt::SignalFailed(error) => {
+                outcome.errors.push(error);
+                remaining.push(target.clone());
+            }
         }
     }
 
     let deadline = Instant::now() + grace;
     while Instant::now() < deadline {
-        remaining.retain(|pid| match process_is_running(*pid) {
-            Ok(true) => true,
-            Ok(false) => false,
-            Err(error) => {
-                errors.push(format!("status pid {pid} failed: {error}"));
-                false
-            }
-        });
-        if remaining.is_empty() {
-            break;
-        }
-        std::thread::sleep(poll);
-    }
-
-    for pid in remaining {
-        match process_is_running(pid) {
-            Ok(true) => {
-                if let Err(error) = signal_pid(pid, libc::SIGKILL) {
-                    errors.push(format!("SIGKILL pid {pid} failed: {error}"));
+        let mut live = Vec::new();
+        for target in std::mem::take(&mut remaining) {
+            match ops.is_running(target.pid) {
+                Ok(true) => live.push(target),
+                Ok(false) => {}
+                Err(error) => {
+                    outcome
+                        .errors
+                        .push(format!("status pid {} failed: {error}", target.pid));
                 }
             }
+        }
+        if live.is_empty() {
+            break;
+        }
+        remaining = live;
+        ops.sleep(poll);
+    }
+
+    for target in remaining {
+        match ops.is_running(target.pid) {
+            Ok(true) => match signal_matching_db_holder(&target, libc::SIGKILL, ops, "SIGKILL") {
+                DbHolderSignalAttempt::Signaled => outcome.killed.push(target.pid),
+                DbHolderSignalAttempt::IdentityMismatch(error)
+                | DbHolderSignalAttempt::SignalFailed(error) => outcome.errors.push(error),
+            },
             Ok(false) => {}
-            Err(error) => errors.push(format!("status pid {pid} failed: {error}")),
+            Err(error) => outcome
+                .errors
+                .push(format!("status pid {} failed: {error}", target.pid)),
         }
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!("{}", errors.join("; ")))
+    outcome
+}
+
+#[cfg(target_os = "linux")]
+fn signal_matching_db_holder(
+    target: &DbHolderRemediationTarget,
+    signal: i32,
+    ops: &mut impl DbHolderProcessOps,
+    stage: &str,
+) -> DbHolderSignalAttempt {
+    let report = ops.inspect_holders();
+    if !report
+        .holders
+        .iter()
+        .any(|holder| target.matches_holder(holder))
+    {
+        return DbHolderSignalAttempt::IdentityMismatch(format_identity_mismatch_error(
+            target, &report, stage,
+        ));
     }
+
+    match ops.signal(target.pid, signal) {
+        Ok(()) => DbHolderSignalAttempt::Signaled,
+        Err(error) => DbHolderSignalAttempt::SignalFailed(format!(
+            "{stage} pid {} failed: {error}",
+            target.pid
+        )),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn format_identity_mismatch_error(
+    target: &DbHolderRemediationTarget,
+    report: &DbHolderReport,
+    stage: &str,
+) -> String {
+    let current = report
+        .holders
+        .iter()
+        .find(|holder| holder.pid == target.pid)
+        .map(describe_current_holder)
+        .unwrap_or_else(|| "no current holder for this DB".to_string());
+    format!(
+        "{stage} pid {} skipped: planned DB holder identity no longer matches; expected {}; current {}; retry daemon startup or inspect with `mempal status --full` before manual cleanup",
+        target.pid,
+        target.describe(),
+        current
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn describe_current_holder(holder: &crate::process_diagnostics::DbHolderProcess) -> String {
+    let started = holder
+        .started_at_unix_secs
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    format!(
+        "pid={} role={} classification={} started_at={} files={}",
+        holder.pid,
+        holder.role,
+        holder.classification,
+        started,
+        holder.opened_files.join(",")
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -652,5 +796,177 @@ mod tests {
         assert!(resolved.is_absolute());
         assert_eq!(resolved, cwd.join(&relative));
         Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[derive(Default)]
+    struct FakeDbHolderOps {
+        reports: Vec<DbHolderReport>,
+        running: std::collections::BTreeMap<i32, bool>,
+        signals: Vec<(i32, i32)>,
+        term_ignored: std::collections::BTreeSet<i32>,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl DbHolderProcessOps for FakeDbHolderOps {
+        fn inspect_holders(&mut self) -> DbHolderReport {
+            if self.reports.len() > 1 {
+                self.reports.remove(0)
+            } else {
+                self.reports
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| db_holder_report(Vec::new()))
+            }
+        }
+
+        fn signal(&mut self, pid: i32, signal: i32) -> Result<()> {
+            self.signals.push((pid, signal));
+            if signal == libc::SIGKILL
+                || (signal == libc::SIGTERM && !self.term_ignored.contains(&pid))
+            {
+                self.running.insert(pid, false);
+            }
+            Ok(())
+        }
+
+        fn is_running(&mut self, pid: i32) -> Result<bool> {
+            Ok(self.running.get(&pid).copied().unwrap_or(false))
+        }
+
+        fn sleep(&mut self, _duration: Duration) {}
+    }
+
+    #[cfg(target_os = "linux")]
+    fn db_holder_report(
+        holders: Vec<crate::process_diagnostics::DbHolderProcess>,
+    ) -> DbHolderReport {
+        DbHolderReport {
+            db_path: "/tmp/palace.db".to_string(),
+            holder_count: holders.len(),
+            extra_holder_count: holders
+                .iter()
+                .filter(|holder| holder.classification == "extra_holder")
+                .count(),
+            stale_mcp_server_count: holders
+                .iter()
+                .filter(|holder| holder.classification == "stale_mcp_server")
+                .count(),
+            orphan_daemon_count: holders
+                .iter()
+                .filter(|holder| holder.classification == "orphan_daemon")
+                .count(),
+            error: None,
+            holders,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn db_holder(
+        pid: i32,
+        role: &str,
+        classification: &str,
+        started_at_unix_secs: u64,
+    ) -> crate::process_diagnostics::DbHolderProcess {
+        crate::process_diagnostics::DbHolderProcess {
+            pid,
+            role: role.to_string(),
+            classification: classification.to_string(),
+            command: match role {
+                "mempal_mcp_server" => "mempal serve".to_string(),
+                "mempal_daemon" => "mempal daemon".to_string(),
+                _ => "other process".to_string(),
+            },
+            opened_files: vec!["db".to_string()],
+            started_at_unix_secs: Some(started_at_unix_secs),
+            age_secs: None,
+            current_process: classification == "current_process",
+            current_daemon: classification == "current_daemon",
+            current_mcp_server: classification == "current_mcp_server",
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_db_holder_termination_skips_pid_reuse_before_sigterm() {
+        let original = db_holder(77, "mempal_mcp_server", "stale_mcp_server", 1_000);
+        let target = DbHolderRemediationTarget::from_holder(&original);
+        let reused = db_holder(77, "other", "extra_holder", 2_000);
+        let mut ops = FakeDbHolderOps {
+            reports: vec![db_holder_report(vec![reused])],
+            running: [(77, true)].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let outcome = terminate_db_holder_targets_with_ops(
+            &[target],
+            &mut ops,
+            Duration::ZERO,
+            Duration::from_millis(1),
+        );
+
+        assert!(ops.signals.is_empty());
+        assert!(outcome.signaled.is_empty());
+        assert_eq!(outcome.errors.len(), 1);
+        assert!(outcome.errors[0].contains("SIGTERM pid 77 skipped"));
+        assert!(outcome.errors[0].contains("classification=stale_mcp_server"));
+        assert!(outcome.errors[0].contains("classification=extra_holder"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_db_holder_termination_skips_pid_reuse_before_sigkill() {
+        let original = db_holder(88, "mempal_daemon", "orphan_daemon", 1_000);
+        let target = DbHolderRemediationTarget::from_holder(&original);
+        let reused = db_holder(88, "mempal_mcp_server", "current_mcp_server", 2_000);
+        let mut ops = FakeDbHolderOps {
+            reports: vec![
+                db_holder_report(vec![original]),
+                db_holder_report(vec![reused]),
+            ],
+            running: [(88, true)].into_iter().collect(),
+            term_ignored: [88].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let outcome = terminate_db_holder_targets_with_ops(
+            &[target],
+            &mut ops,
+            Duration::ZERO,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(ops.signals, vec![(88, libc::SIGTERM)]);
+        assert_eq!(outcome.signaled, vec![88]);
+        assert!(outcome.killed.is_empty());
+        assert_eq!(outcome.errors.len(), 1);
+        assert!(outcome.errors[0].contains("SIGKILL pid 88 skipped"));
+        assert!(outcome.errors[0].contains("classification=orphan_daemon"));
+        assert!(outcome.errors[0].contains("classification=current_mcp_server"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_db_holder_termination_preserves_matching_stale_holder_reap() {
+        let original = db_holder(99, "mempal_mcp_server", "stale_mcp_server", 1_000);
+        let target = DbHolderRemediationTarget::from_holder(&original);
+        let mut ops = FakeDbHolderOps {
+            reports: vec![db_holder_report(vec![original])],
+            running: [(99, true)].into_iter().collect(),
+            term_ignored: [99].into_iter().collect(),
+            ..Default::default()
+        };
+
+        let outcome = terminate_db_holder_targets_with_ops(
+            &[target],
+            &mut ops,
+            Duration::ZERO,
+            Duration::from_millis(1),
+        );
+
+        assert_eq!(ops.signals, vec![(99, libc::SIGTERM), (99, libc::SIGKILL)]);
+        assert_eq!(outcome.signaled, vec![99]);
+        assert_eq!(outcome.killed, vec![99]);
+        assert!(outcome.errors.is_empty());
     }
 }

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -37,10 +37,79 @@ impl DbHolderReport {
 /// Conservative remediation plan for stale mempal-owned DB holders.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DbHolderRemediationPlan {
+    /// Holder identities that are safe to terminate automatically if they
+    /// still match immediately before signalling.
+    pub terminate_targets: Vec<DbHolderRemediationTarget>,
     /// PIDs that are safe to terminate automatically.
+    ///
+    /// This is a convenience projection for diagnostics and tests. Signal
+    /// paths must use `terminate_targets` so PID reuse is guarded by identity.
     pub terminate_pids: Vec<i32>,
     /// Holders that must remain under operator control.
     pub manual_holders: Vec<DbHolderProcess>,
+}
+
+/// Immutable identity of a stale mempal-owned DB holder selected for cleanup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbHolderRemediationTarget {
+    pub pid: i32,
+    pub role: String,
+    pub classification: String,
+    pub opened_files: Vec<String>,
+    pub started_at_unix_secs: Option<u64>,
+}
+
+impl DbHolderRemediationTarget {
+    pub fn from_holder(holder: &DbHolderProcess) -> Self {
+        Self {
+            pid: holder.pid,
+            role: holder.role.clone(),
+            classification: holder.classification.clone(),
+            opened_files: holder.opened_files.clone(),
+            started_at_unix_secs: holder.started_at_unix_secs,
+        }
+    }
+
+    pub fn matches_holder(&self, holder: &DbHolderProcess) -> bool {
+        self.pid == holder.pid
+            && self.role == holder.role
+            && self.classification == holder.classification
+            && matches!(
+                self.classification.as_str(),
+                "stale_mcp_server" | "orphan_daemon"
+            )
+            && !holder.current_process
+            && !holder.current_daemon
+            && !holder.current_mcp_server
+            && self.matches_start_time(holder)
+            && self
+                .opened_files
+                .iter()
+                .all(|expected| holder.opened_files.contains(expected))
+    }
+
+    fn matches_start_time(&self, holder: &DbHolderProcess) -> bool {
+        match (self.started_at_unix_secs, holder.started_at_unix_secs) {
+            (Some(expected), Some(actual)) => expected == actual,
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    pub fn describe(&self) -> String {
+        let started = self
+            .started_at_unix_secs
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        format!(
+            "pid={} role={} classification={} started_at={} files={}",
+            self.pid,
+            self.role,
+            self.classification,
+            started,
+            self.opened_files.join(",")
+        )
+    }
 }
 
 /// Plan cleanup for stale mempal-owned holders already proven to hold this DB.
@@ -49,7 +118,7 @@ pub struct DbHolderRemediationPlan {
 /// which roles are safe to remediate. It never selects `extra_holder`,
 /// `current_daemon`, `current_mcp_server`, or `current_process` entries.
 pub fn plan_stale_db_holder_remediation(report: &DbHolderReport) -> DbHolderRemediationPlan {
-    let mut terminate_pids = Vec::new();
+    let mut terminate_targets = Vec::new();
     let mut manual_holders = Vec::new();
 
     for holder in &report.holders {
@@ -59,17 +128,22 @@ pub fn plan_stale_db_holder_remediation(report: &DbHolderReport) -> DbHolderReme
                     && !holder.current_daemon
                     && !holder.current_mcp_server =>
             {
-                terminate_pids.push(holder.pid);
+                terminate_targets.push(DbHolderRemediationTarget::from_holder(holder));
             }
             _ => manual_holders.push(holder.clone()),
         }
     }
 
-    terminate_pids.sort_unstable();
-    terminate_pids.dedup();
+    terminate_targets.sort_by_key(|target| target.pid);
+    terminate_targets.dedup_by_key(|target| target.pid);
+    let terminate_pids = terminate_targets
+        .iter()
+        .map(|target| target.pid)
+        .collect::<Vec<_>>();
     manual_holders.sort_by_key(|holder| holder.pid);
 
     DbHolderRemediationPlan {
+        terminate_targets,
         terminate_pids,
         manual_holders,
     }
@@ -471,6 +545,15 @@ mod tests {
     use super::*;
 
     fn holder(pid: i32, role: &str, classification: &str) -> DbHolderProcess {
+        holder_with_start(pid, role, classification, None)
+    }
+
+    fn holder_with_start(
+        pid: i32,
+        role: &str,
+        classification: &str,
+        started_at_unix_secs: Option<u64>,
+    ) -> DbHolderProcess {
         DbHolderProcess {
             pid,
             role: role.to_string(),
@@ -481,7 +564,7 @@ mod tests {
                 _ => "other process".to_string(),
             },
             opened_files: vec!["db".to_string()],
-            started_at_unix_secs: None,
+            started_at_unix_secs,
             age_secs: None,
             current_process: classification == "current_process",
             current_daemon: classification == "current_daemon",
@@ -507,12 +590,60 @@ mod tests {
 
         assert_eq!(plan.terminate_pids, vec![11, 22]);
         assert_eq!(
+            plan.terminate_targets
+                .iter()
+                .map(|target| target.pid)
+                .collect::<Vec<_>>(),
+            vec![11, 22]
+        );
+        assert_eq!(
             plan.manual_holders
                 .iter()
                 .map(|holder| holder.pid)
                 .collect::<Vec<_>>(),
             vec![33, 44, 55]
         );
+    }
+
+    #[test]
+    fn test_db_holder_remediation_target_rejects_pid_reuse_identity_mismatch() {
+        let target = DbHolderRemediationTarget::from_holder(&holder_with_start(
+            77,
+            "mempal_mcp_server",
+            "stale_mcp_server",
+            Some(1_000),
+        ));
+
+        assert!(target.matches_holder(&holder_with_start(
+            77,
+            "mempal_mcp_server",
+            "stale_mcp_server",
+            Some(1_000),
+        )));
+        assert!(!target.matches_holder(&holder_with_start(
+            77,
+            "mempal_mcp_server",
+            "stale_mcp_server",
+            None,
+        )));
+        assert!(!target.matches_holder(&holder_with_start(
+            77,
+            "mempal_mcp_server",
+            "stale_mcp_server",
+            Some(2_000),
+        )));
+        assert!(!target.matches_holder(&holder_with_start(
+            77,
+            "other",
+            "extra_holder",
+            Some(1_000),
+        )));
+        assert!(!target.matches_holder(&holder_with_start(
+            77,
+            "mempal_mcp_server",
+            "current_mcp_server",
+            Some(1_000),
+        )));
     }
 
     #[test]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -294,11 +294,19 @@ fn inspect_db_holders_in_proc(
         let role = classify_role(&argv, &binary_name);
         let current_process = pid == current_pid;
         let current_daemon = daemon_pid == Some(pid) && role == "mempal_daemon";
+        let stat_path = pid_dir.join("stat");
+        let parent_pid = read_parent_pid(&stat_path);
         let current_mcp_server = current_process && role == "mempal_mcp_server";
-        let classification =
-            classify_holder(role, current_process, current_daemon, current_mcp_server);
+        let orphan_mcp_server = role == "mempal_mcp_server" && parent_pid == Some(1);
+        let classification = classify_holder(
+            role,
+            current_process,
+            current_daemon,
+            current_mcp_server,
+            orphan_mcp_server,
+        );
         let started_at_unix_secs = boot_time.and_then(|btime| {
-            read_start_ticks(&pid_dir.join("stat")).map(|ticks| {
+            read_start_ticks(&stat_path).map(|ticks| {
                 btime.saturating_add(ticks.saturating_div(clock_ticks_per_second.max(1)))
             })
         });
@@ -436,6 +444,7 @@ fn classify_holder(
     current_process: bool,
     current_daemon: bool,
     current_mcp_server: bool,
+    orphan_mcp_server: bool,
 ) -> &'static str {
     if current_daemon {
         "current_daemon"
@@ -443,7 +452,7 @@ fn classify_holder(
         "current_mcp_server"
     } else if current_process {
         "current_process"
-    } else if role == "mempal_mcp_server" {
+    } else if orphan_mcp_server {
         "stale_mcp_server"
     } else if role == "mempal_daemon" {
         "orphan_daemon"
@@ -498,6 +507,22 @@ fn read_boot_time(proc_root: &Path) -> Option<u64> {
 fn read_start_ticks(path: &Path) -> Option<u64> {
     let content = fs::read(path).ok()?;
     parse_start_ticks(&content)
+}
+
+#[cfg(target_os = "linux")]
+fn read_parent_pid(path: &Path) -> Option<i32> {
+    let content = fs::read(path).ok()?;
+    parse_parent_pid(&content)
+}
+
+#[cfg(target_os = "linux")]
+fn parse_parent_pid(stat: &[u8]) -> Option<i32> {
+    let close = stat.windows(2).rposition(|window| window == b") ")?;
+    let parent_pid = stat[close + 2..]
+        .split(u8::is_ascii_whitespace)
+        .filter(|field| !field.is_empty())
+        .nth(1)?;
+    std::str::from_utf8(parent_pid).ok()?.parse::<i32>().ok()
 }
 
 #[cfg(target_os = "linux")]
@@ -683,13 +708,23 @@ mod tests {
         use std::path::PathBuf;
 
         fn write_process(proc_root: &Path, pid: i32, argv: &[&str], db_files: &[&Path]) {
+            write_process_with_parent(proc_root, pid, 0, argv, db_files);
+        }
+
+        fn write_process_with_parent(
+            proc_root: &Path,
+            pid: i32,
+            parent_pid: i32,
+            argv: &[&str],
+            db_files: &[&Path],
+        ) {
             let pid_dir = proc_root.join(pid.to_string());
             let fd_dir = pid_dir.join("fd");
             fs::create_dir_all(&fd_dir).expect("create fake fd dir");
             fs::write(pid_dir.join("cmdline"), argv.join("\0")).expect("write cmdline");
             fs::write(
                 pid_dir.join("stat"),
-                format!("{pid} (mempal) S 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 250"),
+                format!("{pid} (mempal) S {parent_pid} 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 250"),
             )
             .expect("write stat");
             for (index, file) in db_files.iter().enumerate() {
@@ -776,9 +811,10 @@ mod tests {
                 &["mempal", "daemon", "--foreground"],
                 &[db_path.as_path()],
             );
-            write_process(
+            write_process_with_parent(
                 &proc_root,
                 77,
+                1,
                 &["/usr/local/bin/mempal", "serve"],
                 &[db_path.as_path(), wal_path.as_path(), shm_path.as_path()],
             );
@@ -809,6 +845,40 @@ mod tests {
             assert_eq!(report.holders[1].age_secs, Some(98));
             assert_eq!(report.holders[2].classification, "orphan_daemon");
             assert_eq!(report.holders[3].classification, "extra_holder");
+        }
+
+        #[test]
+        fn test_inspect_db_holders_keeps_supervised_mcp_manual() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::write(proc_root.join("stat"), "cpu 0 0 0 0\nbtime 1000\n").expect("write stat");
+
+            let db_path = tmp.path().join("palace.db");
+            write_process_with_parent(
+                &proc_root,
+                77,
+                1234,
+                &["/usr/local/bin/mempal", "serve"],
+                &[db_path.as_path()],
+            );
+
+            let report = inspect_db_holders_in_proc(&db_path, &proc_root, 1100, 100);
+
+            assert_eq!(report.holder_count, 1);
+            assert_eq!(report.stale_mcp_server_count, 0);
+            assert_eq!(report.extra_holder_count, 1);
+            assert_eq!(report.holders[0].role, "mempal_mcp_server");
+            assert_eq!(report.holders[0].classification, "extra_holder");
+            let plan = plan_stale_db_holder_remediation(&report);
+            assert!(plan.terminate_pids.is_empty());
+            assert_eq!(
+                plan.manual_holders
+                    .iter()
+                    .map(|holder| holder.pid)
+                    .collect::<Vec<_>>(),
+                vec![77]
+            );
         }
 
         #[test]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -252,12 +252,66 @@ pub fn inspect_db_holders(db_path: &Path) -> DbHolderReport {
     }
 }
 
+/// Inspect live DB holders for daemon-startup remediation after the singleton
+/// daemon lock has already been acquired.
+///
+/// A process named by `daemon.pid` is protected in status output, but once the
+/// new daemon owns `daemon.lock`, a pidfile-only daemon holder is stale and can
+/// be classified as an `orphan_daemon` for the cleanup path.
+#[cfg(target_os = "linux")]
+pub(crate) fn inspect_db_holders_for_startup_remediation(db_path: &Path) -> DbHolderReport {
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    inspect_db_holders_in_proc_for_startup_remediation(
+        db_path,
+        Path::new("/proc"),
+        now_secs,
+        clock_ticks_per_second(),
+    )
+}
+
 #[cfg(target_os = "linux")]
 fn inspect_db_holders_in_proc(
     db_path: &Path,
     proc_root: &Path,
     now_secs: u64,
     clock_ticks_per_second: u64,
+) -> DbHolderReport {
+    inspect_db_holders_in_proc_with_daemon_pid_protection(
+        db_path,
+        proc_root,
+        now_secs,
+        clock_ticks_per_second,
+        true,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_db_holders_in_proc_for_startup_remediation(
+    db_path: &Path,
+    proc_root: &Path,
+    now_secs: u64,
+    clock_ticks_per_second: u64,
+) -> DbHolderReport {
+    inspect_db_holders_in_proc_with_daemon_pid_protection(
+        db_path,
+        proc_root,
+        now_secs,
+        clock_ticks_per_second,
+        false,
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_db_holders_in_proc_with_daemon_pid_protection(
+    db_path: &Path,
+    proc_root: &Path,
+    now_secs: u64,
+    clock_ticks_per_second: u64,
+    protect_daemon_pid: bool,
 ) -> DbHolderReport {
     let current_pid = std::process::id() as i32;
     let daemon_pid = read_daemon_pid(db_path);
@@ -293,7 +347,8 @@ fn inspect_db_holders_in_proc(
         let argv = read_cmdline(&pid_dir.join("cmdline"));
         let role = classify_role(&argv, &binary_name);
         let current_process = pid == current_pid;
-        let current_daemon = daemon_pid == Some(pid) && role == "mempal_daemon";
+        let current_daemon =
+            protect_daemon_pid && daemon_pid == Some(pid) && role == "mempal_daemon";
         let stat_path = pid_dir.join("stat");
         let parent_pid = read_parent_pid(&stat_path);
         let current_mcp_server = current_process && role == "mempal_mcp_server";
@@ -845,6 +900,68 @@ mod tests {
             assert_eq!(report.holders[1].age_secs, Some(98));
             assert_eq!(report.holders[2].classification, "orphan_daemon");
             assert_eq!(report.holders[3].classification, "extra_holder");
+        }
+
+        #[test]
+        fn test_startup_remediation_treats_stale_daemon_pidfile_as_orphan() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let proc_root = tmp.path().join("proc");
+            fs::create_dir_all(&proc_root).expect("create proc");
+            fs::write(proc_root.join("stat"), "cpu 0 0 0 0\nbtime 1000\n").expect("write stat");
+
+            let mempal_home = tmp.path().join(".mempal");
+            fs::create_dir_all(&mempal_home).expect("create mempal home");
+            let db_path = mempal_home.join("palace.db");
+            fs::write(mempal_home.join("daemon.pid"), "42042\n").expect("write pidfile");
+
+            write_process(
+                &proc_root,
+                42042,
+                &["mempal", "daemon", "--foreground"],
+                &[db_path.as_path()],
+            );
+            write_process_with_parent(
+                &proc_root,
+                7777,
+                1234,
+                &["/usr/local/bin/mempal", "serve"],
+                &[db_path.as_path()],
+            );
+
+            let report =
+                inspect_db_holders_in_proc_for_startup_remediation(&db_path, &proc_root, 1100, 100);
+
+            assert_eq!(report.holder_count, 2);
+            assert_eq!(report.orphan_daemon_count, 1);
+            assert_eq!(report.stale_mcp_server_count, 0);
+            assert_eq!(report.extra_holder_count, 1);
+            let daemon_holder = report
+                .holders
+                .iter()
+                .find(|holder| holder.pid == 42042)
+                .expect("daemon holder");
+            assert_eq!(daemon_holder.role, "mempal_daemon");
+            assert_eq!(daemon_holder.classification, "orphan_daemon");
+            assert!(!daemon_holder.current_daemon);
+
+            let mcp_holder = report
+                .holders
+                .iter()
+                .find(|holder| holder.pid == 7777)
+                .expect("mcp holder");
+            assert_eq!(mcp_holder.role, "mempal_mcp_server");
+            assert_eq!(mcp_holder.classification, "extra_holder");
+
+            let plan = plan_stale_db_holder_remediation(&report);
+            assert_eq!(plan.terminate_pids, vec![42042]);
+            assert!(plan.terminate_targets[0].matches_holder(daemon_holder));
+            assert_eq!(
+                plan.manual_holders
+                    .iter()
+                    .map(|holder| holder.pid)
+                    .collect::<Vec<_>>(),
+                vec![7777]
+            );
         }
 
         #[test]

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -34,6 +34,107 @@ impl DbHolderReport {
     }
 }
 
+/// Conservative remediation plan for stale mempal-owned DB holders.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DbHolderRemediationPlan {
+    /// PIDs that are safe to terminate automatically.
+    pub terminate_pids: Vec<i32>,
+    /// Holders that must remain under operator control.
+    pub manual_holders: Vec<DbHolderProcess>,
+}
+
+/// Plan cleanup for stale mempal-owned holders already proven to hold this DB.
+///
+/// The report is keyed to one SQLite DB identity, so this function only decides
+/// which roles are safe to remediate. It never selects `extra_holder`,
+/// `current_daemon`, `current_mcp_server`, or `current_process` entries.
+pub fn plan_stale_db_holder_remediation(report: &DbHolderReport) -> DbHolderRemediationPlan {
+    let mut terminate_pids = Vec::new();
+    let mut manual_holders = Vec::new();
+
+    for holder in &report.holders {
+        match holder.classification.as_str() {
+            "stale_mcp_server" | "orphan_daemon"
+                if !holder.current_process
+                    && !holder.current_daemon
+                    && !holder.current_mcp_server =>
+            {
+                terminate_pids.push(holder.pid);
+            }
+            _ => manual_holders.push(holder.clone()),
+        }
+    }
+
+    terminate_pids.sort_unstable();
+    terminate_pids.dedup();
+    manual_holders.sort_by_key(|holder| holder.pid);
+
+    DbHolderRemediationPlan {
+        terminate_pids,
+        manual_holders,
+    }
+}
+
+/// Build an actionable daemon-startup lock diagnostic without exposing argv.
+pub fn format_db_lock_remediation_hint(
+    db_path: &Path,
+    error: &str,
+    report: &DbHolderReport,
+    terminated_pids: &[i32],
+    remediation_errors: &[String],
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "failed to open daemon database {}: {error}",
+        db_path.display()
+    ));
+
+    if !terminated_pids.is_empty() {
+        lines.push(format!(
+            "automatically terminated stale mempal-owned DB holders: {}",
+            format_pid_list(terminated_pids)
+        ));
+    }
+    if !remediation_errors.is_empty() {
+        lines.push(format!(
+            "automatic cleanup encountered errors: {}",
+            remediation_errors.join("; ")
+        ));
+    }
+    if report.holders.is_empty() {
+        lines.push(
+            "no live DB holders were visible in process diagnostics after cleanup".to_string(),
+        );
+    } else {
+        lines.push("live DB holders after cleanup:".to_string());
+        for holder in &report.holders {
+            lines.push(format!(
+                "- pid={} role={} classification={} files={} command={}",
+                holder.pid,
+                holder.role,
+                holder.classification,
+                holder.opened_files.join(","),
+                holder.command
+            ));
+        }
+    }
+
+    lines.push(
+        "remediation: mempal only auto-terminates stale_mcp_server and orphan_daemon holders for \
+         this exact DB; stop extra/current holder processes manually or run `mempal daemon status` \
+         before retrying daemon startup"
+            .to_string(),
+    );
+    lines.join("\n")
+}
+
+fn format_pid_list(pids: &[i32]) -> String {
+    pids.iter()
+        .map(i32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// One live process with an open fd to `palace.db`, `palace.db-wal`, or
 /// `palace.db-shm`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -367,6 +468,80 @@ fn clock_ticks_per_second() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    fn holder(pid: i32, role: &str, classification: &str) -> DbHolderProcess {
+        DbHolderProcess {
+            pid,
+            role: role.to_string(),
+            classification: classification.to_string(),
+            command: match role {
+                "mempal_mcp_server" => "mempal serve".to_string(),
+                "mempal_daemon" => "mempal daemon".to_string(),
+                _ => "other process".to_string(),
+            },
+            opened_files: vec!["db".to_string()],
+            started_at_unix_secs: None,
+            age_secs: None,
+            current_process: classification == "current_process",
+            current_daemon: classification == "current_daemon",
+            current_mcp_server: classification == "current_mcp_server",
+        }
+    }
+
+    #[test]
+    fn test_plan_stale_db_holder_remediation_only_targets_stale_mempal_roles() {
+        let report = build_report(
+            Path::new("/tmp/palace.db"),
+            vec![
+                holder(11, "mempal_mcp_server", "stale_mcp_server"),
+                holder(22, "mempal_daemon", "orphan_daemon"),
+                holder(33, "other", "extra_holder"),
+                holder(44, "mempal_daemon", "current_daemon"),
+                holder(55, "mempal_mcp_server", "current_mcp_server"),
+            ],
+            None,
+        );
+
+        let plan = plan_stale_db_holder_remediation(&report);
+
+        assert_eq!(plan.terminate_pids, vec![11, 22]);
+        assert_eq!(
+            plan.manual_holders
+                .iter()
+                .map(|holder| holder.pid)
+                .collect::<Vec<_>>(),
+            vec![33, 44, 55]
+        );
+    }
+
+    #[test]
+    fn test_format_db_lock_remediation_hint_reports_roles_pids_and_hints() {
+        let report = build_report(
+            Path::new("/tmp/palace.db"),
+            vec![
+                holder(33, "other", "extra_holder"),
+                holder(44, "mempal_daemon", "current_daemon"),
+            ],
+            None,
+        );
+
+        let message = format_db_lock_remediation_hint(
+            Path::new("/tmp/palace.db"),
+            "database is locked",
+            &report,
+            &[11, 22],
+            &["SIGTERM pid 22 failed: permission denied".to_string()],
+        );
+
+        assert!(message.contains("failed to open daemon database /tmp/palace.db"));
+        assert!(message.contains("automatically terminated stale mempal-owned DB holders: 11, 22"));
+        assert!(message.contains("pid=33 role=other classification=extra_holder"));
+        assert!(message.contains("pid=44 role=mempal_daemon classification=current_daemon"));
+        assert!(message.contains("mempal only auto-terminates stale_mcp_server and orphan_daemon"));
+        assert!(message.contains("mempal daemon status"));
+    }
+
     #[cfg(target_os = "linux")]
     mod linux {
         use super::super::*;

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "983e4de193fb9cd31d7a4bdb0fe580918f4ae1db"
+commit = "acb5c3ae605c5522eb644109fc1f02737b8b7474"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "6d9dd5929c80f187d9141d8d564233136cb75ac7"
+commit = "983e4de193fb9cd31d7a4bdb0fe580918f4ae1db"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Auto-remediate daemon startup SQLite lock failures by terminating only stale mempal-owned MCP/daemon holders for the exact DB identity.
- Revalidate holder identity before each SIGTERM/SIGKILL so recycled PIDs are skipped instead of signaled.
- Add actionable diagnostics for remaining DB holders and include the CSA-updated weave.lock pin.

Fixes #391.

## Verification
- just fmt
- cargo test process_diagnostics
- cargo test daemon_bootstrap
- just clippy
- just test
- pre-commit hook: just clippy + just test
- CSA tier-4 codex review PASS: 01KTVD17HH3S1XGGCPCR88EJGX
- CSA range review PASS origin/main...HEAD: 01KTVD94Z99J26KX2FCWWBWWY7
- CSA pre-push range review PASS main...HEAD: 01KTVDPK7VVG2B0WXQADSF0W6G