### PR TITLE
feat(xurl): add Hermes session recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,24 @@ api_model = "nomic-embed-text"
 | `mempal cowork-drain --target <claude\|codex>` | Drain inbox messages (for hook use; exits 0 on any failure) |
 | `mempal cowork-status --cwd <PATH>` | Read-only view of both inboxes at `<PATH>` |
 | `mempal fact-check [PATH\|-] [--wing W] [--room R] [--now <UNIX_SECS>]` | Offline contradiction check against KG triples + known entities |
+| `mempal hermes ingest/search/recall` | Cwd-scoped semantic recall over Hermes Agent sessions |
 | `mempal bench longmemeval <FILE>` | LongMemEval retrieval benchmark |
 
 > **Heads-up — two different `xurl`s.** `mempal xurl` is a mempal subcommand: an `ingest` / `search` / `timeline` / `stats` / `reindex` / `backfill` pipeline over agent session transcripts. It is **not** the standalone `xurl` CLI (Xuanwo's "Resolve and read code-agent threads", invoked as `xurl …` with `agents://` URIs). The two are independent projects that happen to share a name — neither is an alias for the other.
+
+### Hermes Session Recall
+
+Hermes transcripts are indexed through the xurl conversation store but exposed as first-class commands:
+
+```bash
+mempal hermes ingest --profile default --cwd /path/to/repo
+mempal hermes ingest --profile work --export-jsonl hermes-session.jsonl
+mempal hermes search --cwd . --query "mktd Step 7 failure recovery"
+mempal recall hermes --session-id <hermes-session-id> --query "review verdict PASS"
+mempal recall hermes --cwd . --latest --query "what is the current issue queue?"
+```
+
+Default profile reads `~/.hermes/state.db`; named profiles read `~/.hermes/profiles/<profile>/state.db` unless `--db` or `--export-jsonl` is supplied. Searches default to the process cwd, preserve Hermes profile boundaries, and return `profile/session/message` citations so exact pages can be fetched later through Hermes or xurl.
 
 ## MCP Server (11 tools)
 

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 20;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 21;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -95,6 +95,22 @@ WHERE op_state IN ('queued', 'running');
 UPDATE pending_message_completions
 SET created_at = CAST(created_at / 1000 AS INTEGER)
 WHERE created_at BETWEEN 1000000000000000 AND 9999999999999999;
+"#;
+
+pub const FORK_EXT_V21_SCHEMA_SQL: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ct_hermes_message_identity
+    ON conversation_turns(hermes_profile, session_id, message_id)
+    WHERE tool = 'hermes'
+      AND hermes_profile IS NOT NULL
+      AND message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ct_hermes_profile
+    ON conversation_turns(hermes_profile, timestamp_epoch DESC)
+    WHERE tool = 'hermes';
+
+CREATE INDEX IF NOT EXISTS idx_ct_session_source
+    ON conversation_turns(session_source, timestamp_epoch DESC)
+    WHERE session_source IS NOT NULL;
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -419,6 +435,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 20,
             up: apply_v20,
         },
+        Migration {
+            version: 21,
+            up: apply_v21,
+        },
     ]
 }
 
@@ -601,6 +621,18 @@ fn apply_v19(conn: &Connection) -> rusqlite::Result<()> {
 
 fn apply_v20(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(FORK_EXT_V20_SCHEMA_SQL)
+}
+
+fn apply_v21(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_nullable_column(conn, "conversation_turns", "hermes_profile", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "session_title", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "session_source", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "message_id", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "tool_name", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "tool_call_id", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "previous_message_id", "TEXT")?;
+    ensure_nullable_column(conn, "conversation_turns", "next_message_id", "TEXT")?;
+    conn.execute_batch(FORK_EXT_V21_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use mempal::aaak::{AaakCodec, AaakMeta};
 use mempal::adoption_analytics::build_runtime_adoption_analytics;
 #[cfg(feature = "rest")]
@@ -381,6 +381,16 @@ enum Commands {
         include_raw_turns: bool,
         #[arg(long = "include-expired")]
         include_expired: bool,
+    },
+    /// Ingest and search Hermes Agent sessions.
+    Hermes {
+        #[command(subcommand)]
+        command: HermesCommands,
+    },
+    /// Recall agent transcripts through provider-specific semantic indexes.
+    Recall {
+        #[command(subcommand)]
+        command: RecallCommands,
     },
     /// Assemble tiered context for a query.
     Context {
@@ -1218,10 +1228,105 @@ enum XurlTool {
     Hermes,
 }
 
-#[derive(Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
 enum XurlFormat {
     Markdown,
     Json,
+}
+
+#[derive(Subcommand)]
+enum HermesCommands {
+    /// Ingest Hermes state.db or a Hermes JSONL export.
+    Ingest(HermesIngestArgs),
+    /// Semantic search over indexed Hermes turns.
+    Search(HermesQueryArgs),
+    /// Alias for search with recall-oriented flags.
+    Recall(HermesQueryArgs),
+}
+
+#[derive(Subcommand)]
+enum RecallCommands {
+    /// Semantic recall over indexed Hermes turns.
+    Hermes(HermesQueryArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+struct HermesIngestArgs {
+    /// Hermes profile name. `default` maps to ~/.hermes/state.db.
+    #[arg(long, default_value = "default")]
+    profile: String,
+    /// Override Hermes home directory. Defaults to HERMES_HOME or ~/.hermes.
+    #[arg(long = "hermes-home")]
+    hermes_home: Option<PathBuf>,
+    /// Read this state.db instead of resolving one from --profile.
+    #[arg(long = "db")]
+    db_path: Option<PathBuf>,
+    /// Ingest a Hermes CLI JSONL export instead of state.db.
+    #[arg(long = "export-jsonl")]
+    export_jsonl: Option<PathBuf>,
+    /// Restrict ingest to one Hermes session id.
+    #[arg(long = "session-id", alias = "session")]
+    session_id: Option<String>,
+    /// Restrict/tag ingest to this cwd. Defaults to source metadata when omitted.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+    /// Print result as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+struct HermesQueryArgs {
+    /// Search query string.
+    query: Option<String>,
+    /// Search query string, useful for `mempal recall hermes --query ...`.
+    #[arg(long = "query")]
+    query_flag: Option<String>,
+    /// Hermes profile name.
+    #[arg(long, default_value = "default")]
+    profile: String,
+    /// Restrict recall to this cwd. Defaults to the process cwd.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+    /// Disable the default cwd filter.
+    #[arg(long = "all-cwd")]
+    all_cwd: bool,
+    /// Restrict recall to one Hermes session id.
+    #[arg(long = "session-id", alias = "session")]
+    session_id: Option<String>,
+    /// Restrict recall to a Hermes session source such as cli or telegram.
+    #[arg(long = "session-source")]
+    session_source: Option<String>,
+    /// Restrict recall to an exact Hermes session title.
+    #[arg(long = "session-title")]
+    session_title: Option<String>,
+    /// Prefer the newest matching session when no session id is supplied.
+    #[arg(long)]
+    latest: bool,
+    /// Only return turns newer than this duration (e.g. 7d, 24h, 10m).
+    #[arg(long)]
+    since: Option<String>,
+    /// Only return turns older than this duration window endpoint.
+    #[arg(long)]
+    until: Option<String>,
+    /// Maximum number of results to return.
+    #[arg(long, default_value_t = 10)]
+    limit: usize,
+    /// Page number (0-based).
+    #[arg(long, default_value_t = 0)]
+    page: usize,
+    /// Also include CSA-delegated turns.
+    #[arg(long)]
+    include_csa: bool,
+    /// Also include agent-generated user prompts.
+    #[arg(long)]
+    include_agent_prompts: bool,
+    /// Minimum cosine similarity score (0.0-1.0).
+    #[arg(long, default_value_t = 0.70)]
+    min_score: f32,
+    /// Output format: markdown (default) or json.
+    #[arg(long, value_enum, default_value_t = XurlFormat::Markdown)]
+    format: XurlFormat,
 }
 
 #[derive(Serialize)]
@@ -2737,6 +2842,12 @@ fn run() -> Result<()> {
                 include_expired,
             },
         )),
+        Commands::Hermes { command } => {
+            block_on_result(hermes_command(&db, config.as_ref(), command))
+        }
+        Commands::Recall { command } => {
+            block_on_result(recall_command(&db, config.as_ref(), command))
+        }
         Commands::Context {
             query,
             field,
@@ -10106,6 +10217,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 since_epoch,
                 limit,
                 offset: page * limit,
+                ..Default::default()
             };
             let embedder = build_embedder(config).await?;
             let result = mempal::xurl::search::search(
@@ -10154,6 +10266,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                 since_epoch,
                 limit,
                 offset: page * limit,
+                ..Default::default()
             };
             let turns = mempal::xurl::store::get_turns_filtered(
                 db.conn(),
@@ -10417,6 +10530,189 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
             Ok(())
         }
     }
+}
+
+async fn hermes_command(db: &Database, config: &Config, command: HermesCommands) -> Result<()> {
+    match command {
+        HermesCommands::Ingest(args) => hermes_ingest_command(db, config, args).await,
+        HermesCommands::Search(args) | HermesCommands::Recall(args) => {
+            hermes_query_command(db, config, args).await
+        }
+    }
+}
+
+async fn recall_command(db: &Database, config: &Config, command: RecallCommands) -> Result<()> {
+    match command {
+        RecallCommands::Hermes(args) => hermes_query_command(db, config, args).await,
+    }
+}
+
+async fn hermes_ingest_command(
+    db: &Database,
+    config: &Config,
+    args: HermesIngestArgs,
+) -> Result<()> {
+    let embedder = build_embedder(config).await?;
+    let vector_fingerprint = config
+        .embed
+        .current_vector_embedder_fingerprint(embedder.dimensions());
+    let cwd = args
+        .cwd
+        .as_deref()
+        .map(resolve_cli_cwd)
+        .transpose()
+        .context("failed to resolve Hermes cwd filter")?;
+    let options = mempal::xurl::ingest::HermesIngestOptions {
+        profile: args.profile,
+        db_path: args.db_path,
+        export_jsonl: args.export_jsonl,
+        hermes_home: args.hermes_home,
+        session_id: args.session_id,
+        cwd,
+    };
+    let parse_cb = |name: &str, turns: usize| {
+        if args.json {
+            eprintln!(
+                "{}",
+                serde_json::json!({"phase":"parse","file":name,"turns":turns})
+            );
+        } else {
+            eprintln!("[parse] hermes: {name} ({turns} turns)");
+        }
+    };
+    let embed_cb = |done: usize, total: usize| {
+        if args.json {
+            eprintln!(
+                "{}",
+                serde_json::json!({"phase":"embed","done":done,"total":total})
+            );
+        } else {
+            eprintln!("[embed] {done}/{total} Hermes turns vectorized");
+        }
+    };
+    let stats = mempal::xurl::ingest::ingest_hermes_with_vector_fingerprint(
+        db,
+        embedder.as_ref(),
+        &options,
+        &vector_fingerprint,
+        mempal::xurl::ingest::IngestCallbacks {
+            on_file_parsed: Some(&parse_cb),
+            on_embed_progress: Some(&embed_cb),
+        },
+    )
+    .await
+    .context("Hermes ingest failed")?;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string(&stats).context("json serialize")?
+        );
+    } else {
+        println!("turns parsed:   {}", stats.turns_parsed);
+        println!("turns inserted: {}", stats.turns_inserted);
+        println!("turns skipped:  {}", stats.turns_skipped);
+        println!("turns updated:  {}", stats.turns_updated);
+        println!("vectors created:{}", stats.vectors_created);
+    }
+    Ok(())
+}
+
+async fn hermes_query_command(db: &Database, config: &Config, args: HermesQueryArgs) -> Result<()> {
+    let query = resolve_hermes_query(&args)?;
+    let cwd = if args.all_cwd {
+        None
+    } else {
+        Some(match args.cwd.as_deref() {
+            Some(path) => resolve_cli_cwd(path)?,
+            None => env::current_dir()
+                .context("failed to read current directory for Hermes cwd filter")?
+                .to_string_lossy()
+                .to_string(),
+        })
+    };
+    let since_epoch = args
+        .since
+        .as_deref()
+        .map(parse_since_to_epoch)
+        .transpose()?;
+    let until_epoch = args
+        .until
+        .as_deref()
+        .map(parse_since_to_epoch)
+        .transpose()?;
+    let mut filter = mempal::xurl::store::TurnFilter {
+        tool: Some(mempal::xurl::model::Tool::Hermes),
+        session_id: args.session_id.clone(),
+        cwd,
+        hermes_profile: Some(args.profile),
+        session_title: args.session_title,
+        session_source: args.session_source,
+        since_epoch,
+        until_epoch,
+        limit: args.limit,
+        offset: args.page * args.limit,
+    };
+    if args.latest && filter.session_id.is_none() {
+        filter.session_id = mempal::xurl::store::latest_session_id(
+            db.conn(),
+            &filter,
+            args.include_csa,
+            args.include_agent_prompts,
+        )
+        .context("failed to resolve latest Hermes session")?;
+    }
+
+    let embedder = build_embedder(config).await?;
+    let result = mempal::xurl::search::search(
+        db,
+        embedder.as_ref(),
+        &query,
+        mempal::xurl::search::SearchOptions {
+            limit: args.limit,
+            filter: Some(filter),
+            include_csa: args.include_csa,
+            include_agent_prompts: args.include_agent_prompts,
+            min_score: Some(args.min_score),
+        },
+    )
+    .await
+    .context("Hermes recall failed")?;
+
+    match args.format {
+        XurlFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(&result).context("json serialize")?
+            );
+        }
+        XurlFormat::Markdown => {
+            mempal::xurl::search::print_hits_markdown(&result);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_hermes_query(args: &HermesQueryArgs) -> Result<String> {
+    match (&args.query, &args.query_flag) {
+        (Some(_), Some(_)) => {
+            bail!("provide the Hermes query once, not both positional and --query")
+        }
+        (Some(query), None) | (None, Some(query)) => Ok(query.clone()),
+        (None, None) => bail!("Hermes recall requires a query string or --query"),
+    }
+}
+
+fn resolve_cli_cwd(path: &Path) -> Result<String> {
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .context("failed to read current directory")?
+            .join(path)
+    };
+    let canonical = resolved.canonicalize().unwrap_or(resolved);
+    Ok(canonical.to_string_lossy().to_string())
 }
 
 async fn build_embedder(config: &Config) -> Result<Box<dyn Embedder>> {

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -7,7 +7,14 @@ use crate::core::db::Database;
 use crate::embed::Embedder;
 use crate::xurl::embed;
 use crate::xurl::model::Tool;
-use crate::xurl::parser::{cc::parse_cc_jsonl, codex::parse_codex_jsonl, hermes::parse_hermes_db};
+use crate::xurl::parser::{
+    cc::parse_cc_jsonl,
+    codex::parse_codex_jsonl,
+    hermes::{
+        HermesParseOptions, parse_hermes_db, parse_hermes_db_with_options,
+        parse_hermes_jsonl_export,
+    },
+};
 use crate::xurl::store;
 use crate::xurl::{XurlError, XurlResult};
 
@@ -34,6 +41,29 @@ pub struct AutoScanConfig {
     pub cc_root: PathBuf,
     pub codex_root: PathBuf,
     pub hermes_db: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HermesIngestOptions {
+    pub profile: String,
+    pub db_path: Option<PathBuf>,
+    pub export_jsonl: Option<PathBuf>,
+    pub hermes_home: Option<PathBuf>,
+    pub session_id: Option<String>,
+    pub cwd: Option<String>,
+}
+
+impl Default for HermesIngestOptions {
+    fn default() -> Self {
+        Self {
+            profile: "default".to_string(),
+            db_path: None,
+            export_jsonl: None,
+            hermes_home: None,
+            session_id: None,
+            cwd: None,
+        }
+    }
 }
 
 impl Default for AutoScanConfig {
@@ -114,6 +144,63 @@ fn parse_and_store_file(
     Ok((filename, turns_parsed, insert_stats, turn_ids))
 }
 
+fn parse_and_store_hermes_source(
+    db: &Database,
+    options: &HermesIngestOptions,
+) -> XurlResult<(String, usize, store::InsertStats, Vec<String>)> {
+    if options.db_path.is_some() && options.export_jsonl.is_some() {
+        return Err(XurlError::Parse(
+            "Hermes ingest accepts either --db or --export-jsonl, not both".to_string(),
+        ));
+    }
+
+    let fallback_session_id = options
+        .session_id
+        .as_deref()
+        .unwrap_or("hermes-session")
+        .to_string();
+    let mut parse_options = HermesParseOptions::new(&fallback_session_id, &options.profile, false);
+    parse_options.session_id_filter = options.session_id.clone();
+    parse_options.cwd = options.cwd.clone();
+
+    let (name, turns) = if let Some(path) = &options.export_jsonl {
+        let content = fs::read_to_string(path).map_err(XurlError::Io)?;
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("hermes-export.jsonl")
+            .to_string();
+        (name, parse_hermes_jsonl_export(&content, &parse_options)?)
+    } else {
+        let path = options.db_path.clone().unwrap_or_else(|| {
+            default_hermes_db_path(&options.profile, options.hermes_home.as_deref())
+        });
+        let name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("state.db")
+            .to_string();
+        (name, parse_hermes_db_with_options(&path, &parse_options)?)
+    };
+
+    let turns_parsed = turns.len();
+    let turn_ids: Vec<String> = turns.iter().map(store::turn_id_for).collect();
+    let insert_stats = store::insert_turns(db.conn(), &turns)?;
+    Ok((name, turns_parsed, insert_stats, turn_ids))
+}
+
+pub fn default_hermes_db_path(profile: &str, hermes_home: Option<&Path>) -> PathBuf {
+    let root = hermes_home
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::var_os("HERMES_HOME").map(PathBuf::from))
+        .unwrap_or_else(|| home_dir().join(".hermes"));
+    if profile == "default" {
+        root.join("state.db")
+    } else {
+        root.join("profiles").join(profile).join("state.db")
+    }
+}
+
 /// Ingest a single file (or SQLite DB for Hermes) and embed any newly inserted turns.
 ///
 /// `on_file_parsed` is called after parsing with `(filename, turns_parsed)`.
@@ -161,6 +248,36 @@ pub async fn ingest_file_with_vector_fingerprint<E: Embedder + ?Sized>(
         callbacks,
     )
     .await
+}
+
+pub async fn ingest_hermes_with_vector_fingerprint<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    options: &HermesIngestOptions,
+    vector_fingerprint: &str,
+    callbacks: IngestCallbacks<'_>,
+) -> XurlResult<IngestStats> {
+    let (filename, turns_parsed, insert_stats, turn_ids) =
+        parse_and_store_hermes_source(db, options)?;
+    if let Some(callback) = callbacks.on_file_parsed {
+        callback(&filename, turns_parsed);
+    }
+    let embed_stats = embed::embed_unindexed_turns_scoped_with_fingerprint(
+        db,
+        embedder,
+        &turn_ids,
+        vector_fingerprint,
+        callbacks.on_embed_progress,
+    )
+    .await?;
+
+    Ok(IngestStats {
+        turns_parsed,
+        turns_inserted: insert_stats.inserted,
+        turns_skipped: insert_stats.skipped,
+        turns_updated: insert_stats.updated,
+        vectors_created: embed_stats.embedded,
+    })
 }
 
 async fn ingest_file_inner<E: Embedder + ?Sized>(

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -154,16 +154,8 @@ fn parse_and_store_hermes_source(
         ));
     }
 
