### PR TITLE
feat(llm): add endpoint pool guardrails

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,6 +27,7 @@ const DEFAULT_LLM_BACKEND: &str = "openai_compat";
 const DEFAULT_LLM_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_LLM_RETRY_INTERVAL_SECS: u64 = 2;
 const DEFAULT_LLM_MAX_CONCURRENT: usize = 16;
+const DEFAULT_LLM_ENDPOINT_PRIORITY: i32 = 0;
 const DEFAULT_MEMORY_INTELLIGENCE_TIMEOUT_SECS: u64 = 1800;
 const DEFAULT_SEARCH_DEADLINE_SECS: u64 = 5;
 const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
@@ -302,6 +303,7 @@ impl Config {
             ));
         }
         self.llm.validate_endpoint_pool()?;
+        self.validate_llm_judge_guardrails()?;
         if self.llm.enabled && self.llm.effective_endpoints()?.is_empty() {
             return Err(ConfigError::Validation(
                 "llm.base_url must be set when llm.enabled is true".to_string(),
@@ -696,7 +698,47 @@ impl Config {
             });
         }
         warnings.extend(self.llm_base_url_locality_warnings());
+        if let Some(judge) = self.ingest_gating.llm_judge.as_ref()
+            && !judge.enabled
+            && judge.allow_fallback_worse_memory
+        {
+            warnings.push(RuntimeWarning {
+                level: "warn",
+                source: "llm",
+                message: "LLM memory judging is disabled by explicit allow_fallback_worse_memory=true; memory quality may degrade.".to_string(),
+            });
+        }
         warnings
+    }
+
+    fn validate_llm_judge_guardrails(&self) -> Result<(), ConfigError> {
+        let Some(judge) = self.ingest_gating.llm_judge.as_ref() else {
+            return Ok(());
+        };
+        if !judge.enabled {
+            if judge.allow_fallback_worse_memory {
+                return Ok(());
+            }
+            return Err(ConfigError::Validation(
+                "ingest_gating.llm_judge.enabled=false requires allow_fallback_worse_memory=true to acknowledge lower memory quality".to_string(),
+            ));
+        }
+        if !self.llm.enabled {
+            return Err(ConfigError::Validation(
+                "ingest_gating.llm_judge.enabled=true requires [llm].enabled=true".to_string(),
+            ));
+        }
+        if !self.llm.enabled_for.iter().any(|item| item == "gating") {
+            return Err(ConfigError::Validation(
+                "ingest_gating.llm_judge.enabled=true requires llm.enabled_for to include \"gating\"".to_string(),
+            ));
+        }
+        if self.llm.effective_endpoints()?.is_empty() {
+            return Err(ConfigError::Validation(
+                "ingest_gating.llm_judge.enabled=true requires at least one configured LLM endpoint".to_string(),
+            ));
+        }
+        Ok(())
     }
 
     fn llm_base_url_locality_warnings(&self) -> Vec<RuntimeWarning> {
@@ -1206,8 +1248,12 @@ pub struct LlmEndpointConfig {
     pub api_key: Option<String>,
     pub api_key_env: Option<String>,
     pub extra_body: Option<serde_json::Value>,
+    /// Lower numbers are tried first. Equal priority endpoints share active load
+    /// according to each endpoint's `max_concurrent` capacity.
+    pub priority: Option<i32>,
     #[serde(alias = "timeout_secs")]
     pub request_timeout_secs: Option<u64>,
+    pub retry_interval_secs: Option<u64>,
     pub max_concurrent: Option<usize>,
 }
 
@@ -1219,7 +1265,9 @@ pub struct EffectiveLlmEndpoint {
     pub api_key: Option<String>,
     pub api_key_env: Option<String>,
     pub extra_body: Option<serde_json::Value>,
+    pub priority: i32,
     pub request_timeout_secs: u64,
+    pub retry_interval_secs: u64,
     pub max_concurrent: usize,
 }
 
@@ -1268,9 +1316,14 @@ impl LlmConfig {
                     api_key: endpoint.api_key.clone(),
                     api_key_env: endpoint.api_key_env.clone(),
                     extra_body: endpoint.extra_body.clone(),
+                    priority: endpoint.priority.unwrap_or(DEFAULT_LLM_ENDPOINT_PRIORITY),
                     request_timeout_secs: endpoint
                         .request_timeout_secs
                         .unwrap_or(self.request_timeout_secs),
+                    retry_interval_secs: endpoint
+                        .retry_interval_secs
+                        .unwrap_or(self.retry_interval_secs)
+                        .max(1),
                     max_concurrent: endpoint
                         .max_concurrent
                         .unwrap_or(self.max_concurrent)
@@ -1291,6 +1344,19 @@ impl LlmConfig {
             ));
         }
         Ok(())
+    }
+
+    pub fn pool_capacity(&self) -> usize {
+        self.effective_endpoints()
+            .ok()
+            .filter(|endpoints| !endpoints.is_empty())
+            .map(|endpoints| {
+                endpoints
+                    .into_iter()
+                    .map(|endpoint| endpoint.max_concurrent.max(1))
+                    .sum::<usize>()
+            })
+            .unwrap_or_else(|| self.max_concurrent.max(1))
     }
 
     pub fn effective_model_summary(&self) -> Option<String> {
@@ -1320,7 +1386,9 @@ impl LlmConfig {
                     "model": endpoint.model,
                     "api_key_env": endpoint.api_key_env,
                     "extra_body": endpoint.extra_body,
+                    "priority": endpoint.priority,
                     "request_timeout_secs": endpoint.request_timeout_secs,
+                    "retry_interval_secs": endpoint.retry_interval_secs,
                     "max_concurrent": endpoint.max_concurrent,
                 })
             })
@@ -1348,7 +1416,9 @@ impl LlmConfig {
             api_key: self.api_key.clone(),
             api_key_env: self.api_key_env.clone(),
             extra_body: self.extra_body.clone(),
+            priority: DEFAULT_LLM_ENDPOINT_PRIORITY,
             request_timeout_secs: self.request_timeout_secs,
+            retry_interval_secs: self.retry_interval_secs.max(1),
             max_concurrent: self.max_concurrent.max(1),
         }))
     }
