### PR TITLE
fix(mcp): route ingest admission through daemon queue

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -13,6 +13,7 @@ use super::config::scrub_sensitive_text;
 static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 const STARTUP_RECLAIM_STALE_SECS: i64 = 60;
 const COMPLETION_METRICS_WINDOW_MINS: u64 = 10;
+const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 pub const LAST_ERROR_MAX_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Error)]
@@ -338,6 +339,10 @@ impl PendingMessageStore {
         };
         store.reclaim_stale(STARTUP_RECLAIM_STALE_SECS)?;
         Ok(store)
+    }
+
+    pub fn idempotent_message_id(kind: &str, idempotency_key: &str) -> String {
+        idempotent_key_message_id(kind, idempotency_key)
     }
 
     pub fn enqueue(&self, kind: &str, payload: &str) -> Result<String> {
@@ -862,9 +867,7 @@ impl PendingMessageStore {
         busy_timeout: Option<Duration>,
     ) -> Result<Connection> {
         let conn = Connection::open(&self.db_path)?;
-        if let Some(timeout) = busy_timeout {
-            conn.busy_timeout(timeout)?;
-        }
+        conn.busy_timeout(busy_timeout.unwrap_or(DEFAULT_BUSY_TIMEOUT))?;
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         Ok(conn)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -664,7 +664,7 @@ async fn persist_hook_ipc_request(
     request: crate::hook_ipc::HookIpcEnqueueRequest,
 ) -> crate::hook_ipc::HookIpcEnqueueResponse {
     match store
-        .enqueue_idempotent_with_key_fail_fast(
+        .enqueue_idempotent_with_key(
             request.kind.clone(),
             request.payload.clone(),
             request.idempotency_key.clone(),
@@ -2067,7 +2067,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_hook_ipc_rejects_when_sqlite_persistence_fails() {
+    async fn test_hook_ipc_waits_for_sqlite_persistence_after_client_timeout() {
         super::SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
@@ -2081,26 +2081,17 @@ mod tests {
         let observer = crate::daemon_bootstrap::DaemonWriteObserver::for_test();
         let request = crate::hook_ipc::HookIpcEnqueueRequest::new(
             HookEvent::UserPromptSubmit.queue_kind(),
-            r#"{"event":"UserPromptSubmit","payload":"not durable"}"#,
+            r#"{"event":"UserPromptSubmit","payload":"durable after lock"}"#,
         );
 
-        let response = tokio::time::timeout(
-            crate::hook_ipc::HOOK_IPC_TIMEOUT,
-            send_hook_ipc_request(store, observer, request),
-        )
-        .await
-        .expect("locked SQLite persistence must reject before hook IPC timeout");
-        match response {
-            crate::hook_ipc::HookIpcEnqueueResponse::Accepted => {
-                panic!("IPC must not ACK before pending_messages persistence")
-            }
-            crate::hook_ipc::HookIpcEnqueueResponse::Error { message } => {
-                assert!(
-                    message.contains("failed to persist hook IPC capture"),
-                    "{message}"
-                );
-            }
-        }
+        let mut response_task =
+            tokio::spawn(async move { send_hook_ipc_request(store, observer, request).await });
+        assert!(
+            tokio::time::timeout(crate::hook_ipc::HOOK_IPC_TIMEOUT, &mut response_task)
+                .await
+                .is_err(),
+            "locked SQLite persistence must not ACK before durability"
+        );
         let count_while_locked: i64 = rusqlite::Connection::open(&db_path)
             .expect("open read connection")
             .query_row("SELECT COUNT(*) FROM pending_messages", [], |row| {
@@ -2110,6 +2101,18 @@ mod tests {
         assert_eq!(count_while_locked, 0);
 
         lock_conn.execute_batch("ROLLBACK;").expect("release lock");
+        let response = response_task.await.expect("IPC response task");
+        assert_eq!(response, crate::hook_ipc::HookIpcEnqueueResponse::Accepted);
+        let (count_after_unlock, payload): (i64, String) = rusqlite::Connection::open(&db_path)
+            .expect("open read connection")
+            .query_row(
+                "SELECT COUNT(*), COALESCE(MAX(payload), '') FROM pending_messages",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("query pending after unlock");
+        assert_eq!(count_after_unlock, 1);
+        assert!(payload.contains("durable after lock"), "{payload}");
     }
 
     #[cfg(unix)]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 
 use crate::core::{
     config::{Config, ConfigHandle, TurnStorageMode, default_config_path},
-    db::Database,
     queue::PendingMessageStore,
     strata::is_raw_turn,
     utils::current_timestamp,
@@ -146,25 +145,7 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
         },
     );
 
-    let db = match Database::open(&db_path) {
-        Ok(db) => db,
-        Err(error) => {
-            let msg = format!(
-                "failed to open database for hook enqueue after {}: {error:#}",
-                fallback.reason()
-            );
-            crate::hook_diagnostics::log_hook_failure(
-                &mempal_home,
-                event_name,
-                &crate::hook_diagnostics::HookOutcome::Dropped {
-                    error: format!("{error:#}"),
-                    stage: "db_open".to_string(),
-                },
-            );
-            anyhow::bail!(msg);
-        }
-    };
-    let store = match PendingMessageStore::new(db.path()) {
+    let store = match PendingMessageStore::new(&db_path) {
         Ok(store) => store,
         Err(error) => {
             crate::hook_diagnostics::log_hook_failure(

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::core::{
     config::{Config, ConfigHandle, TurnStorageMode, default_config_path},
+    db::Database,
     queue::PendingMessageStore,
     strata::is_raw_turn,
     utils::current_timestamp,
@@ -145,6 +146,20 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
         },
     );
 
+    let database = match Database::open(&db_path) {
+        Ok(database) => database,
+        Err(error) => {
+            crate::hook_diagnostics::log_hook_failure(
+                &mempal_home,
+                event_name,
+                &crate::hook_diagnostics::HookOutcome::Dropped {
+                    error: format!("{error:#}"),
+                    stage: "db_init".to_string(),
+                },
+            );
+            return Err(error).context("failed to initialize pending queue database");
+        }
+    };
     let store = match PendingMessageStore::new(&db_path) {
         Ok(store) => store,
         Err(error) => {
@@ -159,6 +174,7 @@ pub fn enqueue_from_stdin(event: HookEvent) -> Result<()> {
             return Err(error).context("failed to open pending queue");
         }
     };
+    drop(database);
     let enqueue_result = match fallback.identity() {
         FallbackEnqueueIdentity::Fresh => store.enqueue(event.queue_kind(), &payload),
         FallbackEnqueueIdentity::Idempotent { key } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
@@ -26,7 +26,7 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
-    queue::{AsyncPendingMessageStore, ClaimedMessage},
+    queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore},
     reindex::ReindexProgressStore,
     strata::{count_raw_turn_drawers, is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
@@ -137,6 +137,22 @@ const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
 const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
 const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
+
+fn mcp_ingest_idempotency_key(payload: &str) -> String {
+    let now_ns = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(_) => 0,
+    };
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"mempal mcp ingest admission v1");
+    hasher.update(&[0]);
+    hasher.update(&now_ns.to_le_bytes());
+    hasher.update(&[0]);
+    hasher.update(&std::process::id().to_le_bytes());
+    hasher.update(&[0]);
+    hasher.update(payload.as_bytes());
+    format!("mcp-ingest-{}", hasher.finalize().to_hex())
+}
 
 #[derive(Clone)]
 pub struct MempalMcpServer {
@@ -3480,11 +3496,7 @@ impl MempalMcpServer {
         let payload = serde_json::to_string(&prepared).map_err(|error| {
             ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
         })?;
-        let operation_id = match self
-            .async_queue
-            .enqueue(INGEST_ASYNC_KIND.to_string(), payload)
-            .await
-        {
+        let operation_id = match self.enqueue_ingest_operation(payload).await {
             Ok(operation_id) => operation_id,
             Err(error) => {
                 return Err(ErrorData::internal_error(
@@ -3537,6 +3549,51 @@ impl MempalMcpServer {
         }
 
         Ok(Json(queued_response))
+    }
+
+    async fn enqueue_ingest_operation(&self, payload: String) -> anyhow::Result<String> {
+        let idempotency_key = mcp_ingest_idempotency_key(&payload);
+        if let Some(operation_id) = self
+            .try_enqueue_ingest_operation_via_daemon(payload.clone(), idempotency_key.clone())
+            .await?
+        {
+            return Ok(operation_id);
+        }
+
+        self.async_queue
+            .enqueue_idempotent_with_key(INGEST_ASYNC_KIND.to_string(), payload, idempotency_key)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn try_enqueue_ingest_operation_via_daemon(
+        &self,
+        payload: String,
+        idempotency_key: String,
+    ) -> anyhow::Result<Option<String>> {
+        let Some(mempal_home) = self.db_path.parent().map(Path::to_path_buf) else {
+            return Ok(None);
+        };
+        let operation_id =
+            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
+        let request = crate::hook_ipc::HookIpcEnqueueRequest {
+            kind: INGEST_ASYNC_KIND.to_string(),
+            payload,
+            idempotency_key,
+        };
+        let outcome = tokio::task::spawn_blocking(move || {
+            crate::hook_ipc::enqueue_with_default_timeout(&mempal_home, request)
+        })
+        .await
+        .context("blocking daemon ingest enqueue IPC failed")?;
+
+        match outcome {
+            crate::hook_ipc::HookIpcClientOutcome::Accepted => Ok(Some(operation_id)),
+            crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => {
+                tracing::debug!(reason = %reason, "daemon ingest enqueue unavailable; using local queue");
+                Ok(None)
+            }
+        }
     }
 
     async fn prepare_async_ingest_operation(
@@ -7952,6 +8009,54 @@ mod tests {
         .expect("create MCP server")
         .with_async_db_for_test(async_db);
         (tempdir, db_path, server)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_admission_prefers_daemon_ipc_queue() {
+        let (tempdir, db_path, server) = setup_server();
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            crate::hook_ipc::write_enqueue_response(
+                &mut stream,
+                &crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            )
+            .await
+            .expect("write daemon IPC response");
+            request
+        });
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "daemon-owned MCP queue admission".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest admission should succeed")
+            .0;
+
+        let request = daemon.await.expect("daemon IPC task");
+        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(
+            operation_id,
+            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &request.idempotency_key)
+        );
+        let local_record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query local queue");
+        assert!(
+            local_record.is_none(),
+            "MCP admission should not write the local queue when daemon IPC accepts"
+        );
     }
 
     #[tokio::test]

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -5,6 +5,8 @@ use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 #[cfg(unix)]
+use std::sync::mpsc;
+#[cfg(unix)]
 use std::thread;
 #[cfg(unix)]
 use std::time::Duration;
@@ -69,6 +71,23 @@ fn pending_message_count(db_path: &PathBuf) -> i64 {
         row.get(0)
     })
     .expect("query pending count")
+}
+
+#[cfg(unix)]
+fn hold_sqlite_write_lock(db_path: PathBuf, hold_for: Duration) -> thread::JoinHandle<()> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let conn = Connection::open(db_path).expect("open sqlite lock connection");
+        conn.execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold SQLite write lock");
+        ready_tx.send(()).expect("signal lock ready");
+        thread::sleep(hold_for);
+        conn.execute_batch("ROLLBACK;").expect("release lock");
+    });
+    ready_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("SQLite write lock ready");
+    handle
 }
 
 #[cfg(unix)]
@@ -198,6 +217,34 @@ fn test_hook_post_tool_enqueues_to_queue() {
     let envelope_json: Value = serde_json::from_str(&envelope).expect("envelope json");
     assert_eq!(envelope_json["event"], "PostToolUse");
     assert_eq!(envelope_json["payload"], payload);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_hook_direct_fallback_waits_for_transient_sqlite_busy() {
+    let (home, db_path) = setup_home();
+    let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_millis(300));
+    let payload = r#"{"prompt":"transient sqlite busy should be durable"}"#;
+
+    let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    lock.join().expect("lock thread");
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "fallback success must stay quiet, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        pending_message_count(&db_path),
+        1,
+        "hook fallback must persist after a transient SQLite write lock"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/hook_enqueue.rs
+++ b/tests/hook_enqueue.rs
@@ -24,6 +24,27 @@ fn setup_home() -> (TempDir, PathBuf) {
     setup_home_with_extra_config("")
 }
 
+fn setup_home_without_opening_db() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[hooks]
+enabled = true
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
 fn setup_home_with_extra_config(extra_config: &str) -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
     let mempal_home = tmp.path().join(".mempal");
@@ -217,6 +238,31 @@ fn test_hook_post_tool_enqueues_to_queue() {
     let envelope_json: Value = serde_json::from_str(&envelope).expect("envelope json");
     assert_eq!(envelope_json["event"], "PostToolUse");
     assert_eq!(envelope_json["payload"], payload);
+}
+
+#[test]
+fn test_hook_direct_fallback_initializes_missing_db_before_enqueue() {
+    let (home, db_path) = setup_home_without_opening_db();
+    let payload = r#"{"prompt":"first run fallback initializes queue"}"#;
+
+    let output = run_hook(&home, "hook_user_prompt", payload.as_bytes());
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "first-run fallback success must stay quiet, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        pending_message_count(&db_path),
+        1,
+        "hook fallback must create and migrate the queue database before enqueue"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- Route MCP ingest admission through the daemon queue when available, avoiding direct SQLite writes under stale MCP holders.
- Keep hook fallback durable with transient SQLITE_BUSY waits and idempotent daemon/fallback dedupe.
- Initialize/migrate the fallback queue database before direct enqueue on first-run fallback.

## Test Plan
- cargo test test_hook_direct_fallback_waits_for_transient_sqlite_busy --test hook_enqueue
- cargo test test_hook_direct_fallback_initializes_missing_db_before_enqueue --test hook_enqueue
- cargo test --test hook_enqueue
- cargo test test_mcp_ingest_admission_prefers_daemon_ipc_queue --lib
- cargo test test_hook_ipc_waits_for_sqlite_persistence_after_client_timeout --lib
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test --quiet

Closes #388