-    let fallback_session_id = options
-        .session_id
-        .as_deref()
-        .unwrap_or("hermes-session")
-        .to_string();
-    let mut parse_options = HermesParseOptions::new(&fallback_session_id, &options.profile, false);
-    parse_options.session_id_filter = options.session_id.clone();
-    parse_options.cwd = options.cwd.clone();
-
     let (name, turns) = if let Some(path) = &options.export_jsonl {
+        let parse_options = hermes_parse_options(options, "jsonl", path);
         let content = fs::read_to_string(path).map_err(XurlError::Io)?;
         let name = path
             .file_name()
@@ -175,6 +167,7 @@ fn parse_and_store_hermes_source(
         let path = options.db_path.clone().unwrap_or_else(|| {
             default_hermes_db_path(&options.profile, options.hermes_home.as_deref())
         });
+        let parse_options = hermes_parse_options(options, "db", &path);
         let name = path
             .file_name()
             .and_then(|value| value.to_str())
@@ -187,6 +180,46 @@ fn parse_and_store_hermes_source(
     let turn_ids: Vec<String> = turns.iter().map(store::turn_id_for).collect();
     let insert_stats = store::insert_turns(db.conn(), &turns)?;
     Ok((name, turns_parsed, insert_stats, turn_ids))
+}
+
+fn hermes_parse_options(
+    options: &HermesIngestOptions,
+    source_kind: &str,
+    path: &Path,
+) -> HermesParseOptions {
+    let fallback_session_id = options.session_id.clone().unwrap_or_else(|| {
+        let source_identity = stable_source_identity(path);
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(options.profile.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(source_kind.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(source_identity.as_bytes());
+        let digest = hasher.finalize().to_hex().to_string();
+        format!(
+            "hermes-fallback:{}:{}:{}",
+            options.profile,
+            source_kind,
+            &digest[..12]
+        )
+    });
+    let mut parse_options = HermesParseOptions::new(&fallback_session_id, &options.profile, false);
+    parse_options.session_id_filter = options.session_id.clone();
+    parse_options.cwd = options.cwd.clone();
+    parse_options
+}
+
+fn stable_source_identity(path: &Path) -> String {
+    let resolved = path.canonicalize().unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(path))
+                .unwrap_or_else(|_| path.to_path_buf())
+        }
+    });
+    resolved.to_string_lossy().into_owned()
 }
 
 pub fn default_hermes_db_path(profile: &str, hermes_home: Option<&Path>) -> PathBuf {

--- a/src/xurl/ingest.rs
+++ b/src/xurl/ingest.rs
@@ -95,7 +95,7 @@ fn home_dir() -> PathBuf {
 /// Parse a file and insert turns into the DB. Does not embed.
 ///
 /// Returns `(filename, turns_parsed, insert_stats, turn_ids)` where `turn_ids`
-/// are the deterministic IDs of every parsed turn — used to scope a single-file
+/// are the actual stored IDs of every parsed turn — used to scope a single-file
 /// embed pass to just this file's turns.
 fn parse_and_store_file(
     db: &Database,
@@ -139,8 +139,8 @@ fn parse_and_store_file(
         .unwrap_or("unknown")
         .to_string();
     let turns_parsed = turns.len();
-    let turn_ids: Vec<String> = turns.iter().map(store::turn_id_for).collect();
     let insert_stats = store::insert_turns(db.conn(), &turns)?;
+    let turn_ids = insert_stats.turn_ids.clone();
     Ok((filename, turns_parsed, insert_stats, turn_ids))
 }
 
@@ -177,8 +177,8 @@ fn parse_and_store_hermes_source(
     };
 
     let turns_parsed = turns.len();
-    let turn_ids: Vec<String> = turns.iter().map(store::turn_id_for).collect();
     let insert_stats = store::insert_turns(db.conn(), &turns)?;
+    let turn_ids = insert_stats.turn_ids.clone();
     Ok((name, turns_parsed, insert_stats, turn_ids))
 }
 

--- a/src/xurl/model.rs
+++ b/src/xurl/model.rs
@@ -48,6 +48,18 @@ impl Provenance {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TurnMetadata {
+    pub hermes_profile: Option<String>,
+    pub session_title: Option<String>,
+    pub session_source: Option<String>,
+    pub message_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_call_id: Option<String>,
+    pub previous_message_id: Option<String>,
+    pub next_message_id: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RawTurn {
     pub session_id: String,
@@ -61,6 +73,7 @@ pub struct RawTurn {
     pub provenance: Provenance,
     /// 0-based monotonic index within the session (counting only kept turns).
     pub turn_index: u32,
+    pub metadata: TurnMetadata,
 }
 
 #[cfg(test)]

--- a/src/xurl/parser/cc.rs
+++ b/src/xurl/parser/cc.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::xurl::XurlResult;
-use crate::xurl::model::{Provenance, RawTurn, Role, Tool};
+use crate::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 
 const SESSION_ID_SCAN_LIMIT: usize = 64;
 
@@ -85,6 +85,7 @@ pub fn parse_cc_jsonl(
                     is_csa_delegated,
                     provenance,
                     turn_index,
+                    metadata: TurnMetadata::default(),
                 });
                 turn_index += 1;
             }
@@ -117,6 +118,7 @@ pub fn parse_cc_jsonl(
                     is_csa_delegated,
                     provenance: Provenance::Human,
                     turn_index,
+                    metadata: TurnMetadata::default(),
                 });
                 turn_index += 1;
             }

--- a/src/xurl/parser/codex.rs
+++ b/src/xurl/parser/codex.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::xurl::XurlResult;
-use crate::xurl::model::{Provenance, RawTurn, Role, Tool};
+use crate::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 
 /// Parse a Codex rollout JSONL file into screen-visible turns.
 ///
@@ -84,6 +84,7 @@ pub fn parse_codex_jsonl(
                             is_csa_delegated,
                             provenance: Provenance::Human,
                             turn_index,
+                            metadata: TurnMetadata::default(),
                         });
                         turn_index += 1;
                     }
@@ -108,6 +109,7 @@ pub fn parse_codex_jsonl(
                             is_csa_delegated,
                             provenance: Provenance::Human,
                             turn_index,
+                            metadata: TurnMetadata::default(),
                         });
                         turn_index += 1;
                     }
@@ -157,6 +159,7 @@ pub fn parse_codex_jsonl(
                     is_csa_delegated,
                     provenance: Provenance::Human,
                     turn_index,
+                    metadata: TurnMetadata::default(),
                 });
                 turn_index += 1;
             }

--- a/src/xurl/parser/hermes.rs
+++ b/src/xurl/parser/hermes.rs
@@ -422,15 +422,27 @@ fn matches_cwd_filter(project_path: Option<&str>, cwd_filter: Option<&str>) -> b
 
 fn link_neighbor_message_ids(turns: &mut [RawTurn]) {
     for index in 0..turns.len() {
-        let prev = index
-            .checked_sub(1)
-            .and_then(|prev| same_session_message_id(&turns[prev], &turns[index]));
-        let next = turns
-            .get(index + 1)
-            .and_then(|next| same_session_message_id(next, &turns[index]));
+        let prev = previous_session_message_id(turns, index);
+        let next = next_session_message_id(turns, index);
         turns[index].metadata.previous_message_id = prev;
         turns[index].metadata.next_message_id = next;
     }
+}
+
+fn previous_session_message_id(turns: &[RawTurn], index: usize) -> Option<String> {
+    let current = turns.get(index)?;
+    turns[..index]
+        .iter()
+        .rev()
+        .find_map(|candidate| same_session_message_id(candidate, current))
+}
+
+fn next_session_message_id(turns: &[RawTurn], index: usize) -> Option<String> {
+    let current = turns.get(index)?;
+    turns
+        .get(index + 1..)?
+        .iter()
+        .find_map(|candidate| same_session_message_id(candidate, current))
 }
 
 fn same_session_message_id(candidate: &RawTurn, current: &RawTurn) -> Option<String> {
@@ -785,5 +797,56 @@ mod tests {
         assert_eq!(turns[0].metadata.message_id.as_deref(), Some("msg-1"));
         assert_eq!(turns[0].metadata.tool_name.as_deref(), Some("mktd"));
         assert_eq!(turns[0].project_path.as_deref(), Some("/repo/mempal"));
+    }
+
+    #[test]
+    fn hermes_neighbor_links_skip_interleaved_sessions() {
+        let lines = [
+            serde_json::json!({
+                "id": "a1",
+                "session_id": "session-a",
+                "role": "user",
+                "content": "first A",
+                "timestamp": 1.0
+            }),
+            serde_json::json!({
+                "id": "b1",
+                "session_id": "session-b",
+                "role": "user",
+                "content": "first B",
+                "timestamp": 2.0
+            }),
+            serde_json::json!({
+                "id": "a2",
+                "session_id": "session-a",
+                "role": "assistant",
+                "content": "second A",
+                "timestamp": 3.0
+            }),
+            serde_json::json!({
+                "id": "b2",
+                "session_id": "session-b",
+                "role": "assistant",
+                "content": "second B",
+                "timestamp": 4.0
+            }),
+        ]
+        .into_iter()
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+        let options = HermesParseOptions::new("fallback", "default", false);
+        let turns = parse_hermes_jsonl_export(&lines, &options).unwrap();
+
+        assert_eq!(turns.len(), 4);
+        assert_eq!(turns[0].metadata.previous_message_id, None);
+        assert_eq!(turns[0].metadata.next_message_id.as_deref(), Some("a2"));
+        assert_eq!(turns[1].metadata.previous_message_id, None);
+        assert_eq!(turns[1].metadata.next_message_id.as_deref(), Some("b2"));
+        assert_eq!(turns[2].metadata.previous_message_id.as_deref(), Some("a1"));
+        assert_eq!(turns[2].metadata.next_message_id, None);
+        assert_eq!(turns[3].metadata.previous_message_id.as_deref(), Some("b1"));
+        assert_eq!(turns[3].metadata.next_message_id, None);
     }
 }

--- a/src/xurl/parser/hermes.rs
+++ b/src/xurl/parser/hermes.rs
@@ -1,25 +1,66 @@
+use std::collections::HashSet;
 use std::path::Path;
 
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::types::ValueRef;
+use rusqlite::{Connection, OpenFlags, Row};
+use serde_json::Value;
 
-use crate::xurl::model::{Provenance, RawTurn, Role, Tool};
+use crate::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
+use crate::xurl::store::normalize_cwd_filter;
 use crate::xurl::{XurlError, XurlResult};
 