@@ -1967,6 +2037,7 @@ fn default_tier1_skip_events() -> Vec<String> {
 #[serde(default)]
 pub struct LlmJudgeConfig {
     pub enabled: bool,
+    pub allow_fallback_worse_memory: bool,
     pub system_prompt: Option<String>,
     pub threshold: f64,
 }
@@ -1975,6 +2046,7 @@ impl Default for LlmJudgeConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            allow_fallback_worse_memory: false,
             system_prompt: None,
             threshold: 0.3,
         }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -83,6 +83,9 @@ pub struct QueueConfig {
 pub enum QueueFailureDisposition {
     /// Retry with queue backoff without converting the item to a terminal dead-letter.
     Retryable,
+    /// Retry after an explicit producer-provided delay, such as a model router
+    /// cooldown hint. This keeps retry intent durable without holding a worker.
+    RetryableAfter { delay_ms: i64 },
     /// Move directly to the failed/dead-letter state without another attempt.
     Terminal,
 }
@@ -694,11 +697,11 @@ impl PendingMessageStore {
             u32::try_from(next_retry).map_err(|_| QueueError::RetryCountOverflow {
                 id: claim.id.clone(),
             })?;
-        let terminal = disposition == QueueFailureDisposition::Terminal;
-        let backoff_ms = if terminal {
-            0
-        } else {
-            self.compute_backoff_ms(next_retry_u32)
+        let terminal = matches!(disposition, QueueFailureDisposition::Terminal);
+        let backoff_ms = match disposition {
+            QueueFailureDisposition::Terminal => 0,
+            QueueFailureDisposition::Retryable => self.compute_backoff_ms(next_retry_u32),
+            QueueFailureDisposition::RetryableAfter { delay_ms } => delay_ms.max(0),
         };
         let next_attempt_at = if terminal {
             now_secs()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -206,7 +206,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
 
     let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
         let llm_client_runtime = crate::llm::worker::LlmClientRuntime::new(&context.config.llm);
-        let num_workers = context.config.llm.max_concurrent.max(1);
+        let num_workers = context.config.llm.pool_capacity();
         let llm_status = Arc::new(crate::llm::LlmStatus::new(10));
         let llm_store = Arc::new(context.store.clone());
         let llm_client_runtime = Arc::new(Mutex::new(llm_client_runtime));

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -45,11 +45,11 @@ pub enum LlmError {
         #[source]
         source: reqwest::Error,
     },
-    #[error("LLM endpoint returned error status {status}: {body}")]
+    #[error("LLM endpoint returned error status {status}")]
     HttpStatus { status: StatusCode, body: String },
     #[error("failed to decode LLM response: {0}")]
     DecodeResponse(String),
-    #[error("LLM endpoint returned client error status {status}: {body}")]
+    #[error("LLM endpoint returned client error status {status}")]
     ClientError {
         status: StatusCode,
         body: String,
@@ -73,6 +73,14 @@ impl LlmError {
             Self::HttpStatus { status, .. } => status.is_server_error(),
             Self::ClientError { status, .. } => *status == StatusCode::TOO_MANY_REQUESTS,
             Self::DecodeResponse(_) | Self::MissingConfiguration(_) => false,
+        }
+    }
+
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::ClientError { retry_after, .. } => *retry_after,
+            Self::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
+            _ => None,
         }
     }
 }
@@ -169,6 +177,28 @@ impl LlmClient {
 
     pub async fn chat_completion(&self, request: &LlmRequest) -> Result<LlmResponse, LlmError> {
         let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+        self.send_chat_completion(request).await
+    }
+
+    pub async fn try_chat_completion(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<Option<LlmResponse>, LlmError> {
+        let permit = match self.semaphore.try_acquire() {
+            Ok(permit) => permit,
+            Err(tokio::sync::TryAcquireError::NoPermits) => return Ok(None),
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(LlmError::MissingConfiguration(
+                    "llm endpoint semaphore closed".to_string(),
+                ));
+            }
+        };
+        let response = self.send_chat_completion(request).await;
+        drop(permit);
+        response.map(Some)
+    }
+
+    async fn send_chat_completion(&self, request: &LlmRequest) -> Result<LlmResponse, LlmError> {
         let endpoint = format!("{}/chat/completions", self.base_url);
         let model = request.model.as_deref().unwrap_or(&self.model);
         let mut body = serde_json::Map::new();
@@ -203,6 +233,7 @@ impl LlmClient {
         if !status.is_success() {
             let retry_after = parse_retry_after(response.headers());
             let body = response.text().await.map_err(map_reqwest_error)?;
+            let retry_after = retry_after.or_else(|| parse_reset_seconds(&body));
             if status.is_client_error() {
                 return Err(LlmError::ClientError {
                     status,
@@ -294,6 +325,30 @@ fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_secs)
+}
+
+fn parse_reset_seconds(body: &str) -> Option<Duration> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    find_reset_seconds(&value).map(Duration::from_secs)
+}
+
+fn find_reset_seconds(value: &Value) -> Option<u64> {
+    match value {
+        Value::Object(map) => {
+            if let Some(reset) = map.get("reset_seconds").and_then(value_as_u64) {
+                return Some(reset);
+            }
+            map.values().find_map(find_reset_seconds)
+        }
+        Value::Array(values) => values.iter().find_map(find_reset_seconds),
+        _ => None,
+    }
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u64>().ok()))
 }
 
 fn map_reqwest_error(source: reqwest::Error) -> LlmError {

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -11,6 +11,9 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::core::config::{EffectiveLlmEndpoint, LlmConfig, validate_llm_base_url};
 
+pub(crate) const MAX_REMOTE_RETRY_HINT: Duration = Duration::from_secs(60);
+const MAX_REMOTE_RETRY_HINT_SECS: u64 = 60;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LlmMessage {
     pub role: String,
@@ -324,12 +327,16 @@ fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
         .get(RETRY_AFTER)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_secs)
+        .map(clamp_remote_retry_hint_secs)
 }
 
 fn parse_reset_seconds(body: &str) -> Option<Duration> {
     let value = serde_json::from_str::<Value>(body).ok()?;
-    find_reset_seconds(&value).map(Duration::from_secs)
+    find_reset_seconds(&value).map(clamp_remote_retry_hint_secs)
+}
+
+fn clamp_remote_retry_hint_secs(secs: u64) -> Duration {
+    Duration::from_secs(secs.min(MAX_REMOTE_RETRY_HINT_SECS))
 }
 
 fn find_reset_seconds(value: &Value) -> Option<u64> {

--- a/src/llm/retry.rs
+++ b/src/llm/retry.rs
@@ -5,7 +5,6 @@ use super::client::{LlmError, LlmResponse};
 pub type HeartbeatCallback = dyn Fn() -> Result<(), LlmError> + Send + Sync;
 
 const MAX_HEARTBEAT_REFRESH_SECS: u64 = 5;
-const MAX_RETRY_AFTER_SECS: u64 = 60;
 
 pub async fn retry_llm_operation<F, Fut>(
     retry_interval_secs: u64,
@@ -59,16 +58,14 @@ where
 
 fn retry_after_from_error(error: &LlmError, default_secs: u64) -> Duration {
     if let LlmError::TemporarilyUnavailable { retry_after, .. } = error {
-        let capped = retry_after.as_secs().min(MAX_RETRY_AFTER_SECS);
-        return Duration::from_secs(capped);
+        return *retry_after;
     }
     if let LlmError::ClientError {
         retry_after: Some(header_duration),
         ..
     } = error
     {
-        let capped = header_duration.as_secs().min(MAX_RETRY_AFTER_SECS);
-        return Duration::from_secs(capped);
+        return *header_duration;
     }
     Duration::from_secs(default_secs)
 }

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 
 use crate::core::config::{EffectiveLlmEndpoint, LlmConfig};
 
-use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse};
+use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse, MAX_REMOTE_RETRY_HINT};
 use super::retry::HeartbeatCallback;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -192,7 +192,11 @@ impl RoutedEndpoint {
 
     async fn mark_temporarily_unavailable(&self, retry_after: Duration) {
         let mut guard = self.unavailable_until.lock().await;
-        *guard = Some(Instant::now() + retry_after);
+        let now = Instant::now();
+        *guard = Some(
+            now.checked_add(retry_after)
+                .unwrap_or_else(|| now + MAX_REMOTE_RETRY_HINT),
+        );
     }
 }
 

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -9,8 +9,6 @@ use crate::core::config::{EffectiveLlmEndpoint, LlmConfig};
 use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse};
 use super::retry::HeartbeatCallback;
 
-const MAX_RETRY_AFTER_SECS: u64 = 60;
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoutedLlmResponse {
     pub endpoint_id: String,
@@ -44,9 +42,11 @@ impl LlmRouter {
                 "llm endpoints must not be empty".to_string(),
             ));
         }
+        let mut endpoints = endpoints.into_iter().enumerate().collect::<Vec<_>>();
+        endpoints.sort_by_key(|(index, endpoint)| (endpoint.priority, *index));
         let routed = endpoints
             .into_iter()
-            .map(|config| {
+            .map(|(_, config)| {
                 let client = LlmClient::from_endpoint(&config)?;
                 Ok(Arc::new(RoutedEndpoint {
                     config,
@@ -65,8 +65,10 @@ impl LlmRouter {
         request: &LlmRequest,
         heartbeat: Option<&HeartbeatCallback>,
     ) -> Result<RoutedLlmResponse, LlmError> {
-        let mut last_non_cooldown_retryable = None;
+        let mut last_retryable = None;
         let mut earliest_retry_after: Option<Duration> = None;
+        let mut first_saturated_endpoint: Option<Arc<RoutedEndpoint>> = None;
+
         for endpoint in self.endpoints.iter() {
             if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
                 earliest_retry_after = Some(match earliest_retry_after {
@@ -76,35 +78,47 @@ impl LlmRouter {
                 continue;
             }
             refresh_heartbeat(heartbeat)?;
-            match endpoint.client.chat_completion(request).await {
-                Ok(response) => {
+            match endpoint.client.try_chat_completion(request).await {
+                Ok(Some(response)) => {
                     return Ok(RoutedLlmResponse {
                         endpoint_id: endpoint.config.id.clone(),
                         endpoint_model: endpoint.config.model.clone(),
                         response,
                     });
                 }
+                Ok(None) => {
+                    if first_saturated_endpoint.is_none() {
+                        first_saturated_endpoint = Some(Arc::clone(endpoint));
+                    }
+                }
                 Err(error) if should_try_next_endpoint(&error) => {
-                    if let LlmError::ClientError {
-                        status: StatusCode::TOO_MANY_REQUESTS,
-                        retry_after,
-                        ..
-                    } = &error
-                    {
-                        let retry_after = endpoint.mark_temporarily_unavailable(*retry_after).await;
+                    if let Some(retry_after) = endpoint.retry_after_for_error(&error) {
+                        endpoint.mark_temporarily_unavailable(retry_after).await;
                         earliest_retry_after = Some(match earliest_retry_after {
                             Some(current) => current.min(retry_after),
                             None => retry_after,
                         });
-                    } else {
-                        last_non_cooldown_retryable = Some(error);
                     }
+                    last_retryable = Some(error);
                 }
                 Err(error) => return Err(error),
             }
         }
-        match (last_non_cooldown_retryable, earliest_retry_after) {
-            (Some(error), _) => Err(error),
+
+        if let Some(endpoint) = first_saturated_endpoint
+            && earliest_retry_after.is_none()
+            && last_retryable.is_none()
+        {
+            refresh_heartbeat(heartbeat)?;
+            let response = endpoint.client.chat_completion(request).await?;
+            return Ok(RoutedLlmResponse {
+                endpoint_id: endpoint.config.id.clone(),
+                endpoint_model: endpoint.config.model.clone(),
+                response,
+            });
+        }
+
+        match (last_retryable, earliest_retry_after) {
             (None, Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
                 retry_after,
                 reason: format!(
@@ -112,6 +126,14 @@ impl LlmRouter {
                     self.endpoints.len()
                 ),
             }),
+            (Some(_error), Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
+                retry_after,
+                reason: format!(
+                    "{} endpoint(s) are cooling down after retryable failures",
+                    self.endpoints.len()
+                ),
+            }),
+            (Some(error), _) => Err(error),
             (None, None) => Err(LlmError::MissingConfiguration(
                 "no LLM endpoint is currently available".to_string(),
             )),
@@ -120,6 +142,13 @@ impl LlmRouter {
 
     pub fn endpoint_count(&self) -> usize {
         self.endpoints.len()
+    }
+
+    pub fn pool_capacity(&self) -> usize {
+        self.endpoints
+            .iter()
+            .map(|endpoint| endpoint.config.max_concurrent.max(1))
+            .sum()
     }
 }
 
@@ -138,13 +167,32 @@ impl RoutedEndpoint {
         }
     }
 
-    async fn mark_temporarily_unavailable(&self, retry_after: Option<Duration>) -> Duration {
-        let retry_after = retry_after
-            .unwrap_or_else(|| Duration::from_secs(MAX_RETRY_AFTER_SECS))
-            .min(Duration::from_secs(MAX_RETRY_AFTER_SECS));
+    fn retry_after_for_error(&self, error: &LlmError) -> Option<Duration> {
+        match error {
+            LlmError::ClientError {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                retry_after,
+                ..
+            } => Some(
+                retry_after.unwrap_or_else(|| Duration::from_secs(self.config.retry_interval_secs)),
+            ),
+            LlmError::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
+            LlmError::HttpRequest { .. } | LlmError::Timeout => {
+                Some(Duration::from_secs(self.config.retry_interval_secs))
+            }
+            LlmError::HttpStatus { status, .. } if status.is_server_error() => {
+                Some(Duration::from_secs(self.config.retry_interval_secs))
+            }
+            LlmError::HttpStatus { .. }
+            | LlmError::ClientError { .. }
+            | LlmError::DecodeResponse(_)
+            | LlmError::MissingConfiguration(_) => None,
+        }
+    }
+
+    async fn mark_temporarily_unavailable(&self, retry_after: Duration) {
         let mut guard = self.unavailable_until.lock().await;
         *guard = Some(Instant::now() + retry_after);
-        retry_after
     }
 }
 

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -8,7 +8,9 @@ use serde_json::Value;
 use crate::core::AsyncDb;
 use crate::core::config::{Config, ConfigHandle, LlmConfig};
 use crate::core::db::Database;
-use crate::core::queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore};
+use crate::core::queue::{
+    AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueFailureDisposition,
+};
 use crate::daemon_bootstrap::DaemonWriteObserver;
 
 use super::client::{LlmClient, LlmError, LlmMessage, LlmRequest, LlmResponse};
@@ -270,8 +272,9 @@ pub async fn run_llm_worker(
             Some(Err(error)) => {
                 tracing::error!("LLM task {message_id} failed after {latency_ms}ms: {error}");
                 write_observer.record_error(error.to_string());
+                let disposition = llm_task_failure_disposition(&error);
                 store
-                    .mark_failed(message.clone(), error.to_string())
+                    .mark_failed_with_disposition(message.clone(), error.to_string(), disposition)
                     .await
                     .with_context(|| format!("failed to mark_failed LLM task {message_id}"))?;
             }
@@ -364,7 +367,7 @@ async fn process_gating_task(
     config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<()> {
-    let (verdict, score) = request_gating_verdict(router, status, task, config, heartbeat).await?;
+    let (verdict, score) = request_gating_verdict(router, status, task, heartbeat).await?;
     apply_gating_verdict_async(db, task.clone(), config.clone(), verdict, score).await
 }
 
@@ -405,18 +408,13 @@ async fn request_gating_verdict(
     router: &LlmRouter,
     status: &LlmStatus,
     task: &LlmTaskPayload,
-    config: &crate::core::config::Config,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<(String, f64)> {
     let request = gating_request(task);
-    let retry_interval = config.llm.retry_interval_secs;
-    let response = retry::retry_llm_operation(retry_interval, heartbeat, || async {
-        router
-            .chat_completion(&request, heartbeat)
-            .await
-            .map(|routed| routed.response)
-    })
-    .await;
+    let response = router
+        .chat_completion(&request, heartbeat)
+        .await
+        .map(|routed| routed.response);
 
     record_gating_response(status, response)
 }
@@ -475,6 +473,37 @@ fn record_gating_response(
             Err(error).context("LLM gating request failed")
         }
     }
+}
+
+fn llm_task_failure_disposition(error: &anyhow::Error) -> QueueFailureDisposition {
+    if error.chain().any(|cause| {
+        cause
+            .to_string()
+            .contains("failed to decode LLM task payload")
+    }) || error
+        .chain()
+        .any(|cause| cause.to_string().contains("unknown LLM task type"))
+    {
+        return QueueFailureDisposition::Terminal;
+    }
+    let Some(llm_error) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<LlmError>())
+    else {
+        return QueueFailureDisposition::Retryable;
+    };
+    if !llm_error.is_retryable() {
+        return QueueFailureDisposition::Terminal;
+    }
+    llm_error
+        .retry_after()
+        .map(duration_to_retry_delay)
+        .unwrap_or(QueueFailureDisposition::Retryable)
+}
+
+fn duration_to_retry_delay(duration: Duration) -> QueueFailureDisposition {
+    let millis = i64::try_from(duration.as_millis()).unwrap_or(i64::MAX);
+    QueueFailureDisposition::RetryableAfter { delay_ms: millis }
 }
 
 fn apply_gating_verdict(
@@ -819,6 +848,37 @@ threshold = 0.5
             )
             .expect("read optional LLM audit verdict");
         verdict.zip(score)
+    }
+
+    #[test]
+    fn test_llm_task_failure_disposition_uses_retry_after_as_queue_delay() {
+        let error = Err::<(), _>(LlmError::TemporarilyUnavailable {
+            retry_after: Duration::from_secs(7),
+            reason: "model_cooldown".to_string(),
+        })
+        .context("LLM gating request failed")
+        .expect_err("synthetic error");
+
+        assert_eq!(
+            llm_task_failure_disposition(&error),
+            QueueFailureDisposition::RetryableAfter { delay_ms: 7_000 }
+        );
+    }
+
+    #[test]
+    fn test_llm_task_failure_disposition_terminals_non_retryable_errors() {
+        let error = Err::<(), _>(LlmError::ClientError {
+            status: reqwest::StatusCode::BAD_REQUEST,
+            body: "invalid model".to_string(),
+            retry_after: None,
+        })
+        .context("LLM gating request failed")
+        .expect_err("synthetic error");
+
+        assert_eq!(
+            llm_task_failure_disposition(&error),
+            QueueFailureDisposition::Terminal
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/llm/worker.rs
+++ b/src/llm/worker.rs
@@ -36,6 +36,7 @@ struct LlmClientConfigSignature {
     extra_body: Option<Value>,
     endpoints: Vec<crate::core::config::LlmEndpointConfig>,
     request_timeout_secs: u64,
+    retry_interval_secs: u64,
     max_concurrent: usize,
 }
 
@@ -50,6 +51,7 @@ impl From<&LlmConfig> for LlmClientConfigSignature {
             extra_body: config.extra_body.clone(),
             endpoints: config.endpoints.clone(),
             request_timeout_secs: config.request_timeout_secs,
+            retry_interval_secs: config.retry_interval_secs,
             max_concurrent: config.max_concurrent,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9929,7 +9929,7 @@ fn config_intelligence_command(config: &Config) -> Result<()> {
 fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     let cfg_meta = ConfigHandle::snapshot_meta();
     let scrub_stats = ConfigHandle::scrub_stats();
-    let runtime_warnings = ConfigHandle::collect_runtime_warnings();
+    let mut runtime_warnings = ConfigHandle::collect_runtime_warnings();
     let endpoint_health = if full {
         Some(
             mempal::endpoint_health::probe_endpoints_blocking(config)
@@ -10157,6 +10157,12 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
             println!("Endpoints:");
             println!("  embedding: {}", health.embedding.display());
             println!("  llm: {}", health.llm.display());
+            push_model_backend_runtime_warnings(
+                &mut runtime_warnings,
+                config,
+                health,
+                &queue_stats,
+            );
         }
         None => println!("Endpoints: (use --full to probe)"),
     }
@@ -10293,7 +10299,7 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         if let Some(base_url) = config.llm.effective_base_url_summary().as_deref() {
             println!("  base_url: {base_url}");
         }
-        println!("  max_concurrent: {}", config.llm.max_concurrent);
+        println!("  pool_capacity: {}", config.llm.pool_capacity());
         let llm_pending = queue_stats.pending;
         println!("  queue_pending: {llm_pending}");
     }
@@ -10346,6 +10352,41 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("scopes: (use --full for breakdown)");
     }
     Ok(())
+}
+
+fn push_model_backend_runtime_warnings(
+    warnings: &mut Vec<mempal::core::config::RuntimeWarning>,
+    config: &Config,
+    endpoint_health: &mempal::endpoint_health::EndpointHealthSnapshot,
+    queue_stats: &mempal::core::queue::QueueStats,
+) {
+    if config
+        .ingest_gating
+        .llm_judge
+        .as_ref()
+        .is_some_and(|judge| judge.enabled)
+        && !endpoint_health.llm.reachable
+    {
+        warnings.push(mempal::core::config::RuntimeWarning {
+            level: "error",
+            source: "llm",
+            message: "LLM memory judge is configured but no judge endpoint is reachable; memory quality gating is unavailable until an endpoint recovers.".to_string(),
+        });
+    }
+    if queue_stats.pending > 0 && !endpoint_health.embedding.reachable {
+        warnings.push(mempal::core::config::RuntimeWarning {
+            level: "warn",
+            source: "embed",
+            message: "embedding queue has pending work and the embedding endpoint is unreachable; accepted queued writes will retry when an endpoint recovers.".to_string(),
+        });
+    }
+    if queue_stats.failed > 0 {
+        warnings.push(mempal::core::config::RuntimeWarning {
+            level: "warn",
+            source: "queue",
+            message: "queue has failed work; use `mempal reindex --failed` for failed embed-queue items, and resubmit any writes that were rejected before entering the queue.".to_string(),
+        });
+    }
 }
 
 fn display_list_or_none(values: &[String]) -> String {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2240,6 +2240,12 @@ impl MempalMcpServer {
                 source: "project_isolation".to_string(),
             });
         }
+        push_model_backend_warnings(
+            &mut system_warnings,
+            config.as_ref(),
+            &endpoint_health,
+            &queue_stats,
+        );
         push_db_holder_warnings(&mut system_warnings, &db_holders);
 
         let embed_failure_headline =
@@ -2386,10 +2392,12 @@ impl MempalMcpServer {
                         id: endpoint.id,
                         base_url: endpoint.base_url,
                         model: endpoint.model,
+                        priority: endpoint.priority,
+                        retry_interval_secs: endpoint.retry_interval_secs,
                         max_concurrent: endpoint.max_concurrent,
                     })
                     .collect(),
-                max_concurrent: config.llm.max_concurrent,
+                max_concurrent: config.llm.pool_capacity(),
             },
             intelligence_status: IntelligenceStatusDto {
                 mode: config.memory_intelligence.mode.to_string(),
@@ -7661,6 +7669,41 @@ pub(super) fn current_system_warnings() -> Vec<SystemWarning> {
             }),
     );
     warnings
+}
+
+fn push_model_backend_warnings(
+    system_warnings: &mut Vec<SystemWarning>,
+    config: &Config,
+    endpoint_health: &crate::endpoint_health::EndpointHealthSnapshot,
+    queue_stats: &crate::core::queue::QueueStats,
+) {
+    if config
+        .ingest_gating
+        .llm_judge
+        .as_ref()
+        .is_some_and(|judge| judge.enabled)
+        && !endpoint_health.llm.reachable
+    {
+        system_warnings.push(SystemWarning {
+            level: "error".to_string(),
+            message: "LLM memory judge is configured but no judge endpoint is reachable; memory quality gating is unavailable until an endpoint recovers.".to_string(),
+            source: "llm".to_string(),
+        });
+    }
+    if queue_stats.pending > 0 && !endpoint_health.embedding.reachable {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: "embedding queue has pending work and the embedding endpoint is unreachable; accepted queued writes will retry when an endpoint recovers.".to_string(),
+            source: "embed".to_string(),
+        });
+    }
+    if queue_stats.failed > 0 {
+        system_warnings.push(SystemWarning {
+            level: "warn".to_string(),
+            message: "queue has failed work; use `mempal reindex --failed` for failed embed-queue items, and resubmit any writes that were rejected before entering the queue.".to_string(),
+            source: "queue".to_string(),
+        });
+    }
 }
 
 fn format_deadline(deadline: Duration) -> String {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2008,6 +2008,8 @@ pub struct LlmEndpointStatusDto {
     pub id: String,
     pub base_url: String,
     pub model: String,
+    pub priority: i32,
+    pub retry_interval_secs: u64,
     pub max_concurrent: usize,
 }
 

--- a/tests/llm_client.rs
+++ b/tests/llm_client.rs
@@ -216,6 +216,31 @@ async fn test_llm_client_429_retryable() {
 }
 
 #[tokio::test]
+async fn test_llm_client_429_uses_router_reset_seconds_body() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":{"code":"model_cooldown","reset_seconds":7}}"#)
+        .create();
+    let config = config_for(&server, "");
+    let client = LlmClient::from_config(&config).expect("build client");
+
+    let error = client.chat_completion(&request()).await.expect_err("429");
+
+    mock.assert();
+    assert!(matches!(
+        error,
+        LlmError::ClientError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(duration),
+            ..
+        } if duration == Duration::from_secs(7)
+    ));
+}
+
+#[tokio::test]
 async fn test_llm_client_no_api_key_no_auth_header() {
     let _guard = env_guard().await;
     // SAFETY: tests serialize environment mutation with a process-wide mutex.

--- a/tests/llm_client.rs
+++ b/tests/llm_client.rs
@@ -216,6 +216,31 @@ async fn test_llm_client_429_retryable() {
 }
 
 #[tokio::test]
+async fn test_llm_client_429_clamps_absurd_retry_after_header() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "18446744073709551615")
+        .with_body("rate limited")
+        .create();
+    let config = config_for(&server, "");
+    let client = LlmClient::from_config(&config).expect("build client");
+
+    let error = client.chat_completion(&request()).await.expect_err("429");
+
+    mock.assert();
+    assert!(matches!(
+        error,
+        LlmError::ClientError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(duration),
+            ..
+        } if duration == Duration::from_secs(60)
+    ));
+}
+
+#[tokio::test]
 async fn test_llm_client_429_uses_router_reset_seconds_body() {
     let mut server = Server::new_async().await;
     let mock = server
@@ -237,6 +262,31 @@ async fn test_llm_client_429_uses_router_reset_seconds_body() {
             retry_after: Some(duration),
             ..
         } if duration == Duration::from_secs(7)
+    ));
+}
+
+#[tokio::test]
+async fn test_llm_client_429_clamps_absurd_nested_reset_seconds_body() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":{"code":"model_cooldown","reset_seconds":"18446744073709551615"}}"#)
+        .create();
+    let config = config_for(&server, "");
+    let client = LlmClient::from_config(&config).expect("build client");
+
+    let error = client.chat_completion(&request()).await.expect_err("429");
+
+    mock.assert();
+    assert!(matches!(
+        error,
+        LlmError::ClientError {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(duration),
+            ..
+        } if duration == Duration::from_secs(60)
     ));
 }
 

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -103,12 +103,15 @@ enabled = true
 [[llm.endpoints]]
 base_url = "http://primary.local:8317/v1/"
 model = "primary-model"
