### PR TITLE
fix(status): report live queue counts from pending_messages

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -90,7 +90,7 @@ SET op_state = CASE
     WHEN rejected_reason IS NOT NULL THEN 'rejected'
     ELSE 'completed'
 END
-WHERE op_state = 'queued';
+WHERE op_state IN ('queued', 'running');
 
 UPDATE pending_message_completions
 SET created_at = CAST(created_at / 1000 AS INTEGER)

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -367,6 +367,7 @@ fn test_fork_ext_v19_to_v20_backfills_op_state_and_normalizes_completion_created
         )
         VALUES
             ('comp-completed', 'hook_event', 1700000000000001, 1700000001, 1700000001234, 1234, 'drawer-1', 'queued', NULL, NULL, '{{"state":"completed"}}'),
+            ('comp-running-stale', 'hook_event', 1700000000000004, 1700000004, 1700000004234, 1234, 'drawer-2', 'running', NULL, NULL, '{{"state":"completed"}}'),
             ('comp-rejected', 'hook_event', 1700000000000002, 1700000002, 1700000002234, 1234, NULL, 'queued', 'policy', NULL, '{{"state":"rejected"}}'),
             ('comp-failed', 'hook_event', 1700000000000003, 1700000003, 1700000003234, 1234, NULL, 'queued', NULL, 'boom', '{{"state":"failed"}}');
 
@@ -397,6 +398,7 @@ fn test_fork_ext_v19_to_v20_backfills_op_state_and_normalizes_completion_created
 
     for (id, expected_op_state) in [
         ("comp-completed", "completed"),
+        ("comp-running-stale", "completed"),
         ("comp-rejected", "rejected"),
         ("comp-failed", "failed"),
     ] {
@@ -418,6 +420,15 @@ fn test_fork_ext_v19_to_v20_backfills_op_state_and_normalizes_completion_created
         )
         .expect("count queued completions");
     assert_eq!(queued_completions, 0);
+
+    let running_completions: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_message_completions WHERE op_state = 'running'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count running completions");
+    assert_eq!(running_completions, 0);
 
     let (min_created_len, max_created_len): (i64, i64) = conn
         .query_row(

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -236,6 +236,60 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
 }
 
 #[tokio::test]
+async fn test_mcp_status_live_queue_counts_ignore_stale_completion_op_state() {
+    let (_tmp, db_path, config) = setup_env();
+    let store = PendingMessageStore::with_config(
+        &db_path,
+        QueueConfig {
+            base_delay_ms: 0,
+            max_delay_ms: 0,
+            max_retries: 0,
+        },
+    )
+    .expect("create store");
+    let failed_id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let failed = store
+        .claim_next("worker-failed", 60)
+        .expect("claim")
+        .expect("failed row");
+    assert_eq!(failed.id, failed_id);
+    store
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
+
+    let db = Database::open(&db_path).expect("open db");
+    db.conn()
+        .execute_batch(
+            r#"
+            INSERT INTO pending_message_completions (
+                message_id,
+                kind,
+                created_at,
+                claimed_at,
+                completed_at,
+                processing_ms,
+                op_state
+            )
+            VALUES
+                ('history-running', 'hook_event', 1700000000, 1700000001, 1700000002, 1000, 'running'),
+                ('history-queued', 'hook_event', 1700000003, 1700000004, 1700000005, 1000, 'queued');
+            "#,
+        )
+        .expect("insert stale completion history");
+    drop(db);
+
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(response.queue_stats.pending, 0);
+    assert_eq!(response.queue_stats.claimed, 0);
+    assert_eq!(response.queue_stats.failed, 1);
+    assert_eq!(response.embed_status.pending_count, 0);
+    assert_eq!(response.embed_status.claimed_count, 0);
+    assert_eq!(response.embed_status.failed_count, 1);
+}
+
+#[tokio::test]
 async fn test_mcp_status_surfaces_source_type_distribution() {
     let (_tmp, db_path, config) = setup_env();
     insert_drawer_with_source_type(&db_path, "drawer-user", SourceType::UserExplicit);

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -347,6 +347,55 @@ fn test_status_command_shows_queue_stats() {
 }
 
 #[test]
+fn test_status_command_live_queue_counts_ignore_stale_completion_op_state() {
+    let (home, db_path) = setup_home();
+    let store = PendingMessageStore::new(&db_path).expect("create store");
+    let failed_id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let failed = store
+        .claim_next("worker-failed", 60)
+        .expect("claim")
+        .expect("failed row");
+    assert_eq!(failed.id, failed_id);
+    store
+        .mark_failed_with_disposition(&failed, "boom", QueueFailureDisposition::Terminal)
+        .expect("mark terminal failed");
+
+    Connection::open(&db_path)
+        .expect("open sqlite")
+        .execute_batch(
+            r#"
+            INSERT INTO pending_message_completions (
+                message_id,
+                kind,
+                created_at,
+                claimed_at,
+                completed_at,
+                processing_ms,
+                op_state
+            )
+            VALUES
+                ('history-running', 'hook_event', 1700000000, 1700000001, 1700000002, 1000, 'running'),
+                ('history-queued', 'hook_event', 1700000003, 1700000004, 1700000005, 1000, 'queued');
+            "#,
+        )
+        .expect("insert stale completion history");
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal status");
+
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
+    assert!(stdout.contains("Queue:"), "{stdout}");
+    assert!(stdout.contains("pending: 0"), "{stdout}");
+    assert!(stdout.contains("claimed: 0"), "{stdout}");
+    assert!(stdout.contains("failed: 1"), "{stdout}");
+    assert!(stdout.contains("embed_fail_count: 1"), "{stdout}");
+}
+
+#[test]
 fn test_status_command_shows_vector_index_stale_flag() {
     let (home, db_path) = setup_home();
     recreate_vectors_with_metric(&db_path, "l2");


### PR DESCRIPTION
## Summary
- Keep live status queue counts sourced from current pending_messages rows instead of stale completion-history op_state values.
- Normalize completed completion-history op_state rows so historical queued/running states do not mislead status triage.
- Add CLI/MCP/fork-ext regression coverage for #389.

## Test Plan
- cargo test --test fork_ext_schema_axis --test queue_stats --test mcp_status_queue_stats
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- pre-commit quality-gates

Closes #389