### PR TITLE
fix(rest): validate typed ingest before readiness gate

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -336,6 +336,68 @@ fn normalize_refs(values: Option<&[String]>) -> Vec<String> {
         .collect()
 }
 
+struct ValidatedIngestRequest {
+    source_type: SourceType,
+    confidence: f64,
+    typed_memory_kind: Option<MemoryKind>,
+    typed_domain: Option<MemoryDomain>,
+    typed_field: Option<String>,
+    typed_status: Option<KnowledgeStatus>,
+    typed_tier: Option<KnowledgeTier>,
+    typed_is_pinned: bool,
+    typed_statement: Option<String>,
+    typed_supporting_refs: Vec<String>,
+    typed_counterexample_refs: Vec<String>,
+    typed_teaching_refs: Vec<String>,
+    typed_verification_refs: Vec<String>,
+}
+
+fn validate_ingest_request(request: &IngestRequest) -> Result<ValidatedIngestRequest, ApiError> {
+    validate_temporal_param("valid_from", request.valid_from.as_deref())?;
+    validate_temporal_param("valid_until", request.valid_until.as_deref())?;
+    let source_type = parse_source_type_param(request.source_type.as_deref())?;
+    let confidence = resolve_confidence_param(source_type, request.confidence)?;
+    let typed_memory_kind = request
+        .memory_kind
+        .as_deref()
+        .map(parse_memory_kind)
+        .transpose()?;
+    let typed_domain = request.domain.as_deref().map(parse_domain).transpose()?;
+    let typed_field = request
+        .field
+        .as_deref()
+        .map(|f| f.trim().to_string())
+        .filter(|f| !f.is_empty());
+    let typed_status = request
+        .status
+        .as_deref()
+        .map(parse_status_opt)
+        .transpose()?;
+    let typed_tier = request.tier.as_deref().map(parse_tier_opt).transpose()?;
+    let typed_statement = request
+        .statement
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    Ok(ValidatedIngestRequest {
+        source_type,
+        confidence,
+        typed_memory_kind,
+        typed_domain,
+        typed_field,
+        typed_status,
+        typed_tier,
+        typed_is_pinned: request.is_pinned.unwrap_or(false),
+        typed_statement,
+        typed_supporting_refs: normalize_refs(request.supporting_refs.as_deref()),
+        typed_counterexample_refs: normalize_refs(request.counterexample_refs.as_deref()),
+        typed_teaching_refs: normalize_refs(request.teaching_refs.as_deref()),
+        typed_verification_refs: normalize_refs(request.verification_refs.as_deref()),
+    })
+}
+
 #[derive(Debug, Serialize)]
 struct StatusResponse {
     drawer_count: i64,
@@ -620,6 +682,7 @@ async fn ingest_handler(
     State(state): State<ApiState>,
     Json(request): Json<IngestRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    validate_ingest_request(&request)?;
     if global_embed_status().should_block_writes() {
         return Err(ApiError::new(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -645,10 +708,7 @@ async fn process_ingest_request(
         embedder_factory.build().await.map_err(internal_error)?;
     let db = Database::open(&db_path).map_err(internal_error)?;
     let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
-    validate_temporal_param("valid_from", request.valid_from.as_deref())?;
-    validate_temporal_param("valid_until", request.valid_until.as_deref())?;
-    let source_type = parse_source_type_param(request.source_type.as_deref())?;
-    let confidence = resolve_confidence_param(source_type, request.confidence)?;
+    let validated = validate_ingest_request(&request)?;
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
     let raw_turn = is_raw_turn(&request.wing, request.room.as_deref(), &config.turns);
@@ -665,36 +725,6 @@ async fn process_ingest_request(
     let drawer_importance =
         raw_turn_importance(&request.wing, request.room.as_deref(), &config.turns)
             .unwrap_or_else(|| request.importance.unwrap_or(0));
-
-    // Parse typed memory fields.
-    let typed_memory_kind = request
-        .memory_kind
-        .as_deref()
-        .map(parse_memory_kind)
-        .transpose()?;
-    let typed_domain = request.domain.as_deref().map(parse_domain).transpose()?;
-    let typed_field = request
-        .field
-        .as_deref()
-        .map(|f| f.trim().to_string())
-        .filter(|f| !f.is_empty());
-    let typed_status = request
-        .status
-        .as_deref()
-        .map(parse_status_opt)
-        .transpose()?;
-    let typed_tier = request.tier.as_deref().map(parse_tier_opt).transpose()?;
-    let typed_is_pinned = request.is_pinned.unwrap_or(false);
-    let typed_statement = request
-        .statement
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    let typed_supporting_refs = normalize_refs(request.supporting_refs.as_deref());
-    let typed_counterexample_refs = normalize_refs(request.counterexample_refs.as_deref());
-    let typed_teaching_refs = normalize_refs(request.teaching_refs.as_deref());
-    let typed_verification_refs = normalize_refs(request.verification_refs.as_deref());
 
     // Chunk the content using the token-aware chunker (issue #57).
     let chunks =
@@ -744,7 +774,7 @@ async fn process_ingest_request(
             &request.wing,
             request.room.as_deref(),
             chunk,
-            &source_type,
+            &validated.source_type,
         );
         let drawer_id = db
             .resolve_available_drawer_id(&preferred_drawer_id)
@@ -756,7 +786,7 @@ async fn process_ingest_request(
                 &db,
                 project_id.as_deref(),
                 &config.ingest_gating.fact_check,
-                confidence,
+                validated.confidence,
             )
             .map_err(internal_error)?
         {
@@ -831,42 +861,43 @@ async fn process_ingest_request(
                 wing: request.wing.clone(),
                 room: request.room.clone(),
                 source_file: Some(source_file),
-                source_type,
+                source_type: validated.source_type,
                 added_at: iso_timestamp(),
                 chunk_index: Some(*chunk_idx as i64),
                 importance: drawer_importance,
             });
             let drawer = Drawer {
-                confidence,
+                confidence: validated.confidence,
                 normalize_version: CURRENT_NORMALIZE_VERSION,
-                memory_kind: typed_memory_kind.unwrap_or(base.memory_kind),
-                domain: typed_domain.unwrap_or(base.domain),
-                field: typed_field
+                memory_kind: validated.typed_memory_kind.unwrap_or(base.memory_kind),
+                domain: validated.typed_domain.unwrap_or(base.domain),
+                field: validated
+                    .typed_field
                     .clone()
                     .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
-                status: typed_status.clone().or(base.status),
-                tier: typed_tier.clone().or(base.tier),
-                is_pinned: typed_is_pinned,
-                statement: typed_statement.clone().or(base.statement),
-                supporting_refs: if typed_supporting_refs.is_empty() {
+                status: validated.typed_status.clone().or(base.status),
+                tier: validated.typed_tier.clone().or(base.tier),
+                is_pinned: validated.typed_is_pinned,
+                statement: validated.typed_statement.clone().or(base.statement),
+                supporting_refs: if validated.typed_supporting_refs.is_empty() {
                     base.supporting_refs
                 } else {
-                    typed_supporting_refs.clone()
+                    validated.typed_supporting_refs.clone()
                 },
-                counterexample_refs: if typed_counterexample_refs.is_empty() {
+                counterexample_refs: if validated.typed_counterexample_refs.is_empty() {
                     base.counterexample_refs
                 } else {
-                    typed_counterexample_refs.clone()
+                    validated.typed_counterexample_refs.clone()
                 },
-                teaching_refs: if typed_teaching_refs.is_empty() {
+                teaching_refs: if validated.typed_teaching_refs.is_empty() {
                     base.teaching_refs
                 } else {
-                    typed_teaching_refs.clone()
+                    validated.typed_teaching_refs.clone()
                 },
-                verification_refs: if typed_verification_refs.is_empty() {
+                verification_refs: if validated.typed_verification_refs.is_empty() {
                     base.verification_refs
                 } else {
-                    typed_verification_refs.clone()
+                    validated.typed_verification_refs.clone()
                 },
                 ..base
             };

--- a/tests/rest_typed_ingest.rs
+++ b/tests/rest_typed_ingest.rs
@@ -46,6 +46,10 @@ enabled = false
 [search]
 bm25_fallback = true
 
+[embed.degradation]
+degrade_after_n_failures = 1
+block_writes_when_degraded = true
+
 [api]
 write_queue_capacity = 10
 write_drain_timeout_secs = 2
@@ -55,6 +59,7 @@ write_drain_timeout_secs = 2
         )
         .expect("write config");
         ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        global_embed_status().reset_for_tests();
         Self {
             _tmp: tmp,
             db_path,
@@ -338,6 +343,27 @@ async fn test_typed_ingest_invalid_memory_kind_returns_400() {
     .await;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_typed_ingest_invalid_memory_kind_returns_400_when_writes_degraded() {
+    let env = TestEnv::new();
+    let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+    global_embed_status().record_failure(&"synthetic degraded state");
+    assert!(global_embed_status().should_block_writes());
+
+    let (status, body) = post_json(
+        state,
+        "/api/ingest",
+        json!({
+            "content": "Some content.",
+            "wing": "test",
+            "memory_kind": "invalid_kind",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
 }
 
 #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "acb5c3ae605c5522eb644109fc1f02737b8b7474"
+commit = "cb399ff0bdc60b6bce6539b7f2d2dfa0abe4540e"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Validate typed ingest request fields before write-readiness/degraded-status checks.
- Preserve the existing ingest processing path by reusing a validated request bundle inside processing.
- Add regression coverage that invalid memory_kind still returns 400 while writes are degraded.
- Include weave.lock update generated by the verified gate.

## Test Plan
- cargo test --features rest test_typed_ingest_invalid_memory_kind_returns_400 --test rest_typed_ingest
- cargo test --features rest test_typed_ingest_invalid_memory_kind_returns_400_when_writes_degraded --test rest_typed_ingest
- cargo test --features rest --test rest_typed_ingest
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --workspace --features rest

Closes #396