+priority = 10
 
 [[llm.endpoints]]
 id = "lan.backup-1"
 base_url = "http://backup.local:8317/v1"
 model = "backup-model"
+priority = 20
 request_timeout_secs = 12
+retry_interval_secs = 4
 max_concurrent = 3
 "#,
     )
@@ -123,11 +126,16 @@ max_concurrent = 3
     assert_eq!(endpoints[0].id, "endpoint-1");
     assert_eq!(endpoints[0].base_url, "http://primary.local:8317/v1");
     assert_eq!(endpoints[0].model, "primary-model");
+    assert_eq!(endpoints[0].priority, 10);
     assert_eq!(endpoints[0].request_timeout_secs, 30);
+    assert_eq!(endpoints[0].retry_interval_secs, 2);
     assert_eq!(endpoints[0].max_concurrent, 16);
     assert_eq!(endpoints[1].id, "lan.backup-1");
+    assert_eq!(endpoints[1].priority, 20);
     assert_eq!(endpoints[1].request_timeout_secs, 12);
+    assert_eq!(endpoints[1].retry_interval_secs, 4);
     assert_eq!(endpoints[1].max_concurrent, 3);
+    assert_eq!(config.llm.pool_capacity(), 19);
 }
 
 #[test]
@@ -440,6 +448,65 @@ enabled = true
     match err {
         ConfigError::Validation(message) => {
             assert!(message.contains("llm.base_url"), "{message}");
+        }
+        other => panic!("expected ConfigError::Validation, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_llm_judge_disabled_requires_explicit_quality_degradation_opt_in() {
+    let err = Config::parse(
+        r#"
+[gating.llm_judge]
+enabled = false
+"#,
+    )
+    .expect_err("disabled LLM judge must require explicit unsafe opt-in");
+
+    match err {
+        ConfigError::Validation(message) => {
+            assert!(
+                message.contains("allow_fallback_worse_memory=true"),
+                "{message}"
+            );
+        }
+        other => panic!("expected ConfigError::Validation, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_llm_judge_disabled_with_explicit_opt_in_warns() {
+    let config = Config::parse(
+        r#"
+[gating.llm_judge]
+enabled = false
+allow_fallback_worse_memory = true
+"#,
+    )
+    .expect("explicit unsafe opt-in should parse");
+
+    let warnings = config.collect_runtime_warnings();
+    assert!(
+        warnings.iter().any(|warning| {
+            warning.source == "llm" && warning.message.contains("allow_fallback_worse_memory=true")
+        }),
+        "{warnings:?}"
+    );
+}
+
+#[test]
+fn test_llm_judge_enabled_requires_llm_gating_endpoint() {
+    let err = Config::parse(
+        r#"
+[gating.llm_judge]
+enabled = true
+"#,
+    )
+    .expect_err("enabled LLM judge without LLM endpoint must fail");
+
+    match err {
+        ConfigError::Validation(message) => {
+            assert!(message.contains("[llm].enabled=true"), "{message}");
         }
         other => panic!("expected ConfigError::Validation, got {other:?}"),
     }

--- a/tests/llm_router.rs
+++ b/tests/llm_router.rs
@@ -185,6 +185,35 @@ async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
 }
 
 #[tokio::test]
+async fn test_llm_router_clamps_absurd_retry_after_before_cooldown() {
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/chat/completions")
+        .with_status(429)
+        .with_header("retry-after", "18446744073709551615")
+        .with_body("rate limited")
+        .expect(1)
+        .create_async()
+        .await;
+    let config = pool_config(&[("primary", &format!("{}/v1", server.url()), "model-a", 0, 1)]);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let error = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("rate limit should cool down without panicking");
+
+    mock.assert_async().await;
+    assert!(matches!(
+        error,
+        LlmError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after == Duration::from_secs(60)
+    ));
+}
+
+#[tokio::test]
 async fn test_llm_router_all_5xx_reports_configured_retry_interval() {
     let mut primary = Server::new_async().await;
     let mut secondary = Server::new_async().await;

--- a/tests/llm_router.rs
+++ b/tests/llm_router.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use mempal::core::config::Config;
 use mempal::llm::{LlmError, LlmMessage, LlmRequest, LlmRouter};
 use mockito::{Matcher, Server};
+use tokio::sync::Barrier;
 
 fn request() -> LlmRequest {
     LlmRequest {
@@ -183,7 +185,179 @@ async fn test_llm_router_all_temporarily_unavailable_remains_retryable() {
 }
 
 #[tokio::test]
-async fn test_llm_router_mixed_5xx_then_rate_limit_uses_non_cooldown_retry_policy() {
+async fn test_llm_router_all_5xx_reports_configured_retry_interval() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("primary server error")
+        .expect(1)
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(503)
+        .with_body("secondary warming")
+        .expect(1)
+        .create_async()
+        .await;
+    let config = endpoint_pool_config(&primary, &secondary);
+    let router = LlmRouter::from_config(&config).expect("build router");
+
+    let error = router
+        .chat_completion(&request(), None)
+        .await
+        .expect_err("server errors should produce durable retry timing");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(matches!(
+        error,
+        LlmError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after == Duration::from_secs(2)
+    ));
+    assert!(error.is_retryable());
+}
+
+async fn spawn_counting_server(
+    model: &'static str,
+    delay: Duration,
+) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    use axum::{Json, Router, routing::post};
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_for_handler = Arc::clone(&count);
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(delay).await;
+                Json(serde_json::json!({
+                    "model": model,
+                    "choices": [{
+                        "message": {
+                            "role": "assistant",
+                            "content": "ok"
+                        }
+                    }],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2
+                    }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind counting LLM server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve counting LLM server");
+    });
+    (format!("http://{addr}/v1"), count, handle)
+}
+
+fn pool_config(entries: &[(&str, &str, &str, i32, usize)]) -> mempal::core::config::LlmConfig {
+    let mut toml = String::from("[llm]\nenabled = true\n");
+    for (id, base_url, model, priority, max_concurrent) in entries {
+        toml.push_str(&format!(
+            r#"
+[[llm.endpoints]]
+id = "{id}"
+base_url = "{base_url}"
+model = "{model}"
+priority = {priority}
+max_concurrent = {max_concurrent}
+"#
+        ));
+    }
+    Config::parse(&toml).expect("parse pool config").llm
+}
+
+#[tokio::test]
+async fn test_llm_router_same_priority_uses_each_endpoint_capacity_concurrently() {
+    let (qwen_url, qwen_count, qwen_server) =
+        spawn_counting_server("qwen-model", Duration::from_millis(200)).await;
+    let (spark_url, spark_count, spark_server) =
+        spawn_counting_server("spark-model", Duration::from_millis(200)).await;
+    let config = pool_config(&[
+        ("qwen", &qwen_url, "qwen-model", 10, 4),
+        ("spark", &spark_url, "spark-model", 10, 1),
+    ]);
+    let router = Arc::new(LlmRouter::from_config(&config).expect("build router"));
+    assert_eq!(router.pool_capacity(), 5);
+    let barrier = Arc::new(Barrier::new(6));
+    let mut tasks = Vec::new();
+    for _ in 0..5 {
+        let router = Arc::clone(&router);
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            router.chat_completion(&request(), None).await
+        }));
+    }
+    barrier.wait().await;
+    for task in tasks {
+        task.await
+            .expect("join")
+            .expect("same-priority routed response");
+    }
+    qwen_server.abort();
+    spark_server.abort();
+    let _ = qwen_server.await;
+    let _ = spark_server.await;
+
+    assert_eq!(qwen_count.load(Ordering::SeqCst), 4);
+    assert_eq!(spark_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_llm_router_uses_lower_priority_only_when_higher_priority_saturated() {
+    let (primary_url, primary_count, primary_server) =
+        spawn_counting_server("primary-model", Duration::from_millis(200)).await;
+    let (spillover_url, spillover_count, spillover_server) =
+        spawn_counting_server("spillover-model", Duration::from_millis(200)).await;
+    let config = pool_config(&[
+        ("primary", &primary_url, "primary-model", 0, 1),
+        ("spillover", &spillover_url, "spillover-model", 10, 1),
+    ]);
+    let router = Arc::new(LlmRouter::from_config(&config).expect("build router"));
+    let barrier = Arc::new(Barrier::new(3));
+    let mut tasks = Vec::new();
+    for _ in 0..2 {
+        let router = Arc::clone(&router);
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            router.chat_completion(&request(), None).await
+        }));
+    }
+    barrier.wait().await;
+    for task in tasks {
+        task.await
+            .expect("join")
+            .expect("spillover routed response");
+    }
+    primary_server.abort();
+    spillover_server.abort();
+    let _ = primary_server.await;
+    let _ = spillover_server.await;
+
+    assert_eq!(primary_count.load(Ordering::SeqCst), 1);
+    assert_eq!(spillover_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_llm_router_mixed_retryable_failures_report_cooldown() {
     let mut primary = Server::new_async().await;
     let mut secondary = Server::new_async().await;
     let primary_mock = primary
@@ -207,16 +381,16 @@ async fn test_llm_router_mixed_5xx_then_rate_limit_uses_non_cooldown_retry_polic
     let error = router
         .chat_completion(&request(), None)
         .await
-        .expect_err("ordinary retryable failure should win over endpoint cooldown");
+        .expect_err("retryable endpoint failures should report a cooldown");
 
     primary_mock.assert_async().await;
     secondary_mock.assert_async().await;
     assert!(matches!(
         error,
-        LlmError::HttpStatus {
-            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        LlmError::TemporarilyUnavailable {
+            retry_after,
             ..
-        }
+        } if retry_after == Duration::from_secs(2)
     ));
     assert!(error.is_retryable());
 }

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -241,6 +241,48 @@ model = "model-stable"
 }
 
 #[test]
+fn test_llm_gen_increments_on_legacy_retry_interval_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-stable"
+retry_interval_secs = 1
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_llm_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    std::fs::write(
+        &config_path,
+        r#"
+[llm]
+enabled = true
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-stable"
+retry_interval_secs = 9
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert!(
+        gen_after > gen_before,
+        "generation must increment when legacy scalar llm.retry_interval_secs changes (before={gen_before}, after={gen_after})"
+    );
+}
+
+#[test]
 fn test_llm_gen_increments_on_endpoint_list_change() {
     let _guard = TEST_LOCK.lock().expect("test lock");
     let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -362,6 +404,32 @@ fn test_llm_client_runtime_rebuilds_on_endpoint_change() {
     assert!(
         !Arc::ptr_eq(&first, &second),
         "endpoint changes must rebuild LLM router"
+    );
+}
+
+#[test]
+fn test_llm_client_runtime_rebuilds_on_legacy_retry_interval_change() {
+    let config = LlmConfig {
+        enabled: true,
+        base_url: Some("http://127.0.0.1:19999/v1".to_string()),
+        model: Some("model-stable".to_string()),
+        retry_interval_secs: 1,
+        ..Default::default()
+    };
+    let mut runtime = LlmClientRuntime::new(&config);
+    let first = runtime
+        .router_for_config(&config)
+        .expect("load initial router");
+
+    let mut changed = config.clone();
+    changed.retry_interval_secs = 9;
+    let second = runtime
+        .router_for_config(&changed)
+        .expect("rebuild changed retry interval router");
+
+    assert!(
+        !Arc::ptr_eq(&first, &second),
+        "legacy scalar llm.retry_interval_secs changes must rebuild LLM router runtime"
     );
 }
 

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -86,12 +86,15 @@ enabled = true
 id = "primary"
 base_url = "http://primary.local:8317/v1"
 model = "primary-model"
+priority = 10
 max_concurrent = 2
+retry_interval_secs = 3
 
 [[llm.endpoints]]
 id = "secondary"
 base_url = "http://secondary.local:8317/v1"
 model = "secondary-model"
+priority = 10
 max_concurrent = 3
 
 [gating]
@@ -124,7 +127,18 @@ enabled = true
         response.llm_status.endpoints[0].base_url,
         "http://primary.local:8317/v1"
     );
+    assert_eq!(response.llm_status.endpoints[0].priority, 10);
+    assert_eq!(response.llm_status.endpoints[0].retry_interval_secs, 3);
     assert_eq!(response.llm_status.endpoints[1].model, "secondary-model");
+    assert_eq!(response.llm_status.endpoints[1].priority, 10);
+    assert_eq!(response.llm_status.max_concurrent, 5);
+    assert!(
+        response.system_warnings.iter().any(|warning| {
+            warning.source == "llm" && warning.message.contains("no judge endpoint is reachable")
+        }),
+        "{:?}",
+        response.system_warnings
+    );
 }
 
 #[cfg(feature = "integration")]
@@ -233,6 +247,13 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
     assert_eq!(response.embed_status.failed_count, 1);
     assert_eq!(response.embed_status.fail_count, 1);
     assert_eq!(response.embed_status.failure_count, 1);
+    assert!(
+        response.system_warnings.iter().any(|warning| {
+            warning.source == "queue" && warning.message.contains("mempal reindex --failed")
+        }),
+        "{:?}",
+        response.system_warnings
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds prioritized shared LLM endpoint pools with per-endpoint capacity and local/custom-router retry semantics.
- Preserves strict LLM-judge safety by requiring explicit unsafe opt-in before degraded fallback behavior can be accepted.
- Handles local router cooldowns, including remote `reset_seconds`/`Retry-After` hints, while bounding untrusted retry hints to avoid indefinite queue parking.
- Surfaces queue/endpoint health through daemon/MCP/status paths so agent writes can remain durable even when local models are temporarily unavailable.

Closes #413

## Validation

- `cargo fmt --all --check`
- `cargo test --test llm_client`
- `cargo test --test llm_router`
- `cargo test --test llm_worker_hot_reload`
- `cargo check --tests`
- pre-commit hook ran `just clippy` and `just test`
- CSA/Codex full-diff review PASS/CLEAN: `01KTZP3H52H1TW1FR0VMAVJV3X`

## Notes

GitHub CI is not used as the local merge gate for this repository workflow; validation above is local + CSA review.