### PR TITLE
feat(embed): add endpoint pool parity

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -408,6 +408,7 @@ struct StatusResponse {
     taxonomy_count: i64,
     db_size_bytes: u64,
     embedding_status: String,
+    embedding_endpoints: Vec<ApiEmbeddingEndpointStatus>,
     search_mode: String,
     embedder_circuit: EmbedderCircuitStatus,
     write_queue: WriteQueueStats,
@@ -420,6 +421,24 @@ struct StatusResponse {
     search_telemetry: SearchTelemetrySnapshot,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     status_warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiEmbeddingEndpointStatus {
+    id: String,
+    backend: String,
+    base_url: String,
+    model: String,
+    priority: i32,
+    retry_interval_secs: u64,
+    request_timeout_secs: u64,
+    max_concurrent: usize,
+    dimensions: usize,
+    cooldown_remaining_secs: Option<u64>,
+    cooldown_until_unix_ms: Option<u64>,
+    last_failure_at_unix_ms: Option<u64>,
+    last_success_at_unix_ms: Option<u64>,
+    last_error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1314,6 +1333,11 @@ async fn taxonomy_handler(
 async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResponse>, ApiError> {
     let config = ConfigHandle::current();
     let embed_snapshot = crate::embed::global_embed_status().snapshot();
+    let endpoint_runtime = crate::embed::global_embed_status()
+        .endpoint_runtime_snapshots()
+        .into_iter()
+        .map(|snapshot| (snapshot.id.clone(), snapshot))
+        .collect::<std::collections::BTreeMap<_, _>>();
     let vector_search_circuit =
         VectorSearchCircuit::from_config_and_snapshot(config.as_ref(), &embed_snapshot);
     let turns_config = config.turns.clone();
@@ -1375,6 +1399,34 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         taxonomy_count: db_snapshot.taxonomy_count,
         db_size_bytes: db_snapshot.db_size_bytes,
         embedding_status: current_embedding_status(&embed_snapshot).to_string(),
+        embedding_endpoints: config
+            .embed
+            .effective_endpoints()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|endpoint| {
+                let runtime = endpoint_runtime.get(&endpoint.id);
+                ApiEmbeddingEndpointStatus {
+                    id: endpoint.id,
+                    backend: endpoint.backend,
+                    base_url: endpoint.base_url,
+                    model: endpoint.model,
+                    priority: endpoint.priority,
+                    retry_interval_secs: endpoint.retry_interval_secs,
+                    request_timeout_secs: endpoint.request_timeout_secs,
+                    max_concurrent: endpoint.max_concurrent,
+                    dimensions: endpoint.dimensions,
+                    cooldown_remaining_secs: runtime
+                        .and_then(|state| state.cooldown_remaining_secs),
+                    cooldown_until_unix_ms: runtime.and_then(|state| state.cooldown_until_unix_ms),
+                    last_failure_at_unix_ms: runtime
+                        .and_then(|state| state.last_failure_at_unix_ms),
+                    last_success_at_unix_ms: runtime
+                        .and_then(|state| state.last_success_at_unix_ms),
+                    last_error: runtime.and_then(|state| state.last_error.clone()),
+                }
+            })
+            .collect(),
         search_mode: vector_search_circuit
             .vector_search_mode
             .as_str()

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -23,6 +23,8 @@ const DEFAULT_HOT_RELOAD_POLL_FALLBACK_SECS: u64 = 5;
 const DEFAULT_OPENAI_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_OPENAI_DIM: usize = 4096;
 const DEFAULT_RETRY_INTERVAL_SECS: u64 = 2;
+const DEFAULT_EMBED_MAX_CONCURRENT: usize = 16;
+const DEFAULT_EMBED_ENDPOINT_PRIORITY: i32 = 0;
 const DEFAULT_LLM_BACKEND: &str = "openai_compat";
 const DEFAULT_LLM_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_LLM_RETRY_INTERVAL_SECS: u64 = 2;
@@ -302,6 +304,7 @@ impl Config {
                 "embed.retry.search_deadline_secs must be greater than 0".to_string(),
             ));
         }
+        self.embed.validate_endpoint_pool()?;
         self.llm.validate_endpoint_pool()?;
         self.validate_llm_judge_guardrails()?;
         if self.llm.enabled && self.llm.effective_endpoints()?.is_empty() {
@@ -634,6 +637,9 @@ impl Config {
         if self.embed.openai_compat.dim != other.embed.openai_compat.dim {
             fields.push("embedder.openai_compat.dim");
         }
+        if self.embed.endpoint_vector_identity() != other.embed.endpoint_vector_identity() {
+            fields.push("embedder.endpoints.vector_identity");
+        }
         if self.llm.enabled != other.llm.enabled {
             fields.push("llm.enabled");
         }
@@ -661,6 +667,15 @@ impl Config {
         effective.embed.base_url = self.embed.base_url.clone();
         effective.embed.api_model = self.embed.api_model.clone();
         effective.embed.openai_compat = self.embed.openai_compat.clone();
+        if self.embed.endpoint_vector_identity() == candidate.embed.endpoint_vector_identity() {
+            effective.embed.endpoints = candidate.embed.endpoints.clone();
+            effective.embed.max_concurrent = candidate.embed.max_concurrent;
+            effective.embed.retry = candidate.embed.retry.clone();
+        } else {
+            effective.embed.endpoints = self.embed.endpoints.clone();
+            effective.embed.max_concurrent = self.embed.max_concurrent;
+            effective.embed.retry = self.embed.retry.clone();
+        }
         if self.llm.enabled != candidate.llm.enabled || self.llm.backend != candidate.llm.backend {
             effective.llm = self.llm.clone();
         } else {
@@ -858,9 +873,24 @@ fn validate_llm_endpoint_pool_toml(root: &toml::Value) -> Result<(), ConfigError
     )))
 }
 
+fn normalize_embed_endpoint_id(
+    configured: Option<&str>,
+    index: usize,
+) -> Result<String, ConfigError> {
+    normalize_endpoint_id(configured, index, "embed endpoints")
+}
+
 fn normalize_llm_endpoint_id(
     configured: Option<&str>,
     index: usize,
+) -> Result<String, ConfigError> {
+    normalize_endpoint_id(configured, index, "llm endpoint")
+}
+
+fn normalize_endpoint_id(
+    configured: Option<&str>,
+    index: usize,
+    label: &str,
 ) -> Result<String, ConfigError> {
     let id = configured
         .map(str::trim)
@@ -873,10 +903,43 @@ fn normalize_llm_endpoint_id(
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
     {
         return Err(ConfigError::Validation(format!(
-            "llm endpoint id `{id}` must match [A-Za-z0-9_.-]{{1,64}}"
+            "{label} id `{id}` must match [A-Za-z0-9_.-]{{1,64}}"
         )));
     }
     Ok(id)
+}
+
+fn normalize_embed_endpoint_backend(backend: &str, field: &str) -> Result<String, ConfigError> {
+    let backend = backend.trim();
+    if backend.is_empty() {
+        return Err(ConfigError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    match backend {
+        "openai_compat" | "api" => Ok("openai_compat".to_string()),
+        other => Err(ConfigError::Validation(format!(
+            "{field}={other:?} is not supported in embed endpoint pools; use openai_compat-compatible HTTP endpoints"
+        ))),
+    }
+}
+
+fn embed_backend_is_http(backend: &str) -> bool {
+    matches!(backend, "openai_compat" | "api")
+}
+
+fn normalize_embed_endpoint_base_url(
+    base_url: Option<&str>,
+    field: &str,
+) -> Result<String, ConfigError> {
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .ok_or_else(|| ConfigError::Validation(format!("{field} must not be empty")))?
+        .trim_end_matches('/')
+        .to_string();
+    validate_embed_base_url(&base_url, field).map_err(ConfigError::Validation)?;
+    Ok(base_url)
 }
 
 fn normalize_llm_endpoint_base_url(
@@ -893,7 +956,15 @@ fn normalize_llm_endpoint_base_url(
     Ok(base_url)
 }
 
+fn normalize_embed_endpoint_model(model: Option<&str>, field: &str) -> Result<String, ConfigError> {
+    normalize_required_model(model, field)
+}
+
 fn normalize_llm_endpoint_model(model: Option<&str>, field: &str) -> Result<String, ConfigError> {
+    normalize_required_model(model, field)
+}
+
+fn normalize_required_model(model: Option<&str>, field: &str) -> Result<String, ConfigError> {
     model
         .map(str::trim)
         .filter(|model| !model.is_empty())
@@ -901,29 +972,52 @@ fn normalize_llm_endpoint_model(model: Option<&str>, field: &str) -> Result<Stri
         .ok_or_else(|| ConfigError::Validation(format!("{field} must not be empty")))
 }
 
+fn validate_embed_base_url(base_url: &str, field: &str) -> Result<(), String> {
+    validate_base_url(base_url, field, "api_key_env")
+}
+
 pub fn validate_llm_base_url(base_url: &str) -> Result<(), String> {
-    let parsed = Url::parse(base_url)
-        .map_err(|error| format!("invalid llm.base_url `{base_url}`: {error}"))?;
+    validate_base_url(base_url, "llm.base_url", "api_key_env")
+}
+
+fn validate_base_url(base_url: &str, field: &str, credential_hint: &str) -> Result<(), String> {
+    let parsed =
+        Url::parse(base_url).map_err(|error| format!("invalid {field} `{base_url}`: {error}"))?;
     if parsed.scheme().is_empty() {
-        return Err("llm.base_url must include a URL scheme".to_string());
+        return Err(format!("{field} must include a URL scheme"));
     }
     if parsed.host_str().is_none() {
-        return Err("llm.base_url must include a host".to_string());
+        return Err(format!("{field} must include a host"));
     }
     if !parsed.username().is_empty() || parsed.password().is_some() {
-        return Err(
-            "llm.base_url must not include userinfo credentials; use api_key_env instead"
-                .to_string(),
-        );
+        return Err(format!(
+            "{field} must not include userinfo credentials; use {credential_hint} instead"
+        ));
     }
     if parsed.query().is_some() {
-        return Err(
-            "llm.base_url must not include query parameters; move secrets to api_key_env"
-                .to_string(),
-        );
+        return Err(format!(
+            "{field} must not include query parameters; move secrets to {credential_hint}"
+        ));
     }
     if parsed.fragment().is_some() {
-        return Err("llm.base_url must not include URL fragments".to_string());
+        return Err(format!("{field} must not include URL fragments"));
+    }
+    Ok(())
+}
+
+fn validate_embed_endpoint_vector_identity(
+    endpoints: &[EffectiveEmbedEndpoint],
+) -> Result<(), ConfigError> {
+    let Some(first) = endpoints.first().map(EmbedVectorIdentity::from) else {
+        return Ok(());
+    };
+    for endpoint in endpoints.iter().skip(1) {
+        let identity = EmbedVectorIdentity::from(endpoint);
+        if identity != first {
+            return Err(ConfigError::Validation(
+                "embed endpoints must share one vector identity (backend, model, dim); configure separate reindex targets for different embedding models".to_string(),
+            ));
+        }
     }
     Ok(())
 }
@@ -1128,6 +1222,8 @@ pub struct EmbedConfig {
     pub base_url: Option<String>,
     pub api_model: Option<String>,
     pub openai_compat: OpenAiCompatConfig,
+    pub endpoints: Vec<EmbedEndpointConfig>,
+    pub max_concurrent: usize,
     pub retry: RetryConfig,
     pub alert: AlertConfig,
     pub degradation: DegradationConfig,
@@ -1142,6 +1238,8 @@ impl Default for EmbedConfig {
             base_url: None,
             api_model: None,
             openai_compat: OpenAiCompatConfig::default(),
+            endpoints: Vec::new(),
+            max_concurrent: DEFAULT_EMBED_MAX_CONCURRENT,
             retry: RetryConfig::default(),
             alert: AlertConfig::default(),
             degradation: DegradationConfig::default(),
@@ -1151,6 +1249,11 @@ impl Default for EmbedConfig {
 
 impl EmbedConfig {
     pub fn vector_embedder_fingerprint(&self, backend: &str, dim: usize) -> String {
+        if backend == self.backend
+            && let Some(identity) = self.endpoint_vector_identity()
+        {
+            return identity.fingerprint();
+        }
         let base_url = self
             .resolved_openai_base_url()
             .unwrap_or_default()
@@ -1199,6 +1302,245 @@ impl EmbedConfig {
 
     pub fn resolved_openai_dim(&self) -> usize {
         self.openai_compat.dim.unwrap_or(DEFAULT_OPENAI_DIM)
+    }
+
+    pub fn effective_endpoints(&self) -> Result<Vec<EffectiveEmbedEndpoint>, ConfigError> {
+        let endpoints = self.effective_endpoints_without_validation()?;
+        validate_embed_endpoint_vector_identity(&endpoints)?;
+        Ok(endpoints)
+    }
+
+    pub fn validate_endpoint_pool(&self) -> Result<(), ConfigError> {
+        if self.endpoints.is_empty() {
+            return Ok(());
+        }
+        validate_embed_endpoint_vector_identity(&self.effective_endpoints_without_validation()?)
+    }
+
+    pub fn pool_capacity(&self) -> usize {
+        self.effective_endpoints()
+            .ok()
+            .filter(|endpoints| !endpoints.is_empty())
+            .map(|endpoints| {
+                endpoints
+                    .into_iter()
+                    .map(|endpoint| endpoint.max_concurrent.max(1))
+                    .sum::<usize>()
+            })
+            .unwrap_or_else(|| self.max_concurrent.max(1))
+    }
+
+    pub fn effective_model_summary(&self) -> Option<String> {
+        summarize_effective_embed_endpoints(
+            self,
+            |endpoint| endpoint.model.clone(),
+            EffectiveEmbedEndpoint::model_label,
+        )
+    }
+
+    pub fn effective_base_url_summary(&self) -> Option<String> {
+        summarize_effective_embed_endpoints(
+            self,
+            |endpoint| endpoint.base_url.clone(),
+            EffectiveEmbedEndpoint::base_url_label,
+        )
+    }
+
+    pub fn effective_endpoint_fingerprints(&self) -> Vec<serde_json::Value> {
+        self.effective_endpoints()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|endpoint| {
+                serde_json::json!({
+                    "id": endpoint.id,
+                    "backend": endpoint.backend,
+                    "base_url": endpoint.base_url,
+                    "model": endpoint.model,
+                    "api_key_env": endpoint.api_key_env,
+                    "priority": endpoint.priority,
+                    "request_timeout_secs": endpoint.request_timeout_secs,
+                    "retry_interval_secs": endpoint.retry_interval_secs,
+                    "max_concurrent": endpoint.max_concurrent,
+                    "dimensions": endpoint.dimensions,
+                    "max_input_tokens": endpoint.max_input_tokens,
+                })
+            })
+            .collect()
+    }
+
+    fn legacy_effective_endpoint(&self) -> Result<Option<EffectiveEmbedEndpoint>, ConfigError> {
+        let backend = normalize_embed_endpoint_backend(&self.backend, "embed.backend")?;
+        if !embed_backend_is_http(&backend) {
+            return Ok(None);
+        }
+        let has_base_url = self
+            .resolved_openai_base_url()
+            .is_some_and(|base_url| !base_url.trim().is_empty());
+        let has_model = self
+            .resolved_openai_model()
+            .is_some_and(|model| !model.trim().is_empty());
+        if !has_base_url && !has_model {
+            return Ok(None);
+        }
+        let base_url =
+            normalize_embed_endpoint_base_url(self.resolved_openai_base_url(), "embed.base_url")?;
+        let model = normalize_embed_endpoint_model(self.resolved_openai_model(), "embed.model")?;
+        Ok(Some(EffectiveEmbedEndpoint {
+            id: "legacy".to_string(),
+            backend,
+            base_url,
+            model,
+            api_key_env: self.openai_compat.api_key_env.clone(),
+            priority: DEFAULT_EMBED_ENDPOINT_PRIORITY,
+            request_timeout_secs: self.openai_compat.request_timeout_secs.max(1),
+            retry_interval_secs: self.retry.interval_secs.max(1),
+            max_concurrent: self.max_concurrent.max(1),
+            dimensions: self.resolved_openai_dim(),
+            max_input_tokens: self.openai_compat.max_input_tokens,
+        }))
+    }
+
+    fn endpoint_vector_identity(&self) -> Option<EmbedVectorIdentity> {
+        self.effective_endpoints()
+            .ok()
+            .and_then(|endpoints| endpoints.first().map(EmbedVectorIdentity::from))
+    }
+
+    fn effective_endpoints_without_validation(
+        &self,
+    ) -> Result<Vec<EffectiveEmbedEndpoint>, ConfigError> {
+        if self.endpoints.is_empty() {
+            return self.legacy_effective_endpoint().map(|endpoint| {
+                endpoint
+                    .into_iter()
+                    .collect::<Vec<EffectiveEmbedEndpoint>>()
+            });
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        self.endpoints
+            .iter()
+            .enumerate()
+            .map(|(index, endpoint)| {
+                let id = normalize_embed_endpoint_id(endpoint.id.as_deref(), index)?;
+                if !seen.insert(id.clone()) {
+                    return Err(ConfigError::Validation(format!(
+                        "embed endpoints id `{id}` must be unique"
+                    )));
+                }
+                Ok(EffectiveEmbedEndpoint {
+                    id,
+                    backend: normalize_embed_endpoint_backend(
+                        endpoint.backend.as_deref().unwrap_or(self.backend.as_str()),
+                        format!("embed.endpoints[{index}].backend").as_str(),
+                    )?,
+                    base_url: normalize_embed_endpoint_base_url(
+                        endpoint
+                            .base_url
+                            .as_deref()
+                            .or_else(|| self.resolved_openai_base_url()),
+                        format!("embed.endpoints[{index}].base_url").as_str(),
+                    )?,
+                    model: normalize_embed_endpoint_model(
+                        endpoint
+                            .model
+                            .as_deref()
+                            .or_else(|| self.resolved_openai_model()),
+                        format!("embed.endpoints[{index}].model").as_str(),
+                    )?,
+                    api_key_env: endpoint
+                        .api_key_env
+                        .clone()
+                        .or_else(|| self.openai_compat.api_key_env.clone()),
+                    priority: endpoint.priority.unwrap_or(DEFAULT_EMBED_ENDPOINT_PRIORITY),
+                    request_timeout_secs: endpoint
+                        .request_timeout_secs
+                        .unwrap_or(self.openai_compat.request_timeout_secs)
+                        .max(1),
+                    retry_interval_secs: endpoint
+                        .retry_interval_secs
+                        .unwrap_or(self.retry.interval_secs)
+                        .max(1),
+                    max_concurrent: endpoint
+                        .max_concurrent
+                        .unwrap_or(self.max_concurrent)
+                        .max(1),
+                    dimensions: endpoint
+                        .dim
+                        .or(self.openai_compat.dim)
+                        .unwrap_or(DEFAULT_OPENAI_DIM),
+                    max_input_tokens: endpoint
+                        .max_input_tokens
+                        .or(self.openai_compat.max_input_tokens),
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(default)]
+pub struct EmbedEndpointConfig {
+    pub id: Option<String>,
+    pub backend: Option<String>,
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+    pub api_key_env: Option<String>,
+    /// Lower numbers are tried first. Equal priority endpoints share active load
+    /// according to each endpoint's `max_concurrent` capacity.
+    pub priority: Option<i32>,
+    #[serde(alias = "timeout_secs")]
+    pub request_timeout_secs: Option<u64>,
+    pub retry_interval_secs: Option<u64>,
+    pub max_concurrent: Option<usize>,
+    pub dim: Option<usize>,
+    pub max_input_tokens: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveEmbedEndpoint {
+    pub id: String,
+    pub backend: String,
+    pub base_url: String,
+    pub model: String,
+    pub api_key_env: Option<String>,
+    pub priority: i32,
+    pub request_timeout_secs: u64,
+    pub retry_interval_secs: u64,
+    pub max_concurrent: usize,
+    pub dimensions: usize,
+    pub max_input_tokens: Option<usize>,
+}
+
+impl EffectiveEmbedEndpoint {
+    pub fn model_label(&self) -> String {
+        format!("{}={}", self.id, self.model)
+    }
+
+    pub fn base_url_label(&self) -> String {
+        format!("{}={}", self.id, self.base_url)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EmbedVectorIdentity {
+    backend: String,
+    model: String,
+    dimensions: usize,
+}
+
+impl EmbedVectorIdentity {
+    fn fingerprint(&self) -> String {
+        format!("{}:{}:pool:{}", self.backend, self.model, self.dimensions)
+    }
+}
+
+impl From<&EffectiveEmbedEndpoint> for EmbedVectorIdentity {
+    fn from(endpoint: &EffectiveEmbedEndpoint) -> Self {
+        Self {
+            backend: endpoint.backend.clone(),
+            model: endpoint.model.clone(),
+            dimensions: endpoint.dimensions,
+        }
     }
 }
 
@@ -1447,6 +1789,27 @@ fn summarize_effective_endpoints(
     config: &LlmConfig,
     single_label: fn(&EffectiveLlmEndpoint) -> String,
     multi_label: fn(&EffectiveLlmEndpoint) -> String,
+) -> Option<String> {
+    let endpoints = config.effective_endpoints().ok()?;
+    if endpoints.is_empty() {
+        return None;
+    }
+    if endpoints.len() == 1 {
+        return endpoints.first().map(single_label);
+    }
+    Some(
+        endpoints
+            .iter()
+            .map(multi_label)
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+}
+
+fn summarize_effective_embed_endpoints(
+    config: &EmbedConfig,
+    single_label: fn(&EffectiveEmbedEndpoint) -> String,
+    multi_label: fn(&EffectiveEmbedEndpoint) -> String,
 ) -> Option<String> {
     let endpoints = config.effective_endpoints().ok()?;
     if endpoints.is_empty() {
@@ -2206,6 +2569,10 @@ impl ConfigHandle {
         LlmRuntimeSnapshot { config, generation }
     }
 
+    pub fn current_embed_generation() -> u64 {
+        super::hot_reload::global_hot_reload_state().current_embed_generation()
+    }
+
     pub fn scrub_content(input: &str) -> String {
         let (config, compiled) = Self::current_privacy_snapshot();
         config.scrub_content_with_compiled(input, compiled.as_ref())
@@ -2281,6 +2648,14 @@ impl ConfigHandle {
     /// LLM workers subscribe here to cancel in-flight requests on config change.
     pub fn subscribe_llm_gen() -> tokio::sync::watch::Receiver<u64> {
         super::hot_reload::global_hot_reload_state().subscribe_llm_gen()
+    }
+
+    /// Subscribe to embedding endpoint generation changes.
+    ///
+    /// The counter increments when hot-reload applies endpoint pool runtime
+    /// fields while preserving embedding vector identity.
+    pub fn subscribe_embed_gen() -> tokio::sync::watch::Receiver<u64> {
+        super::hot_reload::global_hot_reload_state().subscribe_embed_gen()
     }
 
     #[doc(hidden)]

--- a/src/core/hot_reload.rs
+++ b/src/core/hot_reload.rs
@@ -114,6 +114,10 @@ pub struct HotReloadState {
     /// enabled_for, max_concurrent). LLM workers subscribe to this to cancel
     /// in-flight requests and restart with the new config.
     llm_gen_tx: tokio::sync::watch::Sender<u64>,
+    /// Incremented when hot-reload applies embedding endpoint runtime changes
+    /// that preserve vector identity. Long-lived embedding clients rebuild on
+    /// the next request and keep sharing the configured endpoint pool.
+    embed_gen_tx: tokio::sync::watch::Sender<u64>,
 }
 
 impl HotReloadState {
@@ -122,6 +126,7 @@ impl HotReloadState {
         let snapshot =
             ConfigSnapshot::from_config(initial.clone()).expect("default config is valid");
         let (llm_gen_tx, _) = tokio::sync::watch::channel(0u64);
+        let (embed_gen_tx, _) = tokio::sync::watch::channel(0u64);
         Self {
             snapshot: ArcSwap::from_pointee(snapshot),
             runtime: Mutex::new(None),
@@ -133,6 +138,7 @@ impl HotReloadState {
                 initial.ingest_gating.embedding_classifier.prototypes,
             ),
             llm_gen_tx,
+            embed_gen_tx,
         }
     }
 
@@ -281,6 +287,19 @@ impl HotReloadState {
 
     pub fn current_llm_generation(&self) -> u64 {
         *self.llm_gen_tx.borrow()
+    }
+
+    /// Subscribe to embedding endpoint generation changes.
+    ///
+    /// The channel value is a monotonically-increasing counter that is bumped
+    /// when hot-reload applies endpoint pool runtime fields without changing
+    /// the embedding vector identity.
+    pub fn subscribe_embed_gen(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.embed_gen_tx.subscribe()
+    }
+
+    pub fn current_embed_generation(&self) -> u64 {
+        *self.embed_gen_tx.borrow()
     }
 
     /// Trigger a reload from the given path without going through the watcher.
@@ -483,6 +502,9 @@ impl HotReloadState {
             || previous.config.llm.max_concurrent != effective.llm.max_concurrent
             || previous.config.llm.retry_interval_secs != effective.llm.retry_interval_secs
             || previous.config.llm.enabled_for != effective.llm.enabled_for;
+        let embed_hot_changed = previous.config.embed.endpoints != effective.embed.endpoints
+            || previous.config.embed.max_concurrent != effective.embed.max_concurrent
+            || previous.config.embed.retry != effective.embed.retry;
 
         let next_snapshot = match ConfigSnapshot::from_config(effective) {
             Ok(snapshot) => snapshot,
@@ -504,6 +526,14 @@ impl HotReloadState {
             let _ = self.llm_gen_tx.send(prev_gen.wrapping_add(1));
             self.push_event(format!(
                 "config hot-reload: LLM config changed, generation bumped to {}",
+                prev_gen.wrapping_add(1)
+            ));
+        }
+        if embed_hot_changed {
+            let prev_gen = *self.embed_gen_tx.borrow();
+            let _ = self.embed_gen_tx.send(prev_gen.wrapping_add(1));
+            self.push_event(format!(
+                "config hot-reload: embedding endpoint pool changed, generation bumped to {}",
                 prev_gen.wrapping_add(1)
             ));
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1792,8 +1792,20 @@ pub(crate) fn llm_worker_claim_enabled(config: &crate::core::config::Config) -> 
 }
 
 struct DaemonEmbedder {
-    primary: Box<dyn Embedder>,
-    fallback: Option<Box<dyn Embedder>>,
+    name: String,
+    runtime: Mutex<DaemonEmbedderRuntime>,
+}
+
+struct DaemonEmbedderRuntime {
+    generation: u64,
+    primary: Arc<dyn Embedder>,
+    fallback: Option<Arc<dyn Embedder>>,
+}
+
+#[derive(Clone)]
+struct DaemonEmbedderRuntimeSnapshot {
+    primary: Arc<dyn Embedder>,
+    fallback: Option<Arc<dyn Embedder>>,
 }
 
 #[cfg(unix)]
@@ -1840,22 +1852,63 @@ pub fn shutdown_requested() -> bool {
 
 impl DaemonEmbedder {
     async fn from_config(config: &crate::core::config::Config) -> crate::embed::Result<Self> {
-        let primary = build_backend_from_name(config, config.embed.backend.as_str()).await?;
-        let fallback = match config.embed.fallback.as_deref() {
-            Some(name) if name.eq_ignore_ascii_case(config.embed.backend.as_str()) => None,
-            Some(name) => Some(build_backend_from_name(config, name).await?),
-            None => None,
+        let generation = crate::core::config::ConfigHandle::current_embed_generation();
+        let runtime = DaemonEmbedderRuntime::from_config(config, generation).await?;
+        let name = runtime.primary.name().to_string();
+        Ok(Self {
+            name,
+            runtime: Mutex::new(runtime),
+        })
+    }
+
+    async fn runtime_snapshot(&self) -> crate::embed::Result<DaemonEmbedderRuntimeSnapshot> {
+        let generation = crate::core::config::ConfigHandle::current_embed_generation();
+        if let Some(snapshot) = self.snapshot_if_generation(generation) {
+            return Ok(snapshot);
+        }
+
+        let config = crate::core::config::ConfigHandle::current();
+        let replacement = DaemonEmbedderRuntime::from_config(config.as_ref(), generation).await?;
+        let mut guard = self
+            .runtime
+            .lock()
+            .expect("daemon embedder runtime mutex poisoned");
+        if guard.generation != generation {
+            *guard = replacement;
+        }
+        Ok(guard.snapshot())
+    }
+
+    fn snapshot_if_generation(&self, generation: u64) -> Option<DaemonEmbedderRuntimeSnapshot> {
+        let guard = self
+            .runtime
+            .lock()
+            .expect("daemon embedder runtime mutex poisoned");
+        (guard.generation == generation).then(|| guard.snapshot())
+    }
+
+    #[cfg(test)]
+    fn from_primary_for_test(primary: Box<dyn Embedder>) -> Self {
+        let name = primary.name().to_string();
+        let runtime = DaemonEmbedderRuntime {
+            generation: crate::core::config::ConfigHandle::current_embed_generation(),
+            primary: Arc::from(primary),
+            fallback: None,
         };
-        Ok(Self { primary, fallback })
+        Self {
+            name,
+            runtime: Mutex::new(runtime),
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl Embedder for DaemonEmbedder {
     async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
+        let runtime = self.runtime_snapshot().await?;
         let status = global_embed_status();
-        if let Some(fallback) = &self.fallback {
-            match self.primary.embed(texts).await {
+        if let Some(fallback) = &runtime.fallback {
+            match runtime.primary.embed(texts).await {
                 Ok(vectors) => {
                     status.record_primary_success();
                     Ok(vectors)
@@ -1864,7 +1917,7 @@ impl Embedder for DaemonEmbedder {
                     status.record_failure(&primary_error);
                     let message = format!(
                         "embedder fallback active: {} failed, using {}",
-                        self.primary.name(),
+                        runtime.primary.name(),
                         fallback.name()
                     );
                     let vectors = fallback.embed(texts).await?;
@@ -1873,16 +1926,47 @@ impl Embedder for DaemonEmbedder {
                 }
             }
         } else {
-            self.primary.embed(texts).await
+            runtime.primary.embed(texts).await
         }
     }
 
     fn dimensions(&self) -> usize {
-        self.primary.dimensions()
+        self.runtime
+            .lock()
+            .expect("daemon embedder runtime mutex poisoned")
+            .primary
+            .dimensions()
     }
 
     fn name(&self) -> &str {
-        self.primary.name()
+        &self.name
+    }
+}
+
+impl DaemonEmbedderRuntime {
+    async fn from_config(
+        config: &crate::core::config::Config,
+        generation: u64,
+    ) -> crate::embed::Result<Self> {
+        let primary: Arc<dyn Embedder> =
+            Arc::from(build_backend_from_name(config, config.embed.backend.as_str()).await?);
+        let fallback = match config.embed.fallback.as_deref() {
+            Some(name) if name.eq_ignore_ascii_case(config.embed.backend.as_str()) => None,
+            Some(name) => Some(Arc::from(build_backend_from_name(config, name).await?)),
+            None => None,
+        };
+        Ok(Self {
+            generation,
+            primary,
+            fallback,
+        })
+    }
+
+    fn snapshot(&self) -> DaemonEmbedderRuntimeSnapshot {
+        DaemonEmbedderRuntimeSnapshot {
+            primary: Arc::clone(&self.primary),
+            fallback: self.fallback.as_ref().map(Arc::clone),
+        }
     }
 }
 
@@ -2278,10 +2362,9 @@ mod tests {
                 async_db,
                 store: async_store,
                 worker_id: "bounded-continuation-worker".to_string(),
-                embedder: Arc::new(DaemonEmbedder {
-                    primary: Box::new(StaticEmbedder),
-                    fallback: None,
-                }),
+                embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
+                    StaticEmbedder,
+                ))),
                 prototype_classifier: Arc::new(ArcSwap::from_pointee(None)),
                 config: Arc::new(config),
                 mempal_home,
@@ -2476,15 +2559,14 @@ mod tests {
                 async_db,
                 store: async_store,
                 worker_id: worker_id.to_string(),
-                embedder: std::sync::Arc::new(DaemonEmbedder {
-                    primary: Box::new(HeartbeatProbeEmbedder {
+                embedder: std::sync::Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
+                    HeartbeatProbeEmbedder {
                         db_path,
                         message_id: message.id.clone(),
                         stale_heartbeat_at,
                         attempts: AtomicUsize::new(0),
-                    }),
-                    fallback: None,
-                }),
+                    },
+                ))),
                 prototype_classifier: std::sync::Arc::new(ArcSwap::from_pointee(None)),
                 config: std::sync::Arc::new(config),
                 mempal_home,
@@ -2569,13 +2651,12 @@ mod tests {
                 async_db,
                 store: async_store,
                 worker_id: "merge-conflict-worker".to_string(),
-                embedder: Arc::new(DaemonEmbedder {
-                    primary: Box::new(MergeConflictProbeEmbedder {
+                embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
+                    MergeConflictProbeEmbedder {
                         db_path: db_path.clone(),
                         injected: Arc::clone(&injected),
-                    }),
-                    fallback: None,
-                }),
+                    },
+                ))),
                 prototype_classifier: Arc::new(ArcSwap::from_pointee(None)),
                 config: Arc::new(config),
                 mempal_home,
@@ -2707,12 +2788,11 @@ mod tests {
                 async_db,
                 store: async_store.clone(),
                 worker_id: worker_id.to_string(),
-                embedder: Arc::new(DaemonEmbedder {
-                    primary: Box::new(SlowEmbedder {
+                embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
+                    SlowEmbedder {
                         delay: Duration::from_secs(3),
-                    }),
-                    fallback: None,
-                }),
+                    },
+                ))),
                 prototype_classifier: Arc::new(ArcSwap::from_pointee(None)),
                 config: Arc::new(config),
                 mempal_home,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -6,8 +6,9 @@ use std::time::Duration;
 use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
 
-use crate::core::config::ConfigHandle;
+use crate::core::config::{Config, ConfigHandle};
 use crate::core::db::CURRENT_SCHEMA_VERSION;
+use crate::core::queue::{QueueStats, queue_stats_readonly};
 use crate::process_diagnostics::{DbHolderReport, inspect_db_holders};
 
 pub const REQUIRED_MCP_TOOLS: &[&str] = &[
@@ -76,9 +77,44 @@ pub struct DoctorReport {
     pub db: DoctorDbReport,
     pub db_holders: DbHolderReport,
     pub install: DoctorInstallReport,
+    pub embedding: DoctorEmbeddingReport,
     pub restart_required_config_changes: Vec<String>,
     pub warnings: Vec<String>,
     pub recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DoctorEmbeddingReport {
+    pub backend: String,
+    pub model: Option<String>,
+    pub pool_capacity: usize,
+    pub endpoints: Vec<DoctorEmbeddingEndpointReport>,
+    pub queue: DoctorEmbeddingQueueReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorEmbeddingEndpointReport {
+    pub id: String,
+    pub backend: String,
+    pub base_url: String,
+    pub model: String,
+    pub priority: i32,
+    pub retry_interval_secs: u64,
+    pub request_timeout_secs: u64,
+    pub max_concurrent: usize,
+    pub dimensions: usize,
+    pub cooldown_remaining_secs: Option<u64>,
+    pub cooldown_until_unix_ms: Option<u64>,
+    pub last_failure_at_unix_ms: Option<u64>,
+    pub last_success_at_unix_ms: Option<u64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DoctorEmbeddingQueueReport {
+    pub pending: u64,
+    pub claimed: u64,
+    pub failed: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -136,6 +172,8 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     let db = inspect_db(db_path);
     let db_holders = inspect_db_holders(db_path);
     let install = inspect_install();
+    let config = Config::load().ok();
+    let embedding = build_embedding_report(config.as_ref(), db_path);
     let restart_required_config_changes = ConfigHandle::restart_required_pending();
     let mut warnings = Vec::new();
     let mut recommendations = vec![
@@ -175,9 +213,64 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         db,
         db_holders,
         install,
+        embedding,
         restart_required_config_changes,
         warnings,
         recommendations,
+    }
+}
+
+fn build_embedding_report(config: Option<&Config>, db_path: &Path) -> DoctorEmbeddingReport {
+    let Some(config) = config else {
+        return DoctorEmbeddingReport::default();
+    };
+    let endpoint_runtime = crate::embed::global_embed_status()
+        .endpoint_runtime_snapshots()
+        .into_iter()
+        .map(|snapshot| (snapshot.id.clone(), snapshot))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let endpoints = config
+        .embed
+        .effective_endpoints()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|endpoint| {
+            let runtime = endpoint_runtime.get(&endpoint.id);
+            DoctorEmbeddingEndpointReport {
+                id: endpoint.id,
+                backend: endpoint.backend,
+                base_url: endpoint.base_url,
+                model: endpoint.model,
+                priority: endpoint.priority,
+                retry_interval_secs: endpoint.retry_interval_secs,
+                request_timeout_secs: endpoint.request_timeout_secs,
+                max_concurrent: endpoint.max_concurrent,
+                dimensions: endpoint.dimensions,
+                cooldown_remaining_secs: runtime.and_then(|state| state.cooldown_remaining_secs),
+                cooldown_until_unix_ms: runtime.and_then(|state| state.cooldown_until_unix_ms),
+                last_failure_at_unix_ms: runtime.and_then(|state| state.last_failure_at_unix_ms),
+                last_success_at_unix_ms: runtime.and_then(|state| state.last_success_at_unix_ms),
+                last_error: runtime.and_then(|state| state.last_error.clone()),
+            }
+        })
+        .collect();
+    let queue = queue_stats_readonly(db_path)
+        .map(queue_report_from_stats)
+        .unwrap_or_default();
+    DoctorEmbeddingReport {
+        backend: config.embed.backend.clone(),
+        model: config.embed.effective_model_summary(),
+        pool_capacity: config.embed.pool_capacity(),
+        endpoints,
+        queue,
+    }
+}
+
+fn queue_report_from_stats(stats: QueueStats) -> DoctorEmbeddingQueueReport {
+    DoctorEmbeddingQueueReport {
+        pending: stats.pending,
+        claimed: stats.claimed,
+        failed: stats.failed,
     }
 }
 

--- a/src/embed/api.rs
+++ b/src/embed/api.rs
@@ -65,12 +65,16 @@ impl ApiEmbedder {
             .map_err(|source| EmbedError::HttpRequest {
                 endpoint: endpoint.clone(),
                 source,
-            })?
-            .error_for_status()
-            .map_err(|source| EmbedError::HttpStatus {
-                endpoint: endpoint.clone(),
-                source,
-            })?
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(EmbedError::HttpStatus {
+                endpoint,
+                status,
+                retry_after: None,
+            });
+        }
+        let response = response
             .json::<OpenAiEmbeddingsResponse>()
             .await
             .map_err(|source| EmbedError::DecodeResponse { endpoint, source })?;
@@ -101,18 +105,23 @@ impl ApiEmbedder {
                 .map_err(|source| EmbedError::HttpRequest {
                     endpoint: endpoint.clone(),
                     source,
-                })?
-                .error_for_status()
-                .map_err(|source| EmbedError::HttpStatus {
-                    endpoint: endpoint.clone(),
-                    source,
-                })?
-                .json::<Value>()
-                .await
-                .map_err(|source| EmbedError::DecodeResponse {
-                    endpoint: endpoint.clone(),
-                    source,
                 })?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(EmbedError::HttpStatus {
+                    endpoint,
+                    status,
+                    retry_after: None,
+                });
+            }
+            let response =
+                response
+                    .json::<Value>()
+                    .await
+                    .map_err(|source| EmbedError::DecodeResponse {
+                        endpoint: endpoint.clone(),
+                        source,
+                    })?;
 
             let embedding = response
                 .get("embedding")

--- a/src/embed/factory.rs
+++ b/src/embed/factory.rs
@@ -1,4 +1,7 @@
-use crate::core::config::Config;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use crate::core::config::{Config, ConfigHandle};
 use async_trait::async_trait;
 
 use super::{Embedder, Result};
@@ -17,11 +20,102 @@ impl ConfiguredEmbedderFactory {
     pub fn new(config: Config) -> Self {
         Self { config }
     }
+
+    fn active_config(&self) -> Config {
+        let current = ConfigHandle::current();
+        if current.db_path == self.config.db_path && !config_is_default_snapshot(current.as_ref()) {
+            current.as_ref().clone()
+        } else {
+            self.config.clone()
+        }
+    }
 }
 
 #[async_trait]
 impl EmbedderFactory for ConfiguredEmbedderFactory {
     async fn build(&self) -> Result<Box<dyn Embedder>> {
-        super::from_config(&self.config).await
+        let config = self.active_config();
+        let signature = embedder_runtime_signature(&config);
+        let cache = shared_embedder_cache();
+        let mut guard = cache.lock().await;
+        if let Some(runtime) = guard.as_ref()
+            && runtime.signature == signature
+        {
+            return Ok(Box::new(SharedEmbedder {
+                inner: Arc::clone(&runtime.embedder),
+            }));
+        }
+        let embedder: Arc<dyn Embedder> = Arc::from(super::from_config(&config).await?);
+        *guard = Some(SharedEmbedderRuntime {
+            signature,
+            embedder: Arc::clone(&embedder),
+        });
+        Ok(Box::new(SharedEmbedder { inner: embedder }))
     }
+}
+
+struct SharedEmbedderRuntime {
+    signature: String,
+    embedder: Arc<dyn Embedder>,
+}
+
+struct SharedEmbedder {
+    inner: Arc<dyn Embedder>,
+}
+
+#[async_trait]
+impl Embedder for SharedEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.inner.embed(texts).await
+    }
+
+    fn dimensions(&self) -> usize {
+        self.inner.dimensions()
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn max_input_tokens(&self) -> Option<usize> {
+        self.inner.max_input_tokens()
+    }
+
+    fn estimate_tokens(&self, text: &str) -> usize {
+        self.inner.estimate_tokens(text)
+    }
+}
+
+fn shared_embedder_cache() -> &'static tokio::sync::Mutex<Option<SharedEmbedderRuntime>> {
+    static CACHE: OnceLock<tokio::sync::Mutex<Option<SharedEmbedderRuntime>>> = OnceLock::new();
+    CACHE.get_or_init(|| tokio::sync::Mutex::new(None))
+}
+
+fn config_is_default_snapshot(config: &Config) -> bool {
+    match (config.effective_hash(), Config::default().effective_hash()) {
+        (Ok(current), Ok(default)) => current == default,
+        _ => false,
+    }
+}
+
+fn embedder_runtime_signature(config: &Config) -> String {
+    serde_json::json!({
+        "backend": config.embed.backend,
+        "fallback": config.embed.fallback,
+        "model": config.embed.model,
+        "base_url": config.embed.base_url,
+        "api_model": config.embed.api_model,
+        "openai_compat": {
+            "base_url": config.embed.openai_compat.base_url,
+            "model": config.embed.openai_compat.model,
+            "api_key_env": config.embed.openai_compat.api_key_env,
+            "request_timeout_secs": config.embed.openai_compat.request_timeout_secs,
+            "dim": config.embed.openai_compat.dim,
+            "max_input_tokens": config.embed.openai_compat.max_input_tokens,
+        },
+        "endpoints": config.embed.effective_endpoint_fingerprints(),
+        "max_concurrent": config.embed.max_concurrent,
+        "retry_interval_secs": config.embed.retry.interval_secs,
+    })
+    .to_string()
 }

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::core::config::Config;
 use thiserror::Error;
@@ -14,10 +15,12 @@ pub mod model2vec;
 pub mod onnx;
 pub mod openai_compat;
 pub mod retry;
+pub mod router;
 pub mod status;
 pub mod stub;
 
 pub use factory::{ConfiguredEmbedderFactory, EmbedderFactory};
+pub use router::EmbeddingRouter;
 pub use status::{EmbedHealthSnapshot, EmbedStatus, global_embed_status};
 
 pub type Result<T> = std::result::Result<T, EmbedError>;
@@ -83,11 +86,11 @@ pub enum EmbedError {
         #[source]
         source: reqwest::Error,
     },
-    #[error("embedding endpoint returned error status {endpoint}")]
+    #[error("embedding endpoint returned error status {status} from {endpoint}")]
     HttpStatus {
         endpoint: String,
-        #[source]
-        source: reqwest::Error,
+        status: reqwest::StatusCode,
+        retry_after: Option<Duration>,
     },
     #[error("failed to decode embedding response from {endpoint}")]
     DecodeResponse {
@@ -109,6 +112,11 @@ pub enum EmbedError {
     MissingConfiguration(String),
     #[error("invalid embed configuration: {0}")]
     InvalidConfiguration(String),
+    #[error("embedding endpoints are temporarily unavailable: {reason}")]
+    TemporarilyUnavailable {
+        retry_after: Duration,
+        reason: String,
+    },
     #[error("failed to read embed API key from env var {var}")]
     ReadApiKeyEnv {
         var: String,
@@ -121,13 +129,13 @@ impl EmbedError {
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::HttpRequest { source, .. } => source.status().is_none_or(is_retryable_status),
-            Self::HttpStatus { source, .. } | Self::DownloadStatus { source, .. } => {
-                source.status().is_some_and(is_retryable_status)
-            }
+            Self::HttpStatus { status, .. } => is_retryable_status(*status),
+            Self::DownloadStatus { source, .. } => source.status().is_some_and(is_retryable_status),
             Self::Download { .. }
             | Self::ReadDownloadBody { .. }
             | Self::Runtime(_)
-            | Self::WorkerPanic(_) => true,
+            | Self::WorkerPanic(_)
+            | Self::TemporarilyUnavailable { .. } => true,
             Self::CreateModelDir { .. }
             | Self::CheckPathExists { .. }
             | Self::WriteFile { .. }
@@ -151,6 +159,14 @@ impl EmbedError {
             Self::HttpRequest { endpoint, .. }
             | Self::HttpStatus { endpoint, .. }
             | Self::DecodeResponse { endpoint, .. } => Some(endpoint.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::HttpStatus { retry_after, .. } => *retry_after,
+            Self::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
             _ => None,
         }
     }
@@ -217,9 +233,9 @@ pub async fn build_backend_from_name(config: &Config, backend: &str) -> Result<B
         }
         #[cfg(feature = "onnx")]
         "onnx" => Ok(Box::new(onnx::OnnxEmbedder::new_or_download().await?)),
-        "openai_compat" | "api" => Ok(Box::new(
-            openai_compat::OpenAiCompatibleEmbedder::from_config(config)?,
-        )),
+        "openai_compat" | "api" => Ok(Box::new(router::EmbeddingRouter::from_config(
+            &config.embed,
+        )?)),
         "stub" => {
             let dim = config
                 .embed

--- a/src/embed/openai_compat.rs
+++ b/src/embed/openai_compat.rs
@@ -1,48 +1,57 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use reqwest::Url;
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, RETRY_AFTER};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::{Mutex, Semaphore};
 
-use crate::core::config::Config;
+use crate::core::config::{Config, EffectiveEmbedEndpoint};
 
 use super::{EmbedError, Embedder, Result};
+
+pub(crate) const MAX_REMOTE_RETRY_HINT: Duration = Duration::from_secs(60);
+const MAX_REMOTE_RETRY_HINT_SECS: u64 = 60;
 
 #[derive(Debug, Clone)]
 pub struct OpenAiCompatibleEmbedder {
     client: reqwest::Client,
+    id: String,
+    base_url: String,
     endpoint: String,
     model: String,
     dimensions: usize,
     max_input_tokens: Option<usize>,
+    semaphore: Arc<Semaphore>,
+    current_max: Arc<AtomicUsize>,
+    concurrency_update_lock: Arc<Mutex<()>>,
 }
 
 impl OpenAiCompatibleEmbedder {
     pub fn from_config(config: &Config) -> Result<Self> {
-        let base_url = config
+        let endpoint = config
             .embed
-            .resolved_openai_base_url()
+            .effective_endpoints()
+            .map_err(|error| EmbedError::InvalidConfiguration(error.to_string()))?
+            .into_iter()
+            .next()
             .ok_or_else(|| {
                 EmbedError::MissingConfiguration(
                     "embed.openai_compat.base_url (or legacy embed.base_url) is required for backend=openai_compat; example: http://127.0.0.1:18002/v1 or http://gb10:18002/v1".to_string(),
                 )
-            })?
-            .trim_end_matches('/')
-            .to_string();
+            })?;
+        Self::from_endpoint(&endpoint)
+    }
+
+    pub fn from_endpoint(endpoint: &EffectiveEmbedEndpoint) -> Result<Self> {
+        let base_url = endpoint.base_url.trim_end_matches('/').to_string();
         validate_base_url(&base_url)?;
-        let model = config
-            .embed
-            .resolved_openai_model()
-            .ok_or_else(|| {
-                EmbedError::MissingConfiguration(
-                    "embed.openai_compat.model (or legacy embed.api_model)".to_string(),
-                )
-            })?
-            .to_string();
-        let endpoint = format!("{base_url}/embeddings");
+        let request_endpoint = format!("{base_url}/embeddings");
 
         let mut headers = HeaderMap::new();
-        if let Some(env_var) = config.embed.resolved_api_key_env() {
+        if let Some(env_var) = endpoint.api_key_env.as_deref() {
             let api_key = std::env::var(env_var).map_err(|source| EmbedError::ReadApiKeyEnv {
                 var: env_var.to_string(),
                 source,
@@ -54,23 +63,134 @@ impl OpenAiCompatibleEmbedder {
 
         let client = reqwest::Client::builder()
             .default_headers(headers)
-            .timeout(Duration::from_secs(
-                config.embed.openai_compat.request_timeout_secs,
-            ))
+            .timeout(Duration::from_secs(endpoint.request_timeout_secs))
             .build()
             .map_err(|error| EmbedError::Runtime(error.to_string()))?;
+        let max_concurrent = endpoint.max_concurrent.max(1);
 
         Ok(Self {
             client,
-            endpoint,
-            model,
-            dimensions: config.embed.resolved_openai_dim(),
-            max_input_tokens: config.embed.openai_compat.max_input_tokens,
+            id: endpoint.id.clone(),
+            base_url,
+            endpoint: request_endpoint,
+            model: endpoint.model.clone(),
+            dimensions: endpoint.dimensions,
+            max_input_tokens: endpoint.max_input_tokens,
+            semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            current_max: Arc::new(AtomicUsize::new(max_concurrent)),
+            concurrency_update_lock: Arc::new(Mutex::new(())),
         })
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
     }
 
     pub fn endpoint(&self) -> &str {
         &self.endpoint
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn current_max_concurrent(&self) -> usize {
+        self.current_max.load(Ordering::SeqCst)
+    }
+
+    pub fn available_permits(&self) -> usize {
+        self.semaphore.available_permits()
+    }
+
+    pub async fn update_concurrency(&self, new_max: usize) {
+        let _guard = self.concurrency_update_lock.lock().await;
+        let new_max = new_max.max(1);
+        let old_max = self.current_max.load(Ordering::SeqCst);
+        if new_max == old_max {
+            return;
+        }
+        if new_max > old_max {
+            self.semaphore.add_permits(new_max - old_max);
+        } else {
+            let diff = (old_max - new_max) as u32;
+            let permit = self
+                .semaphore
+                .acquire_many(diff)
+                .await
+                .expect("semaphore closed");
+            permit.forget();
+        }
+        self.current_max.store(new_max, Ordering::SeqCst);
+    }
+
+    pub async fn embed_with_permit(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+        self.send_embed(texts).await
+    }
+
+    pub async fn try_embed(&self, texts: &[&str]) -> Result<Option<Vec<Vec<f32>>>> {
+        let permit = match self.semaphore.try_acquire() {
+            Ok(permit) => permit,
+            Err(tokio::sync::TryAcquireError::NoPermits) => return Ok(None),
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(EmbedError::Runtime(
+                    "embedding endpoint semaphore closed".to_string(),
+                ));
+            }
+        };
+        let response = self.send_embed(texts).await;
+        drop(permit);
+        response.map(Some)
+    }
+
+    async fn send_embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let endpoint = self.endpoint().to_string();
+        let response = self
+            .client
+            .post(self.endpoint())
+            .json(&OpenAiEmbeddingsRequest {
+                input: texts,
+                model: &self.model,
+            })
+            .send()
+            .await
+            .map_err(map_reqwest_error(endpoint.clone()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(response.headers());
+            let body = response
+                .text()
+                .await
+                .map_err(map_reqwest_error(endpoint.clone()))?;
+            let retry_after = retry_after.or_else(|| parse_reset_seconds(&body));
+            return Err(EmbedError::HttpStatus {
+                endpoint,
+                status,
+                retry_after,
+            });
+        }
+
+        let response = response
+            .json::<OpenAiEmbeddingsResponse>()
+            .await
+            .map_err(map_decode_error(endpoint.clone()))?;
+
+        let vectors = response
+            .data
+            .into_iter()
+            .map(|item| item.embedding)
+            .collect::<Vec<_>>();
+        validate_vectors(&vectors, self.dimensions())?;
+        Ok(vectors)
     }
 }
 
@@ -101,40 +221,7 @@ fn validate_base_url(base_url: &str) -> Result<()> {
 #[async_trait::async_trait]
 impl Embedder for OpenAiCompatibleEmbedder {
     async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
-        if texts.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let endpoint = self.endpoint().to_string();
-        let response = self
-            .client
-            .post(self.endpoint())
-            .json(&OpenAiEmbeddingsRequest {
-                input: texts,
-                model: &self.model,
-            })
-            .send()
-            .await
-            .map_err(|source| EmbedError::HttpRequest {
-                endpoint: endpoint.clone(),
-                source,
-            })?
-            .error_for_status()
-            .map_err(|source| EmbedError::HttpStatus {
-                endpoint: endpoint.clone(),
-                source,
-            })?
-            .json::<OpenAiEmbeddingsResponse>()
-            .await
-            .map_err(|source| EmbedError::DecodeResponse { endpoint, source })?;
-
-        let vectors = response
-            .data
-            .into_iter()
-            .map(|item| item.embedding)
-            .collect::<Vec<_>>();
-        validate_vectors(&vectors, self.dimensions())?;
-        Ok(vectors)
+        self.embed_with_permit(texts).await
     }
 
     fn dimensions(&self) -> usize {
@@ -183,4 +270,48 @@ fn validate_vectors(vectors: &[Vec<f32>], expected_dimensions: usize) -> Result<
     }
 
     Ok(())
+}
+
+fn parse_retry_after(headers: &HeaderMap) -> Option<Duration> {
+    headers
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(clamp_remote_retry_hint_secs)
+}
+
+fn parse_reset_seconds(body: &str) -> Option<Duration> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    find_reset_seconds(&value).map(clamp_remote_retry_hint_secs)
+}
+
+fn clamp_remote_retry_hint_secs(secs: u64) -> Duration {
+    Duration::from_secs(secs.min(MAX_REMOTE_RETRY_HINT_SECS))
+}
+
+fn find_reset_seconds(value: &Value) -> Option<u64> {
+    match value {
+        Value::Object(map) => {
+            if let Some(reset) = map.get("reset_seconds").and_then(value_as_u64) {
+                return Some(reset);
+            }
+            map.values().find_map(find_reset_seconds)
+        }
+        Value::Array(values) => values.iter().find_map(find_reset_seconds),
+        _ => None,
+    }
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u64>().ok()))
+}
+
+fn map_reqwest_error(endpoint: String) -> impl FnOnce(reqwest::Error) -> EmbedError {
+    move |source| EmbedError::HttpRequest { endpoint, source }
+}
+
+fn map_decode_error(endpoint: String) -> impl FnOnce(reqwest::Error) -> EmbedError {
+    move |source| EmbedError::DecodeResponse { endpoint, source }
 }

--- a/src/embed/retry.rs
+++ b/src/embed/retry.rs
@@ -26,18 +26,26 @@ where
                 if !error.is_retryable() {
                     return Err(error);
                 }
+                let retry_after = error
+                    .retry_after()
+                    .unwrap_or_else(|| Duration::from_secs(status.retry_interval_secs()));
                 refresh_heartbeat(heartbeat);
-                wait_for_next_retry(status, heartbeat).await;
+                wait_for_next_retry(status, heartbeat, retry_after).await;
             }
         }
     }
 }
 
-async fn wait_for_next_retry(status: &EmbedStatus, heartbeat: Option<&HeartbeatCallback>) {
+async fn wait_for_next_retry(
+    status: &EmbedStatus,
+    heartbeat: Option<&HeartbeatCallback>,
+    retry_after: Duration,
+) {
     let started_at = tokio::time::Instant::now();
     let tick = Duration::from_millis(50);
     loop {
-        let retry_after = Duration::from_secs(status.retry_interval_secs());
+        let configured_retry_after = Duration::from_secs(status.retry_interval_secs());
+        let retry_after = retry_after.max(configured_retry_after);
         let elapsed = started_at.elapsed();
         if elapsed >= retry_after {
             refresh_heartbeat(heartbeat);

--- a/src/embed/router.rs
+++ b/src/embed/router.rs
@@ -1,0 +1,267 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use reqwest::StatusCode;
+use tokio::sync::Mutex;
+
+use crate::core::config::{EffectiveEmbedEndpoint, EmbedConfig};
+
+use super::openai_compat::{MAX_REMOTE_RETRY_HINT, OpenAiCompatibleEmbedder};
+use super::retry::HeartbeatCallback;
+use super::{EmbedError, Embedder, Result};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoutedEmbeddingResponse {
+    pub endpoint_id: String,
+    pub endpoint_model: String,
+    pub vectors: Vec<Vec<f32>>,
+}
+
+#[derive(Debug)]
+struct RoutedEndpoint {
+    config: EffectiveEmbedEndpoint,
+    client: OpenAiCompatibleEmbedder,
+    unavailable_until: Mutex<Option<Instant>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingRouter {
+    endpoints: Arc<Vec<Arc<RoutedEndpoint>>>,
+    dimensions: usize,
+    name: String,
+    max_input_tokens: Option<usize>,
+}
+
+impl EmbeddingRouter {
+    pub fn from_config(config: &EmbedConfig) -> Result<Self> {
+        let endpoints = config
+            .effective_endpoints()
+            .map_err(|error| EmbedError::InvalidConfiguration(error.to_string()))?;
+        Self::from_endpoints(endpoints)
+    }
+
+    pub fn from_endpoints(endpoints: Vec<EffectiveEmbedEndpoint>) -> Result<Self> {
+        if endpoints.is_empty() {
+            return Err(EmbedError::MissingConfiguration(
+                "embedding endpoints must not be empty".to_string(),
+            ));
+        }
+        let dimensions = endpoints[0].dimensions;
+        let name = endpoints[0].backend.clone();
+        let max_input_tokens = endpoints
+            .iter()
+            .filter_map(|endpoint| endpoint.max_input_tokens)
+            .min();
+        let mut endpoints = endpoints.into_iter().enumerate().collect::<Vec<_>>();
+        endpoints.sort_by_key(|(index, endpoint)| (endpoint.priority, *index));
+        let routed = endpoints
+            .into_iter()
+            .map(|(_, config)| {
+                let client = OpenAiCompatibleEmbedder::from_endpoint(&config)?;
+                Ok(Arc::new(RoutedEndpoint {
+                    config,
+                    client,
+                    unavailable_until: Mutex::new(None),
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            endpoints: Arc::new(routed),
+            dimensions,
+            name,
+            max_input_tokens,
+        })
+    }
+
+    pub async fn embed_routed(
+        &self,
+        texts: &[&str],
+        heartbeat: Option<&HeartbeatCallback>,
+    ) -> Result<RoutedEmbeddingResponse> {
+        let mut last_retryable = None;
+        let mut earliest_retry_after: Option<Duration> = None;
+        let mut first_saturated_endpoint: Option<Arc<RoutedEndpoint>> = None;
+
+        for endpoint in self.endpoints.iter() {
+            if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
+                earliest_retry_after = Some(match earliest_retry_after {
+                    Some(current) => current.min(retry_after),
+                    None => retry_after,
+                });
+                continue;
+            }
+            refresh_heartbeat(heartbeat)?;
+            match endpoint.client.try_embed(texts).await {
+                Ok(Some(vectors)) => {
+                    endpoint.mark_available().await;
+                    crate::embed::global_embed_status()
+                        .record_endpoint_success(&endpoint.config.id);
+                    return Ok(RoutedEmbeddingResponse {
+                        endpoint_id: endpoint.config.id.clone(),
+                        endpoint_model: endpoint.config.model.clone(),
+                        vectors,
+                    });
+                }
+                Ok(None) => {
+                    if first_saturated_endpoint.is_none() {
+                        first_saturated_endpoint = Some(Arc::clone(endpoint));
+                    }
+                }
+                Err(error) if should_try_next_endpoint(&error) => {
+                    if let Some(retry_after) = endpoint.retry_after_for_error(&error) {
+                        endpoint.mark_temporarily_unavailable(retry_after).await;
+                        crate::embed::global_embed_status().record_endpoint_cooldown(
+                            &endpoint.config.id,
+                            retry_after,
+                            &error,
+                        );
+                        earliest_retry_after = Some(match earliest_retry_after {
+                            Some(current) => current.min(retry_after),
+                            None => retry_after,
+                        });
+                    }
+                    last_retryable = Some(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        if let Some(endpoint) = first_saturated_endpoint
+            && earliest_retry_after.is_none()
+            && last_retryable.is_none()
+        {
+            refresh_heartbeat(heartbeat)?;
+            let vectors = endpoint.client.embed_with_permit(texts).await?;
+            endpoint.mark_available().await;
+            crate::embed::global_embed_status().record_endpoint_success(&endpoint.config.id);
+            return Ok(RoutedEmbeddingResponse {
+                endpoint_id: endpoint.config.id.clone(),
+                endpoint_model: endpoint.config.model.clone(),
+                vectors,
+            });
+        }
+
+        match (last_retryable, earliest_retry_after) {
+            (None, Some(retry_after)) | (Some(_), Some(retry_after)) => {
+                Err(EmbedError::TemporarilyUnavailable {
+                    retry_after,
+                    reason: format!(
+                        "{} embedding endpoint(s) are cooling down after retryable failures",
+                        self.endpoints.len()
+                    ),
+                })
+            }
+            (Some(error), _) => Err(error),
+            (None, None) => Err(EmbedError::MissingConfiguration(
+                "no embedding endpoint is currently available".to_string(),
+            )),
+        }
+    }
+
+    pub fn endpoint_count(&self) -> usize {
+        self.endpoints.len()
+    }
+
+    pub fn pool_capacity(&self) -> usize {
+        self.endpoints
+            .iter()
+            .map(|endpoint| endpoint.config.max_concurrent.max(1))
+            .sum()
+    }
+}
+
+#[async_trait::async_trait]
+impl Embedder for EmbeddingRouter {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        self.embed_routed(texts, None)
+            .await
+            .map(|response| response.vectors)
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn max_input_tokens(&self) -> Option<usize> {
+        self.max_input_tokens
+    }
+}
+
+impl RoutedEndpoint {
+    async fn temporary_unavailable_remaining(&self) -> Option<Duration> {
+        let mut guard = self.unavailable_until.lock().await;
+        match *guard {
+            Some(until) if until > Instant::now() => {
+                Some(until.saturating_duration_since(Instant::now()))
+            }
+            Some(_) => {
+                *guard = None;
+                crate::embed::global_embed_status().clear_endpoint_cooldown(&self.config.id);
+                None
+            }
+            None => None,
+        }
+    }
+
+    fn retry_after_for_error(&self, error: &EmbedError) -> Option<Duration> {
+        match error {
+            EmbedError::HttpStatus {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                retry_after,
+                ..
+            } => Some(
+                retry_after.unwrap_or_else(|| Duration::from_secs(self.config.retry_interval_secs)),
+            ),
+            EmbedError::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
+            EmbedError::HttpRequest { .. }
+            | EmbedError::Runtime(_)
+            | EmbedError::WorkerPanic(_) => {
+                Some(Duration::from_secs(self.config.retry_interval_secs))
+            }
+            EmbedError::HttpStatus { status, .. } if status.is_server_error() => {
+                Some(Duration::from_secs(self.config.retry_interval_secs))
+            }
+            _ => None,
+        }
+    }
+
+    async fn mark_temporarily_unavailable(&self, retry_after: Duration) {
+        let mut guard = self.unavailable_until.lock().await;
+        let now = Instant::now();
+        *guard = Some(
+            now.checked_add(retry_after)
+                .unwrap_or_else(|| now + MAX_REMOTE_RETRY_HINT),
+        );
+    }
+
+    async fn mark_available(&self) {
+        let mut guard = self.unavailable_until.lock().await;
+        *guard = None;
+    }
+}
+
+fn should_try_next_endpoint(error: &EmbedError) -> bool {
+    match error {
+        EmbedError::HttpRequest { .. }
+        | EmbedError::Runtime(_)
+        | EmbedError::WorkerPanic(_)
+        | EmbedError::TemporarilyUnavailable { .. } => true,
+        EmbedError::HttpStatus { status, .. } => {
+            status.is_server_error()
+                || *status == StatusCode::REQUEST_TIMEOUT
+                || *status == StatusCode::TOO_MANY_REQUESTS
+        }
+        _ => false,
+    }
+}
+
+fn refresh_heartbeat(heartbeat: Option<&HeartbeatCallback>) -> Result<()> {
+    if let Some(callback) = heartbeat {
+        callback()?;
+    }
+    Ok(())
+}

--- a/src/embed/router.rs
+++ b/src/embed/router.rs
@@ -126,10 +126,7 @@ impl EmbeddingRouter {
             }
         }
 
-        if let Some(endpoint) = first_saturated_endpoint
-            && earliest_retry_after.is_none()
-            && last_retryable.is_none()
-        {
+        if let Some(endpoint) = first_saturated_endpoint {
             refresh_heartbeat(heartbeat)?;
             let vectors = endpoint.client.embed_with_permit(texts).await?;
             endpoint.mark_available().await;

--- a/src/embed/status.rs
+++ b/src/embed/status.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use arc_swap::{ArcSwap, ArcSwapOption};
 
@@ -35,6 +37,24 @@ pub struct RetryConfigSnapshot {
     pub alert_enabled: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbedEndpointRuntimeSnapshot {
+    pub id: String,
+    pub cooldown_until_unix_ms: Option<u64>,
+    pub cooldown_remaining_secs: Option<u64>,
+    pub last_error: Option<String>,
+    pub last_failure_at_unix_ms: Option<u64>,
+    pub last_success_at_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct EmbedEndpointRuntimeState {
+    cooldown_until_unix_ms: Option<u64>,
+    last_error: Option<String>,
+    last_failure_at_unix_ms: Option<u64>,
+    last_success_at_unix_ms: Option<u64>,
+}
+
 pub struct EmbedStatus {
     fail_count: AtomicU64,
     degraded: AtomicBool,
@@ -48,6 +68,7 @@ pub struct EmbedStatus {
     last_success_at_unix_ms: AtomicU64,
     fallback_warning: ArcSwapOption<String>,
     audit_db_path: ArcSwapOption<PathBuf>,
+    endpoint_states: Mutex<BTreeMap<String, EmbedEndpointRuntimeState>>,
 }
 
 impl Default for EmbedStatus {
@@ -76,6 +97,7 @@ impl EmbedStatus {
             last_success_at_unix_ms: AtomicU64::new(0),
             fallback_warning: ArcSwapOption::from(None),
             audit_db_path: ArcSwapOption::from(None),
+            endpoint_states: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -171,6 +193,74 @@ impl EmbedStatus {
             .store(now_unix_ms(), Ordering::SeqCst);
     }
 
+    pub fn record_endpoint_success(&self, id: &str) {
+        let now = now_unix_ms();
+        let mut states = self
+            .endpoint_states
+            .lock()
+            .expect("embed endpoint state mutex poisoned");
+        let state = states.entry(id.to_string()).or_default();
+        state.cooldown_until_unix_ms = None;
+        state.last_error = None;
+        state.last_success_at_unix_ms = Some(now);
+    }
+
+    pub fn record_endpoint_cooldown(
+        &self,
+        id: &str,
+        retry_after: Duration,
+        error: &super::EmbedError,
+    ) {
+        let now = now_unix_ms();
+        let retry_ms = u64::try_from(retry_after.as_millis()).unwrap_or(u64::MAX);
+        let cooldown_until = now.saturating_add(retry_ms);
+        let mut states = self
+            .endpoint_states
+            .lock()
+            .expect("embed endpoint state mutex poisoned");
+        let state = states.entry(id.to_string()).or_default();
+        state.cooldown_until_unix_ms = Some(cooldown_until);
+        state.last_error = Some(crate::core::config::scrub_sensitive_text(
+            &error.to_string(),
+        ));
+        state.last_failure_at_unix_ms = Some(now);
+    }
+
+    pub fn clear_endpoint_cooldown(&self, id: &str) {
+        let mut states = self
+            .endpoint_states
+            .lock()
+            .expect("embed endpoint state mutex poisoned");
+        if let Some(state) = states.get_mut(id) {
+            state.cooldown_until_unix_ms = None;
+        }
+    }
+
+    pub fn endpoint_runtime_snapshots(&self) -> Vec<EmbedEndpointRuntimeSnapshot> {
+        let now = now_unix_ms();
+        let states = self
+            .endpoint_states
+            .lock()
+            .expect("embed endpoint state mutex poisoned");
+        states
+            .iter()
+            .map(|(id, state)| {
+                let cooldown_until = state
+                    .cooldown_until_unix_ms
+                    .filter(|cooldown_until| *cooldown_until > now);
+                EmbedEndpointRuntimeSnapshot {
+                    id: id.clone(),
+                    cooldown_until_unix_ms: cooldown_until,
+                    cooldown_remaining_secs: cooldown_until
+                        .map(|cooldown_until| cooldown_until.saturating_sub(now).div_ceil(1000)),
+                    last_error: state.last_error.clone(),
+                    last_failure_at_unix_ms: state.last_failure_at_unix_ms,
+                    last_success_at_unix_ms: state.last_success_at_unix_ms,
+                }
+            })
+            .collect()
+    }
+
     pub fn record_fallback_success(&self, message: String) {
         self.sync_from_config();
         self.fail_count.store(0, Ordering::SeqCst);
@@ -232,6 +322,10 @@ impl EmbedStatus {
         self.last_success_at_unix_ms.store(0, Ordering::SeqCst);
         self.fallback_warning.store(None);
         self.audit_db_path.store(None);
+        self.endpoint_states
+            .lock()
+            .expect("embed endpoint state mutex poisoned")
+            .clear();
     }
 
     pub fn set_audit_db_path(&self, db_path: Option<PathBuf>) {

--- a/src/endpoint_health.rs
+++ b/src/endpoint_health.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use tokio::time::timeout;
 
-use crate::core::config::{Config, EffectiveLlmEndpoint};
+use crate::core::config::{Config, EffectiveEmbedEndpoint, EffectiveLlmEndpoint};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -66,13 +66,31 @@ pub fn probe_endpoints_blocking(config: &Config) -> Result<EndpointHealthSnapsho
 async fn probe_embedding(config: &Config) -> ProbeStatus {
     match config.embed.backend.as_str() {
         "openai_compat" | "api" => {
-            let Some(base_url) = config.embed.resolved_openai_base_url() else {
-                return ProbeStatus::unreachable("missing base_url".to_string());
+            let endpoints = match config.embed.effective_endpoints() {
+                Ok(endpoints) if !endpoints.is_empty() => endpoints,
+                Ok(_) => return ProbeStatus::unreachable("missing base_url".to_string()),
+                Err(error) => return ProbeStatus::unreachable(error.to_string()),
             };
-            probe_models_endpoint(base_url, config.embed.resolved_api_key_env(), None).await
+            probe_embedding_endpoints(&endpoints).await
         }
         backend => ProbeStatus::reachable(None, format!("local backend: {backend}")),
     }
+}
+
+async fn probe_embedding_endpoints(endpoints: &[EffectiveEmbedEndpoint]) -> ProbeStatus {
+    let mut failures = Vec::new();
+    for endpoint in endpoints {
+        let status =
+            probe_models_endpoint(&endpoint.base_url, endpoint.api_key_env.as_deref(), None).await;
+        if status.reachable {
+            return ProbeStatus::reachable(
+                status.latency_ms,
+                format!("http probe via {}", endpoint.id),
+            );
+        }
+        failures.push(format!("{}: {}", endpoint.id, status.detail));
+    }
+    ProbeStatus::unreachable(failures.join("; "))
 }
 
 async fn probe_llm(config: &Config) -> ProbeStatus {

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -105,10 +105,7 @@ impl LlmRouter {
             }
         }
 
-        if let Some(endpoint) = first_saturated_endpoint
-            && earliest_retry_after.is_none()
-            && last_retryable.is_none()
-        {
+        if let Some(endpoint) = first_saturated_endpoint {
             refresh_heartbeat(heartbeat)?;
             let response = endpoint.client.chat_completion(request).await?;
             return Ok(RoutedLlmResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10152,6 +10152,45 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     if let Some(last_success_at) = embed_status.last_success_at_unix_ms {
         println!("embed_last_success_at_unix_ms: {last_success_at}");
     }
+    let embed_endpoint_runtime = global_embed_status()
+        .endpoint_runtime_snapshots()
+        .into_iter()
+        .map(|snapshot| (snapshot.id.clone(), snapshot))
+        .collect::<BTreeMap<_, _>>();
+    println!("Embedding:");
+    println!("  backend: {}", config.embed.backend);
+    if let Some(model) = config.embed.effective_model_summary().as_deref() {
+        println!("  model: {model}");
+    }
+    if let Some(base_url) = config.embed.effective_base_url_summary().as_deref() {
+        println!("  base_url: {base_url}");
+    }
+    println!("  pool_capacity: {}", config.embed.pool_capacity());
+    let endpoints = config.embed.effective_endpoints().unwrap_or_default();
+    if endpoints.is_empty() {
+        println!("  endpoints: none");
+    } else {
+        println!("  endpoints:");
+        for endpoint in endpoints {
+            let runtime = embed_endpoint_runtime.get(&endpoint.id);
+            let cooldown = runtime
+                .and_then(|state| state.cooldown_remaining_secs)
+                .map(|secs| secs.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            println!(
+                "    {}: backend={} model={} base_url={} priority={} max_concurrent={} retry_interval_secs={} dim={} cooldown_remaining_secs={}",
+                endpoint.id,
+                endpoint.backend,
+                endpoint.model,
+                endpoint.base_url,
+                endpoint.priority,
+                endpoint.max_concurrent,
+                endpoint.retry_interval_secs,
+                endpoint.dimensions,
+                cooldown
+            );
+        }
+    }
     match &endpoint_health {
         Some(health) => {
             println!("Endpoints:");
@@ -11137,12 +11176,26 @@ async fn build_embedder(config: &Config) -> Result<Box<dyn Embedder>> {
         .context("failed to initialize embedder")
 }
 async fn build_specific_embedder(config: &Config, backend: &str) -> Result<Box<dyn Embedder>> {
+    if same_embed_backend(config.embed.backend.as_str(), backend) {
+        return build_embedder(config).await;
+    }
     let mut selected = config.clone();
     selected.embed.backend = backend.to_string();
     selected.embed.fallback = None;
     build_backend_from_name(&selected, backend)
         .await
         .context("failed to initialize requested embedder")
+}
+
+fn same_embed_backend(left: &str, right: &str) -> bool {
+    normalize_embed_backend_alias(left) == normalize_embed_backend_alias(right)
+}
+
+fn normalize_embed_backend_alias(backend: &str) -> &str {
+    match backend {
+        "api" => "openai_compat",
+        other => other,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -16723,6 +16776,36 @@ fn doctor_command(format: String) -> Result<()> {
                 "path_matches_current_exe={:?}",
                 report.install.path_matches_current_exe
             );
+            println!("embedding_backend={}", report.embedding.backend);
+            println!(
+                "embedding_model={}",
+                report.embedding.model.as_deref().unwrap_or("none")
+            );
+            println!("embedding_pool_capacity={}", report.embedding.pool_capacity);
+            println!(
+                "embedding_queue=pending:{} claimed:{} failed:{}",
+                report.embedding.queue.pending,
+                report.embedding.queue.claimed,
+                report.embedding.queue.failed
+            );
+            if report.embedding.endpoints.is_empty() {
+                println!("embedding_endpoints=none");
+            } else {
+                for endpoint in &report.embedding.endpoints {
+                    println!(
+                        "embedding_endpoint={} model={} base_url={} priority={} max_concurrent={} cooldown_remaining_secs={}",
+                        endpoint.id,
+                        endpoint.model,
+                        endpoint.base_url,
+                        endpoint.priority,
+                        endpoint.max_concurrent,
+                        endpoint
+                            .cooldown_remaining_secs
+                            .map(|secs| secs.to_string())
+                            .unwrap_or_else(|| "none".to_string())
+                    );
+                }
+            }
             if report.restart_required_config_changes.is_empty() {
                 println!("restart_required_config_changes=none");
             } else {
@@ -17407,6 +17490,13 @@ mod tests {
             vec!["stale".to_string()],
             "drawer with current fingerprint is excluded"
         );
+    }
+
+    #[test]
+    fn embed_backend_aliases_match_for_shared_pool() {
+        assert!(same_embed_backend("api", "openai_compat"));
+        assert!(same_embed_backend("openai_compat", "api"));
+        assert!(!same_embed_backend("model2vec", "openai_compat"));
     }
 
     #[cfg(feature = "model2vec")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -100,20 +100,20 @@ use super::tools::{
     CoworkBusHandoffDto, CoworkBusHandoffFiltersDto, CoworkBusMessageDto, CoworkBusRequest,
     CoworkBusResponse, CoworkBusSessionDto, CoworkBusTmuxPeekDto, CoworkBusTmuxProbeDto,
     CoworkPushRequest, CoworkPushResponse, DatabaseDiagnosticDto, DeleteRequest, DeleteResponse,
-    DoctorMcpDto, DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning, EmbedStatusDto,
-    EmbedderCircuitDto, EndpointHealthDto, FactCheckRequest, FactCheckResponse,
-    FieldTaxonomyEntryDto, FieldTaxonomyResponse, GatingRuntimeStatusDto, IngestControls,
-    IngestOperationState, IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest,
-    KgResponse, KgStatsDto, KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest,
-    KnowledgeCardsResponse, KnowledgeDemoteRequest, KnowledgeDemoteResponse,
-    KnowledgeDistillRequest, KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse,
-    KnowledgePolicyResponse, KnowledgePromoteRequest, KnowledgePromoteResponse,
-    KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest,
-    LeaseResponse, LlmEndpointStatusDto, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT,
-    MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest, PeekMessageDto, PeekPartnerRequest,
-    PeekPartnerResponse, Phase3GateDto, Phase3Request, Phase3Response, PinnedFactDto,
-    PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse, QueueStatsDto,
-    ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
+    DoctorMcpDto, DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning,
+    EmbedEndpointStatusDto, EmbedStatusDto, EmbedderCircuitDto, EndpointHealthDto,
+    FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto, FieldTaxonomyResponse,
+    GatingRuntimeStatusDto, IngestControls, IngestOperationState, IngestRequest, IngestResponse,
+    IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
+    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
+    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
+    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
+    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
+    LeaseInfoDto, LeaseRequest, LeaseResponse, LlmEndpointStatusDto, LlmStatusDto,
+    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
+    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
+    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
     ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
     RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
     SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
@@ -2206,6 +2206,11 @@ impl MempalMcpServer {
         };
         let endpoint_health = crate::endpoint_health::probe_endpoints(config.as_ref()).await;
         let embed_snapshot = global_embed_status().snapshot();
+        let embed_endpoint_runtime = global_embed_status()
+            .endpoint_runtime_snapshots()
+            .into_iter()
+            .map(|snapshot| (snapshot.id.clone(), snapshot))
+            .collect::<BTreeMap<_, _>>();
         let intelligence_snapshot = crate::intelligence::global_intelligence_status().snapshot();
         let db_holders = crate::process_diagnostics::inspect_db_holders(&self.db_path);
         let vector_search_circuit =
@@ -2344,6 +2349,37 @@ impl MempalMcpServer {
                     .embed
                     .resolved_openai_base_url()
                     .map(ToOwned::to_owned),
+                model: config.embed.effective_model_summary(),
+                endpoints: config
+                    .embed
+                    .effective_endpoints()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|endpoint| {
+                        let runtime = embed_endpoint_runtime.get(&endpoint.id);
+                        EmbedEndpointStatusDto {
+                            id: endpoint.id,
+                            backend: endpoint.backend,
+                            base_url: endpoint.base_url,
+                            model: endpoint.model,
+                            priority: endpoint.priority,
+                            retry_interval_secs: endpoint.retry_interval_secs,
+                            request_timeout_secs: endpoint.request_timeout_secs,
+                            max_concurrent: endpoint.max_concurrent,
+                            dimensions: endpoint.dimensions,
+                            cooldown_remaining_secs: runtime
+                                .and_then(|state| state.cooldown_remaining_secs),
+                            cooldown_until_unix_ms: runtime
+                                .and_then(|state| state.cooldown_until_unix_ms),
+                            last_failure_at_unix_ms: runtime
+                                .and_then(|state| state.last_failure_at_unix_ms),
+                            last_success_at_unix_ms: runtime
+                                .and_then(|state| state.last_success_at_unix_ms),
+                            last_error: runtime.and_then(|state| state.last_error.clone()),
+                        }
+                    })
+                    .collect(),
+                max_concurrent: config.embed.pool_capacity(),
                 pending_count: queue_stats.pending,
                 claimed_count: queue_stats.claimed,
                 failed_count: queue_stats.failed,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2140,6 +2140,12 @@ pub struct EmbedStatusDto {
     pub backend: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub endpoints: Vec<EmbedEndpointStatusDto>,
+    #[serde(default)]
+    pub max_concurrent: usize,
     pub pending_count: u64,
     pub claimed_count: u64,
     pub failed_count: u64,
@@ -2150,6 +2156,29 @@ pub struct EmbedStatusDto {
     pub last_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_success_at_unix_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct EmbedEndpointStatusDto {
+    pub id: String,
+    pub backend: String,
+    pub base_url: String,
+    pub model: String,
+    pub priority: i32,
+    pub retry_interval_secs: u64,
+    pub request_timeout_secs: u64,
+    pub max_concurrent: usize,
+    pub dimensions: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cooldown_remaining_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cooldown_until_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_failure_at_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_success_at_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/tests/embedder_router.rs
+++ b/tests/embedder_router.rs
@@ -7,7 +7,7 @@ use mempal::embed::{
     ConfiguredEmbedderFactory, EmbedError, EmbedderFactory, router::EmbeddingRouter,
 };
 use mockito::{Matcher, Server};
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Notify};
 
 fn embedding_body(vector: &[f32]) -> String {
     serde_json::json!({
@@ -155,6 +155,100 @@ async fn spawn_counting_embedding_server(
     (format!("http://{addr}/v1"), count, handle)
 }
 
+async fn spawn_first_request_gated_embedding_server() -> (
+    String,
+    Arc<AtomicUsize>,
+    Arc<Notify>,
+    Arc<Notify>,
+    tokio::task::JoinHandle<()>,
+) {
+    use axum::{Json, Router, routing::post};
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let first_started = Arc::new(Notify::new());
+    let release_first = Arc::new(Notify::new());
+    let count_for_handler = Arc::clone(&count);
+    let first_started_for_handler = Arc::clone(&first_started);
+    let release_first_for_handler = Arc::clone(&release_first);
+    let app = Router::new().route(
+        "/v1/embeddings",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            let first_started = Arc::clone(&first_started_for_handler);
+            let release_first = Arc::clone(&release_first_for_handler);
+            async move {
+                let request_index = count.fetch_add(1, Ordering::SeqCst);
+                if request_index == 0 {
+                    first_started.notify_one();
+                    release_first.notified().await;
+                }
+                Json(serde_json::json!({
+                    "data": [
+                        {
+                            "embedding": [0.1, 0.2, 0.3]
+                        }
+                    ]
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind gated embedding server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve gated embedding server");
+    });
+    (
+        format!("http://{addr}/v1"),
+        count,
+        first_started,
+        release_first,
+        handle,
+    )
+}
+
+async fn spawn_embedding_cooldown_server() -> (
+    String,
+    Arc<AtomicUsize>,
+    Arc<Notify>,
+    tokio::task::JoinHandle<()>,
+) {
+    use axum::{Router, http::StatusCode, routing::post};
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let called = Arc::new(Notify::new());
+    let count_for_handler = Arc::clone(&count);
+    let called_for_handler = Arc::clone(&called);
+    let app = Router::new().route(
+        "/v1/embeddings",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            let called = Arc::clone(&called_for_handler);
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                called.notify_one();
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    r#"{"error":{"code":"model_cooldown","reset_seconds":60}}"#,
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind embedding cooldown server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve embedding cooldown server");
+    });
+    (format!("http://{addr}/v1"), count, called, handle)
+}
+
 #[tokio::test]
 async fn test_embedding_router_same_priority_uses_each_endpoint_capacity_concurrently() {
     let (gb10_url, gb10_count, gb10_server) =
@@ -186,6 +280,46 @@ async fn test_embedding_router_same_priority_uses_each_endpoint_capacity_concurr
 
     assert_eq!(gb10_count.load(Ordering::SeqCst), 4);
     assert_eq!(spark_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_embedding_router_waits_for_saturated_healthy_endpoint_before_cooldown() {
+    let (primary_url, primary_count, first_started, release_first, primary_server) =
+        spawn_first_request_gated_embedding_server().await;
+    let (cooldown_url, cooldown_count, cooldown_called, cooldown_server) =
+        spawn_embedding_cooldown_server().await;
+    let config = pool_config(&[
+        ("primary", &primary_url, 0, 1),
+        ("cooldown", &cooldown_url, 10, 1),
+    ]);
+    let router = Arc::new(EmbeddingRouter::from_config(&config).expect("build embedding router"));
+    let first_router = Arc::clone(&router);
+    let first_task = tokio::spawn(async move { first_router.embed_routed(&["first"], None).await });
+    first_started.notified().await;
+
+    let second_router = Arc::clone(&router);
+    let second_task =
+        tokio::spawn(async move { second_router.embed_routed(&["second"], None).await });
+    cooldown_called.notified().await;
+    release_first.notify_one();
+
+    first_task
+        .await
+        .expect("first join")
+        .expect("first embedding response");
+    let second = tokio::time::timeout(Duration::from_secs(2), second_task)
+        .await
+        .expect("second request should complete after primary permit frees")
+        .expect("second join")
+        .expect("second embedding response");
+    primary_server.abort();
+    cooldown_server.abort();
+    let _ = primary_server.await;
+    let _ = cooldown_server.await;
+
+    assert_eq!(second.endpoint_id, "primary");
+    assert_eq!(primary_count.load(Ordering::SeqCst), 2);
+    assert_eq!(cooldown_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/tests/embedder_router.rs
+++ b/tests/embedder_router.rs
@@ -1,0 +1,226 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use mempal::core::config::Config;
+use mempal::embed::{
+    ConfiguredEmbedderFactory, EmbedError, EmbedderFactory, router::EmbeddingRouter,
+};
+use mockito::{Matcher, Server};
+use tokio::sync::Barrier;
+
+fn embedding_body(vector: &[f32]) -> String {
+    serde_json::json!({
+        "data": [
+            {
+                "embedding": vector
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn pool_config(entries: &[(&str, &str, i32, usize)]) -> mempal::core::config::EmbedConfig {
+    pool_full_config(entries).embed
+}
+
+fn pool_full_config(entries: &[(&str, &str, i32, usize)]) -> Config {
+    let mut toml = String::from("[embed]\nbackend = \"openai_compat\"\n");
+    for (id, base_url, priority, max_concurrent) in entries {
+        toml.push_str(&format!(
+            r#"
+[[embed.endpoints]]
+id = "{id}"
+base_url = "{base_url}"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+priority = {priority}
+max_concurrent = {max_concurrent}
+"#
+        ));
+    }
+    Config::parse(&toml).expect("parse embedding pool config")
+}
+
+#[tokio::test]
+async fn test_embedding_router_primary_5xx_falls_back_to_secondary_success() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/embeddings")
+        .with_status(500)
+        .with_body("server error")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("POST", "/v1/embeddings")
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "model": "Qwen/Qwen3-Embedding-8B",
+            "input": ["hello"]
+        })))
+        .with_status(200)
+        .with_body(embedding_body(&[0.1, 0.2, 0.3]))
+        .create_async()
+        .await;
+    let config = pool_config(&[
+        ("primary", &format!("{}/v1", primary.url()), 0, 1),
+        ("secondary", &format!("{}/v1", secondary.url()), 10, 1),
+    ]);
+    let router = EmbeddingRouter::from_config(&config).expect("build embedding router");
+
+    let response = router
+        .embed_routed(&["hello"], None)
+        .await
+        .expect("fallback response");
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert_eq!(response.endpoint_id, "secondary");
+    assert_eq!(response.vectors, vec![vec![0.1, 0.2, 0.3]]);
+}
+
+#[tokio::test]
+async fn test_embedding_router_429_reset_seconds_marks_cooldown() {
+    let mut primary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("POST", "/v1/embeddings")
+        .with_status(429)
+        .with_body(r#"{"error":{"code":"model_cooldown","reset_seconds":7}}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let config = pool_config(&[("primary", &format!("{}/v1", primary.url()), 0, 1)]);
+    let router = EmbeddingRouter::from_config(&config).expect("build embedding router");
+
+    let error = router
+        .embed_routed(&["hello"], None)
+        .await
+        .expect_err("cooldown should be retryable");
+    let second = router
+        .embed_routed(&["hello"], None)
+        .await
+        .expect_err("cached cooldown should avoid another request");
+
+    primary_mock.assert_async().await;
+    assert!(matches!(
+        error,
+        EmbedError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after == Duration::from_secs(7)
+    ));
+    assert!(error.is_retryable());
+    assert!(matches!(
+        second,
+        EmbedError::TemporarilyUnavailable {
+            retry_after,
+            ..
+        } if retry_after <= Duration::from_secs(7)
+    ));
+}
+
+async fn spawn_counting_embedding_server(
+    delay: Duration,
+) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    use axum::{Json, Router, routing::post};
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_for_handler = Arc::clone(&count);
+    let app = Router::new().route(
+        "/v1/embeddings",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(delay).await;
+                Json(serde_json::json!({
+                    "data": [
+                        {
+                            "embedding": [0.1, 0.2, 0.3]
+                        }
+                    ]
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind counting embedding server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve counting embedding server");
+    });
+    (format!("http://{addr}/v1"), count, handle)
+}
+
+#[tokio::test]
+async fn test_embedding_router_same_priority_uses_each_endpoint_capacity_concurrently() {
+    let (gb10_url, gb10_count, gb10_server) =
+        spawn_counting_embedding_server(Duration::from_millis(200)).await;
+    let (spark_url, spark_count, spark_server) =
+        spawn_counting_embedding_server(Duration::from_millis(200)).await;
+    let config = pool_config(&[("gb10", &gb10_url, 0, 4), ("spark", &spark_url, 0, 1)]);
+    let router = Arc::new(EmbeddingRouter::from_config(&config).expect("build embedding router"));
+    assert_eq!(router.pool_capacity(), 5);
+
+    let barrier = Arc::new(Barrier::new(6));
+    let mut tasks = Vec::new();
+    for _ in 0..5 {
+        let router = Arc::clone(&router);
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            router.embed_routed(&["hello"], None).await
+        }));
+    }
+    barrier.wait().await;
+    for task in tasks {
+        task.await.expect("join").expect("embedding response");
+    }
+    gb10_server.abort();
+    spark_server.abort();
+    let _ = gb10_server.await;
+    let _ = spark_server.await;
+
+    assert_eq!(gb10_count.load(Ordering::SeqCst), 4);
+    assert_eq!(spark_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_configured_embedder_factory_builds_share_endpoint_capacity() {
+    let (gb10_url, gb10_count, gb10_server) =
+        spawn_counting_embedding_server(Duration::from_millis(200)).await;
+    let (spark_url, spark_count, spark_server) =
+        spawn_counting_embedding_server(Duration::from_millis(200)).await;
+    let config = pool_full_config(&[("gb10", &gb10_url, 0, 1), ("spark", &spark_url, 0, 1)]);
+    let factory = ConfiguredEmbedderFactory::new(config);
+    let first = factory.build().await.expect("first embedder");
+    let second = factory.build().await.expect("second embedder");
+
+    let barrier = Arc::new(Barrier::new(3));
+    let first_barrier = Arc::clone(&barrier);
+    let first_task = tokio::spawn(async move {
+        first_barrier.wait().await;
+        first.embed(&["hello"]).await
+    });
+    let second_barrier = Arc::clone(&barrier);
+    let second_task = tokio::spawn(async move {
+        second_barrier.wait().await;
+        second.embed(&["hello"]).await
+    });
+    barrier.wait().await;
+    first_task.await.expect("first join").expect("first embed");
+    second_task
+        .await
+        .expect("second join")
+        .expect("second embed");
+    gb10_server.abort();
+    spark_server.abort();
+    let _ = gb10_server.await;
+    let _ = spark_server.await;
+
+    assert_eq!(gb10_count.load(Ordering::SeqCst), 1);
+    assert_eq!(spark_count.load(Ordering::SeqCst), 1);
+}

--- a/tests/endpoint_health.rs
+++ b/tests/endpoint_health.rs
@@ -45,3 +45,47 @@ model = "secondary-model"
     assert!(health.llm.reachable, "{health:#?}");
     assert_eq!(health.llm.detail, "http probe via secondary");
 }
+
+#[tokio::test]
+async fn test_endpoint_health_probes_embedding_endpoint_pool() {
+    let mut primary = Server::new_async().await;
+    let mut secondary = Server::new_async().await;
+    let primary_mock = primary
+        .mock("GET", "/v1/models")
+        .with_status(500)
+        .with_body("primary unavailable")
+        .create_async()
+        .await;
+    let secondary_mock = secondary
+        .mock("GET", "/v1/models")
+        .with_status(200)
+        .with_body(r#"{"object":"list","data":[]}"#)
+        .create_async()
+        .await;
+    let config = Config::parse(&format!(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "primary"
+base_url = "{}/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+
+[[embed.endpoints]]
+id = "secondary"
+base_url = "{}/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+"#,
+        primary.url(),
+        secondary.url()
+    ))
+    .expect("parse embedding endpoint pool");
+
+    let health = probe_endpoints(&config).await;
+
+    primary_mock.assert_async().await;
+    secondary_mock.assert_async().await;
+    assert!(health.embedding.reachable, "{health:#?}");
+    assert_eq!(health.embedding.detail, "http probe via secondary");
+}

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -169,6 +169,178 @@ model = "secondary-model"
 }
 
 #[test]
+fn test_embed_config_endpoint_pool_yields_effective_endpoints() {
+    let config = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1/"
+model = "Qwen/Qwen3-Embedding-8B"
+priority = 0
+max_concurrent = 4
+
+[[embed.endpoints]]
+id = "spark"
+base_url = "http://spark.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+priority = 0
+request_timeout_secs = 7
+retry_interval_secs = 3
+max_concurrent = 2
+"#,
+    )
+    .expect("embedding endpoint list should parse");
+
+    let endpoints = config
+        .embed
+        .effective_endpoints()
+        .expect("embedding endpoint list should normalize");
+
+    assert_eq!(endpoints.len(), 2);
+    assert_eq!(endpoints[0].id, "gb10");
+    assert_eq!(endpoints[0].base_url, "http://gb10.local:18002/v1");
+    assert_eq!(endpoints[0].model, "Qwen/Qwen3-Embedding-8B");
+    assert_eq!(endpoints[0].dimensions, 4096);
+    assert_eq!(endpoints[0].priority, 0);
+    assert_eq!(endpoints[0].request_timeout_secs, 30);
+    assert_eq!(endpoints[0].retry_interval_secs, 2);
+    assert_eq!(endpoints[0].max_concurrent, 4);
+    assert_eq!(endpoints[1].id, "spark");
+    assert_eq!(endpoints[1].request_timeout_secs, 7);
+    assert_eq!(endpoints[1].retry_interval_secs, 3);
+    assert_eq!(endpoints[1].max_concurrent, 2);
+    assert_eq!(config.embed.pool_capacity(), 6);
+    assert_eq!(
+        config.embed.effective_model_summary().as_deref(),
+        Some("gb10=Qwen/Qwen3-Embedding-8B, spark=Qwen/Qwen3-Embedding-8B")
+    );
+}
+
+#[test]
+fn test_embed_endpoint_pool_rejects_mixed_vector_identity() {
+    let error = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+
+[[embed.endpoints]]
+id = "spark"
+base_url = "http://spark.local:18002/v1"
+model = "other-embedding-model"
+dim = 4096
+"#,
+    )
+    .expect_err("mixed embedding models must not parse");
+
+    assert!(
+        error
+            .to_string()
+            .contains("embed endpoints must share one vector identity"),
+        "{error}"
+    );
+}
+
+#[test]
+fn test_embed_endpoint_pool_runtime_fields_hot_reload_when_identity_matches() {
+    let current = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+max_concurrent = 1
+"#,
+    )
+    .expect("current config");
+    let candidate = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://spark.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+max_concurrent = 3
+retry_interval_secs = 5
+"#,
+    )
+    .expect("candidate config");
+
+    assert!(
+        !current
+            .restart_required_fields_changed(&candidate)
+            .contains(&"embedder.endpoints.vector_identity")
+    );
+    let effective = current.merge_runtime_allowed(&candidate);
+    let endpoints = effective
+        .embed
+        .effective_endpoints()
+        .expect("effective endpoints");
+
+    assert_eq!(endpoints[0].base_url, "http://spark.local:18002/v1");
+    assert_eq!(endpoints[0].max_concurrent, 3);
+    assert_eq!(endpoints[0].retry_interval_secs, 5);
+}
+
+#[test]
+fn test_embed_endpoint_pool_vector_identity_change_requires_restart() {
+    let current = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+"#,
+    )
+    .expect("current config");
+    let candidate = Config::parse(
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 1024
+"#,
+    )
+    .expect("candidate config");
+
+    assert!(
+        current
+            .restart_required_fields_changed(&candidate)
+            .contains(&"embedder.endpoints.vector_identity")
+    );
+    let effective = current.merge_runtime_allowed(&candidate);
+    let endpoints = effective
+        .embed
+        .effective_endpoints()
+        .expect("effective endpoints");
+
+    assert_eq!(endpoints[0].dimensions, 4096);
+}
+
+#[test]
 fn test_endpoint_pool_external_llm_base_url_warns_but_does_not_block_config() {
     let config = Config::parse(
         r#"

--- a/tests/llm_router.rs
+++ b/tests/llm_router.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use mempal::core::config::Config;
 use mempal::llm::{LlmError, LlmMessage, LlmRequest, LlmRouter};
 use mockito::{Matcher, Server};
-use tokio::sync::Barrier;
+use tokio::sync::{Barrier, Notify};
 
 fn request() -> LlmRequest {
     LlmRequest {
@@ -295,6 +295,114 @@ async fn spawn_counting_server(
     (format!("http://{addr}/v1"), count, handle)
 }
 
+async fn spawn_first_request_gated_server(
+    model: &'static str,
+) -> (
+    String,
+    Arc<AtomicUsize>,
+    Arc<Notify>,
+    Arc<Notify>,
+    tokio::task::JoinHandle<()>,
+) {
+    use axum::{Json, Router, routing::post};
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let first_started = Arc::new(Notify::new());
+    let release_first = Arc::new(Notify::new());
+    let count_for_handler = Arc::clone(&count);
+    let first_started_for_handler = Arc::clone(&first_started);
+    let release_first_for_handler = Arc::clone(&release_first);
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            let first_started = Arc::clone(&first_started_for_handler);
+            let release_first = Arc::clone(&release_first_for_handler);
+            async move {
+                let request_index = count.fetch_add(1, Ordering::SeqCst);
+                if request_index == 0 {
+                    first_started.notify_one();
+                    release_first.notified().await;
+                }
+                Json(serde_json::json!({
+                    "model": model,
+                    "choices": [{
+                        "message": {
+                            "role": "assistant",
+                            "content": "ok"
+                        }
+                    }],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2
+                    }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind gated LLM server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve gated LLM server");
+    });
+    (
+        format!("http://{addr}/v1"),
+        count,
+        first_started,
+        release_first,
+        handle,
+    )
+}
+
+async fn spawn_llm_cooldown_server() -> (
+    String,
+    Arc<AtomicUsize>,
+    Arc<Notify>,
+    tokio::task::JoinHandle<()>,
+) {
+    use axum::{
+        Router,
+        http::{StatusCode, header},
+        routing::post,
+    };
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let called = Arc::new(Notify::new());
+    let count_for_handler = Arc::clone(&count);
+    let called_for_handler = Arc::clone(&called);
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let count = Arc::clone(&count_for_handler);
+            let called = Arc::clone(&called_for_handler);
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                called.notify_one();
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(header::RETRY_AFTER, "60")],
+                    "cooling down",
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind LLM cooldown server");
+    let addr = listener.local_addr().expect("server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve LLM cooldown server");
+    });
+    (format!("http://{addr}/v1"), count, called, handle)
+}
+
 fn pool_config(entries: &[(&str, &str, &str, i32, usize)]) -> mempal::core::config::LlmConfig {
     let mut toml = String::from("[llm]\nenabled = true\n");
     for (id, base_url, model, priority, max_concurrent) in entries {
@@ -347,6 +455,48 @@ async fn test_llm_router_same_priority_uses_each_endpoint_capacity_concurrently(
 
     assert_eq!(qwen_count.load(Ordering::SeqCst), 4);
     assert_eq!(spark_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_llm_router_waits_for_saturated_healthy_endpoint_before_cooldown() {
+    let (primary_url, primary_count, first_started, release_first, primary_server) =
+        spawn_first_request_gated_server("primary-model").await;
+    let (cooldown_url, cooldown_count, cooldown_called, cooldown_server) =
+        spawn_llm_cooldown_server().await;
+    let config = pool_config(&[
+        ("primary", &primary_url, "primary-model", 0, 1),
+        ("cooldown", &cooldown_url, "cooldown-model", 10, 1),
+    ]);
+    let router = Arc::new(LlmRouter::from_config(&config).expect("build router"));
+    let first_router = Arc::clone(&router);
+    let first_task =
+        tokio::spawn(async move { first_router.chat_completion(&request(), None).await });
+    first_started.notified().await;
+
+    let second_router = Arc::clone(&router);
+    let second_task =
+        tokio::spawn(async move { second_router.chat_completion(&request(), None).await });
+    cooldown_called.notified().await;
+    release_first.notify_one();
+
+    first_task
+        .await
+        .expect("first join")
+        .expect("first LLM response");
+    let second = tokio::time::timeout(Duration::from_secs(2), second_task)
+        .await
+        .expect("second request should complete after primary permit frees")
+        .expect("second join")
+        .expect("second LLM response");
+    primary_server.abort();
+    cooldown_server.abort();
+    let _ = primary_server.await;
+    let _ = cooldown_server.await;
+
+    assert_eq!(second.endpoint_id, "primary");
+    assert_eq!(second.endpoint_model, "primary-model");
+    assert_eq!(primary_count.load(Ordering::SeqCst), 2);
+    assert_eq!(cooldown_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/tests/llm_worker_hot_reload.rs
+++ b/tests/llm_worker_hot_reload.rs
@@ -383,6 +383,121 @@ preview_chars = 200
 }
 
 #[test]
+fn test_embed_gen_increments_on_endpoint_runtime_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:19999/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+max_concurrent = 1
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_embed_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    std::fs::write(
+        &config_path,
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:20000/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 3
+max_concurrent = 2
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert!(
+        gen_after > gen_before,
+        "embedding generation must increment when endpoint runtime fields change (before={gen_before}, after={gen_after})"
+    );
+    let endpoints = ConfigHandle::current()
+        .embed
+        .effective_endpoints()
+        .expect("effective embed endpoints");
+    assert_eq!(endpoints[0].base_url, "http://127.0.0.1:20000/v1");
+    assert_eq!(endpoints[0].max_concurrent, 2);
+}
+
+#[test]
+fn test_embed_gen_does_not_increment_on_endpoint_vector_identity_change() {
+    let _guard = TEST_LOCK.lock().expect("test lock");
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config_path = tmp.path().join("config.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-a"
+dim = 3
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap");
+
+    let mut rx = ConfigHandle::subscribe_embed_gen();
+    let gen_before = *rx.borrow_and_update();
+
+    std::fs::write(
+        &config_path,
+        r#"
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "primary"
+base_url = "http://127.0.0.1:19999/v1"
+model = "model-b"
+dim = 3
+"#,
+    )
+    .expect("write config");
+    ConfigHandle::harness_reload_from_path(&config_path);
+
+    let gen_after = *rx.borrow_and_update();
+    assert_eq!(
+        gen_after, gen_before,
+        "embedding generation must NOT increment when vector identity change requires restart"
+    );
+    let endpoints = ConfigHandle::current()
+        .embed
+        .effective_endpoints()
+        .expect("effective embed endpoints");
+    assert_eq!(endpoints[0].model, "model-a");
+    assert!(
+        ConfigHandle::restart_required_pending()
+            .iter()
+            .any(|event| event.contains("embedder.endpoints.vector_identity")),
+        "vector identity changes must remain restart-required"
+    );
+}
+
+#[test]
 fn test_llm_client_runtime_rebuilds_on_endpoint_change() {
     let config = LlmConfig {
         enabled: true,

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -141,6 +141,66 @@ enabled = true
     );
 }
 
+#[tokio::test]
+async fn test_mcp_status_reports_embedding_endpoint_pool() {
+    let (tmp, db_path) = setup_home();
+    let mempal_home = tmp.path().join(".mempal");
+    let config_path = mempal_home.join("config.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+
+[[embed.endpoints]]
+id = "gb10"
+base_url = "http://gb10.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+priority = 0
+max_concurrent = 4
+retry_interval_secs = 2
+
+[[embed.endpoints]]
+id = "spark"
+base_url = "http://spark.local:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
+priority = 0
+max_concurrent = 2
+retry_interval_secs = 5
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write embedding endpoint-pool config");
+    ConfigHandle::bootstrap(&config_path).expect("bootstrap embedding endpoint-pool config");
+    let config = Config::load_from(&config_path).expect("load embedding endpoint-pool config");
+
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(response.embed_status.endpoints.len(), 2);
+    assert_eq!(response.embed_status.endpoints[0].id, "gb10");
+    assert_eq!(
+        response.embed_status.endpoints[0].base_url,
+        "http://gb10.local:18002/v1"
+    );
+    assert_eq!(response.embed_status.endpoints[0].priority, 0);
+    assert_eq!(response.embed_status.endpoints[0].max_concurrent, 4);
+    assert_eq!(response.embed_status.endpoints[0].dimensions, 4096);
+    assert_eq!(response.embed_status.endpoints[1].id, "spark");
+    assert_eq!(response.embed_status.endpoints[1].retry_interval_secs, 5);
+    assert_eq!(response.embed_status.max_concurrent, 6);
+    assert_eq!(
+        response.embed_status.model.as_deref(),
+        Some("gb10=Qwen/Qwen3-Embedding-8B, spark=Qwen/Qwen3-Embedding-8B")
+    );
+}
+
 #[cfg(feature = "integration")]
 async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let app = Router::new().route(

--- a/tests/reindex_progress.rs
+++ b/tests/reindex_progress.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::thread;
 
+use mempal::core::config::Config;
 use mempal::core::db::CURRENT_VECTOR_INDEX_VERSION;
 use mempal::core::db::Database;
 use mempal::core::reindex::ReindexProgressStore;
@@ -365,11 +366,9 @@ async fn test_reindex_progress_reconciliation_finalizes_orphan_running_row() {
     assert_eq!(running, "running");
     let before = read_reindex_progress_status_counts(&db);
 
-    let target_fingerprint = format!(
-        "openai_compat:Qwen/Qwen3-Embedding-8B:{}:{}",
-        server.base_url.trim_end_matches('/'),
-        3
-    );
+    let config =
+        Config::load_from(&home.join(".mempal").join("config.toml")).expect("load reindex config");
+    let target_fingerprint = config.embed.current_vector_embedder_fingerprint(3);
     let reconciled = progress
         .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
         .expect("reconcile orphan running row");


### PR DESCRIPTION
## Summary

- Adds embedding endpoint pool parity for prioritized model endpoints.
- Supports capacity-aware routing, health/cooldown handling, and bounded retry hints for embedding providers.
- Fixes mixed saturated-healthy/cooling-endpoint routing so healthy saturated endpoints can be waited on instead of being bypassed by cooldowns.

## Validation

- CSA implementation session: `01KTZPPHMMZKNTYECHE28B76PJ`
- Review-fix session: `01KTZW9WGR80WSYWPV7HWC8ATC`
- Full-diff review: PASS/CLEAN at `2e5a0732ef5ea248155c10f8f4483629cefdd365`
- Local hooks/tests were run by CSA before commits.

Closes #416.