-/// Parse turns from a Hermes `state.db` SQLite database.
-///
-/// Opens the database in read-only mode (`SQLITE_OPEN_READONLY`) so it never
-/// creates -wal or -shm side-car files — the Hermes process owns the DB.
-///
-/// Extracts rows with `role IN ('user', 'assistant')`, ordered by timestamp and id.
-/// Skips `role = 'tool'` in the WHERE clause. Applies `sanitize_content()` to
-/// strip `<context>…</context>` and `<system-reminder>…</system-reminder>` blocks.
-///
-/// `is_csa_delegated`: pass-through flag set by the caller based on the file's
-/// location (CSA state dir vs. user-facing session).
+const DEFAULT_PROFILE: &str = "default";
+
+#[derive(Debug, Clone)]
+pub struct HermesParseOptions {
+    pub fallback_session_id: String,
+    pub profile: String,
+    pub is_csa_delegated: bool,
+    pub session_id_filter: Option<String>,
+    pub cwd: Option<String>,
+}
+
+impl HermesParseOptions {
+    pub fn new(fallback_session_id: &str, profile: &str, is_csa_delegated: bool) -> Self {
+        Self {
+            fallback_session_id: fallback_session_id.to_string(),
+            profile: profile.to_string(),
+            is_csa_delegated,
+            session_id_filter: None,
+            cwd: None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct SessionMetadata {
+    session_id: Option<String>,
+    title: Option<String>,
+    source: Option<String>,
+    cwd: Option<String>,
+}
+
+/// Parse turns from a Hermes `state.db` SQLite database using default profile metadata.
 pub fn parse_hermes_db(
     path: &Path,
     fallback_session_id: &str,
     is_csa_delegated: bool,
+) -> XurlResult<Vec<RawTurn>> {
+    parse_hermes_db_with_options(
+        path,
+        &HermesParseOptions::new(fallback_session_id, DEFAULT_PROFILE, is_csa_delegated),
+    )
+}
+
+/// Parse turns from a Hermes `state.db` SQLite database.
+///
+/// The database is opened read-only so mempal never creates or mutates Hermes
+/// sidecar files. Required message columns are `role`, `content`, and
+/// `timestamp`; all Hermes metadata columns are optional and degrade to
+/// session-level metadata or caller-provided fallbacks.
+pub fn parse_hermes_db_with_options(
+    path: &Path,
+    options: &HermesParseOptions,
 ) -> XurlResult<Vec<RawTurn>> {
     let conn = Connection::open_with_flags(
         path,
@@ -27,77 +68,288 @@ pub fn parse_hermes_db(
     )
     .map_err(|e| XurlError::Parse(format!("cannot open hermes db: {e}")))?;
 
-    // Attempt to read a session_id from the DB metadata (some versions store it).
-    // Fall back to `fallback_session_id` if unavailable.
-    let session_id = read_session_id(&conn).unwrap_or_else(|| fallback_session_id.to_string());
-    let project_path = read_project_path(&conn);
+    let columns = table_columns(&conn, "messages")?;
+    for required in ["role", "content", "timestamp"] {
+        if !columns.contains(required) {
+            return Err(XurlError::Parse(format!(
+                "Hermes messages table is missing required column `{required}`"
+            )));
+        }
+    }
+
+    let meta = read_session_metadata(&conn);
+    let message_id_expr = optional_text_expr(&columns, &["message_id", "messageId", "id"]);
+    let session_id_expr = optional_text_expr(&columns, &["session_id", "sessionId"]);
+    let cwd_expr = optional_text_expr(&columns, &["cwd", "project_path", "project"]);
+    let tool_name_expr = optional_text_expr(&columns, &["tool_name", "toolName"]);
+    let tool_call_id_expr = optional_text_expr(&columns, &["tool_call_id", "toolCallId"]);
+    let title_expr = optional_text_expr(&columns, &["session_title", "title"]);
+    let source_expr = optional_text_expr(&columns, &["session_source", "source"]);
+    let id_order = if columns.contains("id") { ", id" } else { "" };
+    let sql = format!(
+        "SELECT {message_id_expr}, role, content, timestamp, {session_id_expr}, \
+         {cwd_expr}, {tool_name_expr}, {tool_call_id_expr}, {title_expr}, {source_expr} \
+         FROM messages \
+         WHERE role IN ('user', 'assistant') \
+         ORDER BY timestamp{id_order}"
+    );
 
     let mut stmt = conn
-        .prepare(
-            "SELECT id, role, content, timestamp \
-             FROM messages \
-             WHERE role IN ('user', 'assistant') \
-             ORDER BY timestamp, id",
-        )
+        .prepare(&sql)
         .map_err(|e| XurlError::Parse(format!("failed to prepare hermes query: {e}")))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|e| XurlError::Parse(format!("hermes query error: {e}")))?;
 
     let mut turns = Vec::new();
     let mut turn_index: u32 = 0;
-
-    let rows = stmt.query_map([], |row| {
-        let role: String = row.get(1)?;
-        let content: String = row.get(2)?;
-        let timestamp: f64 = row.get(3)?;
-        Ok((role, content, timestamp))
-    });
-
-    for row in rows.map_err(|e| XurlError::Parse(format!("hermes query error: {e}")))? {
-        let (role_str, raw_content, timestamp_epoch) =
-            row.map_err(|e| XurlError::Parse(format!("hermes row error: {e}")))?;
-
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| XurlError::Parse(format!("hermes row error: {e}")))?
+    {
+        let role_str = sql_text(row, 1)?.unwrap_or_default();
         let role = match role_str.as_str() {
             "user" => Role::User,
             "assistant" => Role::Assistant,
-            _ => continue, // defensive: WHERE clause should exclude these
+            _ => continue,
         };
 
+        let raw_content = sql_text(row, 2)?.unwrap_or_default();
         let content = sanitize_content(&raw_content);
         if content.is_empty() {
             continue;
         }
 
+        let session_id = sql_text(row, 4)?
+            .or_else(|| meta.session_id.clone())
+            .unwrap_or_else(|| options.fallback_session_id.clone());
+        if options
+            .session_id_filter
+            .as_deref()
+            .is_some_and(|filter| filter != session_id)
+        {
+            continue;
+        }
+
+        let project_path = sql_text(row, 5)?
+            .or_else(|| meta.cwd.clone())
+            .or_else(|| options.cwd.clone());
+        if !matches_cwd_filter(project_path.as_deref(), options.cwd.as_deref()) {
+            continue;
+        }
+
+        let message_id = sql_text(row, 0)?.unwrap_or_else(|| format!("{session_id}:{turn_index}"));
+        let timestamp_epoch = sql_epoch(row, 3)?;
+        let metadata = TurnMetadata {
+            hermes_profile: Some(options.profile.clone()),
+            session_title: sql_text(row, 8)?.or_else(|| meta.title.clone()),
+            session_source: sql_text(row, 9)?.or_else(|| meta.source.clone()),
+            message_id: Some(message_id),
+            tool_name: sql_text(row, 6)?,
+            tool_call_id: sql_text(row, 7)?,
+            previous_message_id: None,
+            next_message_id: None,
+        };
+
         turns.push(RawTurn {
-            session_id: session_id.clone(),
+            session_id,
             tool: Tool::Hermes,
             role,
             content,
             timestamp_epoch,
-            project_path: project_path.clone(),
+            project_path,
             git_branch: None,
-            is_csa_delegated,
+            is_csa_delegated: options.is_csa_delegated,
             provenance: Provenance::Human,
             turn_index,
+            metadata,
         });
         turn_index += 1;
     }
 
+    link_neighbor_message_ids(&mut turns);
     Ok(turns)
 }
 
-/// Attempt to read a session ID from a `sessions` or `meta` table in the Hermes DB.
-/// Returns `None` when no such table or row exists (graceful fallback).
+pub fn parse_hermes_jsonl_export(
+    content: &str,
+    options: &HermesParseOptions,
+) -> XurlResult<Vec<RawTurn>> {
+    let mut turns = Vec::new();
+    let mut turn_index: u32 = 0;
+    let mut session_meta = SessionMetadata::default();
+
+    for raw_line in content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let obj: Value = match serde_json::from_str(raw_line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+
+        update_session_metadata_from_json(&mut session_meta, &obj);
+        let Some(role) = extract_role(&obj) else {
+            continue;
+        };
+        let Some(raw_content) = extract_content(&obj) else {
+            continue;
+        };
+        let content = sanitize_content(&raw_content);
+        if content.is_empty() {
+            continue;
+        }
+
+        let session_id = extract_json_string(&obj, JSON_SESSION_ID_PATHS)
+            .or_else(|| session_meta.session_id.clone())
+            .unwrap_or_else(|| options.fallback_session_id.clone());
+        if options
+            .session_id_filter
+            .as_deref()
+            .is_some_and(|filter| filter != session_id)
+        {
+            continue;
+        }
+
+        let project_path = extract_json_string(&obj, JSON_CWD_PATHS)
+            .or_else(|| session_meta.cwd.clone())
+            .or_else(|| options.cwd.clone());
+        if !matches_cwd_filter(project_path.as_deref(), options.cwd.as_deref()) {
+            continue;
+        }
+
+        let message_id = extract_json_string(&obj, JSON_MESSAGE_ID_PATHS)
+            .unwrap_or_else(|| format!("{session_id}:{turn_index}"));
+        let metadata = TurnMetadata {
+            hermes_profile: Some(options.profile.clone()),
+            session_title: extract_json_string(&obj, JSON_SESSION_TITLE_PATHS)
+                .or_else(|| session_meta.title.clone()),
+            session_source: extract_json_string(&obj, JSON_SESSION_SOURCE_PATHS)
+                .or_else(|| session_meta.source.clone()),
+            message_id: Some(message_id),
+            tool_name: extract_json_string(&obj, JSON_TOOL_NAME_PATHS),
+            tool_call_id: extract_json_string(&obj, JSON_TOOL_CALL_ID_PATHS),
+            previous_message_id: None,
+            next_message_id: None,
+        };
+
+        turns.push(RawTurn {
+            session_id,
+            tool: Tool::Hermes,
+            role,
+            content,
+            timestamp_epoch: extract_json_epoch(&obj),
+            project_path,
+            git_branch: None,
+            is_csa_delegated: options.is_csa_delegated,
+            provenance: Provenance::Human,
+            turn_index,
+            metadata,
+        });
+        turn_index += 1;
+    }
+
+    link_neighbor_message_ids(&mut turns);
+    Ok(turns)
+}
+
+fn table_columns(conn: &Connection, table: &str) -> XurlResult<HashSet<String>> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(XurlError::Database)?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(XurlError::Database)?;
+
+    let mut columns = HashSet::new();
+    for row in rows {
+        columns.insert(row.map_err(XurlError::Database)?);
+    }
+    if columns.is_empty() {
+        return Err(XurlError::Parse(format!(
+            "Hermes database is missing `{table}` table"
+        )));
+    }
+    Ok(columns)
+}
+
+fn optional_text_expr(columns: &HashSet<String>, candidates: &[&str]) -> String {
+    candidates
+        .iter()
+        .find(|candidate| columns.contains(**candidate))
+        .map(|column| format!("CAST({column} AS TEXT)"))
+        .unwrap_or_else(|| "NULL".to_string())
+}
+
+fn sql_text(row: &Row<'_>, idx: usize) -> XurlResult<Option<String>> {
+    let value = match row.get_ref(idx).map_err(XurlError::Database)? {
+        ValueRef::Null => None,
+        ValueRef::Text(bytes) => Some(String::from_utf8_lossy(bytes).trim().to_string()),
+        ValueRef::Integer(value) => Some(value.to_string()),
+        ValueRef::Real(value) => Some(value.to_string()),
+        ValueRef::Blob(_) => None,
+    };
+    Ok(value.filter(|text| !text.is_empty()))
+}
+
+fn sql_epoch(row: &Row<'_>, idx: usize) -> XurlResult<f64> {
+    match row.get_ref(idx).map_err(XurlError::Database)? {
+        ValueRef::Integer(value) => Ok(normalize_epoch_number(value as f64)),
+        ValueRef::Real(value) => Ok(normalize_epoch_number(value)),
+        ValueRef::Text(bytes) => Ok(parse_epoch_text(&String::from_utf8_lossy(bytes))),
+        ValueRef::Null | ValueRef::Blob(_) => Ok(0.0),
+    }
+}
+
+fn normalize_epoch_number(value: f64) -> f64 {
+    if value > 1_000_000_000_000.0 {
+        value / 1000.0
+    } else {
+        value
+    }
+}
+
+fn parse_epoch_text(value: &str) -> f64 {
+    let trimmed = value.trim();
+    if let Ok(number) = trimmed.parse::<f64>() {
+        return normalize_epoch_number(number);
+    }
+    crate::cowork::peek::parse_rfc3339(trimmed)
+        .map(|secs| secs as f64)
+        .unwrap_or(0.0)
+}
+
+fn read_session_metadata(conn: &Connection) -> SessionMetadata {
+    SessionMetadata {
+        session_id: read_session_id(conn),
+        title: query_optional_text(
+            conn,
+            "SELECT value FROM metadata WHERE key IN ('session_title', 'title') LIMIT 1",
+        )
+        .or_else(|| query_optional_text(conn, "SELECT title FROM sessions LIMIT 1"))
+        .or_else(|| query_optional_text(conn, "SELECT name FROM sessions LIMIT 1")),
+        source: query_optional_text(
+            conn,
+            "SELECT value FROM metadata WHERE key IN ('session_source', 'source') LIMIT 1",
+        )
+        .or_else(|| query_optional_text(conn, "SELECT source FROM sessions LIMIT 1")),
+        cwd: read_project_path(conn),
+    }
+}
+
+/// Attempt to read a session ID from a `sessions` or `metadata` table.
 fn read_session_id(conn: &Connection) -> Option<String> {
-    // Try a `session_id` column in a metadata table if it exists.
-    conn.query_row(
+    query_optional_text(
+        conn,
         "SELECT value FROM metadata WHERE key = 'session_id' LIMIT 1",
-        [],
-        |row| row.get::<_, String>(0),
     )
-    .ok()
+    .or_else(|| query_optional_text(conn, "SELECT session_id FROM sessions LIMIT 1"))
+    .or_else(|| query_optional_text(conn, "SELECT id FROM sessions LIMIT 1"))
+    .or_else(|| query_optional_text(conn, "SELECT session_id FROM messages LIMIT 1"))
 }
 
 /// Attempt to read a project/cwd path from known Hermes metadata shapes.
-/// Returns `None` if the table/column is absent or the stored value is empty.
 pub(crate) fn read_project_path(conn: &Connection) -> Option<String> {
     query_optional_text(
         conn,
@@ -146,14 +398,49 @@ fn query_optional_text(conn: &Connection, sql: &str) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
-/// Strip `<context>…</context>` and `<system-reminder>…</system-reminder>` tags.
-///
-/// These are injected by Hermes into message content but are not visible to the
-/// user on screen. Stripping mirrors Hermes' own scrubber logic.
+fn matches_cwd_filter(project_path: Option<&str>, cwd_filter: Option<&str>) -> bool {
+    let Some(filter) = cwd_filter
+        .map(normalize_cwd_filter)
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return true;
+    };
+    let Some(path) = project_path
+        .map(normalize_cwd_filter)
+        .filter(|cwd| !cwd.is_empty())
+    else {
+        return false;
+    };
+    path == filter
+        || path
+            .strip_prefix(&filter)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || filter
+            .strip_prefix(&path)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn link_neighbor_message_ids(turns: &mut [RawTurn]) {
+    for index in 0..turns.len() {
+        let prev = index
+            .checked_sub(1)
+            .and_then(|prev| same_session_message_id(&turns[prev], &turns[index]));
+        let next = turns
+            .get(index + 1)
+            .and_then(|next| same_session_message_id(next, &turns[index]));
+        turns[index].metadata.previous_message_id = prev;
+        turns[index].metadata.next_message_id = next;
+    }
+}
+
+fn same_session_message_id(candidate: &RawTurn, current: &RawTurn) -> Option<String> {
+    (candidate.session_id == current.session_id)
+        .then(|| candidate.metadata.message_id.clone())
+        .flatten()
+}
+
 fn sanitize_content(input: &str) -> String {
-    // Pattern: strip <context>…</context> (possibly multiline).
     let after_context = strip_tag_blocks(input, "context");
-    // Pattern: strip <system-reminder>…</system-reminder>.
     let after_reminder = strip_tag_blocks(&after_context, "system-reminder");
     after_reminder.trim().to_string()
 }
@@ -169,12 +456,153 @@ fn strip_tag_blocks(input: &str, tag: &str) -> String {
         if let Some(end) = after_open.find(&close) {
             remaining = &after_open[end + close.len()..];
         } else {
-            // No closing tag — drop to end.
             break;
         }
     }
     result.push_str(remaining);
     result
+}
+
+const JSON_SESSION_ID_PATHS: &[&[&str]] = &[
+    &["session_id"],
+    &["sessionId"],
+    &["session", "id"],
+    &["session", "session_id"],
+];
+const JSON_MESSAGE_ID_PATHS: &[&[&str]] =
+    &[&["message_id"], &["messageId"], &["id"], &["message", "id"]];
+const JSON_CWD_PATHS: &[&[&str]] = &[
+    &["cwd"],
+    &["project_path"],
+    &["project"],
+    &["session", "cwd"],
+    &["session", "project_path"],
+];
+const JSON_SESSION_TITLE_PATHS: &[&[&str]] = &[
+    &["session_title"],
+    &["title"],
+    &["session", "title"],
+    &["session", "name"],
+];
+const JSON_SESSION_SOURCE_PATHS: &[&[&str]] =
+    &[&["session_source"], &["source"], &["session", "source"]];
+const JSON_TOOL_NAME_PATHS: &[&[&str]] = &[
+    &["tool_name"],
+    &["toolName"],
+    &["tool", "name"],
+    &["message", "tool_name"],
+];
+const JSON_TOOL_CALL_ID_PATHS: &[&[&str]] = &[
+    &["tool_call_id"],
+    &["toolCallId"],
+    &["tool_use_id"],
+    &["message", "tool_call_id"],
+];
+
+fn update_session_metadata_from_json(meta: &mut SessionMetadata, obj: &Value) {
+    if let Some(session_id) = extract_json_string(obj, JSON_SESSION_ID_PATHS) {
+        meta.session_id = Some(session_id);
+    }
+    if let Some(title) = extract_json_string(obj, JSON_SESSION_TITLE_PATHS) {
+        meta.title = Some(title);
+    }
+    if let Some(source) = extract_json_string(obj, JSON_SESSION_SOURCE_PATHS) {
+        meta.source = Some(source);
+    }
+    if let Some(cwd) = extract_json_string(obj, JSON_CWD_PATHS) {
+        meta.cwd = Some(cwd);
+    }
+}
+
+fn extract_role(obj: &Value) -> Option<Role> {
+    let role = nested_value(obj, &["role"])
+        .or_else(|| nested_value(obj, &["message", "role"]))
+        .or_else(|| nested_value(obj, &["type"]))
+        .and_then(Value::as_str)?;
+    match role {
+        "user" => Some(Role::User),
+        "assistant" => Some(Role::Assistant),
+        _ => None,
+    }
+}
+
+fn extract_content(obj: &Value) -> Option<String> {
+    nested_value(obj, &["content"])
+        .or_else(|| nested_value(obj, &["message", "content"]))
+        .or_else(|| nested_value(obj, &["message"]))
+        .and_then(content_value_to_text)
+}
+
+fn content_value_to_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => non_empty(text),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(|item| {
+                    if item.get("type").and_then(Value::as_str) == Some("text") {
+                        item.get("text").and_then(Value::as_str)
+                    } else {
+                        item.as_str()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim()
+                .to_string();
+            non_empty(&text)
+        }
+        Value::Object(_) => value
+            .get("text")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("content").and_then(Value::as_str))
+            .and_then(non_empty),
+        _ => None,
+    }
+}
+
+fn extract_json_string(obj: &Value, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| nested_value(obj, path))
+        .and_then(value_to_string)
+}
+
+fn nested_value<'a>(value: &'a Value, path: &[&str]) -> Option<&'a Value> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    Some(current)
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => non_empty(text),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn non_empty(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn extract_json_epoch(obj: &Value) -> f64 {
+    nested_value(obj, &["timestamp"])
+        .or_else(|| nested_value(obj, &["created_at"]))
+        .or_else(|| nested_value(obj, &["createdAt"]))
+        .map(parse_json_epoch_value)
+        .unwrap_or(0.0)
+}
+
+fn parse_json_epoch_value(value: &Value) -> f64 {
+    match value {
+        Value::Number(number) => number.as_f64().map(normalize_epoch_number).unwrap_or(0.0),
+        Value::String(text) => parse_epoch_text(text),
+        _ => 0.0,
+    }
 }
 
 #[cfg(test)]
@@ -212,7 +640,7 @@ mod tests {
             &[
                 ("user", "Hello!", 1748356100.0),
                 ("assistant", "Hi there!", 1748356200.0),
-                ("tool", "bash output", 1748356250.0), // should be skipped
+                ("tool", "bash output", 1748356250.0),
                 ("assistant", "Done.", 1748356300.0),
             ],
         );
@@ -225,6 +653,8 @@ mod tests {
         assert_eq!(turns[1].content, "Hi there!");
         assert_eq!(turns[2].role, Role::Assistant);
         assert_eq!(turns[2].content, "Done.");
+        assert_eq!(turns[0].metadata.message_id.as_deref(), Some("1"));
+        assert_eq!(turns[0].metadata.next_message_id.as_deref(), Some("2"));
     }
 
     #[test]
@@ -235,7 +665,6 @@ mod tests {
 
         parse_hermes_db(&db_path, "s1", false).unwrap();
 
-        // No -wal or -shm files should exist.
         assert!(!dir.path().join("state.db-wal").exists());
         assert!(!dir.path().join("state.db-shm").exists());
     }
@@ -260,21 +689,7 @@ mod tests {
         setup_hermes_fixture(&db_path, &[("user", raw, 1.0)]);
 
         let turns = parse_hermes_db(&db_path, "s", false).unwrap();
-        assert_eq!(turns.len(), 1);
         assert_eq!(turns[0].content, "hi  there");
-    }
-
-    #[test]
-    fn hermes_parser_skips_tool_role() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("state.db");
-        setup_hermes_fixture(
-            &db_path,
-            &[("tool", "ls output", 1.0), ("user", "good", 2.0)],
-        );
-        let turns = parse_hermes_db(&db_path, "s", false).unwrap();
-        assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0].content, "good");
     }
 
     #[test]
