### PR TITLE
feat(search): add optional local reranker

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ db_path = "~/.mempal/palace.db"
 [embed]
 backend = "model2vec"                          # default, zero native deps
 # model = "minishlab/potion-multilingual-128M" # default multilingual model (1024d)
+
+[search.reranker]
+enabled = false                                # default: no reranker call
+# endpoint = "http://gb10:18003/v1/rerank"     # local/LAN reranker endpoint
+# model = "qwen3-reranker"
+# timeout_secs = 2
+# top_k = 20
 ```
 
 Other backends:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,13 @@ db_path = "~/.mempal/palace.db"
 [embed]
 backend = "model2vec"
 # model = "minishlab/potion-multilingual-128M" # default multilingual model
+
+[search.reranker]
+enabled = false
+# endpoint = "http://gb10:18003/v1/rerank"
+# model = "qwen3-reranker"
+# timeout_secs = 2
+# top_k = 20
 ```
 
 Use local ONNX instead of the default model2vec backend:
@@ -95,6 +102,13 @@ Notes:
 - First use of `model2vec` or `onnx` may download model assets.
 - If `config.toml` is missing, `mempal` still works with defaults.
 - The benchmark and search commands use whatever embedder backend is configured here.
+- Reranking is disabled by default. To use a local/LAN reranker, set
+  `[search.reranker] enabled = true`, `endpoint`, `model`, `timeout_secs`, and
+  `top_k`. A bare endpoint like `gb10:18003` is normalized to
+  `http://gb10:18003/v1/rerank`; do not put secrets in the endpoint URL.
+- If the reranker is absent, disabled, times out, or returns an error, search
+  keeps the existing BM25/vector ranking and reports a warning instead of
+  failing the request.
 
 ## Command Cheat Sheet
 

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -29,8 +29,9 @@ use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
 use crate::search::{
     SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
     bm25_fallback_warning_dimension_mismatch, bm25_fallback_warning_embed_error,
-    bm25_fallback_warning_missing_query_vector, bm25_fallback_warning_timeout, resolve_route,
-    search_bm25_only_with_options, search_with_vector_and_scope_options,
+    bm25_fallback_warning_missing_query_vector, bm25_fallback_warning_timeout,
+    maybe_rerank_search_results, resolve_route, search_bm25_only_with_options,
+    search_with_vector_and_scope_options,
 };
 use axum::{
     Json, Router,
@@ -658,6 +659,9 @@ async fn search_handler(
         search_bm25_only_with_options(&db, &query.q, route, &scope, search_options, top_k)
             .map_err(internal_error)?
     };
+    let rerank_outcome = maybe_rerank_search_results(&query.q, results).await;
+    warnings.extend(rerank_outcome.warnings);
+    let results = rerank_outcome.results;
 
     let mut response = Json(
         results

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -37,6 +37,8 @@ const DEFAULT_SEARCH_DECAY_HALF_LIFE_DAYS: u64 = 90;
 const DEFAULT_SEARCH_DECAY_STEP_FULL_DAYS: u64 = 30;
 const DEFAULT_SEARCH_DECAY_STEP_REDUCED_WEIGHT: f64 = 0.5;
 const DEFAULT_SEARCH_BM25_FALLBACK: bool = true;
+const DEFAULT_SEARCH_RERANKER_TIMEOUT_SECS: u64 = 2;
+const DEFAULT_SEARCH_RERANKER_TOP_K: usize = 20;
 const DEFAULT_TURN_STORAGE_MODE: TurnStorageMode = TurnStorageMode::RawEvidence;
 const DEFAULT_TURN_IMPORTANCE: i32 = 0;
 const DEFAULT_ALERT_EVERY_N_FAILURES: u64 = 100;
@@ -338,6 +340,36 @@ impl Config {
             return Err(ConfigError::InvalidConfig(
                 "search.tunnel_penalty must be a finite value in 0.0..=1.0".to_string(),
             ));
+        }
+        if self.search.reranker.timeout_secs == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "search.reranker.timeout_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.search.reranker.top_k == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "search.reranker.top_k must be greater than 0".to_string(),
+            ));
+        }
+        if self.search.reranker.enabled {
+            normalize_reranker_endpoint_url(
+                self.search.reranker.endpoint.as_deref().unwrap_or_default(),
+            )
+            .map_err(ConfigError::Validation)?;
+            if self
+                .search
+                .reranker
+                .model
+                .as_deref()
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                .is_none()
+            {
+                return Err(ConfigError::Validation(
+                    "search.reranker.model must not be empty when search.reranker.enabled is true"
+                        .to_string(),
+                ));
+            }
         }
         if self.search.decay.half_life_days == 0 {
             return Err(ConfigError::InvalidConfig(
@@ -682,6 +714,23 @@ impl Config {
                     .unwrap_or(&[]),
             ));
         }
+        if self.search.reranker.enabled
+            && let Ok(endpoint) = normalize_reranker_endpoint_url(
+                self.search.reranker.endpoint.as_deref().unwrap_or_default(),
+            )
+            && !llm_base_url_is_local_or_lan(&endpoint)
+        {
+            let host = llm_base_url_host(&endpoint)
+                .map(|host| format!(" host `{host}`"))
+                .unwrap_or_default();
+            warnings.push(RuntimeWarning {
+                level: "warn",
+                source: "reranker",
+                message: format!(
+                    "search.reranker.endpoint{host} appears outside localhost/LAN; mempal assumes user-configured reranker endpoints are local or private network and does not block operation"
+                ),
+            });
+        }
         warnings
     }
 }
