### PR TITLE
feat(hermes): harden mempal integration

### DIFF
--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -19,6 +19,7 @@ MemoryProvider — the hooks plugin gracefully becomes redundant.
 1. mempal built with `--features rest` and running:
    ```bash
    cargo build --features rest
+   mempal doctor rest
    mempal serve   # starts MCP + REST on 127.0.0.1:3080
    ```
    Or start the daemon (auto-starts REST when built with `rest` feature):
@@ -35,10 +36,14 @@ Replaces mem0 with a fully local BM25 + vector hybrid backend — no cloud API c
 
 ### Setup
 
-1. Copy or symlink into hermes-agent's memory plugin search path:
+1. Copy or symlink into hermes-agent's user plugin search path:
    ```bash
-   cp -r contrib/hermes-agent-plugin/mempal  /path/to/hermes-agent/plugins/memory/mempal
+   mkdir -p "$HERMES_HOME/plugins"
+   cp -r contrib/hermes-agent-plugin/mempal "$HERMES_HOME/plugins/mempal"
    ```
+   The provider keeps Hermes' `MemoryProvider` / `register_memory_provider`
+   discovery markers in the first 8192 bytes of `__init__.py`, so user plugin
+   discovery works without copying into Hermes' bundled provider directory.
 
 2. Configure hermes-agent:
    ```yaml
@@ -56,7 +61,15 @@ Replaces mem0 with a fully local BM25 + vector hybrid backend — no cloud API c
    ```json
    {
      "base_url": "http://127.0.0.1:3080",
-     "user_id": "your-username"
+     "user_id": "your-username",
+     "memory_intelligence": { "mode": "deterministic" },
+     "safe_mode": {
+       "enabled": true,
+       "min_importance": 3,
+       "memory_kinds": ["knowledge", "profile_fact"],
+       "context_budget_chars": 4000,
+       "include_raw_turns": false
+     }
    }
    ```
 
@@ -104,6 +117,38 @@ Optional LLM-enhanced memory classification. Configure in `$HERMES_HOME/mempal.j
 | `local_llm` | Use a local OpenAI-compatible endpoint for metadata extraction, fact extraction from turns, and session summaries. |
 | `cloud_llm` | Use a paid/cloud endpoint for the same enhancements. |
 | `auto` | Try configured LLM, fall back to deterministic on failure or missing config. |
+
+### Safe mode for coding-agent workflows
+
+Safe mode is enabled by default. It keeps Hermes on the low-risk path:
+
+- deterministic memory intelligence unless explicitly configured otherwise
+- pinned/canonical facts are shown first and labeled authoritative
+- search/profile hits keep `drawer_id`, source, importance, typed metadata, and
+  are labeled `evidence/background` unless pinned or canonical
+- low-importance raw evidence is filtered unless it passes `min_importance` or
+  `memory_kinds`
+- raw-turn retrieval is disabled unless `safe_mode.include_raw_turns=true`
+- injected prefetch/pinned context is capped by `safe_mode.context_budget_chars`
+
+Do not enable the separate `mempal-hooks` plugin for per-turn injection unless
+you explicitly want raw turn capture/injection behavior beyond the conservative
+MemoryProvider path.
+
+### Multi-profile REST ports
+
+Each mempal daemon profile should use a distinct local REST address. Keep the
+host loopback-only:
+
+```toml
+[api]
+enabled = true
+addr = "127.0.0.1:3081"
+```
+
+Run `mempal doctor rest --addr 127.0.0.1:3081` to verify the binary feature,
+endpoint reachability, required routes, and port owner before pointing Hermes at
+that profile.
 
 ## Path 2: Hooks plugin (deep context injection)
 

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -3,6 +3,8 @@
 Local memory backend via mempal REST API.
 BM25 + vector hybrid search, zero cloud dependency.
 