@@ -283,11 +698,8 @@ mod tests {
         let db_path = dir.path().join("state.db");
         setup_hermes_fixture(&db_path, &[("user", "hi", 1.0)]);
 
-        let turns_csa = parse_hermes_db(&db_path, "s", true).unwrap();
-        assert!(turns_csa[0].is_csa_delegated);
-
-        let turns_user = parse_hermes_db(&db_path, "s", false).unwrap();
-        assert!(!turns_user[0].is_csa_delegated);
+        let turns = parse_hermes_db(&db_path, "s", true).unwrap();
+        assert!(turns[0].is_csa_delegated);
     }
 
     #[test]
@@ -295,29 +707,83 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("state.db");
         setup_hermes_fixture(&db_path, &[("user", "hi", 1.0)]);
-        let conn = Connection::open(&db_path).expect("open fixture db");
+        let conn = Connection::open(&db_path).expect("open fixture");
         conn.execute_batch(
-            "CREATE TABLE metadata (key TEXT NOT NULL, value TEXT NOT NULL);
-             INSERT INTO metadata (key, value) VALUES ('cwd', '/repo/hermes');",
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('cwd', '/repo/mempal');",
         )
         .expect("insert metadata");
         drop(conn);
 
         let turns = parse_hermes_db(&db_path, "s", false).unwrap();
+        assert_eq!(turns[0].project_path.as_deref(), Some("/repo/mempal"));
+    }
+
+    #[test]
+    fn hermes_parser_preserves_profile_session_and_message_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("state.db");
+        let conn = Connection::open(&db_path).expect("open fixture db");
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_id TEXT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                cwd TEXT,
+                tool_name TEXT,
+                session_title TEXT,
+                session_source TEXT
+            );
+             INSERT INTO messages
+             (id, session_id, role, content, timestamp, cwd, tool_name, session_title, session_source)
+             VALUES
+             ('msg-1', 'sess-1', 'assistant', 'review verdict PASS', '2026-06-01T00:00:00Z',
+              '/repo/mempal', 'shell', 'Issue 399', 'cli');",
+        )
+        .expect("create rich fixture");
+        drop(conn);
+
+        let mut options = HermesParseOptions::new("fallback", "work", false);
+        options.cwd = Some("/repo".to_string());
+        let turns = parse_hermes_db_with_options(&db_path, &options).unwrap();
 
         assert_eq!(turns.len(), 1);
-        assert_eq!(turns[0].project_path.as_deref(), Some("/repo/hermes"));
+        assert_eq!(turns[0].session_id, "sess-1");
+        assert_eq!(turns[0].project_path.as_deref(), Some("/repo/mempal"));
+        assert_eq!(turns[0].metadata.hermes_profile.as_deref(), Some("work"));
+        assert_eq!(turns[0].metadata.message_id.as_deref(), Some("msg-1"));
+        assert_eq!(
+            turns[0].metadata.session_title.as_deref(),
+            Some("Issue 399")
+        );
+        assert_eq!(turns[0].metadata.session_source.as_deref(), Some("cli"));
+        assert_eq!(turns[0].metadata.tool_name.as_deref(), Some("shell"));
     }
 
     #[test]
-    fn hermes_sanitize_preserves_untagged_content() {
-        assert_eq!(sanitize_content("hello world"), "hello world");
-        assert_eq!(sanitize_content("  trimmed  "), "trimmed");
-    }
+    fn hermes_jsonl_export_parser_reads_metadata_and_filters_cwd() {
+        let jsonl = serde_json::json!({
+            "id": "msg-1",
+            "session_id": "sess-1",
+            "role": "assistant",
+            "content": "mktd Step 7 failure recovery",
+            "timestamp": "2026-06-01T00:00:00Z",
+            "cwd": "/repo/mempal",
+            "session_title": "Queue drain",
+            "session_source": "cli",
+            "tool_name": "mktd"
+        })
+        .to_string();
+        let mut options = HermesParseOptions::new("fallback", "default", false);
+        options.cwd = Some("/repo".to_string());
 
-    #[test]
-    fn hermes_sanitize_multiple_context_blocks() {
-        let input = "<context>a</context>keep1<context>b</context>keep2";
-        assert_eq!(sanitize_content(input), "keep1keep2");
+        let turns = parse_hermes_jsonl_export(&jsonl, &options).unwrap();
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].metadata.message_id.as_deref(), Some("msg-1"));
+        assert_eq!(turns[0].metadata.tool_name.as_deref(), Some("mktd"));
+        assert_eq!(turns[0].project_path.as_deref(), Some("/repo/mempal"));
     }
 }

--- a/src/xurl/search.rs
+++ b/src/xurl/search.rs
@@ -3,12 +3,27 @@ use std::collections::{HashMap, HashSet};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-/// Internal per-turn accumulator: (score, session_id, tool, role, content, timestamp, source_path).
-type TurnBestEntry = (f32, String, String, String, String, f64, Option<String>);
+struct TurnBestEntry {
+    score: f32,
+    session_id: String,
+    tool: String,
+    role: String,
+    content: String,
+    timestamp_epoch: f64,
+    source_path: Option<String>,
+    hermes_profile: Option<String>,
+    session_title: Option<String>,
+    session_source: Option<String>,
+    message_id: Option<String>,
+    tool_name: Option<String>,
+    tool_call_id: Option<String>,
+    previous_message_id: Option<String>,
+    next_message_id: Option<String>,
+}
 
 use crate::core::db::Database;
 use crate::embed::Embedder;
-use crate::xurl::store::TurnFilter;
+use crate::xurl::store::{TurnFilter, push_filter_conditions};
 use crate::xurl::{XurlError, XurlResult};
 
 #[derive(Debug, Serialize)]
@@ -21,6 +36,14 @@ pub struct SearchHit {
     pub timestamp_epoch: f64,
     pub score: f32,
     pub source_path: Option<String>,
+    pub hermes_profile: Option<String>,
+    pub session_title: Option<String>,
+    pub session_source: Option<String>,
+    pub message_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_call_id: Option<String>,
+    pub previous_message_id: Option<String>,
+    pub next_message_id: Option<String>,
 }
 
 /// Aggregated result returned by [`search`].
