### PR TITLE
feat(maintenance): add rejudge verbose help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2093,6 +2093,9 @@ enum MaintenanceCommands {
     Rejudge {
         #[command(subcommand)]
         command: Option<MaintenanceRejudgeCommands>,
+        /// Print the historical rejudge / forget sweep runbook and exit.
+        #[arg(long = "help-verbose", default_value_t = false)]
+        help_verbose: bool,
         /// Mutate storage. Omit for dry-run.
         #[arg(long, default_value_t = false)]
         execute: bool,
@@ -2813,6 +2816,14 @@ fn run() -> Result<()> {
             return maintenance_runbook_command(format.clone());
         }
         Commands::Maintenance {
+            command:
+                MaintenanceCommands::Rejudge {
+                    help_verbose: true, ..
+                },
+        } => {
+            return maintenance_rejudge_help_verbose_command();
+        }
+        Commands::Maintenance {
             command: MaintenanceCommands::GuidedRun { format },
         } => {
             return maintenance_guided_run_command(format.clone());
@@ -3251,6 +3262,7 @@ fn run() -> Result<()> {
             command:
                 MaintenanceCommands::Rejudge {
                     command: None,
+                    help_verbose: false,
                     execute,
                     hard_delete,
                     backup_dir,
@@ -12792,6 +12804,64 @@ Mempal Maintenance Runbook
         }
         other => bail!("unknown format: {other}"),
     }
+}
+
+fn maintenance_rejudge_help_verbose_command() -> Result<()> {
+    const HELP: &str = "\
+Historical Rejudge / Forget Sweep
+==================================
+
+Purpose
+-------
+Re-run the current retention policy over existing active drawers and identify
+records that should no longer be retained. This is the operational cleanup path
+for migrations/imports or periods when passive memory filtering was too loose.
+
+Safety model
+------------
+- Run a dry-run first: omit --execute to preview decisions without mutating the
+  database, backup files, or checkpoint state.
+- Full sweeps use --all and a bounded historical snapshot so concurrent new
+  writes are handled by a future sweep instead of drifting into the current run.
+- Execution requires --backup-dir unless you explicitly combine --hard-delete
+  with --unsafe-no-backup. Prefer the default auditable soft-delete path.
+- Backup-before-delete is mandatory for normal execution: records are exported
+  before active rows and embeddings/index rows are removed or marked forgotten.
+- Resume interrupted full sweeps with --resume using the same database and
+  compatible options.
+- Restore forgotten drawers with the restore subcommand, then run reindex if
+  embeddings/search indexes need to be rebuilt.
+
+Typical commands
+----------------
+Dry-run a bounded batch:
+  mempal maintenance rejudge --limit 100 --format plain
+
+Dry-run the full active database, oldest-to-newest snapshot:
+  mempal maintenance rejudge --all --page-size 500 --format plain
+
+Execute the full forget sweep with an explicit backup directory:
+  mempal maintenance rejudge --all --execute --backup-dir /ssd/mirror-rootfs/home/obj/bak/mempal/
+
+Resume an interrupted execute sweep:
+  mempal maintenance rejudge --all --resume --execute --backup-dir /ssd/mirror-rootfs/home/obj/bak/mempal/
+
+Restore from a backup file:
+  mempal maintenance rejudge restore --backup /path/to/rejudge-backup.sqlite --execute
+
+Operational notes
+-----------------
+- Configure LLM/text retention judges through [llm] / memory-intelligence config
+  before running the sweep. The command records the effective judge model and
+  config version in the report/backup metadata.
+- Do not put API keys in command lines. Use configured environment variables or
+  local/LAN endpoints; mempal rejects URL userinfo/query secrets.
+- If a provider/model fails during execute, stop and resume later rather than
+  deleting based on uncertain fallback judgments.
+- Use --hard-delete only when you intentionally want irreversible deletion.
+- Use --help for the concise flag list; use --help-verbose for this runbook.";
+    println!("{HELP}");
+    Ok(())
 }
 
 fn maintenance_guided_run_command(format: String) -> Result<()> {

--- a/tests/cowork_bus.rs
+++ b/tests/cowork_bus.rs
@@ -2128,6 +2128,20 @@ fn test_cli_maintenance_runbook_json() {
 }
 
 #[test]
+fn test_cli_maintenance_rejudge_help_verbose() {
+    let home = TempDir::new().expect("home");
+    let output = run_mempal(&home, &["maintenance", "rejudge", "--help-verbose"]);
+    assert_success(&output);
+    let out = stdout(&output);
+    assert!(out.contains("Historical Rejudge / Forget Sweep"), "{out}");
+    assert!(out.contains("dry-run first"), "{out}");
+    assert!(out.contains("--all --execute --backup-dir"), "{out}");
+    assert!(out.contains("--resume"), "{out}");
+    assert!(out.contains("mempal maintenance rejudge restore"), "{out}");
+    assert!(!home.path().join(".mempal").exists());
+}
+
+#[test]
 
 fn test_cli_maintenance_runbook_rejects_invalid_format() {
     let home = TempDir::new().expect("home");

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3525cea17b7c19038cfc08ef34ddb04d4d37668f"
+commit = "3024209d4f6d0d38a5718c4b8f005cd868a3b360"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Adds `mempal maintenance rejudge --help-verbose` as CLI-local operational documentation for historical rejudge / forget sweeps.
- Documents dry-run-first usage, `--all`, `--resume`, page sizing, execute backup requirements, restore/reindex flow, and safe LLM/secret handling.
- Keeps the verbose help path before config/database bootstrap so it can be used without initializing `~/.mempal`.

## Tests

- `cargo test --test cowork_bus test_cli_maintenance_rejudge_help_verbose -- --nocapture`
- `cargo test --test cowork_bus test_cli_maintenance_runbook -- --nocapture`
- `cargo check --bin mempal`
- hook quality-gates during `git commit`
- Codex tier-4 full-diff review: PASS/CLEAN (`findings = []`)

Closes #410