@@ -829,6 +878,41 @@ pub fn validate_llm_base_url(base_url: &str) -> Result<(), String> {
         return Err("llm.base_url must not include URL fragments".to_string());
     }
     Ok(())
+}
+
+pub fn normalize_reranker_endpoint_url(endpoint: &str) -> Result<String, String> {
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() {
+        return Err(
+            "search.reranker.endpoint must not be empty when reranker is enabled".to_string(),
+        );
+    }
+    let raw = if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.to_string()
+    } else {
+        format!("http://{endpoint}")
+    };
+    let mut parsed = Url::parse(&raw)
+        .map_err(|error| format!("invalid search.reranker.endpoint `{endpoint}`: {error}"))?;
+    if parsed.host_str().is_none() {
+        return Err("search.reranker.endpoint must include a host".to_string());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(
+            "search.reranker.endpoint must not include userinfo credentials; run rerankers on trusted local/LAN endpoints"
+                .to_string(),
+        );
+    }
+    if parsed.query().is_some() {
+        return Err(
+            "search.reranker.endpoint must not include query parameters; configure a plain local/LAN endpoint URL"
+                .to_string(),
+        );
+    }
+    if parsed.path().is_empty() || parsed.path() == "/" {
+        parsed.set_path("/v1/rerank");
+    }
+    Ok(parsed.to_string().trim_end_matches('/').to_string())
 }
 
 pub(crate) fn scrub_sensitive_text(input: &str) -> String {
@@ -1635,6 +1719,7 @@ pub struct SearchConfig {
     /// `1.0` disables the penalty. Default `0.7` deprioritizes cross-project rows
     /// when their raw embedding score clusters near direct in-project matches.
     pub tunnel_penalty: f32,
+    pub reranker: SearchRerankerConfig,
     pub decay: DecayConfig,
 }
 
@@ -1649,7 +1734,30 @@ impl Default for SearchConfig {
             tunnel_fanout_cap: DEFAULT_SEARCH_TUNNEL_FANOUT_CAP,
             tunnel_hints_display_cap: DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP,
             tunnel_penalty: DEFAULT_SEARCH_TUNNEL_PENALTY,
+            reranker: SearchRerankerConfig::default(),
             decay: DecayConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct SearchRerankerConfig {
+    pub enabled: bool,
+    pub endpoint: Option<String>,
+    pub model: Option<String>,
+    pub timeout_secs: u64,
+    pub top_k: usize,
+}
+
+impl Default for SearchRerankerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: None,
+            model: None,
+            timeout_secs: DEFAULT_SEARCH_RERANKER_TIMEOUT_SECS,
+            top_k: DEFAULT_SEARCH_RERANKER_TOP_K,
         }
     }
 }