@@ -131,20 +154,13 @@ pub async fn search<E: Embedder + ?Sized>(
     if !include_agent_prompts {
         conditions.push("ct.provenance = 'human'".into());
     }
-    if let Some(ref tool) = filter.tool {
-        conditions.push(format!("ct.tool = ?{pidx}"));
-        param_values.push(Box::new(tool.as_str().to_string()));
-        pidx += 1;
-    }
-    if let Some(ref sid) = filter.session_id {
-        conditions.push(format!("ct.session_id = ?{pidx}"));
-        param_values.push(Box::new(sid.clone()));
-        pidx += 1;
-    }
-    if let Some(since) = filter.since_epoch {
-        conditions.push(format!("ct.timestamp_epoch >= ?{pidx}"));
-        param_values.push(Box::new(since));
-    }
+    push_filter_conditions(
+        &filter,
+        Some("ct"),
+        &mut conditions,
+        &mut param_values,
+        &mut pidx,
+    );
 
     let where_clause = if conditions.is_empty() {
         String::new()
@@ -154,7 +170,9 @@ pub async fn search<E: Embedder + ?Sized>(
 
     let sql = format!(
         "SELECT ctv.turn_id, ctv.vector, \
-         ct.session_id, ct.tool, ct.role, ct.content, ct.timestamp_epoch, ct.project_path \
+         ct.session_id, ct.tool, ct.role, ct.content, ct.timestamp_epoch, ct.project_path, \
+         ct.hermes_profile, ct.session_title, ct.session_source, ct.message_id, \
+         ct.tool_name, ct.tool_call_id, ct.previous_message_id, ct.next_message_id \
          FROM conversation_turn_vectors ctv \
          JOIN conversation_turns ct ON ct.id = ctv.turn_id \
          {where_clause}"
@@ -169,6 +187,14 @@ pub async fn search<E: Embedder + ?Sized>(
         content: String,
         timestamp_epoch: f64,
         project_path: Option<String>,
+        hermes_profile: Option<String>,
+        session_title: Option<String>,
+        session_source: Option<String>,
+        message_id: Option<String>,
+        tool_name: Option<String>,
+        tool_call_id: Option<String>,
+        previous_message_id: Option<String>,
+        next_message_id: Option<String>,
     }
 
     let refs: Vec<&dyn rusqlite::ToSql> = param_values.iter().map(|b| b.as_ref()).collect();
@@ -184,6 +210,14 @@ pub async fn search<E: Embedder + ?Sized>(
                 content: row.get(5)?,
                 timestamp_epoch: row.get(6)?,
                 project_path: row.get(7)?,
+                hermes_profile: row.get(8)?,
+                session_title: row.get(9)?,
+                session_source: row.get(10)?,
+                message_id: row.get(11)?,
+                tool_name: row.get(12)?,
+                tool_call_id: row.get(13)?,
+                previous_message_id: row.get(14)?,
+                next_message_id: row.get(15)?,
             })
         })
         .map_err(XurlError::Database)?
@@ -196,37 +230,51 @@ pub async fn search<E: Embedder + ?Sized>(
     for row in rows {
         let vec = deserialize_vector(&row.vector);
         let score = cosine_similarity(&query_vec, &vec);
-        let entry = best_by_turn.entry(row.turn_id.clone()).or_insert((
-            -1.0,
-            row.session_id,
-            row.tool,
-            row.role,
-            row.content,
-            row.timestamp_epoch,
-            row.project_path,
-        ));
-        if score > entry.0 {
-            entry.0 = score;
+        let entry = best_by_turn
+            .entry(row.turn_id.clone())
+            .or_insert(TurnBestEntry {
+                score: -1.0,
+                session_id: row.session_id,
+                tool: row.tool,
+                role: row.role,
+                content: row.content,
+                timestamp_epoch: row.timestamp_epoch,
+                source_path: row.project_path,
+                hermes_profile: row.hermes_profile,
+                session_title: row.session_title,
+                session_source: row.session_source,
+                message_id: row.message_id,
+                tool_name: row.tool_name,
+                tool_call_id: row.tool_call_id,
+                previous_message_id: row.previous_message_id,
+                next_message_id: row.next_message_id,
+            });
+        if score > entry.score {
+            entry.score = score;
         }
     }
 
     // Convert to SearchHit and sort by descending score.
     let mut all_hits: Vec<SearchHit> = best_by_turn
         .into_iter()
-        .map(
-            |(turn_id, (score, session_id, tool, role, content, timestamp_epoch, source_path))| {
-                SearchHit {
-                    turn_id,
-                    session_id,
-                    tool,
-                    role,
-                    content,
-                    timestamp_epoch,
-                    score,
-                    source_path,
-                }
-            },
-        )
+        .map(|(turn_id, entry)| SearchHit {
+            turn_id,
+            session_id: entry.session_id,
+            tool: entry.tool,
+            role: entry.role,
+            content: entry.content,
+            timestamp_epoch: entry.timestamp_epoch,
+            score: entry.score,
+            source_path: entry.source_path,
+            hermes_profile: entry.hermes_profile,
+            session_title: entry.session_title,
+            session_source: entry.session_source,
+            message_id: entry.message_id,
+            tool_name: entry.tool_name,
+            tool_call_id: entry.tool_call_id,
+            previous_message_id: entry.previous_message_id,
+            next_message_id: entry.next_message_id,
+        })
         .collect();
 
     all_hits.sort_by(|a, b| {
@@ -362,6 +410,33 @@ pub fn format_hits_markdown(result: &SearchResult) -> String {
         output.push('\n');
         if let Some(ref path) = hit.source_path {
             output.push_str(&format!("  source: {path}\n"));
+        }
+        if hit.tool == "hermes" {
+            let mut parts = Vec::new();
+            if let Some(ref profile) = hit.hermes_profile {
+                parts.push(format!("profile={profile}"));
+            }
+            parts.push(format!("session={}", hit.session_id));
+            if let Some(ref message_id) = hit.message_id {
+                parts.push(format!("message={message_id}"));
+            }
+            if let Some(ref source) = hit.session_source {
+                parts.push(format!("source={source}"));
+            }
+            if let Some(ref title) = hit.session_title {
+                parts.push(format!("title={title}"));
+            }
+            output.push_str(&format!("  citation: hermes {}\n", parts.join(" ")));
+            if hit.previous_message_id.is_some() || hit.next_message_id.is_some() {
+                output.push_str(&format!(
+                    "  neighbors: prev={} next={}\n",
+                    hit.previous_message_id.as_deref().unwrap_or("-"),
+                    hit.next_message_id.as_deref().unwrap_or("-")
+                ));
+            }
+            if let Some(ref tool_name) = hit.tool_name {
+                output.push_str(&format!("  tool: {tool_name}\n"));
+            }
         }
         output.push('\n');
         output.push_str(hit.content.trim());

--- a/src/xurl/store.rs
+++ b/src/xurl/store.rs
@@ -27,6 +27,7 @@ pub struct InsertStats {
     pub inserted: usize,
     pub skipped: usize,
     pub updated: usize,
+    pub turn_ids: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -128,10 +129,10 @@ fn generate_turn_id(session_id: &str, tool: &str, turn_index: u32) -> String {
     generate_turn_id_from_parts(&[session_id, tool, &turn_index])
 }
 
-/// Deterministic turn ID for a raw turn, matching the key `insert_turns` uses.
+/// Deterministic turn ID for newly inserted raw turns.
 ///
-/// Lets callers (e.g. a single-file ingest) compute the IDs of just-stored
-/// turns so the embed pass can be scoped to them without re-scanning the table.
+/// Existing legacy rows may keep their historical IDs when `insert_turns`
+/// updates them; use `InsertStats::turn_ids` when callers need actual row IDs.
 pub fn turn_id_for(turn: &RawTurn) -> String {
     if turn.tool == Tool::Hermes {
         if let (Some(profile), Some(message_id)) = (
@@ -185,7 +186,7 @@ fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<Ex
             turn.metadata.hermes_profile.as_deref(),
             turn.metadata.message_id.as_deref(),
         ) {
-            return conn
+            let existing = conn
                 .query_row(
                     "SELECT id, content, timestamp_epoch, project_path, git_branch, \
                      is_csa_delegated, provenance, hermes_profile, session_title, session_source, \
@@ -196,7 +197,12 @@ fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<Ex
                     existing_turn_from_row,
                 )
                 .optional()
-                .map_err(XurlError::Database);
+                .map_err(XurlError::Database)?;
+            if existing.is_some() {
+                return Ok(existing);
+            }
+
+            return find_existing_legacy_hermes_turn(conn, turn);
         }
     }
 
@@ -208,6 +214,24 @@ fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<Ex
          FROM conversation_turns \
          WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
         params![&turn.session_id, turn.tool.as_str(), turn_index],
+        existing_turn_from_row,
+    )
+    .optional()
+    .map_err(XurlError::Database)
+}
+
+fn find_existing_legacy_hermes_turn(
+    conn: &Connection,
+    turn: &RawTurn,
+) -> XurlResult<Option<ExistingTurn>> {
+    conn.query_row(
+        "SELECT id, content, timestamp_epoch, project_path, git_branch, \
+         is_csa_delegated, provenance, hermes_profile, session_title, session_source, \
+         message_id, tool_name, tool_call_id, previous_message_id, next_message_id \
+         FROM conversation_turns \
+         WHERE session_id=?1 AND tool=?2 AND turn_index=?3 \
+           AND hermes_profile IS NULL AND message_id IS NULL",
+        params![&turn.session_id, turn.tool.as_str(), turn.turn_index],
         existing_turn_from_row,
     )
     .optional()
@@ -359,7 +383,7 @@ hermes_profile, session_title, session_source, message_id, tool_name, \
 tool_call_id, previous_message_id, next_message_id";
 
 /// Insert or update a batch of turns. For each turn:
-/// - If no row with (session_id, tool, turn_index) exists: INSERT.
+/// - If no row with the tool-specific identity exists: INSERT.
 /// - If a row exists with identical content and metadata: skip (no write).
 /// - If a row exists with identical content but changed metadata: UPDATE metadata only.
 /// - If a row exists with different content: UPDATE content and metadata fields.
@@ -410,9 +434,11 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                         ],
                     )
                     .map_err(XurlError::Database)?;
+                    stats.turn_ids.push(id);
                     stats.inserted += 1;
                 }
                 Some(existing) if existing.content == turn.content => {
+                    stats.turn_ids.push(existing.id.clone());
                     if stored_metadata_matches(&existing, turn) {
                         stats.skipped += 1;
                     } else {
@@ -421,6 +447,7 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                     }
                 }
                 Some(existing) => {
+                    stats.turn_ids.push(existing.id.clone());
                     conn.execute(
                         "UPDATE conversation_turns SET \
                          content=?2, timestamp_epoch=?3, token_count=?4, \
@@ -664,16 +691,9 @@ pub(crate) fn push_filter_conditions(
         let cwd = normalize_cwd_filter(cwd);
         if !cwd.is_empty() {
             let project_col = filter_column(column_prefix, "project_path");
-            conditions.push(format!(
-                "({project_col} = ?{} OR {project_col} LIKE ?{} OR ?{} LIKE {project_col} || '/%')",
-                *idx,
-                *idx + 1,
-                *idx + 2
-            ));
-            params_vec.push(Box::new(cwd.clone()));
-            params_vec.push(Box::new(descendant_like_pattern(&cwd)));
+            conditions.push(cwd_filter_condition(&project_col, *idx, &cwd));
             params_vec.push(Box::new(cwd));
-            *idx += 3;
+            *idx += 1;
         }
     }
     if let Some(ref profile) = filter.hermes_profile {
@@ -732,12 +752,18 @@ pub(crate) fn normalize_cwd_filter(cwd: &str) -> String {
     }
 }
 
-fn descendant_like_pattern(cwd: &str) -> String {
+fn cwd_filter_condition(project_col: &str, param_idx: usize, cwd: &str) -> String {
     if cwd == "/" {
-        "/%".to_string()
-    } else {
-        format!("{cwd}/%")
+        return format!("substr({project_col}, 1, 1) = ?{param_idx}");
     }
+
+    format!(
+        "({project_col} = ?{param_idx} \
+         OR (substr({project_col}, 1, length(?{param_idx})) = ?{param_idx} \
+             AND substr({project_col}, length(?{param_idx}) + 1, 1) = '/') \
+         OR (substr(?{param_idx}, 1, length({project_col})) = {project_col} \
+             AND substr(?{param_idx}, length({project_col}) + 1, 1) = '/'))"
+    )
 }
 
 /// Per-tool aggregate statistics.

--- a/src/xurl/store.rs
+++ b/src/xurl/store.rs
@@ -1,8 +1,8 @@
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Row, params};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::xurl::model::{Provenance, RawTurn, Role, Tool};
+use crate::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use crate::xurl::{XurlError, XurlResult};
 
 pub struct StoredTurn {
@@ -19,6 +19,7 @@ pub struct StoredTurn {
     pub git_branch: Option<String>,
     pub is_csa_delegated: bool,
     pub provenance: Provenance,
+    pub metadata: TurnMetadata,
 }
 
 #[derive(Debug, Default)]
@@ -32,7 +33,12 @@ pub struct InsertStats {
 pub struct TurnFilter {
     pub tool: Option<Tool>,
     pub session_id: Option<String>,
+    pub cwd: Option<String>,
+    pub hermes_profile: Option<String>,
+    pub session_title: Option<String>,
+    pub session_source: Option<String>,
     pub since_epoch: Option<f64>,
+    pub until_epoch: Option<f64>,
     pub limit: usize,
     pub offset: usize,
 }
@@ -59,6 +65,11 @@ pub struct TimelineTurn {
     pub content: String,
     pub timestamp_epoch: f64,
     pub source_path: Option<String>,
+    pub hermes_profile: Option<String>,
+    pub session_title: Option<String>,
+    pub session_source: Option<String>,
+    pub message_id: Option<String>,
+    pub tool_name: Option<String>,
 }
 
 impl From<&StoredTurn> for TimelineTurn {
@@ -71,6 +82,11 @@ impl From<&StoredTurn> for TimelineTurn {
             content: turn.content.clone(),
             timestamp_epoch: turn.timestamp_epoch,
             source_path: turn.source_path.clone(),
+            hermes_profile: turn.metadata.hermes_profile.clone(),
+            session_title: turn.metadata.session_title.clone(),
+            session_source: turn.metadata.session_source.clone(),
+            message_id: turn.metadata.message_id.clone(),
+            tool_name: turn.metadata.tool_name.clone(),
         }
     }
 }
@@ -97,15 +113,19 @@ pub fn format_timeline_header(turn: &StoredTurn) -> String {
 
 /// Generate a deterministic turn ID from the natural key fields.
 /// Uses SHA-256 truncated to 16 hex chars for a stable, compact identifier.
-fn generate_turn_id(session_id: &str, tool: &str, turn_index: u32) -> String {
+fn generate_turn_id_from_parts(parts: &[&str]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(session_id.as_bytes());
-    hasher.update(b"\x00");
-    hasher.update(tool.as_bytes());
-    hasher.update(b"\x00");
-    hasher.update(turn_index.to_le_bytes());
+    for part in parts {
+        hasher.update(part.as_bytes());
+        hasher.update(b"\x00");
+    }
     let digest = format!("{:x}", hasher.finalize());
     format!("turn_{}", &digest[..16])
+}
+
+fn generate_turn_id(session_id: &str, tool: &str, turn_index: u32) -> String {
+    let turn_index = turn_index.to_string();
+    generate_turn_id_from_parts(&[session_id, tool, &turn_index])
 }
 
 /// Deterministic turn ID for a raw turn, matching the key `insert_turns` uses.
@@ -113,7 +133,68 @@ fn generate_turn_id(session_id: &str, tool: &str, turn_index: u32) -> String {
 /// Lets callers (e.g. a single-file ingest) compute the IDs of just-stored
 /// turns so the embed pass can be scoped to them without re-scanning the table.
 pub fn turn_id_for(turn: &RawTurn) -> String {
+    if turn.tool == Tool::Hermes {
+        if let (Some(profile), Some(message_id)) = (
+            turn.metadata.hermes_profile.as_deref(),
+            turn.metadata.message_id.as_deref(),
+        ) {
+            return generate_turn_id_from_parts(&[
+                turn.tool.as_str(),
+                profile,
+                &turn.session_id,
+                message_id,
+            ]);
+        }
+    }
     generate_turn_id(&turn.session_id, turn.tool.as_str(), turn.turn_index)
+}
+
+fn storage_turn_index(turn: &RawTurn) -> u32 {
+    if turn.tool == Tool::Hermes {
+        if let (Some(profile), Some(message_id)) = (
+            turn.metadata.hermes_profile.as_deref(),
+            turn.metadata.message_id.as_deref(),
+        ) {
+            let mut hasher = Sha256::new();
+            hasher.update(profile.as_bytes());
+            hasher.update(b"\x00");
+            hasher.update(turn.session_id.as_bytes());
+            hasher.update(b"\x00");
+            hasher.update(message_id.as_bytes());
+            let digest = hasher.finalize();
+            return u32::from_le_bytes([digest[0], digest[1], digest[2], digest[3]]);
+        }
+    }
+    turn.turn_index
+}
+
+fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<(String, String)>> {
+    if turn.tool == Tool::Hermes {
+        if let (Some(profile), Some(message_id)) = (
+            turn.metadata.hermes_profile.as_deref(),
+            turn.metadata.message_id.as_deref(),
+        ) {
+            return conn
+                .query_row(
+                    "SELECT id, content FROM conversation_turns \
+                     WHERE tool = ?1 AND hermes_profile = ?2 AND session_id = ?3 AND message_id = ?4",
+                    params![turn.tool.as_str(), profile, &turn.session_id, message_id],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(XurlError::Database);
+        }
+    }
+
+    let turn_index = storage_turn_index(turn);
+    conn.query_row(
+        "SELECT id, content FROM conversation_turns \
+         WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
+        params![&turn.session_id, turn.tool.as_str(), turn_index],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )
+    .optional()
+    .map_err(XurlError::Database)
 }
 
 /// Count turns that still lack a vector (no row in `conversation_turn_vectors`).
@@ -188,6 +269,45 @@ fn parse_provenance(s: &str) -> Provenance {
     }
 }
 
+fn stored_turn_from_row(row: &Row<'_>) -> rusqlite::Result<StoredTurn> {
+    let tool_str: String = row.get(2)?;
+    let role_str: String = row.get(4)?;
+    let provenance_str: String = row.get(11)?;
+    let is_csa: i64 = row.get(10)?;
+    let project_path: Option<String> = row.get(8)?;
+    Ok(StoredTurn {
+        id: row.get(0)?,
+        session_id: row.get(1)?,
+        tool: parse_tool(&tool_str).unwrap_or(Tool::Cc),
+        turn_index: row.get::<_, i64>(3)? as u32,
+        role: parse_role(&role_str).unwrap_or(Role::User),
+        content: row.get(5)?,
+        timestamp_epoch: row.get(6)?,
+        token_count: row.get(7)?,
+        source_path: project_path.clone(),
+        project_path,
+        git_branch: row.get(9)?,
+        is_csa_delegated: is_csa != 0,
+        provenance: parse_provenance(&provenance_str),
+        metadata: TurnMetadata {
+            hermes_profile: row.get(12)?,
+            session_title: row.get(13)?,
+            session_source: row.get(14)?,
+            message_id: row.get(15)?,
+            tool_name: row.get(16)?,
+            tool_call_id: row.get(17)?,
+            previous_message_id: row.get(18)?,
+            next_message_id: row.get(19)?,
+        },
+    })
+}
+
+const TURN_SELECT_COLUMNS: &str = "\
+id, session_id, tool, turn_index, role, content, timestamp_epoch, \
+token_count, project_path, git_branch, is_csa_delegated, provenance, \
+hermes_profile, session_title, session_source, message_id, tool_name, \
+tool_call_id, previous_message_id, next_message_id";
+
 /// Insert or update a batch of turns. For each turn:
 /// - If no row with (session_id, tool, turn_index) exists: INSERT.
 /// - If a row exists with identical content: skip (no write).
@@ -202,29 +322,24 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
     let insert_result = (|| -> XurlResult<()> {
         for turn in turns {
             let tool = turn.tool.as_str();
-            let existing: Option<(String, String)> = conn
-                .query_row(
-                    "SELECT id, content FROM conversation_turns \
-                     WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
-                    params![&turn.session_id, tool, turn.turn_index],
-                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-                )
-                .optional()
-                .map_err(XurlError::Database)?;
+            let turn_index = storage_turn_index(turn);
+            let existing = find_existing_turn(conn, turn)?;
 
             match existing {
                 None => {
-                    let id = generate_turn_id(&turn.session_id, tool, turn.turn_index);
+                    let id = turn_id_for(turn);
                     conn.execute(
                         "INSERT INTO conversation_turns \
                          (id, session_id, tool, turn_index, role, content, timestamp_epoch, \
-                          token_count, project_path, git_branch, is_csa_delegated, provenance) \
-                         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+                          token_count, project_path, git_branch, is_csa_delegated, provenance, \
+                          hermes_profile, session_title, session_source, message_id, tool_name, \
+                          tool_call_id, previous_message_id, next_message_id) \
+                         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
                         params![
                             id,
                             &turn.session_id,
                             tool,
-                            turn.turn_index,
+                            turn_index,
                             turn.role.as_str(),
                             &turn.content,
                             turn.timestamp_epoch,
@@ -233,6 +348,14 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                             &turn.git_branch,
                             turn.is_csa_delegated as i64,
                             turn.provenance.as_str(),
+                            &turn.metadata.hermes_profile,
+                            &turn.metadata.session_title,
+                            &turn.metadata.session_source,
+                            &turn.metadata.message_id,
+                            &turn.metadata.tool_name,
+                            &turn.metadata.tool_call_id,
+                            &turn.metadata.previous_message_id,
+                            &turn.metadata.next_message_id,
                         ],
                     )
                     .map_err(XurlError::Database)?;
@@ -245,7 +368,9 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                     conn.execute(
                         "UPDATE conversation_turns SET \
                          content=?2, timestamp_epoch=?3, token_count=?4, \
-                         project_path=?5, git_branch=?6, is_csa_delegated=?7, provenance=?8 \
+                         project_path=?5, git_branch=?6, is_csa_delegated=?7, provenance=?8, \
+                         hermes_profile=?9, session_title=?10, session_source=?11, message_id=?12, \
+                         tool_name=?13, tool_call_id=?14, previous_message_id=?15, next_message_id=?16 \
                          WHERE id=?1",
                         params![
                             existing_id,
@@ -256,6 +381,14 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                             &turn.git_branch,
                             turn.is_csa_delegated as i64,
                             turn.provenance.as_str(),
+                            &turn.metadata.hermes_profile,
+                            &turn.metadata.session_title,
+                            &turn.metadata.session_source,
+                            &turn.metadata.message_id,
+                            &turn.metadata.tool_name,
+                            &turn.metadata.tool_call_id,
+                            &turn.metadata.previous_message_id,
+                            &turn.metadata.next_message_id,
                         ],
                     )
                     .map_err(XurlError::Database)?;
@@ -290,22 +423,7 @@ pub fn get_turns(conn: &Connection, filter: TurnFilter) -> XurlResult<Vec<Stored
     let mut conditions = Vec::<String>::new();
     let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
     let mut idx = 1usize;
-
-    if let Some(ref tool) = filter.tool {
-        conditions.push(format!("tool = ?{idx}"));
-        params_vec.push(Box::new(tool.as_str().to_string()));
-        idx += 1;
-    }
-    if let Some(ref sid) = filter.session_id {
-        conditions.push(format!("session_id = ?{idx}"));
-        params_vec.push(Box::new(sid.clone()));
-        idx += 1;
-    }
-    if let Some(since) = filter.since_epoch {
-        conditions.push(format!("timestamp_epoch >= ?{idx}"));
-        params_vec.push(Box::new(since));
-        idx += 1;
-    }
+    push_filter_conditions(&filter, None, &mut conditions, &mut params_vec, &mut idx);
 
     let where_clause = if conditions.is_empty() {
         String::new()
@@ -314,8 +432,7 @@ pub fn get_turns(conn: &Connection, filter: TurnFilter) -> XurlResult<Vec<Stored
     };
 
     let sql = format!(
-        "SELECT id, session_id, tool, turn_index, role, content, timestamp_epoch, \
-         token_count, project_path, git_branch, is_csa_delegated, provenance \
+        "SELECT {TURN_SELECT_COLUMNS} \
          FROM conversation_turns \
          {where_clause} \
          ORDER BY timestamp_epoch DESC \
@@ -330,28 +447,7 @@ pub fn get_turns(conn: &Connection, filter: TurnFilter) -> XurlResult<Vec<Stored
 
     let mut stmt = conn.prepare(&sql).map_err(XurlError::Database)?;
     let rows = stmt
-        .query_map(refs.as_slice(), |row| {
-            let tool_str: String = row.get(2)?;
-            let role_str: String = row.get(4)?;
-            let provenance_str: String = row.get(11)?;
-            let is_csa: i64 = row.get(10)?;
-            let project_path: Option<String> = row.get(8)?;
-            Ok(StoredTurn {
-                id: row.get(0)?,
-                session_id: row.get(1)?,
-                tool: parse_tool(&tool_str).unwrap_or(Tool::Cc),
-                turn_index: row.get::<_, i64>(3)? as u32,
-                role: parse_role(&role_str).unwrap_or(Role::User),
-                content: row.get(5)?,
-                timestamp_epoch: row.get(6)?,
-                token_count: row.get(7)?,
-                source_path: project_path.clone(),
-                project_path,
-                git_branch: row.get(9)?,
-                is_csa_delegated: is_csa != 0,
-                provenance: parse_provenance(&provenance_str),
-            })
-        })
+        .query_map(refs.as_slice(), stored_turn_from_row)
         .map_err(XurlError::Database)?;
 
     let mut turns = Vec::new();
@@ -380,21 +476,7 @@ pub fn get_turns_filtered(
     if !include_agent_prompts {
         conditions.push("provenance = 'human'".into());
     }
-    if let Some(ref tool) = filter.tool {
-        conditions.push(format!("tool = ?{idx}"));
-        params_vec.push(Box::new(tool.as_str().to_string()));
-        idx += 1;
-    }
-    if let Some(ref sid) = filter.session_id {
-        conditions.push(format!("session_id = ?{idx}"));
-        params_vec.push(Box::new(sid.clone()));
-        idx += 1;
-    }
-    if let Some(since) = filter.since_epoch {
-        conditions.push(format!("timestamp_epoch >= ?{idx}"));
-        params_vec.push(Box::new(since));
-        idx += 1;
-    }
+    push_filter_conditions(&filter, None, &mut conditions, &mut params_vec, &mut idx);
 
     let where_clause = if conditions.is_empty() {
         String::new()
@@ -403,8 +485,7 @@ pub fn get_turns_filtered(
     };
 
     let sql = format!(
-        "SELECT id, session_id, tool, turn_index, role, content, timestamp_epoch, \
-         token_count, project_path, git_branch, is_csa_delegated, provenance \
+        "SELECT {TURN_SELECT_COLUMNS} \
          FROM conversation_turns \
          {where_clause} \
          ORDER BY timestamp_epoch DESC \
@@ -419,28 +500,7 @@ pub fn get_turns_filtered(
 
     let mut stmt = conn.prepare(&sql).map_err(XurlError::Database)?;
     let rows = stmt
-        .query_map(refs.as_slice(), |row| {
-            let tool_str: String = row.get(2)?;
-            let role_str: String = row.get(4)?;
-            let provenance_str: String = row.get(11)?;
-            let is_csa: i64 = row.get(10)?;
-            let project_path: Option<String> = row.get(8)?;
-            Ok(StoredTurn {
-                id: row.get(0)?,
-                session_id: row.get(1)?,
-                tool: parse_tool(&tool_str).unwrap_or(Tool::Cc),
-                turn_index: row.get::<_, i64>(3)? as u32,
-                role: parse_role(&role_str).unwrap_or(Role::User),
-                content: row.get(5)?,
-                timestamp_epoch: row.get(6)?,
-                token_count: row.get(7)?,
-                source_path: project_path.clone(),
-                project_path,
-                git_branch: row.get(9)?,
-                is_csa_delegated: is_csa != 0,
-                provenance: parse_provenance(&provenance_str),
-            })
-        })
+        .query_map(refs.as_slice(), stored_turn_from_row)
         .map_err(XurlError::Database)?;
 
     let mut turns = Vec::new();
@@ -450,11 +510,48 @@ pub fn get_turns_filtered(
     Ok(turns)
 }
 
+pub fn latest_session_id(
+    conn: &Connection,
+    filter: &TurnFilter,
+    include_csa: bool,
+    include_agent_prompts: bool,
+) -> XurlResult<Option<String>> {
+    let mut conditions = Vec::<String>::new();
+    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut idx = 1usize;
+
+    if !include_csa {
+        conditions.push("is_csa_delegated = 0".into());
+    }
+    if !include_agent_prompts {
+        conditions.push("provenance = 'human'".into());
+    }
+    push_filter_conditions(filter, None, &mut conditions, &mut params_vec, &mut idx);
+
+    let where_clause = if conditions.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", conditions.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT session_id \
+         FROM conversation_turns \
+         {where_clause} \
+         GROUP BY session_id \
+         ORDER BY MAX(timestamp_epoch) DESC \
+         LIMIT 1"
+    );
+    let refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
+    conn.query_row(&sql, refs.as_slice(), |row| row.get::<_, String>(0))
+        .optional()
+        .map_err(XurlError::Database)
+}
+
 fn filter_column(prefix: Option<&str>, column: &str) -> String {
     prefix.map_or_else(|| column.to_string(), |prefix| format!("{prefix}.{column}"))
 }
 
-fn push_filter_conditions(
+pub(crate) fn push_filter_conditions(
     filter: &TurnFilter,
     column_prefix: Option<&str>,
     conditions: &mut Vec<String>,
@@ -479,6 +576,49 @@ fn push_filter_conditions(
         params_vec.push(Box::new(sid.clone()));
         *idx += 1;
     }
+    if let Some(ref cwd) = filter.cwd {
+        let cwd = normalize_cwd_filter(cwd);
+        if !cwd.is_empty() {
+            let project_col = filter_column(column_prefix, "project_path");
+            conditions.push(format!(
+                "({project_col} = ?{} OR {project_col} LIKE ?{} OR ?{} LIKE {project_col} || '/%')",
+                *idx,
+                *idx + 1,
+                *idx + 2
+            ));
+            params_vec.push(Box::new(cwd.clone()));
+            params_vec.push(Box::new(descendant_like_pattern(&cwd)));
+            params_vec.push(Box::new(cwd));
+            *idx += 3;
+        }
+    }
+    if let Some(ref profile) = filter.hermes_profile {
+        conditions.push(format!(
+            "{} = ?{}",
+            filter_column(column_prefix, "hermes_profile"),
+            *idx
+        ));
+        params_vec.push(Box::new(profile.clone()));
+        *idx += 1;
+    }
+    if let Some(ref title) = filter.session_title {
+        conditions.push(format!(
+            "{} = ?{}",
+            filter_column(column_prefix, "session_title"),
+            *idx
+        ));
+        params_vec.push(Box::new(title.clone()));
+        *idx += 1;
+    }
+    if let Some(ref source) = filter.session_source {
+        conditions.push(format!(
+            "{} = ?{}",
+            filter_column(column_prefix, "session_source"),
+            *idx
+        ));
+        params_vec.push(Box::new(source.clone()));
+        *idx += 1;
+    }
     if let Some(since) = filter.since_epoch {
         conditions.push(format!(
             "{} >= ?{}",
@@ -487,6 +627,32 @@ fn push_filter_conditions(
         ));
         params_vec.push(Box::new(since));
         *idx += 1;
+    }
+    if let Some(until) = filter.until_epoch {
+        conditions.push(format!(
+            "{} <= ?{}",
+            filter_column(column_prefix, "timestamp_epoch"),
+            *idx
+        ));
+        params_vec.push(Box::new(until));
+        *idx += 1;
+    }
+}
+
+pub(crate) fn normalize_cwd_filter(cwd: &str) -> String {
+    let trimmed = cwd.trim();
+    if trimmed == "/" {
+        trimmed.to_string()
+    } else {
+        trimmed.trim_end_matches('/').to_string()
+    }
+}
+
+fn descendant_like_pattern(cwd: &str) -> String {
+    if cwd == "/" {
+        "/%".to_string()
+    } else {
+        format!("{cwd}/%")
     }
 }
 

--- a/src/xurl/store.rs
+++ b/src/xurl/store.rs
@@ -149,6 +149,17 @@ pub fn turn_id_for(turn: &RawTurn) -> String {
     generate_turn_id(&turn.session_id, turn.tool.as_str(), turn.turn_index)
 }
 
+struct ExistingTurn {
+    id: String,
+    content: String,
+    timestamp_epoch: f64,
+    project_path: Option<String>,
+    git_branch: Option<String>,
+    is_csa_delegated: bool,
+    provenance: Provenance,
+    metadata: TurnMetadata,
+}
+
 fn storage_turn_index(turn: &RawTurn) -> u32 {
     if turn.tool == Tool::Hermes {
         if let (Some(profile), Some(message_id)) = (
@@ -168,7 +179,7 @@ fn storage_turn_index(turn: &RawTurn) -> u32 {
     turn.turn_index
 }
 
-fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<(String, String)>> {
+fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<ExistingTurn>> {
     if turn.tool == Tool::Hermes {
         if let (Some(profile), Some(message_id)) = (
             turn.metadata.hermes_profile.as_deref(),
@@ -176,10 +187,13 @@ fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<(S
         ) {
             return conn
                 .query_row(
-                    "SELECT id, content FROM conversation_turns \
+                    "SELECT id, content, timestamp_epoch, project_path, git_branch, \
+                     is_csa_delegated, provenance, hermes_profile, session_title, session_source, \
+                     message_id, tool_name, tool_call_id, previous_message_id, next_message_id \
+                     FROM conversation_turns \
                      WHERE tool = ?1 AND hermes_profile = ?2 AND session_id = ?3 AND message_id = ?4",
                     params![turn.tool.as_str(), profile, &turn.session_id, message_id],
-                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    existing_turn_from_row,
                 )
                 .optional()
                 .map_err(XurlError::Database);
@@ -188,13 +202,49 @@ fn find_existing_turn(conn: &Connection, turn: &RawTurn) -> XurlResult<Option<(S
 
     let turn_index = storage_turn_index(turn);
     conn.query_row(
-        "SELECT id, content FROM conversation_turns \
+        "SELECT id, content, timestamp_epoch, project_path, git_branch, \
+         is_csa_delegated, provenance, hermes_profile, session_title, session_source, \
+         message_id, tool_name, tool_call_id, previous_message_id, next_message_id \
+         FROM conversation_turns \
          WHERE session_id=?1 AND tool=?2 AND turn_index=?3",
         params![&turn.session_id, turn.tool.as_str(), turn_index],
-        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        existing_turn_from_row,
     )
     .optional()
     .map_err(XurlError::Database)
+}
+
+fn existing_turn_from_row(row: &Row<'_>) -> rusqlite::Result<ExistingTurn> {
+    let is_csa: i64 = row.get(5)?;
+    let provenance_str: String = row.get(6)?;
+    Ok(ExistingTurn {
+        id: row.get(0)?,
+        content: row.get(1)?,
+        timestamp_epoch: row.get(2)?,
+        project_path: row.get(3)?,
+        git_branch: row.get(4)?,
+        is_csa_delegated: is_csa != 0,
+        provenance: parse_provenance(&provenance_str),
+        metadata: TurnMetadata {
+            hermes_profile: row.get(7)?,
+            session_title: row.get(8)?,
+            session_source: row.get(9)?,
+            message_id: row.get(10)?,
+            tool_name: row.get(11)?,
+            tool_call_id: row.get(12)?,
+            previous_message_id: row.get(13)?,
+            next_message_id: row.get(14)?,
+        },
+    })
+}
+
+fn stored_metadata_matches(existing: &ExistingTurn, turn: &RawTurn) -> bool {
+    existing.timestamp_epoch.to_bits() == turn.timestamp_epoch.to_bits()
+        && existing.project_path == turn.project_path
+        && existing.git_branch == turn.git_branch
+        && existing.is_csa_delegated == turn.is_csa_delegated
+        && existing.provenance == turn.provenance
+        && existing.metadata == turn.metadata
 }
 
 /// Count turns that still lack a vector (no row in `conversation_turn_vectors`).
@@ -310,7 +360,8 @@ tool_call_id, previous_message_id, next_message_id";
 
 /// Insert or update a batch of turns. For each turn:
 /// - If no row with (session_id, tool, turn_index) exists: INSERT.
-/// - If a row exists with identical content: skip (no write).
+/// - If a row exists with identical content and metadata: skip (no write).
+/// - If a row exists with identical content but changed metadata: UPDATE metadata only.
 /// - If a row exists with different content: UPDATE content and metadata fields.
 ///
 /// Returns stats for the batch.
@@ -361,19 +412,24 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                     .map_err(XurlError::Database)?;
                     stats.inserted += 1;
                 }
-                Some((_, ref existing_content)) if existing_content == &turn.content => {
-                    stats.skipped += 1;
+                Some(existing) if existing.content == turn.content => {
+                    if stored_metadata_matches(&existing, turn) {
+                        stats.skipped += 1;
+                    } else {
+                        update_turn_metadata(conn, &existing.id, turn)?;
+                        stats.updated += 1;
+                    }
                 }
-                Some((existing_id, _)) => {
+                Some(existing) => {
                     conn.execute(
                         "UPDATE conversation_turns SET \
                          content=?2, timestamp_epoch=?3, token_count=?4, \
                          project_path=?5, git_branch=?6, is_csa_delegated=?7, provenance=?8, \
                          hermes_profile=?9, session_title=?10, session_source=?11, message_id=?12, \
                          tool_name=?13, tool_call_id=?14, previous_message_id=?15, next_message_id=?16 \
-                         WHERE id=?1",
+                        WHERE id=?1",
                         params![
-                            existing_id,
+                            &existing.id,
                             &turn.content,
                             turn.timestamp_epoch,
                             Option::<i64>::None,
@@ -394,7 +450,7 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
                     .map_err(XurlError::Database)?;
                     conn.execute(
                         "DELETE FROM conversation_turn_vectors WHERE turn_id = ?1",
-                        params![existing_id],
+                        params![&existing.id],
                     )
                     .map_err(XurlError::Database)?;
                     stats.updated += 1;
@@ -413,6 +469,34 @@ pub fn insert_turns(conn: &Connection, turns: &[RawTurn]) -> XurlResult<InsertSt
     }
 
     Ok(stats)
+}
+
+fn update_turn_metadata(conn: &Connection, id: &str, turn: &RawTurn) -> XurlResult<()> {
+    conn.execute(
+        "UPDATE conversation_turns SET \
+         timestamp_epoch=?2, project_path=?3, git_branch=?4, is_csa_delegated=?5, provenance=?6, \
+         hermes_profile=?7, session_title=?8, session_source=?9, message_id=?10, \
+         tool_name=?11, tool_call_id=?12, previous_message_id=?13, next_message_id=?14 \
+         WHERE id=?1",
+        params![
+            id,
+            turn.timestamp_epoch,
+            &turn.project_path,
+            &turn.git_branch,
+            turn.is_csa_delegated as i64,
+            turn.provenance.as_str(),
+            &turn.metadata.hermes_profile,
+            &turn.metadata.session_title,
+            &turn.metadata.session_source,
+            &turn.metadata.message_id,
+            &turn.metadata.tool_name,
+            &turn.metadata.tool_call_id,
+            &turn.metadata.previous_message_id,
+            &turn.metadata.next_message_id,
+        ],
+    )
+    .map_err(XurlError::Database)?;
+    Ok(())
 }
 
 /// Query stored turns with optional filtering and pagination.

--- a/tests/fork_ext_schema_axis.rs
+++ b/tests/fork_ext_schema_axis.rs
@@ -452,6 +452,80 @@ fn test_fork_ext_v19_to_v20_backfills_op_state_and_normalizes_completion_created
 }
 
 #[test]
+fn test_fork_ext_v20_to_v21_adds_hermes_metadata_idempotently() {
+    let conn = Connection::open_in_memory().expect("open sqlite connection");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '20');
+        CREATE TABLE conversation_turns (
+            id              TEXT PRIMARY KEY,
+            session_id      TEXT NOT NULL,
+            tool            TEXT NOT NULL,
+            turn_index      INTEGER NOT NULL,
+            role            TEXT NOT NULL,
+            content         TEXT NOT NULL,
+            timestamp_epoch REAL NOT NULL,
+            token_count     INTEGER,
+            project_path    TEXT,
+            git_branch      TEXT,
+            is_csa_delegated BOOLEAN NOT NULL DEFAULT FALSE,
+            provenance       TEXT NOT NULL DEFAULT 'human',
+            UNIQUE(session_id, tool, turn_index)
+        );
+        "#,
+    )
+    .expect("create v20 xurl schema");
+
+    apply_fork_ext_migrations_to(&conn, 21).expect("first v21 migration");
+    apply_fork_ext_migrations_to(&conn, 21).expect("second v21 migration");
+
+    let columns = table_columns(&conn, "conversation_turns");
+    for name in [
+        "hermes_profile",
+        "session_title",
+        "session_source",
+        "message_id",
+        "tool_name",
+        "tool_call_id",
+        "previous_message_id",
+        "next_message_id",
+    ] {
+        assert!(has_column(&columns, name, "TEXT"), "missing {name}");
+    }
+
+    conn.execute(
+        "INSERT INTO conversation_turns
+         (id, session_id, tool, turn_index, role, content, timestamp_epoch,
+          is_csa_delegated, provenance, hermes_profile, message_id)
+         VALUES ('h1', 'sess', 'hermes', 0, 'user', 'hello', 1.0, 0, 'human', 'default', 'msg-1')",
+        [],
+    )
+    .expect("insert first Hermes turn");
+    let duplicate = conn.execute(
+        "INSERT INTO conversation_turns
+         (id, session_id, tool, turn_index, role, content, timestamp_epoch,
+          is_csa_delegated, provenance, hermes_profile, message_id)
+         VALUES ('h2', 'sess', 'hermes', 1, 'user', 'hello again', 2.0, 0, 'human', 'default', 'msg-1')",
+        [],
+    );
+    assert!(duplicate.is_err());
+    conn.execute(
+        "INSERT INTO conversation_turns
+         (id, session_id, tool, turn_index, role, content, timestamp_epoch,
+          is_csa_delegated, provenance, hermes_profile, message_id)
+         VALUES ('h3', 'sess', 'hermes', 2, 'user', 'work profile', 3.0, 0, 'human', 'work', 'msg-1')",
+        [],
+    )
+    .expect("same message id may exist in another profile");
+
+    assert_eq!(read_fork_ext_version(&conn).expect("read version"), 21);
+}
+
+#[test]
 fn test_fork_ext_meta_table_exists_after_init() {
     let (_tmp, _db_path, db) = new_test_db();
 

--- a/tests/xurl_backfill.rs
+++ b/tests/xurl_backfill.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use mempal::core::db::Database;
 use mempal::xurl::backfill::{self, BackfillOptions, BackfillSourceConfig};
-use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::store::{self, TurnFilter};
 use serde_json::Value;
 use tempfile::TempDir;
@@ -47,6 +47,7 @@ fn make_turn(session_id: &str, turn_index: u32, project_path: Option<&str>) -> R
         is_csa_delegated: false,
         provenance: Provenance::Human,
         turn_index,
+        metadata: TurnMetadata::default(),
     }
 }
 

--- a/tests/xurl_embed.rs
+++ b/tests/xurl_embed.rs
@@ -1,7 +1,7 @@
 use mempal::core::db::{CURRENT_VECTOR_INDEX_VERSION, Database};
 use mempal::embed::Embedder;
 use mempal::xurl::embed;
-use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::store;
 use rusqlite::{OptionalExtension, params};
 use serde_json::Value;
@@ -312,6 +312,7 @@ fn make_raw_turn(session_id: &str, turn_index: u32, content: &str) -> RawTurn {
         is_csa_delegated: false,
         provenance: Provenance::Human,
         turn_index,
+        metadata: TurnMetadata::default(),
     }
 }
 

--- a/tests/xurl_ingest.rs
+++ b/tests/xurl_ingest.rs
@@ -5,6 +5,7 @@ use mempal::xurl::ingest;
 use mempal::xurl::model::Tool;
 use mempal::xurl::search::{self, SearchOptions};
 use mempal::xurl::store::{self, TurnFilter};
+use rusqlite::{Connection, params};
 use tempfile::TempDir;
 
 struct TestDb {
@@ -309,6 +310,76 @@ fn write_hermes_export(dir: &TempDir, session_id: &str, cwd: &str) -> PathBuf {
     path
 }
 
+fn write_metadata_less_hermes_export(dir: &TempDir, name: &str, marker: &str) -> PathBuf {
+    let lines = [
+        serde_json::json!({
+            "role": "user",
+            "content": format!("metadata-less {marker} user turn"),
+            "timestamp": "2026-06-01T00:00:00Z"
+        }),
+        serde_json::json!({
+            "role": "assistant",
+            "content": format!("metadata-less {marker} assistant turn"),
+            "timestamp": "2026-06-01T00:01:00Z"
+        }),
+    ];
+    let path = dir.path().join(name);
+    let content = lines
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, content).expect("write metadata-less Hermes export");
+    path
+}
+
+fn write_metadata_less_hermes_db(dir: &TempDir, name: &str, marker: &str) -> PathBuf {
+    let path = dir.path().join(name);
+    let conn = Connection::open(&path).expect("open Hermes fixture db");
+    conn.execute_batch(
+        "CREATE TABLE messages (
+            role      TEXT NOT NULL,
+            content   TEXT NOT NULL,
+            timestamp REAL NOT NULL
+        );",
+    )
+    .expect("create Hermes fixture table");
+    conn.execute(
+        "INSERT INTO messages (role, content, timestamp) VALUES (?1, ?2, ?3)",
+        params!["user", format!("metadata-less {marker} db user turn"), 1.0],
+    )
+    .expect("insert user row");
+    conn.execute(
+        "INSERT INTO messages (role, content, timestamp) VALUES (?1, ?2, ?3)",
+        params![
+            "assistant",
+            format!("metadata-less {marker} db assistant turn"),
+            2.0
+        ],
+    )
+    .expect("insert assistant row");
+    path
+}
+
+async fn ingest_hermes_options(
+    db: &Database,
+    embedder: &MockEmbedder,
+    options: ingest::HermesIngestOptions,
+) -> ingest::IngestStats {
+    ingest::ingest_hermes_with_vector_fingerprint(
+        db,
+        embedder,
+        &options,
+        "mock:64",
+        ingest::IngestCallbacks {
+            on_file_parsed: None,
+            on_embed_progress: None,
+        },
+    )
+    .await
+    .expect("ingest Hermes source")
+}
+
 #[tokio::test]
 async fn ingest_hermes_jsonl_is_idempotent_by_profile_session_message() {
     let dir = TempDir::new().unwrap();
@@ -407,6 +478,146 @@ async fn ingest_hermes_jsonl_is_idempotent_by_profile_session_message() {
         default_turns[0].metadata.session_title.as_deref(),
         Some("Issue 399 recall")
     );
+}
+
+#[tokio::test]
+async fn ingest_metadata_less_hermes_jsonl_uses_source_scoped_fallback_session() {
+    let dir = TempDir::new().unwrap();
+    let db = open_temp_db_at_fork_ext(21);
+    let embedder = MockEmbedder::new_fixed_dim(64);
+    let first_export = write_metadata_less_hermes_export(&dir, "first.jsonl", "alpha");
+    let second_export = write_metadata_less_hermes_export(&dir, "second.jsonl", "beta");
+
+    let first = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            export_jsonl: Some(first_export.clone()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let second = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            export_jsonl: Some(second_export),
+            ..Default::default()
+        },
+    )
+    .await;
+    let first_again = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            export_jsonl: Some(first_export),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert_eq!(first.turns_inserted, 2);
+    assert_eq!(second.turns_inserted, 2);
+    assert_eq!(second.turns_updated, 0);
+    assert_eq!(first_again.turns_inserted, 0);
+    assert_eq!(first_again.turns_skipped, 2);
+
+    let turns = store::get_turns_filtered(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            hermes_profile: Some("default".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+        false,
+        false,
+    )
+    .unwrap();
+    let mut sessions = turns
+        .iter()
+        .map(|turn| turn.session_id.as_str())
+        .collect::<Vec<_>>();
+    sessions.sort_unstable();
+    sessions.dedup();
+
+    assert_eq!(turns.len(), 4);
+    assert_eq!(sessions.len(), 2);
+    assert!(turns.iter().any(|turn| turn.content.contains("alpha")));
+    assert!(turns.iter().any(|turn| turn.content.contains("beta")));
+}
+
+#[tokio::test]
+async fn ingest_metadata_less_hermes_dbs_use_source_scoped_fallback_session() {
+    let dir = TempDir::new().unwrap();
+    let db = open_temp_db_at_fork_ext(21);
+    let embedder = MockEmbedder::new_fixed_dim(64);
+    let first_db = write_metadata_less_hermes_db(&dir, "first-state.db", "alpha");
+    let second_db = write_metadata_less_hermes_db(&dir, "second-state.db", "beta");
+
+    let first = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            db_path: Some(first_db.clone()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let second = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            db_path: Some(second_db),
+            ..Default::default()
+        },
+    )
+    .await;
+    let first_again = ingest_hermes_options(
+        &db.inner,
+        &embedder,
+        ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            db_path: Some(first_db),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert_eq!(first.turns_inserted, 2);
+    assert_eq!(second.turns_inserted, 2);
+    assert_eq!(second.turns_updated, 0);
+    assert_eq!(first_again.turns_inserted, 0);
+    assert_eq!(first_again.turns_skipped, 2);
+
+    let turns = store::get_turns_filtered(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            hermes_profile: Some("default".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+        false,
+        false,
+    )
+    .unwrap();
+    let mut sessions = turns
+        .iter()
+        .map(|turn| turn.session_id.as_str())
+        .collect::<Vec<_>>();
+    sessions.sort_unstable();
+    sessions.dedup();
+
+    assert_eq!(turns.len(), 4);
+    assert_eq!(sessions.len(), 2);
+    assert!(turns.iter().any(|turn| turn.content.contains("alpha")));
+    assert!(turns.iter().any(|turn| turn.content.contains("beta")));
 }
 
 #[tokio::test]

--- a/tests/xurl_ingest.rs
+++ b/tests/xurl_ingest.rs
@@ -274,3 +274,205 @@ async fn ingest_cc_default_scan_populates_project_path_from_parent_dir() {
     assert_eq!(turns.len(), 1);
     assert_eq!(turns[0].source_path.as_deref(), Some(cwd));
 }
+
+fn write_hermes_export(dir: &TempDir, session_id: &str, cwd: &str) -> PathBuf {
+    let lines = [
+        serde_json::json!({
+            "id": "msg-user-1",
+            "session_id": session_id,
+            "role": "user",
+            "content": "why did mktd Step 7 fail?",
+            "timestamp": "2026-06-01T00:00:00Z",
+            "cwd": cwd,
+            "session_title": "Issue 399 recall",
+            "session_source": "cli"
+        }),
+        serde_json::json!({
+            "id": "msg-assistant-1",
+            "session_id": session_id,
+            "role": "assistant",
+            "content": "Step 7 failed because the review verdict was not PASS yet.",
+            "timestamp": "2026-06-01T00:01:00Z",
+            "cwd": cwd,
+            "session_title": "Issue 399 recall",
+            "session_source": "cli",
+            "tool_name": "mktd"
+        }),
+    ];
+    let path = dir.path().join(format!("{session_id}.jsonl"));
+    let content = lines
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, content).expect("write Hermes export");
+    path
+}
+
+#[tokio::test]
+async fn ingest_hermes_jsonl_is_idempotent_by_profile_session_message() {
+    let dir = TempDir::new().unwrap();
+    let db = open_temp_db_at_fork_ext(21);
+    let cwd = "/home/obj/project/github/RyderFreeman4Logos/mempal";
+    let export = write_hermes_export(&dir, "hermes-session-1", cwd);
+    let embedder = MockEmbedder::new_fixed_dim(64);
+    let options = ingest::HermesIngestOptions {
+        profile: "default".to_string(),
+        export_jsonl: Some(export.clone()),
+        cwd: Some(cwd.to_string()),
+        ..Default::default()
+    };
+
+    let first = ingest::ingest_hermes_with_vector_fingerprint(
+        &db.inner,
+        &embedder,
+        &options,
+        "mock:64",
+        ingest::IngestCallbacks {
+            on_file_parsed: None,
+            on_embed_progress: None,
+        },
+    )
+    .await
+    .unwrap();
+    let second = ingest::ingest_hermes_with_vector_fingerprint(
+        &db.inner,
+        &embedder,
+        &options,
+        "mock:64",
+        ingest::IngestCallbacks {
+            on_file_parsed: None,
+            on_embed_progress: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(first.turns_inserted, 2);
+    assert_eq!(first.vectors_created, 2);
+    assert_eq!(second.turns_inserted, 0);
+    assert_eq!(second.turns_skipped, 2);
+
+    let work_profile = ingest::HermesIngestOptions {
+        profile: "work".to_string(),
+        export_jsonl: Some(export),
+        cwd: Some(cwd.to_string()),
+        ..Default::default()
+    };
+    let third = ingest::ingest_hermes_with_vector_fingerprint(
+        &db.inner,
+        &embedder,
+        &work_profile,
+        "mock:64",
+        ingest::IngestCallbacks {
+            on_file_parsed: None,
+            on_embed_progress: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(third.turns_inserted, 2);
+
+    let default_turns = store::get_turns_filtered(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            hermes_profile: Some("default".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+        false,
+        false,
+    )
+    .unwrap();
+    let work_turns = store::get_turns_filtered(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            hermes_profile: Some("work".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+        false,
+        false,
+    )
+    .unwrap();
+    assert_eq!(default_turns.len(), 2);
+    assert_eq!(work_turns.len(), 2);
+    assert_eq!(
+        default_turns[0].metadata.hermes_profile.as_deref(),
+        Some("default")
+    );
+    assert_eq!(
+        default_turns[0].metadata.session_title.as_deref(),
+        Some("Issue 399 recall")
+    );
+}
+
+#[tokio::test]
+async fn search_hermes_filters_by_cwd_profile_and_returns_message_citations() {
+    let dir = TempDir::new().unwrap();
+    let db = open_temp_db_at_fork_ext(21);
+    let cwd = "/home/obj/project/github/RyderFreeman4Logos/mempal";
+    let other_cwd = "/home/obj/project/github/RyderFreeman4Logos/other";
+    let export = write_hermes_export(&dir, "hermes-session-1", cwd);
+    let other_export = write_hermes_export(&dir, "hermes-session-2", other_cwd);
+    let embedder = MockEmbedder::new_fixed_dim(64);
+
+    for path in [export, other_export] {
+        let options = ingest::HermesIngestOptions {
+            profile: "default".to_string(),
+            export_jsonl: Some(path),
+            ..Default::default()
+        };
+        ingest::ingest_hermes_with_vector_fingerprint(
+            &db.inner,
+            &embedder,
+            &options,
+            "mock:64",
+            ingest::IngestCallbacks {
+                on_file_parsed: None,
+                on_embed_progress: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let result = search::search(
+        &db.inner,
+        &embedder,
+        "review verdict PASS",
+        SearchOptions {
+            limit: 10,
+            filter: Some(TurnFilter {
+                tool: Some(Tool::Hermes),
+                hermes_profile: Some("default".to_string()),
+                cwd: Some(cwd.to_string()),
+                limit: 10,
+                ..Default::default()
+            }),
+            min_score: Some(0.0),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.hits.len(), 2);
+    assert!(
+        result
+            .hits
+            .iter()
+            .all(|hit| hit.session_id == "hermes-session-1")
+    );
+    let assistant = result
+        .hits
+        .iter()
+        .find(|hit| hit.message_id.as_deref() == Some("msg-assistant-1"))
+        .expect("assistant hit");
+    assert_eq!(assistant.hermes_profile.as_deref(), Some("default"));
+    assert_eq!(assistant.session_source.as_deref(), Some("cli"));
+    assert_eq!(assistant.tool_name.as_deref(), Some("mktd"));
+    assert_eq!(assistant.previous_message_id.as_deref(), Some("msg-user-1"));
+}

--- a/tests/xurl_schema.rs
+++ b/tests/xurl_schema.rs
@@ -42,13 +42,19 @@ fn fork_ext_v16_unique_constraint() {
     let db = open_temp_db_at_fork_ext(16);
     db.conn()
         .execute(
-            "INSERT INTO conversation_turns VALUES ('id1','sess1','cc',0,'user','hello',1.0,5,NULL,NULL,0,'human')",
+            "INSERT INTO conversation_turns
+             (id, session_id, tool, turn_index, role, content, timestamp_epoch,
+              token_count, project_path, git_branch, is_csa_delegated, provenance)
+             VALUES ('id1','sess1','cc',0,'user','hello',1.0,5,NULL,NULL,0,'human')",
             [],
         )
         .unwrap();
     // Same (session_id, tool, turn_index) must fail
     let result = db.conn().execute(
-        "INSERT INTO conversation_turns VALUES ('id2','sess1','cc',0,'user','world',1.0,5,NULL,NULL,0,'human')",
+        "INSERT INTO conversation_turns
+         (id, session_id, tool, turn_index, role, content, timestamp_epoch,
+          token_count, project_path, git_branch, is_csa_delegated, provenance)
+         VALUES ('id2','sess1','cc',0,'user','world',1.0,5,NULL,NULL,0,'human')",
         [],
     );
     assert!(result.is_err());

--- a/tests/xurl_search.rs
+++ b/tests/xurl_search.rs
@@ -1,6 +1,6 @@
 use mempal::core::db::Database;
 use mempal::embed::Embedder;
-use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::search::{self, SearchOptions};
 use mempal::xurl::store::{self, TurnFilter};
 use std::path::Path;
@@ -151,6 +151,7 @@ fn make_turn(session_id: &str, tool: Tool, turn_index: u32, role: Role, content:
         is_csa_delegated: false,
         provenance: Provenance::Human,
         turn_index,
+        metadata: TurnMetadata::default(),
     }
 }
 
@@ -659,6 +660,14 @@ fn markdown_keeps_confident_match_output_free_of_sub_floor_hint() {
             timestamp_epoch: 1_748_000_000.0,
             score: 0.910,
             source_path: None,
+            hermes_profile: None,
+            session_title: None,
+            session_source: None,
+            message_id: None,
+            tool_name: None,
+            tool_call_id: None,
+            previous_message_id: None,
+            next_message_id: None,
         }],
         passing_total: 1,
         best_score_below_floor: Some(0.645),

--- a/tests/xurl_store.rs
+++ b/tests/xurl_store.rs
@@ -1,6 +1,7 @@
 use mempal::core::db::Database;
 use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::store::{self, TurnFilter};
+use std::collections::BTreeSet;
 use tempfile::TempDir;
 
 struct TestDb {
@@ -155,6 +156,131 @@ fn insert_turns_updates_changed_metadata_without_deleting_vectors() {
         )
         .unwrap();
     assert_eq!(vector_count, 1);
+}
+
+#[test]
+fn insert_turns_updates_pre_v21_hermes_row_instead_of_duplicating() {
+    let db = open_temp_db_at_fork_ext(16);
+    let legacy_id = "turn_legacy_pre_v21";
+    db.conn()
+        .execute(
+            "INSERT INTO conversation_turns \
+             (id, session_id, tool, turn_index, role, content, timestamp_epoch, \
+              project_path, is_csa_delegated, provenance) \
+             VALUES (?1, ?2, 'hermes', 0, 'assistant', ?3, ?4, ?5, 0, 'human')",
+            rusqlite::params![legacy_id, "sess-upgrade", "Hello", 1_000.0, "/repo/old"],
+        )
+        .unwrap();
+
+    let mut updated = make_hermes_turn("sess-upgrade", "msg-upgrade", "Hello");
+    updated.timestamp_epoch = 2_500.0;
+    updated.project_path = Some("/repo/new".to_string());
+    updated.metadata.session_title = Some("Upgraded title".to_string());
+    updated.metadata.session_source = Some("cli".to_string());
+    updated.metadata.tool_name = Some("review".to_string());
+    updated.metadata.previous_message_id = Some("msg-before".to_string());
+    updated.metadata.next_message_id = Some("msg-after".to_string());
+
+    let stats = store::insert_turns(db.conn(), std::slice::from_ref(&updated)).unwrap();
+
+    assert_eq!(stats.inserted, 0);
+    assert_eq!(stats.updated, 1);
+    assert_eq!(stats.skipped, 0);
+    assert_eq!(stats.turn_ids, vec![legacy_id.to_string()]);
+
+    let stored = store::get_turns(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            session_id: Some("sess-upgrade".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].id, legacy_id);
+    assert_eq!(stored[0].content, "Hello");
+    assert_eq!(stored[0].timestamp_epoch, 2_500.0);
+    assert_eq!(stored[0].project_path.as_deref(), Some("/repo/new"));
+    assert_eq!(
+        stored[0].metadata.hermes_profile.as_deref(),
+        Some("default")
+    );
+    assert_eq!(
+        stored[0].metadata.message_id.as_deref(),
+        Some("msg-upgrade")
+    );
+    assert_eq!(
+        stored[0].metadata.session_title.as_deref(),
+        Some("Upgraded title")
+    );
+    assert_eq!(stored[0].metadata.session_source.as_deref(), Some("cli"));
+    assert_eq!(stored[0].metadata.tool_name.as_deref(), Some("review"));
+    assert_eq!(
+        stored[0].metadata.previous_message_id.as_deref(),
+        Some("msg-before")
+    );
+    assert_eq!(
+        stored[0].metadata.next_message_id.as_deref(),
+        Some("msg-after")
+    );
+
+    let second = store::insert_turns(db.conn(), std::slice::from_ref(&updated)).unwrap();
+    assert_eq!(second.inserted, 0);
+    assert_eq!(second.updated, 0);
+    assert_eq!(second.skipped, 1);
+    let count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM conversation_turns WHERE session_id = 'sess-upgrade'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1);
+}
+
+#[test]
+fn cwd_filter_treats_sql_wildcards_as_literal_path_characters() {
+    let db = open_temp_db_at_fork_ext(16);
+    let cwd = r"/repo/a_b%literal\root";
+    let rows = [
+        ("exact", cwd, "exact match"),
+        ("child", r"/repo/a_b%literal\root/child", "descendant match"),
+        (
+            "underscore-sibling",
+            r"/repo/axb%literal\root/child",
+            "underscore wildcard sibling",
+        ),
+        (
+            "percent-sibling",
+            r"/repo/a_bZZliteral\root/child",
+            "percent wildcard sibling",
+        ),
+    ];
+
+    for (index, (session_id, project_path, content)) in rows.iter().enumerate() {
+        let mut turn = make_raw_turn(session_id, index as u32, Role::User, content);
+        turn.project_path = Some((*project_path).to_string());
+        store::insert_turns(db.conn(), std::slice::from_ref(&turn)).unwrap();
+    }
+
+    let turns = store::get_turns(
+        db.conn(),
+        TurnFilter {
+            cwd: Some(cwd.to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let sessions = turns
+        .iter()
+        .map(|turn| turn.session_id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(sessions, BTreeSet::from(["child", "exact"]));
 }
 
 #[test]

--- a/tests/xurl_store.rs
+++ b/tests/xurl_store.rs
@@ -1,5 +1,5 @@
 use mempal::core::db::Database;
-use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::store::{self, TurnFilter};
 use tempfile::TempDir;
 
@@ -36,6 +36,7 @@ fn make_raw_turn(session_id: &str, turn_index: u32, role: Role, content: &str) -
         is_csa_delegated: false,
         provenance: Provenance::Human,
         turn_index,
+        metadata: TurnMetadata::default(),
     }
 }
 

--- a/tests/xurl_store.rs
+++ b/tests/xurl_store.rs
@@ -40,6 +40,24 @@ fn make_raw_turn(session_id: &str, turn_index: u32, role: Role, content: &str) -
     }
 }
 
+fn make_hermes_turn(session_id: &str, message_id: &str, content: &str) -> RawTurn {
+    let mut turn = make_raw_turn(session_id, 0, Role::Assistant, content);
+    turn.tool = Tool::Hermes;
+    turn.timestamp_epoch = 2_000.0;
+    turn.project_path = Some("/repo/old".to_string());
+    turn.metadata = TurnMetadata {
+        hermes_profile: Some("default".to_string()),
+        session_title: Some("Old title".to_string()),
+        session_source: Some("old-source".to_string()),
+        message_id: Some(message_id.to_string()),
+        tool_name: Some("old-tool".to_string()),
+        tool_call_id: Some("old-call".to_string()),
+        previous_message_id: None,
+        next_message_id: None,
+    };
+    turn
+}
+
 #[tokio::test]
 async fn insert_turns_idempotent_same_content() {
     let db = open_temp_db_at_fork_ext(16);
@@ -69,6 +87,74 @@ async fn insert_turns_updates_changed_content() {
         )
         .unwrap();
     assert_eq!(content, "Hello v2");
+}
+
+#[test]
+fn insert_turns_updates_changed_metadata_without_deleting_vectors() {
+    let db = open_temp_db_at_fork_ext(16);
+    let turn = make_hermes_turn("sess1", "msg1", "Hello");
+    store::insert_turns(db.conn(), std::slice::from_ref(&turn)).unwrap();
+    let turn_id = store::turn_id_for(&turn);
+    db.conn()
+        .execute(
+            "INSERT INTO conversation_turn_vectors (turn_id, chunk_index, vector) VALUES (?1, 0, ?2)",
+            rusqlite::params![&turn_id, vec![1_u8, 2, 3, 4]],
+        )
+        .unwrap();
+
+    let mut updated = make_hermes_turn("sess1", "msg1", "Hello");
+    updated.timestamp_epoch = 3_000.0;
+    updated.project_path = Some("/repo/new".to_string());
+    updated.metadata.session_title = Some("New title".to_string());
+    updated.metadata.session_source = Some("new-source".to_string());
+    updated.metadata.tool_name = Some("new-tool".to_string());
+    updated.metadata.previous_message_id = Some("msg0".to_string());
+    updated.metadata.next_message_id = Some("msg2".to_string());
+
+    let stats = store::insert_turns(db.conn(), std::slice::from_ref(&updated)).unwrap();
+
+    assert_eq!(stats.inserted, 0);
+    assert_eq!(stats.updated, 1);
+    assert_eq!(stats.skipped, 0);
+    let stored = store::get_turns(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            session_id: Some("sess1".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].id, turn_id);
+    assert_eq!(stored[0].content, "Hello");
+    assert_eq!(stored[0].timestamp_epoch, 3_000.0);
+    assert_eq!(stored[0].project_path.as_deref(), Some("/repo/new"));
+    assert_eq!(
+        stored[0].metadata.session_title.as_deref(),
+        Some("New title")
+    );
+    assert_eq!(
+        stored[0].metadata.session_source.as_deref(),
+        Some("new-source")
+    );
+    assert_eq!(stored[0].metadata.tool_name.as_deref(), Some("new-tool"));
+    assert_eq!(
+        stored[0].metadata.previous_message_id.as_deref(),
+        Some("msg0")
+    );
+    assert_eq!(stored[0].metadata.next_message_id.as_deref(), Some("msg2"));
+
+    let vector_count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM conversation_turn_vectors WHERE turn_id = ?1",
+            rusqlite::params![&turn_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(vector_count, 1);
 }
 
 #[test]

--- a/tests/xurl_timeline.rs
+++ b/tests/xurl_timeline.rs
@@ -1,5 +1,5 @@
 use mempal::core::db::Database;
-use mempal::xurl::model::{Provenance, RawTurn, Role, Tool};
+use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
 use mempal::xurl::store::{self, TurnFilter};
 use rusqlite::params;
 use serde_json::Value;
@@ -169,6 +169,7 @@ fn make_raw_turn(
         is_csa_delegated: false,
         provenance: Provenance::Human,
         turn_index,
+        metadata: TurnMetadata::default(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Add Hermes session ingestion/search support under xurl so agent transcripts can be indexed and recalled by cwd/profile/session metadata.
- Preserve stable citations to Hermes session/message ids while supporting metadata-less exports with source-scoped fallback ids.
- Harden re-ingest behavior: refresh citation metadata, preserve legacy identity compatibility, avoid duplicate turns, and make cwd filtering path-segment safe.

## Test Plan
- pre-commit quality-gates from commits
- tier-4 full-diff review: PASS/CLEAN
- GitHub Actions PR CI will verify fmt/default/rest

Closes #399