### PR TITLE
feat(search): add daemon-owned global search safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ mempal cowork-status --cwd "$PWD"
 - **Two Claude-side artifacts**: Claude Code does not auto-discover hook scripts by filename. Both `.claude/hooks/user-prompt-submit.sh` and the matching entry in `.claude/settings.json` are required. `install-hooks` writes both; do not remove either by hand.
 - **TUI restart needed after config changes on the Codex side**: Codex reads `config.toml` + `hooks.json` at process startup only. After enabling the feature flag or running `install-hooks`, fully quit and relaunch the Codex TUI before expecting hooks to fire.
 - **MCP server re-spawn**: Claude Code spawns the mempal MCP server at client startup. After upgrading the mempal binary (`cargo install ...`), restart Claude Code so the MCP server respawns and exposes newly added tools like `mempal_cowork_push` or `mempal_fact_check`.
+- **Hermes production path**: prefer the Hermes MemoryProvider/hooks integration against the daemon REST API. Avoid long-lived stdio MCP registrations for routine Hermes use because they create additional SQLite holders; direct HTTP MCP at `/mcp` is not the supported Hermes path until that transport has production coverage.
 - **Bidirectional scope**: `mempal_cowork_push` currently requires an MCP client identifying itself as `claude-code` or `codex` (or their aliases). Generic MCP clients cannot push because caller identity is required to fill the `from` field and enforce self-push rejection. This is by design for the Claude ↔ Codex pair.
 
 ## Concurrent Ingest Safety (P9-B)

--- a/contrib/hermes-agent-plugin/README.md
+++ b/contrib/hermes-agent-plugin/README.md
@@ -6,7 +6,7 @@ Three complementary integration paths — use any combination:
 |------|-------------|-------------|------|
 | **MemoryProvider** | Memory plugin | Mirror/sync hermes built-in memory to mempal, expose search/conclude tools | No |
 | **Hooks** | General plugin | Inject deep mempal context per turn, capture tool observations | No |