+Hermes discovery marker: MemoryProvider register_memory_provider.
+
 Config via environment variables:
   MEMPAL_BASE_URL  -- mempal REST endpoint (default: http://127.0.0.1:3080)
   MEMPAL_USER_ID   -- user identifier (default: hermes-user)
@@ -34,6 +36,10 @@ _PINNED_FACTS_TTL = 300.0
 _LLM_DEFAULT_TIMEOUT = 30
 _LLM_BREAKER_THRESHOLD = 3
 _LLM_BREAKER_COOLDOWN = 300.0
+_DEFAULT_SAFE_MIN_IMPORTANCE = 3
+_DEFAULT_SAFE_CONTEXT_BUDGET_CHARS = 4000
+_SAFE_MEMORY_KINDS = {"knowledge", "profile_fact"}
+_AUTHORITATIVE_STATUSES = {"canonical"}
 
 _VALID_MODES = {"deterministic", "local_llm", "cloud_llm", "auto"}
 _VALID_MEMORY_KINDS = {
@@ -107,8 +113,12 @@ def _load_config(hermes_home: str = "") -> dict:
         config_path = os.path.join(hermes_home, "mempal.json")
         if os.path.exists(config_path):
             try:
-                file_cfg = json.loads(open(config_path, encoding="utf-8").read())
-                config.update({k: v for k, v in file_cfg.items() if v})
+                with open(config_path, encoding="utf-8") as handle:
+                    file_cfg = json.loads(handle.read())
+                config.update({
+                    k: v for k, v in file_cfg.items()
+                    if v is not None and not (isinstance(v, str) and not v)
+                })
             except Exception:
                 pass
     return config
@@ -116,6 +126,14 @@ def _load_config(hermes_home: str = "") -> dict:
 
 def _strip_none(d: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in d.items() if v is not None}
+
+
+def _bounded_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
 
 
 class _LLMClient:
@@ -346,6 +364,11 @@ class MempalMemoryProvider:
         self._intelligence_mode = "deterministic"
         self._llm = _LLMClient({})
         self._enhancer: Optional[_IntelligenceEnhancer] = None
+        self._safe_mode = True
+        self._safe_min_importance = _DEFAULT_SAFE_MIN_IMPORTANCE
+        self._safe_context_budget_chars = _DEFAULT_SAFE_CONTEXT_BUDGET_CHARS
+        self._safe_include_raw_turns = False
+        self._safe_memory_kinds = set(_SAFE_MEMORY_KINDS)
 
     def _configure_intelligence(self, cfg: dict) -> None:
         mi = cfg.get("memory_intelligence") or {}
@@ -367,6 +390,37 @@ class MempalMemoryProvider:
             self._enhancer = _IntelligenceEnhancer(self._llm)
         else:
             self._enhancer = None
+
+    def _configure_safe_mode(self, cfg: dict) -> None:
+        safe = cfg.get("safe_mode") or {}
+        if not isinstance(safe, dict):
+            safe = {}
+        enabled = safe.get("enabled", True)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() not in {"0", "false", "no", "off"}
+        self._safe_mode = bool(enabled)
+        self._safe_min_importance = _bounded_int(
+            safe.get("min_importance"),
+            _DEFAULT_SAFE_MIN_IMPORTANCE,
+            0,
+            5,
+        )
+        self._safe_context_budget_chars = _bounded_int(
+            safe.get("context_budget_chars"),
+            _DEFAULT_SAFE_CONTEXT_BUDGET_CHARS,
+            500,
+            20000,
+        )
+        include_raw = safe.get("include_raw_turns", False)
+        if isinstance(include_raw, str):
+            include_raw = include_raw.strip().lower() in {"1", "true", "yes", "on"}
+        self._safe_include_raw_turns = bool(include_raw)
+        kinds = safe.get("memory_kinds")
+        if isinstance(kinds, list):
+            clean = {str(kind).strip().lower() for kind in kinds if str(kind).strip()}
+            self._safe_memory_kinds = clean or set(_SAFE_MEMORY_KINDS)
+        else:
+            self._safe_memory_kinds = set(_SAFE_MEMORY_KINDS)
 
     def _should_enhance(self) -> bool:
         if self._intelligence_mode == "deterministic":
@@ -496,6 +550,7 @@ class MempalMemoryProvider:
         self._facts_room = "facts"
         self._project_id = str(project_id) if project_id else None
         self._configure_intelligence(cfg)
+        self._configure_safe_mode(cfg)
 
     @staticmethod
     def _derive_turns_room(platform, chat_id, thread_id):
@@ -513,6 +568,61 @@ class MempalMemoryProvider:
         if self._project_id:
             scoped["project_id"] = self._project_id
         return scoped
+
+    def _retrieval_params(self, payload):
+        params = dict(payload)
+        if self._safe_mode:
+            params["include_raw_turns"] = self._safe_include_raw_turns
+        else:
+            params["include_raw_turns"] = bool(params.get("include_raw_turns", self._safe_include_raw_turns))
+        return self._with_project_id(params)
+
+    def _is_authoritative_memory(self, item):
+        status = str(item.get("status", "")).strip().lower()
+        return bool(item.get("is_pinned")) or status in _AUTHORITATIVE_STATUSES
+
+    def _memory_authority_label(self, item):
+        if self._is_authoritative_memory(item):
+            return "authoritative"
+        return "evidence/background"
+
+    @staticmethod
+    def _item_importance(item):
+        try:
+            return int(item.get("importance", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _safe_allows_item(self, item):
+        if not self._safe_mode:
+            return True
+        if self._is_authoritative_memory(item):
+            return True
+        if "memory_kind" not in item and "importance" not in item:
+            return True
+        kind = str(item.get("memory_kind", "")).strip().lower()
+        importance = self._item_importance(item)
+        return kind in self._safe_memory_kinds or importance >= self._safe_min_importance
+
+    def _rank_safe_items(self, items):
+        indexed = list(enumerate(items))
+        indexed.sort(
+            key=lambda pair: (
+                0 if self._is_authoritative_memory(pair[1]) else 1,
+                -self._item_importance(pair[1]),
+                pair[0],
+            )
+        )
+        return [item for _, item in indexed]
+
+    def _safe_filter_items(self, items):
+        return self._rank_safe_items([item for item in items if self._safe_allows_item(item)])
+
+    def _append_with_budget(self, lines, line, used):
+        if used + len(line) > self._safe_context_budget_chars:
+            return used, False
+        lines.append(line)
+        return used + len(line), True
 
     def _session_room(self):
         return f"sessions/{self._session_id}" if self._session_id else "sessions"
@@ -594,11 +704,20 @@ class MempalMemoryProvider:
         if not facts:
             return ""
         lines = []
+        used = 0
         for f in facts:
             kind = f.get("memory_kind", "fact")
             imp = f.get("importance", 0)
+            drawer_id = f.get("drawer_id") or "unknown"
+            source = f.get("source_file") or "unknown"
             content = f.get("content", "").replace("\n", " ")[:200]
-            lines.append(f"- [{kind}] {content} (importance: {imp})")
+            line = (
+                f"- [authoritative/pinned][{kind}] {content} "
+                f"(drawer_id: {drawer_id}, source: {source}, importance: {imp})"
+            )
+            used, accepted = self._append_with_budget(lines, line, used)
+            if not accepted:
+                break
         return "## Pinned Facts (always active)\n" + "\n".join(lines)
 
     def system_prompt_block(self):
@@ -611,7 +730,8 @@ class MempalMemoryProvider:
             f"Mode: {mode_label}. "
             "Local BM25+vector backend, zero cloud.\n"
             "Use mempal_search to recall facts, mempal_conclude to store, "
-            "mempal_profile for recent overview."
+            "mempal_profile for recent overview. Treat search/profile hits as "
+            "evidence/background unless marked authoritative."
         )
         pinned = self._fetch_pinned_facts()
         pinned_block = self._format_pinned_block(pinned)
@@ -638,15 +758,31 @@ class MempalMemoryProvider:
         key = self._session_key(session_id)
         wing = self._wing
         generation = self._prefetch_generation
-        params = self._with_project_id({"q": query, "wing": wing, "top_k": 5, "include_raw_turns": False})
+        params = self._retrieval_params({"q": query, "wing": wing, "top_k": 8})
         def _run():
             try:
                 results = self._get("/api/search", params)
                 if results:
-                    lines = [r.get("content", "") for r in results if r.get("content")]
+                    lines = []
+                    used = 0
+                    for r in self._safe_filter_items(results):
+                        content = r.get("content", "").replace("\n", " ")
+                        if not content:
+                            continue
+                        drawer_id = r.get("drawer_id") or "unknown"
+                        source = r.get("source") or r.get("source_file") or "unknown"
+                        label = self._memory_authority_label(r)
+                        line = (
+                            f"- [{label}] {content} "
+                            f"(drawer_id: {drawer_id}, source: {source}, "
+                            f"importance: {r.get('importance', 0)})"
+                        )
+                        used, accepted = self._append_with_budget(lines, line, used)
+                        if not accepted:
+                            break
                     with self._prefetch_lock:
                         if generation == self._prefetch_generation:
-                            result = "\n".join(f"- {line}" for line in lines)
+                            result = "\n".join(lines)
                             self._prefetch_results[key] = result
                             if key == self._session_id:
                                 self._prefetch_result = result
@@ -691,11 +827,22 @@ class MempalMemoryProvider:
                     limit = min(int(args.get("limit", 20)), 100)
                 except (ValueError, TypeError):
                     limit = 20
-                entries = self._get("/api/timeline", self._with_project_id({"wing": self._wing, "limit": limit, "include_raw_turns": False}))
+                entries = self._get("/api/timeline", self._retrieval_params({"wing": self._wing, "limit": limit}))
                 self._record_success()
                 if not entries:
                     return json.dumps({"result": "No memories stored yet."})
-                items = [_strip_none({"content": e.get("content", ""), "drawer_id": e.get("drawer_id"), "importance": e.get("importance"), "added_at": e.get("added_at")}) for e in entries if e.get("content")]
+                items = [
+                    _strip_none({
+                        "content": e.get("content", ""),
+                        "drawer_id": e.get("drawer_id"),
+                        "source": e.get("source_file"),
+                        "importance": e.get("importance"),
+                        "added_at": e.get("added_at"),
+                        "authority": self._memory_authority_label(e),
+                    })
+                    for e in self._safe_filter_items(entries)
+                    if e.get("content")
+                ]
                 return json.dumps({"results": items, "count": len(items)})
             except Exception as exc:
                 self._record_failure()
@@ -709,11 +856,11 @@ class MempalMemoryProvider:
             except (ValueError, TypeError):
                 top_k = 10
             try:
-                results = self._get("/api/search", self._with_project_id({"q": q, "wing": self._wing, "top_k": top_k, "include_raw_turns": False}))
+                results = self._get("/api/search", self._retrieval_params({"q": q, "wing": self._wing, "top_k": top_k}))
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                items = [_strip_none({"memory": r.get("content", ""), "score": r.get("similarity", 0), "drawer_id": r.get("drawer_id"), "source": r.get("source"), "source_type": r.get("source_type"), "provenance": r.get("provenance"), "status": r.get("status"), "memory_kind": r.get("memory_kind"), "domain": r.get("domain"), "field": r.get("field"), "importance": r.get("importance"), "is_pinned": r.get("is_pinned"), "confidence": r.get("confidence")}) for r in results]
+                items = [_strip_none({"memory": r.get("content", ""), "score": r.get("similarity", 0), "drawer_id": r.get("drawer_id"), "source": r.get("source"), "source_type": r.get("source_type"), "provenance": r.get("provenance"), "status": r.get("status"), "memory_kind": r.get("memory_kind"), "domain": r.get("domain"), "field": r.get("field"), "importance": r.get("importance"), "is_pinned": r.get("is_pinned"), "confidence": r.get("confidence"), "authority": self._memory_authority_label(r)}) for r in self._safe_filter_items(results)]
                 return json.dumps({"results": items, "count": len(items)})
             except Exception as exc:
                 self._record_failure()
@@ -723,7 +870,14 @@ class MempalMemoryProvider:
             if not conclusion:
                 return json.dumps({"error": "Missing required parameter: conclusion"})
             try:
-                result = self._post("/api/ingest", self._with_project_id({"content": conclusion, "wing": self._wing, "room": self._facts_room}))
+                result = self._post("/api/ingest", self._with_project_id({
+                    "content": conclusion,
+                    "wing": self._wing,
+                    "room": self._facts_room,
+                    "memory_kind": "profile_fact",
+                    "importance": self._safe_min_importance,
+                    "source_type": "user_explicit",
+                }))
                 drawer_id = result.get("drawer_id", "") if isinstance(result, dict) else ""
                 self._record_success()
                 resp = {"result": "Fact stored."}
@@ -764,6 +918,10 @@ class MempalMemoryProvider:
                 logger.debug("mempal remove: no tracked drawer_id for %s", target)
             return
         body = self._with_project_id({"content": content, "wing": self._wing, "room": room})
+        if room == self._facts_room:
+            body.setdefault("memory_kind", "profile_fact")
+            body.setdefault("importance", self._safe_min_importance)
+            body.setdefault("source_type", "user_explicit")
         if metadata:
             for field in ("memory_kind", "domain", "field", "importance", "status", "is_pinned", "source_type"):
                 if field in metadata and metadata[field] is not None:
@@ -808,6 +966,11 @@ class MempalMemoryProvider:
             {"key": "memory_intelligence.llm.model", "description": "Model name for LLM enhancement", "default": ""},
             {"key": "memory_intelligence.llm.api_key", "description": "API key for LLM endpoint (optional for local)", "default": ""},
             {"key": "memory_intelligence.llm.timeout_secs", "description": "LLM request timeout in seconds", "default": "30"},
+            {"key": "safe_mode.enabled", "description": "Conservative coding-agent retrieval mode", "default": "true"},
+            {"key": "safe_mode.min_importance", "description": "Minimum importance for non-authoritative recalled evidence", "default": str(_DEFAULT_SAFE_MIN_IMPORTANCE)},
+            {"key": "safe_mode.memory_kinds", "description": "REST memory_kind values allowed below the importance threshold", "default": "knowledge,profile_fact"},
+            {"key": "safe_mode.context_budget_chars", "description": "Maximum injected mempal context characters", "default": str(_DEFAULT_SAFE_CONTEXT_BUDGET_CHARS)},
+            {"key": "safe_mode.include_raw_turns", "description": "Allow raw turn retrieval in injected/search context", "default": "false"},
         ]
 
     def save_config(self, values, hermes_home):

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import tempfile
 import time
 import unittest
 from typing import Any, Dict, List, Optional, Tuple
@@ -11,6 +12,16 @@ if PLUGIN_DIR not in sys.path:
     sys.path.insert(0, PLUGIN_DIR)
 
 from mempal import MempalMemoryProvider, _LLMClient, _IntelligenceEnhancer  # noqa: E402
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_user_plugin_marker_is_visible_to_hermes_scan_window(self) -> None:
+        init_path = os.path.join(PLUGIN_DIR, "mempal", "__init__.py")
+        with open(init_path, encoding="utf-8") as handle:
+            scan_window = handle.read(8192)
+
+        self.assertIn("register_memory_provider", scan_window)
+        self.assertIn("MemoryProvider", scan_window)
 
 
 class RecordingProvider(MempalMemoryProvider):
@@ -327,6 +338,69 @@ class SearchResultTests(unittest.TestCase):
         result = json.loads(provider.handle_tool_call("mempal_profile", {"limit": 5}))
         self.assertEqual(result["results"][0]["drawer_id"], "d1")
         self.assertEqual(result["results"][0]["importance"], 3)
+
+
+class SafeModeTests(unittest.TestCase):
+    def test_search_filters_low_importance_raw_evidence_and_labels_background(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.responses["/api/search"] = [
+            {"content": "low raw turn", "drawer_id": "raw1", "memory_kind": "evidence", "importance": 1},
+            {"content": "durable fact", "drawer_id": "fact1", "memory_kind": "profile_fact", "importance": 1},
+            {"content": "important evidence", "drawer_id": "ev1", "memory_kind": "evidence", "importance": 4},
+        ]
+
+        result = json.loads(provider.handle_tool_call("mempal_search", {"query": "memory"}))
+
+        drawer_ids = [item["drawer_id"] for item in result["results"]]
+        self.assertNotIn("raw1", drawer_ids)
+        self.assertEqual(drawer_ids, ["ev1", "fact1"])
+        self.assertEqual(result["results"][0]["authority"], "evidence/background")
+        self.assertFalse(provider.gets[-1][1]["include_raw_turns"])
+
+    def test_search_labels_pinned_and_canonical_as_authoritative(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider.responses["/api/search"] = [
+            {"content": "canonical rule", "drawer_id": "c1", "status": "canonical", "memory_kind": "evidence", "importance": 0},
+            {"content": "pinned rule", "drawer_id": "p1", "is_pinned": True, "memory_kind": "evidence", "importance": 0},
+        ]
+
+        result = json.loads(provider.handle_tool_call("mempal_search", {"query": "rule"}))
+
+        self.assertEqual([item["authority"] for item in result["results"]], ["authoritative", "authoritative"])
+
+    def test_prefetch_preserves_citations_and_budget(self) -> None:
+        provider = RecordingProvider()
+        provider.initialize("session-a", user_id="alice", profile="work")
+        provider._safe_context_budget_chars = 140
+        provider.responses["/api/search"] = [
+            {"content": "important cited memory", "drawer_id": "d1", "source": "source-a", "memory_kind": "evidence", "importance": 4},
+            {"content": "second important memory that should exceed the tiny budget", "drawer_id": "d2", "source": "source-b", "memory_kind": "evidence", "importance": 4},
+        ]
+
+        provider.queue_prefetch("memory", session_id="session-a")
+        block = provider.prefetch("memory", session_id="session-a")
+
+        self.assertIn("drawer_id: d1", block)
+        self.assertIn("source: source-a", block)
+        self.assertNotIn("drawer_id: d2", block)
+        self.assertIn("evidence/background", block)
+
+    def test_safe_mode_can_be_disabled_by_config(self) -> None:
+        with tempfile.TemporaryDirectory() as hermes_home:
+            with open(os.path.join(hermes_home, "mempal.json"), "w", encoding="utf-8") as handle:
+                json.dump({"safe_mode": {"enabled": False, "include_raw_turns": True}}, handle)
+            provider = RecordingProvider()
+            provider.initialize("session-a", hermes_home=hermes_home, user_id="alice", profile="work")
+            provider.responses["/api/search"] = [
+                {"content": "low raw turn", "drawer_id": "raw1", "memory_kind": "evidence", "importance": 0},
+            ]
+
+            result = json.loads(provider.handle_tool_call("mempal_search", {"query": "raw"}))
+
+            self.assertEqual(result["results"][0]["drawer_id"], "raw1")
+            self.assertTrue(provider.gets[-1][1]["include_raw_turns"])
 
 
 class PinnedFactsTests(unittest.TestCase):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -716,14 +716,29 @@ Lists both inbox targets (`claude` and `codex`) for the given cwd along with mes
 Build with `--features rest` to enable REST:
 
 ```bash
+cargo install --path . --locked --features rest --force --root ~/.local
+mempal doctor rest
 mempal serve
 ```
 
 With REST enabled:
 
 - MCP still runs over stdio
-- REST listens on `127.0.0.1:3080`
+- REST listens on `127.0.0.1:3080` by default
 - CORS only allows localhost origins
+
+For daemon profiles, configure the REST address in `~/.mempal/config.toml`:
+
+```toml
+[api]
+enabled = true
+addr = "127.0.0.1:3080"
+```
+
+If you run multiple mempal daemons, assign each profile a different loopback
+port such as `127.0.0.1:3081`. `mempal doctor rest` reports whether the binary
+has REST support, whether the endpoint is reachable, which required routes are
+present, and which process owns the configured port when there is a collision.
 
 Endpoints:
 
@@ -731,6 +746,8 @@ Endpoints:
 - `GET /api/search?q=...&wing=...&room=...&top_k=...`
 - `POST /api/ingest`
 - `GET /api/taxonomy`
+- `GET /api/timeline`
+- `GET /api/pinned_facts`
 
 Examples:
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -188,8 +188,12 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
     let endpoint_reachable = routes.iter().any(|route| route.http_status.is_some());
     let missing_routes = routes
         .iter()
-        .filter(|route| !route.available)
+        .filter(|route| is_missing_rest_route(route))
         .map(|route| format!("{} {}", route.method, route.path))
+        .collect::<Vec<_>>();
+    let unhealthy_routes = routes
+        .iter()
+        .filter_map(unhealthy_rest_route_detail)
         .collect::<Vec<_>>();
 
     let mut warnings = Vec::new();
@@ -233,13 +237,23 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
         _ => {}
     }
 
-    if !missing_routes.is_empty() {
+    if endpoint_reachable && !missing_routes.is_empty() {
         warnings.push(format!(
             "REST endpoint is reachable but required route(s) are missing: {}",
             missing_routes.join(", ")
         ));
         recommendations.push(
             "Reinstall mempal with `--features rest` and restart the daemon serving this endpoint."
+                .to_string(),
+        );
+    }
+    if endpoint_reachable && !unhealthy_routes.is_empty() {
+        warnings.push(format!(
+            "REST endpoint is reachable but required route(s) returned unhealthy response(s): {}",
+            unhealthy_routes.join(", ")
+        ));
+        recommendations.push(
+            "Inspect the REST daemon logs and fix the failing route handler or database/profile configuration."
                 .to_string(),
         );
     }
@@ -269,6 +283,8 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
         "daemon_not_running"
     } else if !endpoint_reachable {
         "port_conflict"
+    } else if !unhealthy_routes.is_empty() {
+        "routes_unhealthy"
     } else if !missing_routes.is_empty() {
         "routes_missing"
     } else {
@@ -436,15 +452,13 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
         match request.send().await {
             Ok(response) => {
                 let status = response.status();
+                let (available, error) = classify_rest_route_probe(method, path, status);
                 reports.push(RestRouteReport {
                     method: (*method).to_string(),
                     path: (*path).to_string(),
-                    available: !matches!(
-                        status,
-                        reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
-                    ),
+                    available,
                     http_status: Some(status.as_u16()),
-                    error: None,
+                    error,
                 });
             }
             Err(error) => reports.push(RestRouteReport {
@@ -457,6 +471,56 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
         }
     }
     reports
+}
+
+fn classify_rest_route_probe(
+    method: &str,
+    path: &str,
+    status: reqwest::StatusCode,
+) -> (bool, Option<String>) {
+    if status.is_success() || is_expected_ingest_validation(method, path, status) {
+        return (true, None);
+    }
+    if matches!(
+        status,
+        reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+    ) {
+        return (false, None);
+    }
+    if status.is_server_error() {
+        return (
+            false,
+            Some(format!("server error HTTP {}", status.as_u16())),
+        );
+    }
+    (
+        false,
+        Some(format!("unexpected HTTP status {}", status.as_u16())),
+    )
+}
+
+fn is_expected_ingest_validation(method: &str, path: &str, status: reqwest::StatusCode) -> bool {
+    method == "POST" && path == "/api/ingest" && status == reqwest::StatusCode::BAD_REQUEST
+}
+
+fn is_missing_rest_route(route: &RestRouteReport) -> bool {
+    matches!(route.http_status, Some(404 | 405))
+}
+
+fn unhealthy_rest_route_detail(route: &RestRouteReport) -> Option<String> {
+    if route.available || is_missing_rest_route(route) {
+        return None;
+    }
+    let status = route
+        .http_status
+        .map(|status| format!("HTTP {status}"))
+        .unwrap_or_else(|| "no HTTP response".to_string());
+    let detail = route
+        .error
+        .as_deref()
+        .map(|error| format!("{status} ({error})"))
+        .unwrap_or(status);
+    Some(format!("{} {} {detail}", route.method, route.path))
 }
 
 fn route_probe_url(endpoint: &str, path: &str) -> String {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -500,7 +500,12 @@ fn classify_rest_route_probe(
 }
 
 fn is_expected_ingest_validation(method: &str, path: &str, status: reqwest::StatusCode) -> bool {
-    method == "POST" && path == "/api/ingest" && status == reqwest::StatusCode::BAD_REQUEST
+    method == "POST"
+        && path == "/api/ingest"
+        && matches!(
+            status,
+            reqwest::StatusCode::BAD_REQUEST | reqwest::StatusCode::UNPROCESSABLE_ENTITY
+        )
 }
 
 fn is_missing_rest_route(route: &RestRouteReport) -> bool {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,5 +1,7 @@
 use std::env;
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
@@ -59,6 +61,14 @@ pub const COWORK_BUS_ACTIONS: &[&str] = &[
     "capture",
 ];
 
+pub const REQUIRED_REST_ROUTES: &[(&str, &str)] = &[
+    ("GET", "/api/status"),
+    ("GET", "/api/search"),
+    ("POST", "/api/ingest"),
+    ("GET", "/api/timeline"),
+    ("GET", "/api/pinned_facts"),
+];
+
 #[derive(Debug, Clone, Serialize)]
 pub struct DoctorReport {
     pub current_version: String,
@@ -85,6 +95,41 @@ pub struct DoctorInstallReport {
     pub current_exe: Option<String>,
     pub path_mempal: Option<String>,
     pub path_matches_current_exe: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RestDoctorReport {
+    pub rest_feature_enabled: bool,
+    pub endpoint: String,
+    pub endpoint_reachable: bool,
+    pub status: String,
+    pub routes: Vec<RestRouteReport>,
+    pub port: Option<RestPortReport>,
+    pub warnings: Vec<String>,
+    pub recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RestRouteReport {
+    pub method: String,
+    pub path: String,
+    pub available: bool,
+    pub http_status: Option<u16>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RestPortReport {
+    pub addr: String,
+    pub bind_available: bool,
+    pub error: Option<String>,
+    pub owner: Option<RestPortOwner>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct RestPortOwner {
+    pub pid: i32,
+    pub command: String,
 }
 
 pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
@@ -131,6 +176,112 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         db_holders,
         install,
         restart_required_config_changes,
+        warnings,
+        recommendations,
+    }
+}
+
+pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) -> RestDoctorReport {
+    let endpoint = normalize_rest_endpoint(endpoint);
+    let port = inspect_rest_port(&endpoint);
+    let routes = probe_rest_routes(&endpoint).await;
+    let endpoint_reachable = routes.iter().any(|route| route.http_status.is_some());
+    let missing_routes = routes
+        .iter()
+        .filter(|route| !route.available)
+        .map(|route| format!("{} {}", route.method, route.path))
+        .collect::<Vec<_>>();
+
+    let mut warnings = Vec::new();
+    let mut recommendations = Vec::new();
+
+    if !cfg!(feature = "rest") {
+        warnings.push(
+            "this mempal binary was built without the `rest` feature; it cannot serve REST"
+                .to_string(),
+        );
+        recommendations.push(suggest_rest_install_command());
+    }
+
+    match (&port, endpoint_reachable) {
+        (Some(port), false) if port.bind_available => {
+            warnings.push(format!(
+                "REST endpoint {endpoint} is unreachable and {} is free; daemon is not running, REST is disabled, or the daemon was built without REST",
+                port.addr
+            ));
+            recommendations.push(
+                "Start a REST-enabled daemon with `[api].enabled = true`, then rerun `mempal doctor rest`."
+                    .to_string(),
+            );
+        }
+        (Some(port), false) if !port.bind_available => {
+            warnings.push(format!(
+                "REST endpoint {endpoint} is unreachable but {} is already bound",
+                port.addr
+            ));
+            if let Some(owner) = &port.owner {
+                warnings.push(format!(
+                    "REST port owner: pid={} command={}",
+                    owner.pid, owner.command
+                ));
+            }
+            recommendations.push(
+                "Use a profile-specific local `[api].addr`, for example `127.0.0.1:3081`, or stop the conflicting process."
+                    .to_string(),
+            );
+        }
+        _ => {}
+    }
+
+    if !missing_routes.is_empty() {
+        warnings.push(format!(
+            "REST endpoint is reachable but required route(s) are missing: {}",
+            missing_routes.join(", ")
+        ));
+        recommendations.push(
+            "Reinstall mempal with `--features rest` and restart the daemon serving this endpoint."
+                .to_string(),
+        );
+    }
+
+    if let (Some(db_path), Some(port)) = (db_path, &port)
+        && endpoint_reachable
+        && let Some(owner) = &port.owner
+    {
+        let holders = inspect_db_holders(db_path);
+        let owner_holds_current_db = holders.holders.iter().any(|holder| holder.pid == owner.pid);
+        if db_path.exists() && !owner_holds_current_db {
+            warnings.push(format!(
+                "REST port owner pid={} was not observed holding configured DB {}; verify this endpoint is not another mempal profile",
+                owner.pid,
+                db_path.display()
+            ));
+            recommendations.push(
+                "For multiple daemon profiles, assign each profile a distinct local `[api].addr`."
+                    .to_string(),
+            );
+        }
+    }
+
+    let status = if !cfg!(feature = "rest") {
+        "missing_rest_feature"
+    } else if !endpoint_reachable && port.as_ref().is_some_and(|p| p.bind_available) {
+        "daemon_not_running"
+    } else if !endpoint_reachable {
+        "port_conflict"
+    } else if !missing_routes.is_empty() {
+        "routes_missing"
+    } else {
+        "ok"
+    };
+
+    RestDoctorReport {
+        rest_feature_enabled: cfg!(feature = "rest"),
+        endpoint,
+        endpoint_reachable,
+        status: status.to_string(),
+        routes,
+        port,
         warnings,
         recommendations,
     }
@@ -236,6 +387,216 @@ fn paths_match(left: &Path, right: &Path) -> bool {
     left == right
 }
 
+fn normalize_rest_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    }
+}
+
+async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            return REQUIRED_REST_ROUTES
+                .iter()
+                .map(|(method, path)| RestRouteReport {
+                    method: (*method).to_string(),
+                    path: (*path).to_string(),
+                    available: false,
+                    http_status: None,
+                    error: Some(error.to_string()),
+                })
+                .collect();
+        }
+    };
+
+    let mut reports = Vec::new();
+    for (method, path) in REQUIRED_REST_ROUTES {
+        let url = route_probe_url(endpoint, path);
+        let request = match *method {
+            "GET" => client.get(url),
+            "POST" => client.post(url).json(&serde_json::json!({})),
+            other => {
+                reports.push(RestRouteReport {
+                    method: other.to_string(),
+                    path: (*path).to_string(),
+                    available: false,
+                    http_status: None,
+                    error: Some("unsupported route probe method".to_string()),
+                });
+                continue;
+            }
+        };
+        match request.send().await {
+            Ok(response) => {
+                let status = response.status();
+                reports.push(RestRouteReport {
+                    method: (*method).to_string(),
+                    path: (*path).to_string(),
+                    available: !matches!(
+                        status,
+                        reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+                    ),
+                    http_status: Some(status.as_u16()),
+                    error: None,
+                });
+            }
+            Err(error) => reports.push(RestRouteReport {
+                method: (*method).to_string(),
+                path: (*path).to_string(),
+                available: false,
+                http_status: None,
+                error: Some(error.to_string()),
+            }),
+        }
+    }
+    reports
+}
+
+fn route_probe_url(endpoint: &str, path: &str) -> String {
+    match path {
+        "/api/search" => format!("{endpoint}{path}?q=mempal-doctor-rest&top_k=1"),
+        "/api/timeline" | "/api/pinned_facts" => format!("{endpoint}{path}?limit=1"),
+        _ => format!("{endpoint}{path}"),
+    }
+}
+
+fn inspect_rest_port(endpoint: &str) -> Option<RestPortReport> {
+    let addr = endpoint_socket_addr(endpoint)?;
+    match TcpListener::bind(addr) {
+        Ok(listener) => {
+            drop(listener);
+            Some(RestPortReport {
+                addr: addr.to_string(),
+                bind_available: true,
+                error: None,
+                owner: None,
+            })
+        }
+        Err(error) => Some(RestPortReport {
+            addr: addr.to_string(),
+            bind_available: false,
+            error: Some(error.to_string()),
+            owner: inspect_port_owner(addr),
+        }),
+    }
+}
+
+fn endpoint_socket_addr(endpoint: &str) -> Option<SocketAddr> {
+    let url = reqwest::Url::parse(endpoint).ok()?;
+    let host = url.host_str()?;
+    let port = url.port_or_known_default()?;
+    (host, port)
+        .to_socket_addrs()
+        .ok()?
+        .find(|addr| addr.ip().is_loopback())
+        .or_else(|| (host, port).to_socket_addrs().ok()?.next())
+}
+
+fn inspect_port_owner(addr: SocketAddr) -> Option<RestPortOwner> {
+    #[cfg(target_os = "linux")]
+    {
+        inspect_port_owner_in_proc(addr.port(), Path::new("/proc"))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = addr;
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_port_owner_in_proc(port: u16, proc_root: &Path) -> Option<RestPortOwner> {
+    let inodes = listening_socket_inodes(port, proc_root);
+    if inodes.is_empty() {
+        return None;
+    }
+    let entries = std::fs::read_dir(proc_root).ok()?;
+    for entry in entries.flatten() {
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        let fd_dir = entry.path().join("fd");
+        let Ok(fds) = std::fs::read_dir(fd_dir) else {
+            continue;
+        };
+        for fd in fds.flatten() {
+            let Ok(target) = std::fs::read_link(fd.path()) else {
+                continue;
+            };
+            let target = target.to_string_lossy();
+            if let Some(inode) = target
+                .strip_prefix("socket:[")
+                .and_then(|value| value.strip_suffix(']'))
+                && inodes.iter().any(|known| known == inode)
+            {
+                return Some(RestPortOwner {
+                    pid,
+                    command: read_proc_command(proc_root, pid),
+                });
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn listening_socket_inodes(port: u16, proc_root: &Path) -> Vec<String> {
+    [proc_root.join("net/tcp"), proc_root.join("net/tcp6")]
+        .into_iter()
+        .filter_map(|path| std::fs::read_to_string(path).ok())
+        .flat_map(|content| {
+            content
+                .lines()
+                .filter_map(move |line| listening_socket_inode_from_line(line, port))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn listening_socket_inode_from_line(line: &str, port: u16) -> Option<String> {
+    let columns = line.split_whitespace().collect::<Vec<_>>();
+    let local_address = columns.get(1)?;
+    let state = columns.get(3)?;
+    if *state != "0A" {
+        return None;
+    }
+    let port_hex = local_address.split_once(':')?.1;
+    let parsed_port = u16::from_str_radix(port_hex, 16).ok()?;
+    if parsed_port != port {
+        return None;
+    }
+    columns.get(9).map(|inode| (*inode).to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_command(proc_root: &Path, pid: i32) -> String {
+    let comm = proc_root.join(pid.to_string()).join("comm");
+    std::fs::read_to_string(comm)
+        .map(|value| value.trim().to_string())
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn suggest_rest_install_command() -> String {
+    let root = env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().and_then(Path::parent).map(Path::to_path_buf))
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "<install-root>".to_string());
+    format!(
+        "Install REST support with `cargo install --path . --locked --features rest --force --root {root}` and restart the daemon."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,6 +631,47 @@ mod tests {
             warnings
                 .iter()
                 .any(|warning| warning.contains("extra process"))
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_listening_socket_inode_from_proc_net_tcp_line() {
+        let line = "0: 0100007F:0C08 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 4242 1 0000000000000000";
+
+        assert_eq!(
+            listening_socket_inode_from_line(line, 3080),
+            Some("4242".to_string())
+        );
+        assert_eq!(listening_socket_inode_from_line(line, 3081), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_inspect_port_owner_in_proc_maps_socket_inode_to_process() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let proc_root = tmp.path();
+        std::fs::create_dir_all(proc_root.join("net")).expect("create net");
+        std::fs::write(
+            proc_root.join("net/tcp"),
+            "sl local_address rem_address st tx_queue rx_queue tr tm->when retrnsmt uid timeout inode\n 0: 0100007F:0C08 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 4242 1 0\n",
+        )
+        .expect("write tcp");
+        std::fs::write(proc_root.join("net/tcp6"), "").expect("write tcp6");
+        std::fs::create_dir_all(proc_root.join("123/fd")).expect("create fd");
+        std::fs::write(proc_root.join("123/comm"), "mempal\n").expect("write comm");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("socket:[4242]", proc_root.join("123/fd/7"))
+            .expect("symlink socket");
+
+        let owner = inspect_port_owner_in_proc(3080, proc_root).expect("owner");
+
+        assert_eq!(
+            owner,
+            RestPortOwner {
+                pid: 123,
+                command: "mempal".to_string(),
+            }
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ use mempal::cowork::{
     SendOperation, SendRequest,
 };
 use mempal::crystallize::{CrystallizeOptions, CrystallizeSummary, run_crystallization};
-use mempal::doctor::build_doctor_report;
+use mempal::doctor::{RestDoctorReport, build_doctor_report, build_rest_doctor_report};
 use mempal::embed::build_backend_from_name;
 use mempal::embed::{ConfiguredEmbedderFactory, Embedder, global_embed_status};
 use mempal::field_taxonomy::{FieldTaxonomyEntry, field_taxonomy};
@@ -1018,6 +1018,8 @@ enum Commands {
     },
     /// System health check (schema version, install path, warnings).
     Doctor {
+        #[command(subcommand)]
+        command: Option<DoctorCommands>,
         #[arg(long, default_value = "plain")]
         format: String,
     },
@@ -1038,6 +1040,18 @@ enum OperationCommands {
         operation_id: String,
         #[arg(long = "timeout-secs", default_value_t = 30)]
         timeout_secs: u64,
+    },
+}
+
+#[derive(Subcommand)]
+enum DoctorCommands {
+    /// Diagnose REST feature, endpoint readiness, routes, and port ownership.
+    Rest {
+        /// REST endpoint or host:port to probe. Defaults to config api.addr.
+        #[arg(long)]
+        addr: Option<String>,
+        #[arg(long, default_value = "plain")]
+        format: String,
     },
 }
 
@@ -2806,7 +2820,20 @@ fn run() -> Result<()> {
         Commands::ReleaseReadiness { format } => {
             return release_readiness_command(format.clone());
         }
-        Commands::Doctor { format } => {
+        Commands::Doctor {
+            command:
+                Some(DoctorCommands::Rest {
+                    addr,
+                    format: rest_format,
+                }),
+            ..
+        } => {
+            return block_on_result(doctor_rest_command(addr.clone(), rest_format.clone()));
+        }
+        Commands::Doctor {
+            command: None,
+            format,
+        } => {
             return doctor_command(format.clone());
         }
         _ => {}
@@ -15949,6 +15976,68 @@ fn doctor_command(format: String) -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn doctor_rest_command(addr: Option<String>, format: String) -> Result<()> {
+    if !matches!(format.as_str(), "plain" | "json") {
+        bail!("unsupported doctor rest format: {format}");
+    }
+    let config = Config::load().ok();
+    let endpoint = addr
+        .or_else(|| config.as_ref().map(|config| config.api.addr.clone()))
+        .unwrap_or_else(|| "127.0.0.1:3080".to_string());
+    let db_path = config
+        .as_ref()
+        .map(|config| expand_home(&config.db_path))
+        .unwrap_or_else(|| mempal_home().join("palace.db"));
+    let report = build_rest_doctor_report(&endpoint, Some(&db_path)).await;
+    match format.as_str() {
+        "json" => println!("{}", serde_json::to_string_pretty(&report)?),
+        _ => print_rest_doctor_plain(&report),
+    }
+    Ok(())
+}
+
+fn print_rest_doctor_plain(report: &RestDoctorReport) {
+    println!("rest_feature_enabled={}", report.rest_feature_enabled);
+    println!("endpoint={}", report.endpoint);
+    println!("endpoint_reachable={}", report.endpoint_reachable);
+    println!("status={}", report.status);
+    if let Some(port) = &report.port {
+        println!("port_addr={}", port.addr);
+        println!("port_bind_available={}", port.bind_available);
+        if let Some(error) = port.error.as_deref() {
+            println!("port_error={error}");
+        }
+        if let Some(owner) = &port.owner {
+            println!("port_owner_pid={}", owner.pid);
+            println!("port_owner_command={}", owner.command);
+        } else {
+            println!("port_owner=unknown");
+        }
+    } else {
+        println!("port=unresolved");
+    }
+    println!("routes:");
+    for route in &report.routes {
+        let status = route
+            .http_status
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        println!(
+            "  {} {} available={} http_status={}",
+            route.method, route.path, route.available, status
+        );
+        if let Some(error) = route.error.as_deref() {
+            println!("    error={error}");
+        }
+    }
+    for warning in &report.warnings {
+        println!("warning: {warning}");
+    }
+    for recommendation in &report.recommendations {
+        println!("recommendation: {recommendation}");
+    }
 }
 
 fn print_db_holder_report(

--- a/tests/doctor_rest.rs
+++ b/tests/doctor_rest.rs
@@ -80,6 +80,72 @@ fn test_doctor_rest_reports_required_routes_and_feature_state() {
 }
 
 #[test]
+fn test_doctor_rest_accepts_axum_ingest_validation_response() {
+    let home = temp_home();
+    let mut server = Server::new();
+    let _status = server
+        .mock("GET", "/api/status")
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let _search = server
+        .mock("GET", "/api/search")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _ingest = server
+        .mock("POST", "/api/ingest")
+        .match_body(Matcher::PartialJson(serde_json::json!({})))
+        .with_status(422)
+        .with_body(r#"{"error":"missing field `content`"}"#)
+        .create();
+    let _timeline = server
+        .mock("GET", "/api/timeline")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _pinned = server
+        .mock("GET", "/api/pinned_facts")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+
+    let output = run_doctor_rest(&home, &["--addr", &server.url(), "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "ok");
+    }
+    assert_eq!(report["endpoint_reachable"], true);
+    let ingest_route = report["routes"]
+        .as_array()
+        .expect("routes")
+        .iter()
+        .find(|route| route["method"] == "POST" && route["path"] == "/api/ingest")
+        .expect("ingest route");
+    assert_eq!(ingest_route["available"], true);
+    assert_eq!(ingest_route["http_status"], 422);
+    assert_eq!(ingest_route["error"], Value::Null);
+    assert!(
+        report["routes"]
+            .as_array()
+            .expect("routes")
+            .iter()
+            .all(|route| route["available"] == true),
+        "all required routes should be available: {report:#}"
+    );
+}
+
+#[test]
 fn test_doctor_rest_reports_server_error_routes_as_unhealthy() {
     let home = temp_home();
     let mut server = Server::new();

--- a/tests/doctor_rest.rs
+++ b/tests/doctor_rest.rs
@@ -80,6 +80,76 @@ fn test_doctor_rest_reports_required_routes_and_feature_state() {
 }
 
 #[test]
+fn test_doctor_rest_reports_server_error_routes_as_unhealthy() {
+    let home = temp_home();
+    let mut server = Server::new();
+    let _status = server
+        .mock("GET", "/api/status")
+        .with_status(500)
+        .with_body("status failed")
+        .create();
+    let _search = server
+        .mock("GET", "/api/search")
+        .match_query(Matcher::Any)
+        .with_status(500)
+        .with_body("search failed")
+        .create();
+    let _ingest = server
+        .mock("POST", "/api/ingest")
+        .match_body(Matcher::PartialJson(serde_json::json!({})))
+        .with_status(500)
+        .with_body("ingest failed")
+        .create();
+    let _timeline = server
+        .mock("GET", "/api/timeline")
+        .match_query(Matcher::Any)
+        .with_status(500)
+        .with_body("timeline failed")
+        .create();
+    let _pinned = server
+        .mock("GET", "/api/pinned_facts")
+        .match_query(Matcher::Any)
+        .with_status(500)
+        .with_body("pinned facts failed")
+        .create();
+
+    let output = run_doctor_rest(&home, &["--addr", &server.url(), "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    assert_ne!(report["status"], "ok");
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "routes_unhealthy");
+    }
+    assert_eq!(report["endpoint_reachable"], true);
+    let routes = report["routes"].as_array().expect("routes");
+    assert_eq!(routes.len(), 5);
+    assert!(
+        routes.iter().all(|route| route["available"] == false
+            && route["http_status"] == 500
+            && route["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("server error"))),
+        "server-error routes should be unavailable with route errors: {report:#}"
+    );
+    assert!(
+        report["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("server error"))),
+        "warnings should mention server route failures: {report:#}"
+    );
+}
+
+#[test]
 fn test_doctor_rest_distinguishes_daemon_not_running_from_missing_rest_feature() {
     let home = temp_home();
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");

--- a/tests/doctor_rest.rs
+++ b/tests/doctor_rest.rs
@@ -1,0 +1,138 @@
+use std::net::TcpListener;
+use std::process::Command;
+
+use mockito::{Matcher, Server};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn temp_home() -> TempDir {
+    TempDir::new().expect("tempdir")
+}
+
+fn run_doctor_rest(home: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(mempal_bin())
+        .arg("doctor")
+        .arg("rest")
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal doctor rest")
+}
+
+#[test]
+fn test_doctor_rest_reports_required_routes_and_feature_state() {
+    let home = temp_home();
+    let mut server = Server::new();
+    let _status = server
+        .mock("GET", "/api/status")
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let _search = server
+        .mock("GET", "/api/search")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _ingest = server
+        .mock("POST", "/api/ingest")
+        .match_body(Matcher::PartialJson(serde_json::json!({})))
+        .with_status(400)
+        .with_body(r#"{"error":"missing content"}"#)
+        .create();
+    let _timeline = server
+        .mock("GET", "/api/timeline")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _pinned = server
+        .mock("GET", "/api/pinned_facts")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+
+    let output = run_doctor_rest(&home, &["--addr", &server.url(), "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    assert_eq!(report["rest_feature_enabled"], cfg!(feature = "rest"));
+    assert_eq!(report["endpoint_reachable"], true);
+    assert_eq!(report["routes"].as_array().expect("routes").len(), 5);
+    assert!(
+        report["routes"]
+            .as_array()
+            .expect("routes")
+            .iter()
+            .all(|route| route["available"] == true),
+        "all required routes should be available: {report:#}"
+    );
+}
+
+#[test]
+fn test_doctor_rest_distinguishes_daemon_not_running_from_missing_rest_feature() {
+    let home = temp_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");
+    let addr = listener.local_addr().expect("local addr");
+    drop(listener);
+    let endpoint = format!("http://{addr}");
+
+    let output = run_doctor_rest(&home, &["--addr", &endpoint, "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "daemon_not_running");
+    } else {
+        assert_eq!(report["status"], "missing_rest_feature");
+        assert!(
+            report["recommendations"]
+                .as_array()
+                .expect("recommendations")
+                .iter()
+                .any(|item| item.as_str().is_some_and(|s| s.contains("--features rest")))
+        );
+    }
+    assert_eq!(report["endpoint_reachable"], false);
+    assert_eq!(report["port"]["bind_available"], true);
+}
+
+#[test]
+fn test_doctor_rest_reports_port_conflict_owner_when_unreachable() {
+    let home = temp_home();
+    let _listener = TcpListener::bind("127.0.0.1:0").expect("bind occupied port");
+    let addr = _listener.local_addr().expect("local addr");
+    let endpoint = format!("http://{addr}");
+
+    let output = run_doctor_rest(&home, &["--addr", &endpoint, "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    assert_eq!(report["endpoint_reachable"], false);
+    assert_eq!(report["port"]["bind_available"], false);
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "port_conflict");
+    }
+    #[cfg(target_os = "linux")]
+    assert!(report["port"]["owner"]["pid"].as_i64().is_some());
+}


### PR DESCRIPTION
## Summary

- Makes the Hermes memory provider installable from `$HERMES_HOME/plugins/mempal` by keeping provider discovery markers visible to Hermes' plugin scanner.
- Adds conservative safe-mode retrieval defaults for coding-agent memory use: deterministic mode, raw-turn injection disabled by default, authority/evidence labeling, drawer citations, and safer memory-kind/importance filtering.
- Adds `mempal doctor rest` diagnostics for REST feature/readiness, required route probing, port conflicts/owner hints, and multi-profile `api.addr` guidance.
- Tightens REST doctor route health so server errors are unhealthy while expected `/api/ingest` validation responses are accepted as route-present.
- Documents safe Hermes setup, user-plugin installation, REST doctor usage, and profile-specific REST ports.

## Tests

- `contrib/hermes-agent-plugin/test_mempal_provider.py` provider test suite passed in CSA validation.
- `cargo test --test doctor_rest` passed.
- `cargo test --features rest --test doctor_rest` passed.
- `cargo test --lib` passed: 488 tests.
- `cargo clippy --all-targets --features rest -- -D warnings` passed.
- Hook quality-gates passed for all local commits.
- Codex tier-4 full-diff review: PASS/CLEAN (`findings = []`).

Closes #390