@@ -2390,6 +2498,100 @@ mod tests {
         assert_eq!(config.search.decay.half_life_days, 90);
         assert_eq!(config.search.decay.step_full_days, 30);
         assert_eq!(config.search.decay.step_reduced_weight, 0.5);
+        assert!(!config.search.reranker.enabled);
+        assert!(config.search.reranker.endpoint.is_none());
+        assert!(config.search.reranker.model.is_none());
+    }
+
+    #[test]
+    fn search_reranker_config_parses_nested_section() {
+        let config = Config::parse(
+            r#"
+            [search.reranker]
+            enabled = true
+            endpoint = "gb10:18003"
+            model = "qwen3-reranker"
+            timeout_secs = 3
+            top_k = 12
+            "#,
+        )
+        .expect("reranker config should parse");
+
+        assert!(config.search.reranker.enabled);
+        assert_eq!(
+            super::normalize_reranker_endpoint_url(
+                config
+                    .search
+                    .reranker
+                    .endpoint
+                    .as_deref()
+                    .expect("endpoint")
+            )
+            .expect("normalize endpoint"),
+            "http://gb10:18003/v1/rerank"
+        );
+        assert_eq!(
+            config.search.reranker.model.as_deref(),
+            Some("qwen3-reranker")
+        );
+        assert_eq!(config.search.reranker.timeout_secs, 3);
+        assert_eq!(config.search.reranker.top_k, 12);
+    }
+
+    #[test]
+    fn search_reranker_config_rejects_invalid_enabled_config() {
+        let err = Config::parse(
+            r#"
+            [search.reranker]
+            enabled = true
+            model = "qwen3-reranker"
+            "#,
+        )
+        .expect_err("enabled reranker without endpoint must be rejected");
+        assert!(
+            err.to_string().contains("search.reranker.endpoint"),
+            "unexpected error: {err}"
+        );
+
+        let err = Config::parse(
+            r#"
+            [search.reranker]
+            enabled = true
+            endpoint = "gb10:18003"
+            "#,
+        )
+        .expect_err("enabled reranker without model must be rejected");
+        assert!(
+            err.to_string().contains("search.reranker.model"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn search_reranker_config_rejects_invalid_timeout_and_top_k() {
+        let err = Config::parse(
+            r#"
+            [search.reranker]
+            timeout_secs = 0
+            "#,
+        )
+        .expect_err("zero timeout must be rejected");
+        assert!(
+            err.to_string().contains("search.reranker.timeout_secs"),
+            "unexpected error: {err}"
+        );
+
+        let err = Config::parse(
+            r#"
+            [search.reranker]
+            top_k = 0
+            "#,
+        )
+        .expect_err("zero top_k must be rejected");
+        assert!(
+            err.to_string().contains("search.reranker.top_k"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ use mempal::mcp::{
     OperationStatusRequest,
 };
 use mempal::observability;
-use mempal::search::{SearchFilters, SearchOptions, search_with_all_options};
+use mempal::search::{SearchFilters, SearchOptions, search_with_all_options_outcome};
 use mempal::sleep::{
     NremSummary, RemSummary, SalienceSummary, SleepCycleSummary, SleepPhaseSelection,
     SleepRunOptions, run_sleep_cycle,
@@ -5218,7 +5218,7 @@ async fn search_command(
         config.search.strict_project_isolation,
     );
     let embedder = build_embedder(config).await?;
-    let results = search_with_all_options(
+    let outcome = search_with_all_options_outcome(
         db,
         &*embedder,
         options.query,
@@ -5234,7 +5234,11 @@ async fn search_command(
         options.top_k,
     )
     .await?;
-    let results = results
+    for warning in &outcome.warnings {
+        eprintln!("warning: {warning}");
+    }
+    let results = outcome
+        .results
         .into_iter()
         .map(build_cli_search_result)
         .collect::<Vec<_>>();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -76,7 +76,8 @@ use crate::knowledge_lifecycle::{
 use crate::search::{
     SearchFilters, SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
     bm25_fallback_warning_embed_error, bm25_fallback_warning_timeout, dispatch_access_update,
-    resolve_route, search_bm25_only_with_options, search_with_vector_and_scope_options,
+    maybe_rerank_search_results, resolve_route, search_bm25_only_with_options,
+    search_with_vector_and_scope_options,
 };
 use anyhow::Context;
 use rmcp::{
@@ -2790,6 +2791,17 @@ impl MempalMcpServer {
                 }
             }
         };
+
+        let rerank_outcome = maybe_rerank_search_results(&request.query, results).await;
+        for warning in &rerank_outcome.warnings {
+            response_warnings.push(warning.clone());
+            extra_warnings.push(SystemWarning {
+                level: "warn".to_string(),
+                message: warning.clone(),
+                source: "reranker".to_string(),
+            });
+        }
+        let results = rerank_outcome.results;
 
         // Track hit drawer IDs for session-ingest boost (P13).
         let hit_ids: Vec<String> = results.iter().map(|r| r.drawer_id.clone()).collect();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -165,6 +165,26 @@ impl SearchOutcome {
     }
 }
 
+pub async fn maybe_rerank_search_results(
+    query: &str,
+    results: Vec<SearchResult>,
+) -> rerank::RerankOutcome {
+    let config = crate::core::config::ConfigHandle::current();
+    rerank::maybe_rerank_with_config(&config.search.reranker, query, results).await
+}
+
+async fn apply_optional_reranker_to_outcome(
+    query: &str,
+    mut outcome: SearchOutcome,
+) -> SearchOutcome {
+    let config = crate::core::config::ConfigHandle::current();
+    let rerank_outcome =
+        rerank::maybe_rerank_with_config(&config.search.reranker, query, outcome.results).await;
+    outcome.results = rerank_outcome.results;
+    outcome.warnings.extend(rerank_outcome.warnings);
+    outcome
+}
+
 #[derive(Debug, Error)]
 pub enum SearchError {
     #[error("failed to embed search query")]
@@ -312,7 +332,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
 
     let vector_search_circuit = VectorSearchCircuit::current();
     if vector_search_circuit.bm25_fallback_enabled && vector_search_circuit.open {
-        return bm25_fallback_outcome(
+        let outcome = bm25_fallback_outcome(
             db,
             query,
             route,
@@ -320,13 +340,14 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
             options,
             top_k,
             bm25_fallback_warning_degraded(vector_search_circuit.failure_count),
-        );
+        )?;
+        return Ok(apply_optional_reranker_to_outcome(query, outcome).await);
     }
 
     let embeddings = match embedder.embed(&[query]).await {
         Ok(embeddings) => embeddings,
         Err(error) if vector_search_circuit.bm25_fallback_enabled => {
-            return bm25_fallback_outcome(
+            let outcome = bm25_fallback_outcome(
                 db,
                 query,
                 route,
@@ -336,13 +357,14 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 bm25_fallback_warning_embed_error(&crate::core::config::scrub_sensitive_text(
                     &error.to_string(),
                 )),
-            );
+            )?;
+            return Ok(apply_optional_reranker_to_outcome(query, outcome).await);
         }
         Err(error) => return Err(SearchError::EmbedQuery(error)),
     };
     let Some(query_vector) = embeddings.into_iter().next() else {
         if vector_search_circuit.bm25_fallback_enabled {
-            return bm25_fallback_outcome(
+            let outcome = bm25_fallback_outcome(
                 db,
                 query,
                 route,
@@ -350,7 +372,8 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 options,
                 top_k,
                 bm25_fallback_warning_missing_query_vector(),
-            );
+            )?;
+            return Ok(apply_optional_reranker_to_outcome(query, outcome).await);
         }
         return Err(SearchError::MissingQueryVector);
     };
@@ -358,7 +381,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
         && current_dim != query_vector.len()
     {
         if vector_search_circuit.bm25_fallback_enabled {
-            return bm25_fallback_outcome(
+            let outcome = bm25_fallback_outcome(
                 db,
                 query,
                 route,
@@ -366,7 +389,8 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
                 options,
                 top_k,
                 bm25_fallback_warning_dimension_mismatch(query_vector.len(), current_dim),
-            );
+            )?;
+            return Ok(apply_optional_reranker_to_outcome(query, outcome).await);
         }
         return Err(SearchError::VectorDimensionMismatch {
             current_dim,
@@ -374,7 +398,7 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
         });
     }
 
-    Ok(SearchOutcome::hybrid(search_with_vector_and_scope_options(
+    let outcome = SearchOutcome::hybrid(search_with_vector_and_scope_options(
         db,
         query,
         &query_vector,
@@ -382,7 +406,8 @@ pub async fn search_with_route_options_outcome<E: Embedder + ?Sized>(
         scope,
         options,
         top_k,
-    )?))
+    )?);
+    Ok(apply_optional_reranker_to_outcome(query, outcome).await)
 }
 
 fn bm25_fallback_outcome(

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -16,6 +16,8 @@ use crate::core::config::{
 };
 use crate::core::types::SearchResult;
 
+const MAX_RERANKER_RESPONSE_BODY_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RerankOutcome {
     pub results: Vec<SearchResult>,
@@ -51,8 +53,16 @@ pub enum RerankError {
         #[source]
         source: reqwest::Error,
     },
-    #[error("reranker endpoint returned error status {status}: {body}")]
-    HttpStatus { status: StatusCode, body: String },
+    #[error("reranker endpoint returned error status {status}")]
+    HttpStatus { status: StatusCode },
+    #[error(
+        "reranker endpoint response body exceeded {limit} bytes (status {status}, received {received} bytes)"
+    )]
+    ResponseBodyTooLarge {
+        status: StatusCode,
+        limit: u64,
+        received: u64,
+    },
     #[error("failed to decode reranker response: {0}")]
     DecodeResponse(String),
     #[error("invalid reranker response: {0}")]
@@ -145,15 +155,52 @@ impl Reranker for HttpReranker {
             .map_err(map_reqwest_error)?;
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.map_err(map_reqwest_error)?;
-            return Err(RerankError::HttpStatus { status, body });
+            read_limited_response_body(response).await?;
+            return Err(RerankError::HttpStatus { status });
         }
-        let response = response
-            .json::<RerankResponse>()
-            .await
+        let body = read_limited_response_body(response).await?;
+        let response = serde_json::from_slice::<RerankResponse>(&body)
             .map_err(|source| RerankError::DecodeResponse(source.to_string()))?;
         reorder_results(results, response.items())
     }
+}
+
+async fn read_limited_response_body(
+    mut response: reqwest::Response,
+) -> Result<Vec<u8>, RerankError> {
+    let status = response.status();
+    let limit = max_reranker_response_body_bytes_u64();
+    if let Some(content_length) = response.content_length()
+        && content_length > limit
+    {
+        return Err(RerankError::ResponseBodyTooLarge {
+            status,
+            limit,
+            received: content_length,
+        });
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(map_reqwest_error)? {
+        let next_len = body.len().saturating_add(chunk.len());
+        if next_len > MAX_RERANKER_RESPONSE_BODY_BYTES {
+            return Err(RerankError::ResponseBodyTooLarge {
+                status,
+                limit,
+                received: usize_to_u64(next_len),
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn max_reranker_response_body_bytes_u64() -> u64 {
+    usize_to_u64(MAX_RERANKER_RESPONSE_BODY_BYTES)
+}
+
+fn usize_to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
 }
 
 fn map_reqwest_error(source: reqwest::Error) -> RerankError {
@@ -331,6 +378,16 @@ mod tests {
         }
     }
 
+    fn result_with_content(id: &str, content: &str) -> SearchResult {
+        let mut result = result(id);
+        result.content = content.to_string();
+        result
+    }
+
+    fn warning_text(outcome: &RerankOutcome) -> String {
+        outcome.warnings.join("\n")
+    }
+
     #[test]
     fn reorder_results_sorts_by_score_and_appends_unscored_candidates() {
         let results = vec![result("a"), result("b"), result("c")];
@@ -432,9 +489,107 @@ mod tests {
 
         mock.assert_async().await;
         assert_eq!(ids(&outcome.results), vec!["a", "b"]);
-        assert!(outcome.warnings.iter().any(|warning| {
-            warning.contains("reranker unavailable") && warning.contains("original search ranking")
-        }));
+        let warnings = warning_text(&outcome);
+        assert!(warnings.contains("reranker unavailable"));
+        assert!(warnings.contains("original search ranking"));
+        assert!(warnings.contains("500 Internal Server Error"));
+        assert!(!warnings.contains("reranker down"));
+    }
+
+    #[tokio::test]
+    async fn reranker_http_error_body_echoing_candidate_is_not_warned() {
+        let raw_drawer_content = "UNIQUE_RAW_DRAWER_CONTENT_SHOULD_NOT_LEAK";
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/rerank")
+            .with_status(400)
+            .with_body(format!("invalid document: {raw_drawer_content}"))
+            .create_async()
+            .await;
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(server.url())),
+            "query",
+            vec![
+                result_with_content("a", raw_drawer_content),
+                result_with_content("b", "ordinary candidate"),
+            ],
+        )
+        .await;
+
+        mock.assert_async().await;
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+        let warnings = warning_text(&outcome);
+        assert!(warnings.contains("400 Bad Request"));
+        assert!(!warnings.contains(raw_drawer_content));
+        assert!(!warnings.contains("invalid document"));
+    }
+
+    #[tokio::test]
+    async fn oversized_reranker_error_body_preserves_order_without_warning_body() {
+        let raw_drawer_content = "OVERSIZED_ERROR_ECHO_SHOULD_NOT_LEAK";
+        let oversized_body = format!(
+            "{raw_drawer_content}{}",
+            "x".repeat(MAX_RERANKER_RESPONSE_BODY_BYTES + 1)
+        );
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/rerank")
+            .with_status(503)
+            .with_body(oversized_body)
+            .create_async()
+            .await;
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(server.url())),
+            "query",
+            vec![
+                result_with_content("a", raw_drawer_content),
+                result_with_content("b", "ordinary candidate"),
+            ],
+        )
+        .await;
+
+        mock.assert_async().await;
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+        let warnings = warning_text(&outcome);
+        assert!(warnings.contains("response body exceeded"));
+        assert!(warnings.contains("503 Service Unavailable"));
+        assert!(!warnings.contains(raw_drawer_content));
+    }
+
+    #[tokio::test]
+    async fn oversized_reranker_success_body_preserves_order_without_warning_body() {
+        let raw_drawer_content = "OVERSIZED_SUCCESS_ECHO_SHOULD_NOT_LEAK";
+        let oversized_invalid_json = format!(
+            "{{\"echo\":\"{raw_drawer_content}\",\"padding\":\"{}",
+            "x".repeat(MAX_RERANKER_RESPONSE_BODY_BYTES + 1)
+        );
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/rerank")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(oversized_invalid_json)
+            .create_async()
+            .await;
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(server.url())),
+            "query",
+            vec![
+                result_with_content("a", raw_drawer_content),
+                result_with_content("b", "ordinary candidate"),
+            ],
+        )
+        .await;
+
+        mock.assert_async().await;
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+        let warnings = warning_text(&outcome);
+        assert!(warnings.contains("response body exceeded"));
+        assert!(warnings.contains("200 OK"));
+        assert!(!warnings.contains(raw_drawer_content));
     }
 
     #[tokio::test]

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -1,22 +1,466 @@
-//! Reranker trait for optional cross-encoder reranking of search results.
+//! Optional local reranker support for search results.
 //!
-//! Default: `NoopReranker` — passes results through unchanged.
-//! Future: ONNX cross-encoder reranker, API-based reranker.
+//! The default configuration never calls a reranker. When enabled, the HTTP
+//! reranker receives only the configured top-K candidate contents and failures
+//! degrade to the original search order with a diagnostic warning.
 
+use std::collections::HashSet;
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::core::config::{
+    SearchRerankerConfig, normalize_reranker_endpoint_url, scrub_sensitive_text,
+};
 use crate::core::types::SearchResult;
 
-/// Reranks a list of search results given the original query.
-/// Implementations should reorder (and optionally re-score) the results
-/// based on cross-encoder or other fine-grained relevance signals.
-pub trait Reranker: Send + Sync {
-    fn rerank(&self, query: &str, results: Vec<SearchResult>) -> Vec<SearchResult>;
+#[derive(Debug, Clone, PartialEq)]
+pub struct RerankOutcome {
+    pub results: Vec<SearchResult>,
+    pub warnings: Vec<String>,
 }
 
-/// Default reranker that does nothing — preserves the RRF-merged order.
+impl RerankOutcome {
+    fn unchanged(results: Vec<SearchResult>) -> Self {
+        Self {
+            results,
+            warnings: Vec::new(),
+        }
+    }
+
+    fn fallback(results: Vec<SearchResult>, error: RerankError) -> Self {
+        Self {
+            results,
+            warnings: vec![reranker_fallback_warning(&error)],
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RerankError {
+    #[error("missing reranker configuration: {0}")]
+    MissingConfiguration(&'static str),
+    #[error("{0}")]
+    InvalidEndpoint(String),
+    #[error("reranker request timed out")]
+    Timeout,
+    #[error("failed to call reranker endpoint: {source}")]
+    HttpRequest {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("reranker endpoint returned error status {status}: {body}")]
+    HttpStatus { status: StatusCode, body: String },
+    #[error("failed to decode reranker response: {0}")]
+    DecodeResponse(String),
+    #[error("invalid reranker response: {0}")]
+    InvalidResponse(String),
+}
+
+/// Reranks a list of search results given the original query.
+#[async_trait::async_trait]
+pub trait Reranker: Send + Sync {
+    async fn try_rerank(
+        &self,
+        query: &str,
+        results: Vec<SearchResult>,
+    ) -> Result<Vec<SearchResult>, RerankError>;
+}
+
+/// Default reranker that does nothing and performs no network calls.
 pub struct NoopReranker;
 
+#[async_trait::async_trait]
 impl Reranker for NoopReranker {
-    fn rerank(&self, _query: &str, results: Vec<SearchResult>) -> Vec<SearchResult> {
+    async fn try_rerank(
+        &self,
+        _query: &str,
+        results: Vec<SearchResult>,
+    ) -> Result<Vec<SearchResult>, RerankError> {
+        Ok(results)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpReranker {
+    client: reqwest::Client,
+    endpoint: String,
+    model: String,
+}
+
+impl HttpReranker {
+    pub fn from_config(config: &SearchRerankerConfig) -> Result<Self, RerankError> {
+        let endpoint = config
+            .endpoint
+            .as_deref()
+            .ok_or(RerankError::MissingConfiguration("endpoint"))?;
+        let endpoint =
+            normalize_reranker_endpoint_url(endpoint).map_err(RerankError::InvalidEndpoint)?;
+        let model = config
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .ok_or(RerankError::MissingConfiguration("model"))?
+            .to_string();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(config.timeout_secs))
+            .build()
+            .map_err(|source| RerankError::HttpRequest { source })?;
+        Ok(Self {
+            client,
+            endpoint,
+            model,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Reranker for HttpReranker {
+    async fn try_rerank(
+        &self,
+        query: &str,
+        results: Vec<SearchResult>,
+    ) -> Result<Vec<SearchResult>, RerankError> {
+        if results.len() <= 1 {
+            return Ok(results);
+        }
+        let request = RerankRequest {
+            model: &self.model,
+            query,
+            documents: results
+                .iter()
+                .map(|result| result.content.as_str())
+                .collect(),
+            top_n: results.len(),
+        };
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .map_err(map_reqwest_error)?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.map_err(map_reqwest_error)?;
+            return Err(RerankError::HttpStatus { status, body });
+        }
+        let response = response
+            .json::<RerankResponse>()
+            .await
+            .map_err(|source| RerankError::DecodeResponse(source.to_string()))?;
+        reorder_results(results, response.items())
+    }
+}
+
+fn map_reqwest_error(source: reqwest::Error) -> RerankError {
+    if source.is_timeout() {
+        RerankError::Timeout
+    } else {
+        RerankError::HttpRequest { source }
+    }
+}
+
+pub async fn maybe_rerank_with_config(
+    config: &SearchRerankerConfig,
+    query: &str,
+    mut results: Vec<SearchResult>,
+) -> RerankOutcome {
+    if !config.enabled || results.len() <= 1 {
+        return RerankOutcome::unchanged(results);
+    }
+
+    let candidate_count = config.top_k.min(results.len());
+    let tail = results.split_off(candidate_count);
+    let candidates = results;
+    let reranker = match HttpReranker::from_config(config) {
+        Ok(reranker) => reranker,
+        Err(error) => {
+            let mut original = candidates;
+            original.extend(tail);
+            return RerankOutcome::fallback(original, error);
+        }
+    };
+    match reranker.try_rerank(query, candidates.clone()).await {
+        Ok(mut reranked) => {
+            reranked.extend(tail);
+            RerankOutcome::unchanged(reranked)
+        }
+        Err(error) => {
+            let mut original = candidates;
+            original.extend(tail);
+            RerankOutcome::fallback(original, error)
+        }
+    }
+}
+
+fn reranker_fallback_warning(error: &RerankError) -> String {
+    format!(
+        "reranker unavailable; using original search ranking: {}",
+        scrub_sensitive_text(&error.to_string())
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct RerankRequest<'a> {
+    model: &'a str,
+    query: &'a str,
+    documents: Vec<&'a str>,
+    top_n: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct RerankResponse {
+    #[serde(default)]
+    results: Vec<RerankItem>,
+    #[serde(default)]
+    data: Vec<RerankItem>,
+}
+
+impl RerankResponse {
+    fn items(self) -> Vec<RerankItem> {
+        if self.results.is_empty() {
+            self.data
+        } else {
+            self.results
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RerankItem {
+    index: usize,
+    #[serde(default, alias = "relevance_score")]
+    score: Option<f32>,
+}
+
+fn reorder_results(
+    results: Vec<SearchResult>,
+    items: Vec<RerankItem>,
+) -> Result<Vec<SearchResult>, RerankError> {
+    if items.is_empty() {
+        return Err(RerankError::InvalidResponse(
+            "missing results or data array".to_string(),
+        ));
+    }
+
+    let original = results;
+    let mut ranked = items
+        .into_iter()
+        .filter_map(|item| {
+            if item.index >= original.len() {
+                return None;
+            }
+            let score = item.score?;
+            if score.is_finite() {
+                Some((item.index, score))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    if ranked.is_empty() {
+        return Err(RerankError::InvalidResponse(
+            "no valid scored candidate indices".to_string(),
+        ));
+    }
+    ranked.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::with_capacity(original.len());
+    for (index, _) in ranked {
+        if seen.insert(index) {
+            ordered.push(original[index].clone());
+        }
+    }
+    for (index, result) in original.into_iter().enumerate() {
+        if seen.insert(index) {
+            ordered.push(result);
+        }
+    }
+    Ok(ordered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::project::SearchResultSource;
+    use crate::core::types::{AnchorKind, MemoryDomain, MemoryKind, RouteDecision, SourceType};
+    use tokio::io::AsyncReadExt;
+
+    fn result(id: &str) -> SearchResult {
+        SearchResult {
+            drawer_id: id.to_string(),
+            content: format!("content {id}"),
+            wing: "mempal".to_string(),
+            room: Some("search".to_string()),
+            source_file: format!("{id}.md"),
+            source: SearchResultSource::Project,
+            source_type: SourceType::AgentInference,
+            confidence: 0.8,
+            memory_kind: MemoryKind::Evidence,
+            domain: MemoryDomain::Project,
+            field: String::new(),
+            statement: None,
+            tier: None,
+            status: None,
+            anchor_kind: AnchorKind::Global,
+            anchor_id: String::new(),
+            parent_anchor_id: None,
+            is_pinned: false,
+            importance: 0,
+            similarity: 0.5,
+            route: RouteDecision {
+                wing: None,
+                room: None,
+                confidence: 0.0,
+                reason: "test".to_string(),
+            },
+            chunk_index: None,
+            neighbors: None,
+            tunnel_hints: Vec::new(),
+            effective_importance: 0.0,
+            matched_pattern_id: None,
+        }
+    }
+
+    #[test]
+    fn reorder_results_sorts_by_score_and_appends_unscored_candidates() {
+        let results = vec![result("a"), result("b"), result("c")];
+        let reranked = reorder_results(
+            results,
+            vec![
+                RerankItem {
+                    index: 1,
+                    score: Some(0.9),
+                },
+                RerankItem {
+                    index: 0,
+                    score: Some(0.1),
+                },
+            ],
+        )
+        .expect("rerank");
+
+        let ids = reranked
+            .iter()
+            .map(|result| result.drawer_id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["b", "a", "c"]);
+    }
+
+    fn config(endpoint: Option<String>) -> SearchRerankerConfig {
+        SearchRerankerConfig {
+            enabled: true,
+            endpoint,
+            model: Some("test-reranker".to_string()),
+            timeout_secs: 1,
+            top_k: 2,
+        }
+    }
+
+    fn ids(results: &[SearchResult]) -> Vec<&str> {
         results
+            .iter()
+            .map(|result| result.drawer_id.as_str())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn disabled_reranker_preserves_order_without_endpoint() {
+        let config = SearchRerankerConfig::default();
+        let outcome =
+            maybe_rerank_with_config(&config, "query", vec![result("a"), result("b")]).await;
+
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn successful_http_reranker_reorders_configured_top_k_only() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/rerank")
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "model": "test-reranker",
+                "query": "query",
+                "top_n": 2
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"results":[{"index":1,"relevance_score":0.98},{"index":0,"relevance_score":0.12}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(server.url())),
+            "query",
+            vec![result("a"), result("b"), result("c")],
+        )
+        .await;
+
+        mock.assert_async().await;
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(ids(&outcome.results), vec!["b", "a", "c"]);
+    }
+
+    #[tokio::test]
+    async fn reranker_http_error_preserves_order_and_warns() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/rerank")
+            .with_status(500)
+            .with_body("reranker down")
+            .create_async()
+            .await;
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(server.url())),
+            "query",
+            vec![result("a"), result("b")],
+        )
+        .await;
+
+        mock.assert_async().await;
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+        assert!(outcome.warnings.iter().any(|warning| {
+            warning.contains("reranker unavailable") && warning.contains("original search ranking")
+        }));
+    }
+
+    #[tokio::test]
+    async fn reranker_timeout_preserves_order_and_warns() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind delayed reranker");
+        let addr = listener.local_addr().expect("local addr");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer).await;
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let outcome = maybe_rerank_with_config(
+            &config(Some(format!("http://{addr}/v1/rerank"))),
+            "query",
+            vec![result("a"), result("b")],
+        )
+        .await;
+        server.abort();
+
+        assert_eq!(ids(&outcome.results), vec!["a", "b"]);
+        assert!(outcome.warnings.iter().any(|warning| {
+            warning.contains("reranker unavailable") && warning.contains("timed out")
+        }));
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "ce5e49a071834887081759a20d7053d579203e2f"
+commit = "d838d92472970d46b627790b6c063bab7995f1a1"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Adds optional local HTTP reranking for search results, disabled by default.
- Adds reranker configuration for endpoint/model/timeout/top-K and graceful fallback diagnostics.
- Applies reranking across the shared search path and user-facing CLI/REST/MCP search surfaces.
- Sanitizes and bounds reranker HTTP response diagnostics so fallback warnings do not expose raw reranker bodies or echoed drawer content.
- Documents local configuration with an example endpoint such as `gb10:18003` without secrets.

Closes #400

## Verification

- `cargo test --lib` — 486 passed
- focused reranker tests — 8 passed
- `cargo clippy --lib --bins --features rest -- -D warnings`
- hook quality-gates during commits
- Codex tier-4 full-diff review PASS/CLEAN for `0cf94f9decef80bcc58678b5c6378ef8c6e43cd5`

## Notes

- Reranking is opt-in and preserves existing behavior when disabled or unavailable.
- Reranker failures/timeouts/oversized responses fall back to the original result ordering with safe warnings.