-| **MCP** | Config entry | Give hermes LLM direct access to all mempal tools | No |
+| **MCP** | Config entry | Debug-only direct access to all mempal tools | No |
 
 All three work without forking hermes-agent. When hermes upstream resolves
 [#25526](https://github.com/NousResearch/hermes-agent/issues/25526) and
@@ -20,7 +20,7 @@ MemoryProvider — the hooks plugin gracefully becomes redundant.
    ```bash
    cargo build --features rest
    mempal doctor rest
-   mempal serve   # starts MCP + REST on 127.0.0.1:3080
+   mempal serve   # starts MCP + REST on 127.0.0.1:3080 for local testing
    ```
    Or start the daemon (auto-starts REST when built with `rest` feature):
    ```bash
@@ -191,15 +191,23 @@ After allowlisted tool calls (bash, web_search, python, etc.), the `post_tool_ca
 
 These low-importance observations enrich future searches without cluttering high-priority memory.
 
-## Path 3: MCP server (full tool access)
+## Path 3: MCP server (debug-only full tool access)
 
-Register mempal's MCP server directly with hermes, giving the LLM access to
-**all** mempal tools (context, knowledge cards, timeline, kg, etc.) — far
-beyond the 3 tools the MemoryProvider interface allows.
+For routine Hermes use, prefer Path 1 (MemoryProvider) and Path 2 (hooks) against
+the daemon REST API. That path is daemon-owned, keeps automatic searches scoped,
+and does not create extra SQLite holders.
 
-### Setup
+Direct MCP registration gives the LLM access to **all** mempal tools (context,
+knowledge cards, timeline, kg, etc.), but it is currently a debug/admin path:
+long-lived stdio MCP servers can hold `palace.db` open, and Hermes HTTP MCP
+against the daemon `/mcp` endpoint is not treated as production-supported until
+that transport has dedicated coverage.
 
-Add to hermes `~/.hermes/config.yaml`:
+### Temporary stdio setup
+
+Only use this for a short debugging session, then remove it from
+`~/.hermes/config.yaml` so Hermes does not keep a second mempal server process
+alive:
 
 ```yaml
 mcp_servers:
@@ -207,15 +215,6 @@ mcp_servers:
     transport: stdio
     command: "mempal"
     args: ["mcp"]
-```
-
-Or if mempal runs as a daemon with REST+MCP:
-
-```yaml
-mcp_servers:
-  mempal:
-    transport: http
-    url: "http://127.0.0.1:3080/mcp"
 ```
 
 Hermes discovers all mempal MCP tools at startup and makes them available to

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -733,6 +733,7 @@ For daemon profiles, configure the REST address in `~/.mempal/config.toml`:
 [api]
 enabled = true
 addr = "127.0.0.1:3080"
+search_db_deadline_secs = 30
 ```
 
 If you run multiple mempal daemons, assign each profile a different loopback
@@ -740,10 +741,18 @@ port such as `127.0.0.1:3081`. `mempal doctor rest` reports whether the binary
 has REST support, whether the endpoint is reachable, which required routes are
 present, and which process owns the configured port when there is a collision.
 
+REST search runs inside the daemon process and uses the daemon-owned async
+database pool. Explicit full-corpus searches should use `scope=global` (or
+`scope=all_projects`) and remain bounded by `api.search_db_deadline_secs`: if a
+database stage exceeds the deadline, the response returns partial/fallback
+results with `mempal-warnings` and `search-mode` headers instead of hanging.
+Automatic hooks and Hermes provider prefetches should continue to pass
+project/profile filters and avoid implicit global searches.
+
 Endpoints:
 
 - `GET /api/status`
-- `GET /api/search?q=...&wing=...&room=...&top_k=...`
+- `GET /api/search?q=...&wing=...&room=...&top_k=...&scope=project|all_wings|project_plus_global|global|all_projects`
 - `POST /api/ingest`
 - `GET /api/taxonomy`
 - `GET /api/timeline`
@@ -754,6 +763,7 @@ Examples:
 ```bash
 curl 'http://127.0.0.1:3080/api/status'
 curl 'http://127.0.0.1:3080/api/search?q=clerk&wing=myapp'
+curl 'http://127.0.0.1:3080/api/search?q=Hermes+Agent+local+embedding&scope=global&top_k=10'
 curl -X POST 'http://127.0.0.1:3080/api/ingest' \
   -H 'content-type: application/json' \
   -d '{"content":"decided to use Clerk","wing":"myapp","room":"auth"}'

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -50,6 +50,7 @@ use super::state::{ApiState, SearchTelemetryOutcome, SearchTelemetrySnapshot};
 pub const DEFAULT_REST_ADDR: &str = "127.0.0.1:3080";
 const HERMES_COMPAT_VERSION: &str = "mempal-hermes-compat/1";
 const REST_SEARCH_WARNING_HEADER: &str = "mempal-warnings";
+const STATUS_DB_SNAPSHOT_DEADLINE: Duration = Duration::from_secs(1);
 
 pub async fn serve(listener: tokio::net::TcpListener, state: ApiState) -> std::io::Result<()> {
     serve_with_shutdown(listener, state, shutdown_signal()).await
@@ -1316,7 +1317,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
     let vector_search_circuit =
         VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let turns_config = config.turns.clone();
-    let db_deadline = Duration::from_secs(config.api.search_db_deadline_secs);
+    let db_deadline = STATUS_DB_SNAPSHOT_DEADLINE;
     let search_telemetry = state.search_telemetry().snapshot();
     let (db_snapshot, status_warnings) = match state
         .run_read_anyhow_bounded(

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -417,6 +417,8 @@ struct StatusResponse {
     source_type_distribution: Vec<SourceTypeCount>,
     turn_storage: TurnStorageStatus,
     search_telemetry: SearchTelemetrySnapshot,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    status_warnings: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -467,6 +469,7 @@ struct TurnStorageStatus {
     raw_turn_rooms: Vec<String>,
 }
 
+#[derive(Default)]
 struct StatusDbSnapshot {
     drawer_count: i64,
     taxonomy_count: i64,
@@ -1314,7 +1317,8 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let turns_config = config.turns.clone();
     let db_deadline = Duration::from_secs(config.api.search_db_deadline_secs);
-    let db_snapshot = state
+    let search_telemetry = state.search_telemetry().snapshot();
+    let (db_snapshot, status_warnings) = match state
         .run_read_anyhow_bounded(
             move |db| {
                 let drawer_count = db.drawer_count()?;
@@ -1350,13 +1354,20 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             db_deadline,
         )
         .await
-        .map_err(internal_error)?
-        .ok_or_else(|| {
-            ApiError::new(
-                StatusCode::GATEWAY_TIMEOUT,
-                rest_search_timeout_warning("status database snapshot", db_deadline),
-            )
-        })?;
+    {
+        Ok(Some(snapshot)) => (snapshot, Vec::new()),
+        Ok(None) => (
+            StatusDbSnapshot::default(),
+            vec![rest_search_timeout_warning(
+                "status database snapshot",
+                db_deadline,
+            )],
+        ),
+        Err(error) => (
+            StatusDbSnapshot::default(),
+            vec![status_database_snapshot_error_warning(error)],
+        ),
+    };
 
     Ok(Json(StatusResponse {
         drawer_count: db_snapshot.drawer_count,
@@ -1388,8 +1399,14 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             raw_turn_wings: config.turns.raw_turn_wings.clone(),
             raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
         },
-        search_telemetry: state.search_telemetry().snapshot(),
+        search_telemetry,
+        status_warnings,
     }))
+}
+
+fn status_database_snapshot_error_warning(error: impl std::fmt::Display) -> String {
+    let detail = crate::core::config::scrub_sensitive_text(&error.to_string());
+    format!("status database snapshot unavailable; returning partial status: {detail}")
 }
 
 fn current_embedding_status(snapshot: &crate::embed::EmbedHealthSnapshot) -> &'static str {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -5,7 +5,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use crate::core::{
@@ -36,7 +36,7 @@ use crate::search::{
 use axum::{
     Json, Router,
     extract::{Query, State},
-    http::{HeaderValue, Method, StatusCode, header::CONTENT_TYPE},
+    http::{HeaderMap, HeaderValue, Method, StatusCode, header::CONTENT_TYPE, header::USER_AGENT},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -45,10 +45,11 @@ use serde_json::json;
 use tokio::sync::{Notify, mpsc, oneshot};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
-use super::state::ApiState;
+use super::state::{ApiState, SearchTelemetryOutcome, SearchTelemetrySnapshot};
 
 pub const DEFAULT_REST_ADDR: &str = "127.0.0.1:3080";
 const HERMES_COMPAT_VERSION: &str = "mempal-hermes-compat/1";
+const REST_SEARCH_WARNING_HEADER: &str = "mempal-warnings";
 
 pub async fn serve(listener: tokio::net::TcpListener, state: ApiState) -> std::io::Result<()> {
     serve_with_shutdown(listener, state, shutdown_signal()).await
@@ -135,6 +136,7 @@ struct SearchQuery {
     wing: Option<String>,
     room: Option<String>,
     top_k: Option<usize>,
+    scope: Option<String>,
     project_id: Option<String>,
     include_global: Option<bool>,
     all_projects: Option<bool>,
@@ -414,6 +416,7 @@ struct StatusResponse {
     wings: Vec<ScopeCount>,
     source_type_distribution: Vec<SourceTypeCount>,
     turn_storage: TurnStorageStatus,
+    search_telemetry: SearchTelemetrySnapshot,
 }
 
 #[derive(Debug, Serialize)]
@@ -462,6 +465,15 @@ struct TurnStorageStatus {
     raw_turn_count: i64,
     raw_turn_wings: Vec<String>,
     raw_turn_rooms: Vec<String>,
+}
+
+struct StatusDbSnapshot {
+    drawer_count: i64,
+    taxonomy_count: i64,
+    db_size_bytes: u64,
+    wings: Vec<ScopeCount>,
+    source_type_distribution: Vec<SourceTypeCount>,
+    raw_turn_count: i64,
 }
 
 #[derive(Debug, Serialize)]
@@ -543,29 +555,150 @@ struct TaxonomyEntryDto {
     keywords: Vec<String>,
 }
 
+fn resolve_api_search_scope(
+    query: &SearchQuery,
+    config: &crate::core::config::Config,
+) -> Result<(ProjectSearchScope, String), ApiError> {
+    let mut include_global = query.include_global.unwrap_or(false);
+    let mut all_projects = query.all_projects.unwrap_or(false);
+    let explicit_scope = query
+        .scope
+        .as_deref()
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty());
+    match explicit_scope {
+        Some("global" | "all_projects") => {
+            all_projects = true;
+        }
+        Some("all_wings" | "project") => {
+            include_global = false;
+            all_projects = false;
+        }
+        Some("project_plus_global" | "project_global") => {
+            include_global = true;
+            all_projects = false;
+        }
+        Some(other) => {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "invalid scope: {other}; expected project, all_wings, project_plus_global, global, or all_projects"
+                ),
+            ));
+        }
+        None => {}
+    }
+    let resolved_project =
+        resolve_project_id(query.project_id.as_deref(), config, None).map_err(internal_error)?;
+    let scope = ProjectSearchScope::from_request(
+        resolved_project,
+        include_global,
+        all_projects,
+        config.search.strict_project_isolation,
+    );
+    let wing = query.wing.as_deref().unwrap_or("*");
+    let room = query.room.as_deref().unwrap_or("*");
+    let label = format!(
+        "scope={} project={} wing={} room={}",
+        explicit_scope.unwrap_or("legacy"),
+        scope.mode.as_sql_mode(),
+        wing,
+        room
+    );
+    Ok((scope, label))
+}
+
+fn rest_search_timeout_warning(stage: &str, deadline: Duration) -> String {
+    format!(
+        "{stage} deadline exceeded after {}s; returning partial/fallback search results",
+        deadline.as_secs()
+    )
+}
+
+fn search_client_from_headers(headers: &HeaderMap) -> String {
+    headers
+        .get(USER_AGENT)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("rest:{value}"))
+        .unwrap_or_else(|| "rest:unknown".to_string())
+}
+
+fn attach_search_headers(response: &mut Response, search_mode: SearchMode, warnings: &[String]) {
+    response.headers_mut().insert(
+        "search-mode",
+        HeaderValue::from_static(search_mode.as_str()),
+    );
+    if search_mode == SearchMode::Bm25Only {
+        response
+            .headers_mut()
+            .insert("degraded", HeaderValue::from_static("true"));
+    }
+    if !warnings.is_empty()
+        && let Ok(value) = HeaderValue::from_str(&warnings.join(" | "))
+    {
+        response
+            .headers_mut()
+            .insert(REST_SEARCH_WARNING_HEADER, value);
+    }
+}
+
+async fn run_rest_bm25_search_bounded(
+    state: &ApiState,
+    query: String,
+    route: RouteDecision,
+    scope: ProjectSearchScope,
+    search_options: SearchOptions,
+    top_k: usize,
+    deadline: Duration,
+) -> anyhow::Result<Option<crate::search::Result<Vec<SearchResult>>>> {
+    state
+        .run_read_anyhow_bounded(
+            move |db| {
+                Ok(search_bm25_only_with_options(
+                    db,
+                    &query,
+                    route,
+                    &scope,
+                    search_options,
+                    top_k,
+                ))
+            },
+            deadline,
+        )
+        .await
+}
+
 async fn search_handler(
     State(state): State<ApiState>,
+    headers: HeaderMap,
     Query(query): Query<SearchQuery>,
 ) -> Result<Response, ApiError> {
     let config = ConfigHandle::current();
-    let scope = ProjectSearchScope::from_request(
-        resolve_project_id(query.project_id.as_deref(), config.as_ref(), None)
-            .map_err(internal_error)?,
-        query.include_global.unwrap_or(false),
-        query.all_projects.unwrap_or(false),
-        config.search.strict_project_isolation,
-    );
+    let (scope, scope_label) = resolve_api_search_scope(&query, config.as_ref())?;
     let search_options = SearchOptions {
         include_raw_turns: query.include_raw_turns.unwrap_or(false),
         include_expired: query.include_expired.unwrap_or(false),
         ..SearchOptions::default()
     };
     let top_k = query.top_k.unwrap_or(10);
+    let db_deadline = Duration::from_secs(config.api.search_db_deadline_secs);
+    let telemetry = state.search_telemetry().start(
+        search_client_from_headers(&headers),
+        scope_label,
+        top_k,
+        db_deadline,
+    );
     let embed_snapshot = crate::embed::global_embed_status().snapshot();
     let vector_search_circuit =
         VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let mut search_mode = SearchMode::Hybrid;
     let mut warnings = Vec::new();
+    let mut partial = false;
+    let route_elapsed;
+    let mut embed_elapsed = Duration::ZERO;
+    let mut db_elapsed = Duration::ZERO;
     let query_vector = if vector_search_circuit.bm25_fallback_enabled && vector_search_circuit.open
     {
         search_mode = SearchMode::Bm25Only;
@@ -574,6 +707,8 @@ async fn search_handler(
         ));
         None
     } else {
+        telemetry.set_stage("embedding");
+        let embed_started = Instant::now();
         match state.embedder_factory.build().await {
             Ok(embedder) => match tokio::time::timeout(
                 Duration::from_secs(vector_search_circuit.search_deadline_secs),
@@ -581,30 +716,38 @@ async fn search_handler(
             )
             .await
             {
-                Ok(Ok(vectors)) => match vectors.into_iter().next() {
-                    Some(vector) => Some(vector),
-                    None if vector_search_circuit.bm25_fallback_enabled => {
-                        search_mode = SearchMode::Bm25Only;
-                        warnings.push(bm25_fallback_warning_missing_query_vector());
-                        None
+                Ok(Ok(vectors)) => {
+                    embed_elapsed = embed_started.elapsed();
+                    match vectors.into_iter().next() {
+                        Some(vector) => Some(vector),
+                        None if vector_search_circuit.bm25_fallback_enabled => {
+                            search_mode = SearchMode::Bm25Only;
+                            warnings.push(bm25_fallback_warning_missing_query_vector());
+                            None
+                        }
+                        None => {
+                            return Err(ApiError::new(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "embedder returned no vector",
+                            ));
+                        }
                     }
-                    None => {
-                        return Err(ApiError::new(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "embedder returned no vector",
-                        ));
-                    }
-                },
+                }
                 Ok(Err(error)) if vector_search_circuit.bm25_fallback_enabled => {
+                    embed_elapsed = embed_started.elapsed();
                     search_mode = SearchMode::Bm25Only;
                     warnings.push(bm25_fallback_warning_embed_error(
                         &crate::core::config::scrub_sensitive_text(&error.to_string()),
                     ));
                     None
                 }
-                Ok(Err(error)) => return Err(internal_error(error)),
+                Ok(Err(error)) => {
+                    return Err(internal_error(error));
+                }
                 Err(_) if vector_search_circuit.bm25_fallback_enabled => {
+                    embed_elapsed = embed_started.elapsed();
                     search_mode = SearchMode::Bm25Only;
+                    partial = true;
                     warnings.push(bm25_fallback_warning_timeout(
                         vector_search_circuit.search_deadline_secs,
                     ));
@@ -618,50 +761,215 @@ async fn search_handler(
                 }
             },
             Err(error) if vector_search_circuit.bm25_fallback_enabled => {
+                embed_elapsed = embed_started.elapsed();
                 search_mode = SearchMode::Bm25Only;
                 warnings.push(bm25_fallback_warning_embed_error(
                     &crate::core::config::scrub_sensitive_text(&error.to_string()),
                 ));
                 None
             }
-            Err(error) => return Err(internal_error(error)),
+            Err(error) => {
+                return Err(internal_error(error));
+            }
         }
     };
-    let db = Database::open(&state.db_path).map_err(internal_error)?;
-    let route = resolve_route(&db, &query.q, query.wing.as_deref(), query.room.as_deref())
-        .map_err(internal_error)?;
+
+    telemetry.set_stage("routing");
+    let route_started = Instant::now();
+    let fallback_route = RouteDecision {
+        wing: query.wing.clone(),
+        room: query.room.clone(),
+        confidence: if query.wing.is_some() || query.room.is_some() {
+            1.0
+        } else {
+            0.0
+        },
+        reason: "bounded REST fallback: route resolution timed out".to_string(),
+    };
+    let route_query = query.q.clone();
+    let route_wing = query.wing.clone();
+    let route_room = query.room.clone();
+    let route = match state
+        .run_read_anyhow_bounded(
+            move |db| {
+                Ok(resolve_route(
+                    db,
+                    &route_query,
+                    route_wing.as_deref(),
+                    route_room.as_deref(),
+                ))
+            },
+            db_deadline,
+        )
+        .await
+    {
+        Ok(Some(Ok(route))) => {
+            route_elapsed = route_started.elapsed();
+            route
+        }
+        Ok(Some(Err(error))) => return Err(internal_error(error)),
+        Ok(None) => {
+            route_elapsed = route_started.elapsed();
+            partial = true;
+            warnings.push(rest_search_timeout_warning("route resolution", db_deadline));
+            fallback_route
+        }
+        Err(error) => return Err(internal_error(error)),
+    };
+
     let results = if let Some(query_vector) = query_vector {
-        match search_with_vector_and_scope_options(
-            &db,
-            &query.q,
-            &query_vector,
-            route.clone(),
-            &scope,
-            search_options.clone(),
-            top_k,
-        ) {
-            Ok(results) => results,
-            Err(crate::search::SearchError::VectorDimensionMismatch {
+        telemetry.set_stage("hybrid_db");
+        let search_started = Instant::now();
+        let hybrid_query = query.q.clone();
+        let hybrid_route = route.clone();
+        let hybrid_scope = scope.clone();
+        let hybrid_options = search_options.clone();
+        match state
+            .run_read_anyhow_bounded(
+                move |db| {
+                    Ok(search_with_vector_and_scope_options(
+                        db,
+                        &hybrid_query,
+                        &query_vector,
+                        hybrid_route,
+                        &hybrid_scope,
+                        hybrid_options,
+                        top_k,
+                    ))
+                },
+                db_deadline,
+            )
+            .await
+        {
+            Ok(Some(Ok(results))) => {
+                db_elapsed += search_started.elapsed();
+                results
+            }
+            Ok(Some(Err(crate::search::SearchError::VectorDimensionMismatch {
                 current_dim,
                 new_dim,
-            }) if vector_search_circuit.bm25_fallback_enabled => {
+            }))) if vector_search_circuit.bm25_fallback_enabled => {
+                db_elapsed += search_started.elapsed();
                 search_mode = SearchMode::Bm25Only;
                 warnings.push(bm25_fallback_warning_dimension_mismatch(
                     new_dim,
                     current_dim,
                 ));
-                search_bm25_only_with_options(&db, &query.q, route, &scope, search_options, top_k)
-                    .map_err(internal_error)?
+                telemetry.set_stage("bm25_fallback_db");
+                let bm25_started = Instant::now();
+                match run_rest_bm25_search_bounded(
+                    &state,
+                    query.q.clone(),
+                    route,
+                    scope,
+                    search_options,
+                    top_k,
+                    db_deadline,
+                )
+                .await
+                {
+                    Ok(Some(Ok(results))) => {
+                        db_elapsed += bm25_started.elapsed();
+                        results
+                    }
+                    Ok(Some(Err(error))) => return Err(internal_error(error)),
+                    Ok(None) => {
+                        db_elapsed += bm25_started.elapsed();
+                        partial = true;
+                        warnings.push(rest_search_timeout_warning("BM25 fallback", db_deadline));
+                        Vec::new()
+                    }
+                    Err(error) => return Err(internal_error(error)),
+                }
+            }
+            Ok(Some(Err(error))) => return Err(internal_error(error)),
+            Ok(None) if vector_search_circuit.bm25_fallback_enabled => {
+                db_elapsed += search_started.elapsed();
+                search_mode = SearchMode::Bm25Only;
+                partial = true;
+                warnings.push(rest_search_timeout_warning("hybrid search", db_deadline));
+                telemetry.set_stage("bm25_fallback_db");
+                let bm25_started = Instant::now();
+                match run_rest_bm25_search_bounded(
+                    &state,
+                    query.q.clone(),
+                    route,
+                    scope,
+                    search_options,
+                    top_k,
+                    db_deadline,
+                )
+                .await
+                {
+                    Ok(Some(Ok(results))) => {
+                        db_elapsed += bm25_started.elapsed();
+                        results
+                    }
+                    Ok(Some(Err(error))) => return Err(internal_error(error)),
+                    Ok(None) => {
+                        db_elapsed += bm25_started.elapsed();
+                        warnings.push(rest_search_timeout_warning("BM25 fallback", db_deadline));
+                        Vec::new()
+                    }
+                    Err(error) => return Err(internal_error(error)),
+                }
+            }
+            Ok(None) => {
+                db_elapsed += search_started.elapsed();
+                return Err(ApiError::new(
+                    StatusCode::GATEWAY_TIMEOUT,
+                    rest_search_timeout_warning("hybrid search", db_deadline),
+                ));
             }
             Err(error) => return Err(internal_error(error)),
         }
     } else {
-        search_bm25_only_with_options(&db, &query.q, route, &scope, search_options, top_k)
-            .map_err(internal_error)?
+        telemetry.set_stage("bm25_db");
+        let bm25_started = Instant::now();
+        match run_rest_bm25_search_bounded(
+            &state,
+            query.q.clone(),
+            route,
+            scope,
+            search_options,
+            top_k,
+            db_deadline,
+        )
+        .await
+        {
+            Ok(Some(Ok(results))) => {
+                db_elapsed += bm25_started.elapsed();
+                results
+            }
+            Ok(Some(Err(error))) => return Err(internal_error(error)),
+            Ok(None) => {
+                db_elapsed += bm25_started.elapsed();
+                partial = true;
+                warnings.push(rest_search_timeout_warning("BM25 search", db_deadline));
+                Vec::new()
+            }
+            Err(error) => return Err(internal_error(error)),
+        }
     };
+    telemetry.set_stage("rerank");
+    let rerank_started = Instant::now();
     let rerank_outcome = maybe_rerank_search_results(&query.q, results).await;
+    let rerank_elapsed = rerank_started.elapsed();
     warnings.extend(rerank_outcome.warnings);
     let results = rerank_outcome.results;
+
+    let result_count = results.len();
+    telemetry.finish(SearchTelemetryOutcome {
+        search_mode: search_mode.as_str().to_string(),
+        route: route_elapsed,
+        embed: embed_elapsed,
+        db: db_elapsed,
+        rerank: rerank_elapsed,
+        lock_wait: Duration::ZERO,
+        result_count,
+        warning_count: warnings.len(),
+        partial,
+    });
 
     let mut response = Json(
         results
@@ -670,15 +978,7 @@ async fn search_handler(
             .collect::<Vec<_>>(),
     )
     .into_response();
-    response.headers_mut().insert(
-        "search-mode",
-        HeaderValue::from_static(search_mode.as_str()),
-    );
-    if search_mode == SearchMode::Bm25Only {
-        response
-            .headers_mut()
-            .insert("degraded", HeaderValue::from_static("true"));
-    }
+    attach_search_headers(&mut response, search_mode, &warnings);
     Ok(response)
 }
 
@@ -1008,39 +1308,60 @@ async fn taxonomy_handler(
 }
 
 async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResponse>, ApiError> {
-    let db = Database::open(&state.db_path).map_err(internal_error)?;
-    let drawer_count = db.drawer_count().map_err(internal_error)?;
     let config = ConfigHandle::current();
     let embed_snapshot = crate::embed::global_embed_status().snapshot();
     let vector_search_circuit =
         VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
-    let raw_turn_count = count_raw_turn_drawers(&db, &config.turns).map_err(internal_error)?;
-    let taxonomy_count = db.taxonomy_count().map_err(internal_error)?;
-    let db_size_bytes = db.database_size_bytes().map_err(internal_error)?;
-    let wings = db
-        .scope_counts()
+    let turns_config = config.turns.clone();
+    let db_deadline = Duration::from_secs(config.api.search_db_deadline_secs);
+    let db_snapshot = state
+        .run_read_anyhow_bounded(
+            move |db| {
+                let drawer_count = db.drawer_count()?;
+                let raw_turn_count = count_raw_turn_drawers(db, &turns_config)?;
+                let taxonomy_count = db.taxonomy_count()?;
+                let db_size_bytes = db.database_size_bytes()?;
+                let wings = db
+                    .scope_counts()?
+                    .into_iter()
+                    .map(|(wing, room, drawer_count)| ScopeCount {
+                        wing,
+                        room,
+                        drawer_count,
+                    })
+                    .collect();
+                let source_type_distribution = db
+                    .source_type_counts()?
+                    .into_iter()
+                    .map(|(source_type, count)| SourceTypeCount {
+                        source_type: source_type.to_string(),
+                        count,
+                    })
+                    .collect();
+                Ok(StatusDbSnapshot {
+                    drawer_count,
+                    taxonomy_count,
+                    db_size_bytes,
+                    wings,
+                    source_type_distribution,
+                    raw_turn_count,
+                })
+            },
+            db_deadline,
+        )
+        .await
         .map_err(internal_error)?
-        .into_iter()
-        .map(|(wing, room, drawer_count)| ScopeCount {
-            wing,
-            room,
-            drawer_count,
-        })
-        .collect();
-    let source_type_distribution = db
-        .source_type_counts()
-        .map_err(internal_error)?
-        .into_iter()
-        .map(|(source_type, count)| SourceTypeCount {
-            source_type: source_type.to_string(),
-            count,
-        })
-        .collect();
+        .ok_or_else(|| {
+            ApiError::new(
+                StatusCode::GATEWAY_TIMEOUT,
+                rest_search_timeout_warning("status database snapshot", db_deadline),
+            )
+        })?;
 
     Ok(Json(StatusResponse {
-        drawer_count,
-        taxonomy_count,
-        db_size_bytes,
+        drawer_count: db_snapshot.drawer_count,
+        taxonomy_count: db_snapshot.taxonomy_count,
+        db_size_bytes: db_snapshot.db_size_bytes,
         embedding_status: current_embedding_status(&embed_snapshot).to_string(),
         search_mode: vector_search_circuit
             .vector_search_mode
@@ -1058,15 +1379,16 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         },
         hermes_compat_version: HERMES_COMPAT_VERSION.to_string(),
         search_decay_mode: config.search.decay.mode.to_string(),
-        wings,
-        source_type_distribution,
+        wings: db_snapshot.wings,
+        source_type_distribution: db_snapshot.source_type_distribution,
         turn_storage: TurnStorageStatus {
             storage_mode: config.turns.storage_mode.to_string(),
             default_importance: config.turns.default_importance,
-            raw_turn_count,
+            raw_turn_count: db_snapshot.raw_turn_count,
             raw_turn_wings: config.turns.raw_turn_wings.clone(),
             raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
         },
+        search_telemetry: state.search_telemetry().snapshot(),
     }))
 }
 

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -1,15 +1,25 @@
+use std::collections::{BTreeMap, VecDeque};
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::core::config::ConfigHandle;
+use crate::core::{AsyncDb, config::ConfigHandle, db::DbError};
 use crate::embed::EmbedderFactory;
+use serde::Serialize;
+use tokio::sync::OnceCell;
+
+const API_ASYNC_DB_READERS: usize = 4;
+const MAX_SLOW_SEARCHES: usize = 10;
+const SLOW_SEARCH_THRESHOLD: Duration = Duration::from_secs(1);
 
 #[derive(Clone)]
 pub struct ApiState {
     pub db_path: PathBuf,
     pub embedder_factory: Arc<dyn EmbedderFactory>,
+    async_db: Arc<OnceCell<AsyncDb>>,
     write_queue: Arc<super::handlers::WriteQueue>,
+    search_telemetry: Arc<SearchTelemetry>,
 }
 
 impl ApiState {
@@ -38,7 +48,9 @@ impl ApiState {
         Self {
             db_path,
             embedder_factory,
+            async_db: Arc::new(OnceCell::new()),
             write_queue,
+            search_telemetry: Arc::new(SearchTelemetry::default()),
         }
     }
 
@@ -46,7 +58,274 @@ impl ApiState {
         &self.write_queue
     }
 
+    pub(crate) async fn async_db(&self) -> Result<AsyncDb, DbError> {
+        let db_path = self.db_path.clone();
+        self.async_db
+            .get_or_try_init(|| async move { AsyncDb::open(&db_path, API_ASYNC_DB_READERS) })
+            .await
+            .cloned()
+    }
+
+    pub(crate) async fn run_read_anyhow_bounded<F, R>(
+        &self,
+        f: F,
+        deadline: Duration,
+    ) -> anyhow::Result<Option<R>>
+    where
+        F: FnOnce(&crate::core::db::Database) -> anyhow::Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        let async_db = self.async_db().await?;
+        match tokio::time::timeout(deadline, async_db.run_read_anyhow(f)).await {
+            Ok(result) => result.map(Some),
+            Err(_) => Ok(None),
+        }
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_async_db_for_test(mut self, async_db: AsyncDb) -> Self {
+        let cell = Arc::new(OnceCell::new());
+        debug_assert!(cell.set(async_db).is_ok());
+        self.async_db = cell;
+        self
+    }
+
+    pub(crate) fn search_telemetry(&self) -> &Arc<SearchTelemetry> {
+        &self.search_telemetry
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn search_telemetry_snapshot_for_test(&self) -> SearchTelemetrySnapshot {
+        self.search_telemetry.snapshot()
+    }
+
     pub async fn drain_write_queue(&self) -> bool {
         self.write_queue.drain().await
     }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchTelemetrySnapshot {
+    pub active_count: usize,
+    pub active_searches: Vec<ActiveSearchSnapshot>,
+    pub slow_queries: Vec<SlowSearchSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ActiveSearchSnapshot {
+    pub id: u64,
+    pub client: String,
+    pub scope: String,
+    pub top_k: usize,
+    pub stage: String,
+    pub started_at_unix_ms: u64,
+    pub elapsed_ms: u64,
+    pub deadline_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SlowSearchSnapshot {
+    pub id: u64,
+    pub client: String,
+    pub scope: String,
+    pub top_k: usize,
+    pub search_mode: String,
+    pub elapsed_ms: u64,
+    pub deadline_ms: u64,
+    pub route_ms: u64,
+    pub embed_ms: u64,
+    pub db_ms: u64,
+    pub rerank_ms: u64,
+    pub lock_wait_ms: u64,
+    pub result_count: usize,
+    pub warning_count: usize,
+    pub partial: bool,
+    pub completed_at_unix_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ActiveSearch {
+    id: u64,
+    client: String,
+    scope: String,
+    top_k: usize,
+    stage: String,
+    started_at_unix_ms: u64,
+    started_at: Instant,
+    deadline_ms: u64,
+}
+
+#[derive(Default)]
+pub(crate) struct SearchTelemetry {
+    next_id: AtomicU64,
+    active: Mutex<BTreeMap<u64, ActiveSearch>>,
+    slow_queries: Mutex<VecDeque<SlowSearchSnapshot>>,
+}
+
+impl SearchTelemetry {
+    pub(crate) fn start(
+        self: &Arc<Self>,
+        client: String,
+        scope: String,
+        top_k: usize,
+        deadline: Duration,
+    ) -> SearchTelemetryGuard {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed) + 1;
+        let search = ActiveSearch {
+            id,
+            client,
+            scope,
+            top_k,
+            stage: "queued".to_string(),
+            started_at_unix_ms: unix_ms_now(),
+            started_at: Instant::now(),
+            deadline_ms: duration_ms(deadline),
+        };
+        self.active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(id, search);
+        SearchTelemetryGuard {
+            telemetry: Arc::clone(self),
+            id,
+            finished: false,
+        }
+    }
+
+    fn set_stage(&self, id: u64, stage: &str) {
+        if let Some(search) = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get_mut(&id)
+        {
+            search.stage = stage.to_string();
+        }
+    }
+
+    fn finish(&self, id: u64, outcome: SearchTelemetryOutcome) {
+        let Some(active) = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&id)
+        else {
+            return;
+        };
+        let elapsed_ms = duration_ms(active.started_at.elapsed());
+        if active.started_at.elapsed() < SLOW_SEARCH_THRESHOLD && !outcome.partial {
+            return;
+        }
+        let snapshot = SlowSearchSnapshot {
+            id: active.id,
+            client: active.client,
+            scope: active.scope,
+            top_k: active.top_k,
+            search_mode: outcome.search_mode,
+            elapsed_ms,
+            deadline_ms: active.deadline_ms,
+            route_ms: duration_ms(outcome.route),
+            embed_ms: duration_ms(outcome.embed),
+            db_ms: duration_ms(outcome.db),
+            rerank_ms: duration_ms(outcome.rerank),
+            lock_wait_ms: duration_ms(outcome.lock_wait),
+            result_count: outcome.result_count,
+            warning_count: outcome.warning_count,
+            partial: outcome.partial,
+            completed_at_unix_ms: unix_ms_now(),
+        };
+        let mut slow_queries = self
+            .slow_queries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        slow_queries.push_front(snapshot);
+        slow_queries.truncate(MAX_SLOW_SEARCHES);
+    }
+
+    fn remove_active(&self, id: u64) {
+        self.active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&id);
+    }
+
+    pub(crate) fn snapshot(&self) -> SearchTelemetrySnapshot {
+        let active_searches = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .map(|search| ActiveSearchSnapshot {
+                id: search.id,
+                client: search.client.clone(),
+                scope: search.scope.clone(),
+                top_k: search.top_k,
+                stage: search.stage.clone(),
+                started_at_unix_ms: search.started_at_unix_ms,
+                elapsed_ms: duration_ms(search.started_at.elapsed()),
+                deadline_ms: search.deadline_ms,
+            })
+            .collect::<Vec<_>>();
+        let slow_queries = self
+            .slow_queries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        SearchTelemetrySnapshot {
+            active_count: active_searches.len(),
+            active_searches,
+            slow_queries,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SearchTelemetryOutcome {
+    pub search_mode: String,
+    pub route: Duration,
+    pub embed: Duration,
+    pub db: Duration,
+    pub rerank: Duration,
+    pub lock_wait: Duration,
+    pub result_count: usize,
+    pub warning_count: usize,
+    pub partial: bool,
+}
+
+pub(crate) struct SearchTelemetryGuard {
+    telemetry: Arc<SearchTelemetry>,
+    id: u64,
+    finished: bool,
+}
+
+impl SearchTelemetryGuard {
+    pub(crate) fn set_stage(&self, stage: &str) {
+        self.telemetry.set_stage(self.id, stage);
+    }
+
+    pub(crate) fn finish(mut self, outcome: SearchTelemetryOutcome) {
+        self.telemetry.finish(self.id, outcome);
+        self.finished = true;
+    }
+}
+
+impl Drop for SearchTelemetryGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.telemetry.remove_active(self.id);
+        }
+    }
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn unix_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(duration_ms)
+        .unwrap_or(0)
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -53,6 +53,7 @@ const DEFAULT_SESSION_REVIEW_MIN_LENGTH: usize = 100;
 const DEFAULT_SESSION_REVIEW_TRAILING_MESSAGES: usize = 1;
 const DEFAULT_API_WRITE_QUEUE_CAPACITY: usize = 1_000;
 const DEFAULT_API_WRITE_DRAIN_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_API_SEARCH_DB_DEADLINE_SECS: u64 = 30;
 const DEFAULT_HOTPATCH_MIN_IMPORTANCE_STARS: i32 = 4;
 const DEFAULT_HOTPATCH_MAX_SUGGESTION_LENGTH: usize = 80;
 const DEFAULT_IMPORTANCE_DECAY_RATE: f64 = 0.01;
@@ -327,6 +328,11 @@ impl Config {
         if self.api.write_drain_timeout_secs == 0 {
             return Err(ConfigError::InvalidConfig(
                 "api.write_drain_timeout_secs must be greater than 0".to_string(),
+            ));
+        }
+        if self.api.search_db_deadline_secs == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "api.search_db_deadline_secs must be greater than 0".to_string(),
             ));
         }
         if !(0..=5).contains(&self.turns.default_importance) {
@@ -1001,6 +1007,9 @@ pub struct ApiConfig {
     pub write_queue_capacity: usize,
     /// Maximum time to wait for queued REST writes during graceful shutdown.
     pub write_drain_timeout_secs: u64,
+    /// Maximum time a REST search may spend in synchronous database work before
+    /// returning a partial/fallback response.
+    pub search_db_deadline_secs: u64,
 }
 
 impl Default for ApiConfig {
@@ -1010,6 +1019,7 @@ impl Default for ApiConfig {
             addr: "127.0.0.1:3080".to_string(),
             write_queue_capacity: DEFAULT_API_WRITE_QUEUE_CAPACITY,
             write_drain_timeout_secs: DEFAULT_API_WRITE_DRAIN_TIMEOUT_SECS,
+            search_db_deadline_secs: DEFAULT_API_SEARCH_DB_DEADLINE_SECS,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11930,8 +11930,105 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
     }
     let db_holders = mempal::process_diagnostics::inspect_db_holders(db_path);
     print_db_holder_report("db_holders", &db_holders, "");
+    #[cfg(feature = "rest")]
+    if let Ok(config) = Config::load()
+        && config.api.enabled
+        && let Ok(Some(telemetry)) =
+            block_on_result(fetch_daemon_search_telemetry(&config.api.addr))
+    {
+        print_daemon_search_telemetry(&telemetry);
+    }
     Ok(())
 }
+
+#[cfg(feature = "rest")]
+async fn fetch_daemon_search_telemetry(addr: &str) -> Result<Option<Value>> {
+    let endpoint = normalize_rest_endpoint(addr);
+    let url = format!("{endpoint}/api/status");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(2))
+        .build()
+        .context("failed to build REST status client")?;
+    let response = match client.get(url).send().await {
+        Ok(response) => response,
+        Err(_) => return Ok(None),
+    };
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    let body = response
+        .json::<Value>()
+        .await
+        .context("failed to parse REST status JSON")?;
+    Ok(body.get("search_telemetry").cloned())
+}
+
+#[cfg(feature = "rest")]
+fn normalize_rest_endpoint(endpoint: &str) -> String {
+    let trimmed = endpoint.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    }
+}
+
+#[cfg(feature = "rest")]
+fn print_daemon_search_telemetry(telemetry: &Value) {
+    println!(
+        "search.active: {}",
+        telemetry
+            .get("active_count")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+    );
+    if let Some(active_searches) = telemetry.get("active_searches").and_then(Value::as_array) {
+        for item in active_searches {
+            println!(
+                "search.active_search: id={} client={} scope={} stage={} elapsed_ms={} deadline_ms={}",
+                json_u64(item, "id"),
+                json_str(item, "client"),
+                json_str(item, "scope"),
+                json_str(item, "stage"),
+                json_u64(item, "elapsed_ms"),
+                json_u64(item, "deadline_ms")
+            );
+        }
+    }
+    if let Some(slow_queries) = telemetry.get("slow_queries").and_then(Value::as_array) {
+        for item in slow_queries.iter().take(5) {
+            println!(
+                "search.slow_query: id={} client={} scope={} mode={} elapsed_ms={} db_ms={} route_ms={} embed_ms={} rerank_ms={} lock_wait_ms={} results={} warnings={} partial={}",
+                json_u64(item, "id"),
+                json_str(item, "client"),
+                json_str(item, "scope"),
+                json_str(item, "search_mode"),
+                json_u64(item, "elapsed_ms"),
+                json_u64(item, "db_ms"),
+                json_u64(item, "route_ms"),
+                json_u64(item, "embed_ms"),
+                json_u64(item, "rerank_ms"),
+                json_u64(item, "lock_wait_ms"),
+                json_u64(item, "result_count"),
+                json_u64(item, "warning_count"),
+                item.get("partial")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            );
+        }
+    }
+}
+
+#[cfg(feature = "rest")]
+fn json_str<'a>(value: &'a Value, key: &str) -> &'a str {
+    value.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+#[cfg(feature = "rest")]
+fn json_u64(value: &Value, key: &str) -> u64 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0)
+}
+
 fn prime_embedder_degraded() -> bool {
     if std::env::var_os("MEMPAL_TEST_EMBED_DEGRADED").is_some() {
         return true;

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -268,6 +268,20 @@ fn insert_search_drawer(db: &Database) {
     db.insert_drawer(&drawer).expect("insert drawer");
 }
 
+#[cfg(feature = "db-test-seam")]
+async fn wait_for_active_searches(state: &ApiState, expected: usize) {
+    let mut latest_active_count = 0;
+    for _ in 0..100 {
+        let telemetry = state.search_telemetry_snapshot_for_test();
+        latest_active_count = telemetry.active_count;
+        if latest_active_count >= expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("expected at least {expected} active searches, saw {latest_active_count}");
+}
+
 #[tokio::test]
 async fn test_shutdown_drain_completes_pending() {
     let _guard = TEST_LOCK.lock().await;
@@ -541,6 +555,74 @@ async fn test_search_db_deadline_returns_partial_warning_and_telemetry() {
     assert_eq!(telemetry.slow_queries[0].warning_count, 3);
 }
 
+#[cfg(feature = "db-test-seam")]
+#[tokio::test]
+async fn test_status_returns_telemetry_when_search_db_pool_is_saturated() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new_with_api_search_deadline_secs(1);
+    insert_search_drawer(&env.db());
+    let async_db = AsyncDb::open(&env.db_path, 4)
+        .expect("open async db")
+        .with_read_delay(Duration::from_secs(5));
+    let state = env
+        .state(Arc::new(FailingEmbedderFactory))
+        .with_async_db_for_test(async_db);
+
+    let mut requests = Vec::new();
+    for _ in 0..4 {
+        let request_state = state.clone();
+        requests.push(tokio::spawn(async move {
+            get_json(request_state, "/api/search?q=alpha&scope=global&top_k=5").await
+        }));
+    }
+    wait_for_active_searches(&state, 4).await;
+
+    let (status, _headers, body) = get_json(state.clone(), "/api/status").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["drawer_count"].as_i64(), Some(0));
+    assert_eq!(body["taxonomy_count"].as_i64(), Some(0));
+    assert_eq!(body["db_size_bytes"].as_u64(), Some(0));
+    assert_eq!(body["turn_storage"]["raw_turn_count"].as_i64(), Some(0));
+    assert!(
+        body["wings"].as_array().expect("wings").is_empty(),
+        "partial status should not report stale scope counts"
+    );
+    assert!(
+        body["source_type_distribution"]
+            .as_array()
+            .expect("source type distribution")
+            .is_empty(),
+        "partial status should not report stale source counts"
+    );
+    let warnings = body["status_warnings"].as_array().expect("status warnings");
+    assert_eq!(warnings.len(), 1);
+    let warning = warnings[0].as_str().expect("status warning");
+    assert!(
+        warning.contains("status database snapshot deadline exceeded after 1s"),
+        "warning={warning}"
+    );
+    assert!(
+        !warning.contains("alpha"),
+        "status warning must not leak query text: {warning}"
+    );
+    let telemetry = body["search_telemetry"]
+        .as_object()
+        .expect("search telemetry");
+    assert!(
+        telemetry
+            .get("active_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|count| count >= 4),
+        "search telemetry={telemetry:#?}"
+    );
+
+    for request in requests {
+        request.abort();
+        let _ = request.await;
+    }
+}
+
 #[tokio::test]
 async fn test_feature_flags_in_status() {
     let _guard = TEST_LOCK.lock().await;
@@ -566,6 +648,7 @@ async fn test_feature_flags_in_status() {
     assert_eq!(queue.get("pending").and_then(Value::as_u64), Some(0));
     assert!(queue.contains_key("completed"));
     assert!(queue.contains_key("failed"));
+    assert!(body.get("status_warnings").is_none());
 }
 
 #[tokio::test]

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -282,6 +282,24 @@ async fn wait_for_active_searches(state: &ApiState, expected: usize) {
     panic!("expected at least {expected} active searches, saw {latest_active_count}");
 }
 
+#[cfg(feature = "db-test-seam")]
+async fn wait_for_active_search_stage(state: &ApiState, expected: usize, stage: &str) {
+    let mut latest_stage_count = 0;
+    for _ in 0..100 {
+        let telemetry = state.search_telemetry_snapshot_for_test();
+        latest_stage_count = telemetry
+            .active_searches
+            .iter()
+            .filter(|search| search.stage == stage)
+            .count();
+        if latest_stage_count >= expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("expected at least {expected} active searches in {stage}, saw {latest_stage_count}");
+}
+
 #[tokio::test]
 async fn test_shutdown_drain_completes_pending() {
     let _guard = TEST_LOCK.lock().await;
@@ -559,7 +577,7 @@ async fn test_search_db_deadline_returns_partial_warning_and_telemetry() {
 #[tokio::test]
 async fn test_status_returns_telemetry_when_search_db_pool_is_saturated() {
     let _guard = TEST_LOCK.lock().await;
-    let env = TestEnv::new_with_api_search_deadline_secs(1);
+    let env = TestEnv::new();
     insert_search_drawer(&env.db());
     let async_db = AsyncDb::open(&env.db_path, 4)
         .expect("open async db")
@@ -576,8 +594,15 @@ async fn test_status_returns_telemetry_when_search_db_pool_is_saturated() {
         }));
     }
     wait_for_active_searches(&state, 4).await;
+    wait_for_active_search_stage(&state, 4, "routing").await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let (status, _headers, body) = get_json(state.clone(), "/api/status").await;
+    let (status, _headers, body) = tokio::time::timeout(
+        Duration::from_millis(1_800),
+        get_json(state.clone(), "/api/status"),
+    )
+    .await
+    .expect("status should return before daemon status 2s timeout");
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["drawer_count"].as_i64(), Some(0));
@@ -615,6 +640,18 @@ async fn test_status_returns_telemetry_when_search_db_pool_is_saturated() {
             .and_then(Value::as_u64)
             .is_some_and(|count| count >= 4),
         "search telemetry={telemetry:#?}"
+    );
+    let active_searches = telemetry["active_searches"]
+        .as_array()
+        .expect("active searches");
+    assert!(
+        active_searches.iter().all(|search| {
+            search
+                .get("deadline_ms")
+                .and_then(Value::as_u64)
+                .is_some_and(|deadline_ms| deadline_ms >= 30_000)
+        }),
+        "active searches should retain the configured search deadline: {active_searches:#?}"
     );
 
     for request in requests {

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -10,6 +10,8 @@ use async_trait::async_trait;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode, header::CONTENT_TYPE};
 use mempal::api::ApiState;
+#[cfg(feature = "db-test-seam")]
+use mempal::core::AsyncDb;
 use mempal::core::config::ConfigHandle;
 use mempal::core::db::Database;
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
@@ -30,6 +32,10 @@ struct TestEnv {
 
 impl TestEnv {
     fn new() -> Self {
+        Self::new_with_api_search_deadline_secs(30)
+    }
+
+    fn new_with_api_search_deadline_secs(api_search_deadline_secs: u64) -> Self {
         let tmp = TempDir::new().expect("tempdir");
         let mempal_home = tmp.path().join(".mempal");
         fs::create_dir_all(&mempal_home).expect("create mempal home");
@@ -58,6 +64,7 @@ block_writes_when_degraded = true
 [api]
 write_queue_capacity = 10
 write_drain_timeout_secs = 2
+search_db_deadline_secs = {api_search_deadline_secs}
 "#,
                 db_path.display()
             ),
@@ -199,14 +206,20 @@ impl Embedder for BlockingEmbedder {
 }
 
 async fn get_json(state: ApiState, uri: &str) -> (StatusCode, axum::http::HeaderMap, Value) {
+    get_json_with_user_agent(state, uri, None).await
+}
+
+async fn get_json_with_user_agent(
+    state: ApiState,
+    uri: &str,
+    user_agent: Option<&str>,
+) -> (StatusCode, axum::http::HeaderMap, Value) {
+    let mut request = Request::builder().method("GET").uri(uri);
+    if let Some(user_agent) = user_agent {
+        request = request.header("user-agent", user_agent);
+    }
     let response = mempal::api::router(state)
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri(uri)
-                .body(Body::empty())
-                .expect("build request"),
-        )
+        .oneshot(request.body(Body::empty()).expect("build request"))
         .await
         .expect("REST request");
     let status = response.status();
@@ -424,6 +437,108 @@ async fn test_search_deadline_warning_surfaces_timeout_reason() {
         results[0]["warnings"][0].as_str(),
         Some("embedding deadline exceeded after 5s; using BM25-only search (retry may help)")
     );
+}
+
+#[tokio::test]
+async fn test_status_exposes_active_search_client_telemetry() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    insert_search_drawer(&env.db());
+    let started = Arc::new(Notify::new());
+    let released = Arc::new(Notify::new());
+    let has_started = Arc::new(AtomicBool::new(false));
+    let state = env.state(Arc::new(BlockingEmbedderFactory {
+        started: Arc::clone(&started),
+        released: Arc::clone(&released),
+        has_started: Arc::clone(&has_started),
+    }));
+
+    let request = tokio::spawn({
+        let state = state.clone();
+        async move {
+            get_json_with_user_agent(
+                state,
+                "/api/search?q=alpha&scope=global&top_k=5",
+                Some("hermes-test"),
+            )
+            .await
+        }
+    });
+
+    while !has_started.load(Ordering::SeqCst) {
+        started.notified().await;
+    }
+
+    let (status, _headers, body) = get_json(state.clone(), "/api/status").await;
+    assert_eq!(status, StatusCode::OK);
+    let telemetry = body["search_telemetry"]
+        .as_object()
+        .expect("search telemetry");
+    assert_eq!(
+        telemetry.get("active_count").and_then(Value::as_u64),
+        Some(1)
+    );
+    let active = telemetry["active_searches"]
+        .as_array()
+        .expect("active searches");
+    assert_eq!(active[0]["client"].as_str(), Some("rest:hermes-test"));
+    assert_eq!(active[0]["stage"].as_str(), Some("embedding"));
+    assert!(
+        active[0]["scope"]
+            .as_str()
+            .expect("scope label")
+            .contains("scope=global")
+    );
+
+    request.abort();
+    assert!(
+        request
+            .await
+            .expect_err("search request should be cancelled")
+            .is_cancelled()
+    );
+    released.notify_waiters();
+}
+
+#[cfg(feature = "db-test-seam")]
+#[tokio::test]
+async fn test_search_db_deadline_returns_partial_warning_and_telemetry() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new_with_api_search_deadline_secs(1);
+    insert_search_drawer(&env.db());
+    let async_db = AsyncDb::open(&env.db_path, 4)
+        .expect("open async db")
+        .with_read_delay(Duration::from_millis(1_500));
+    let state = env
+        .state(Arc::new(FailingEmbedderFactory))
+        .with_async_db_for_test(async_db);
+
+    let (status, headers, body) =
+        get_json(state.clone(), "/api/search?q=alpha&scope=global&top_k=5").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        headers.get("search-mode").and_then(|v| v.to_str().ok()),
+        Some("bm25_only")
+    );
+    let warning = headers
+        .get("mempal-warnings")
+        .and_then(|v| v.to_str().ok())
+        .expect("warning header");
+    assert!(
+        warning.contains("deadline exceeded after 1s"),
+        "warning header={warning}"
+    );
+    assert!(body.as_array().expect("search response array").is_empty());
+
+    let telemetry = state.search_telemetry_snapshot_for_test();
+    assert!(
+        !telemetry.slow_queries.is_empty(),
+        "slow query telemetry missing: {telemetry:#?}"
+    );
+    assert!(telemetry.slow_queries[0].partial);
+    assert_eq!(telemetry.slow_queries[0].search_mode, "bm25_only");
+    assert_eq!(telemetry.slow_queries[0].warning_count, 3);
 }
 
 #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "d838d92472970d46b627790b6c063bab7995f1a1"
+commit = "3525cea17b7c19038cfc08ef34ddb04d4d37668f"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Adds daemon-owned REST search safeguards so `/api/search` uses the daemon's async DB path with bounded database-stage deadlines and warning/partial fallback semantics for explicit broad/global search.
- Exposes sanitized search telemetry through `/api/status` and `mempal daemon status` so active/slow searches can be diagnosed without leaking query text.
- Keeps `/api/status` responsive under saturated search DB reads by returning telemetry plus partial/default DB counters and warnings instead of timing out before diagnostics are visible.
- Documents Hermes production guidance: keep automatic hooks/provider scoped and conservative, and avoid long-lived stdio MCP lock holders for daemon-owned workflows.

## Validation

- Hook quality-gates passed for commits on this branch.
- Focused REST reliability tests passed with `rest,db-test-seam`.
- Normal REST feature tests passed.
- `cargo check --bin mempal --features rest` passed.
- `cargo test --lib` passed: 488 tests.
- Clippy with relevant REST/test features passed.
- Codex tier-4 full-diff review PASS/CLEAN for HEAD `a575f3a48f112cb750682fea6832e0f0b6002b50`.

Closes #393
