### PR TITLE
feat(insights): add design insight learning loop

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -40,7 +40,7 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-pub const CURRENT_SCHEMA_VERSION: u32 = 17;
+pub const CURRENT_SCHEMA_VERSION: u32 = 18;
 pub const CURRENT_VECTOR_INDEX_VERSION: &str = "v2";
 pub const VECTOR_DISTANCE_METRIC: &str = "cosine";
 /// SQLite page cache budget for issue #311's large-DB stale reindex path.
@@ -6155,6 +6155,35 @@ CREATE VIRTUAL TABLE IF NOT EXISTS drawers_fts USING fts5(
 );
 "#;
 
+const V18_MIGRATION_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS design_insights (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL CHECK(source IN ('user_idea', 'review_finding', 'tool_friction', 'incident', 'research')),
+    scope TEXT NOT NULL CHECK(scope IN ('project', 'cross_project', 'repo', 'issue')),
+    target_artifact TEXT NOT NULL CHECK(target_artifact IN ('memory', 'skill', 'agents_rule', 'agents_rules_ref', 'codex_skill', 'github_issue', 'mempal_knowledge')),
+    evidence_ref TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    rule_text TEXT,
+    priority INTEGER NOT NULL CHECK(priority BETWEEN 1 AND 5),
+    status TEXT NOT NULL CHECK(status IN ('open', 'resolved')) DEFAULT 'open',
+    created_at TEXT NOT NULL,
+    resolved_at TEXT,
+    resolved_by TEXT,
+    resolution_note TEXT,
+    redaction_count INTEGER NOT NULL DEFAULT 0,
+    project_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_insights_status_priority
+    ON design_insights(status, priority DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_design_insights_target_status
+    ON design_insights(target_artifact, status, priority DESC);
+
+CREATE INDEX IF NOT EXISTS idx_design_insights_project_status
+    ON design_insights(project_id, status, priority DESC);
+"#;
+
 const V12_COMPACTION_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_drawers_compacted_into
     ON drawers(compacted_into)
@@ -6305,6 +6334,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 17,
             sql: V17_MIGRATION_SQL,
+        },
+        Migration {
+            version: 18,
+            sql: V18_MIGRATION_SQL,
         },
     ];
     MIGRATIONS

--- a/src/core/design_insights.rs
+++ b/src/core/design_insights.rs
@@ -1,0 +1,833 @@
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use regex::{Captures, Regex};
+use rusqlite::{Connection, OptionalExtension, Row, params};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::utils::iso_timestamp;
+
+const MAX_SUMMARY_CHARS: usize = 1_200;
+const MAX_RULE_TEXT_CHARS: usize = 2_000;
+const MAX_EVIDENCE_REF_CHARS: usize = 512;
+const HIGH_VALUE_PRIORITY: u8 = 4;
+
+#[derive(Debug, Error)]
+pub enum DesignInsightError {
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("invalid {kind}: {value}")]
+    InvalidEnum { kind: &'static str, value: String },
+    #[error("{field} is required")]
+    MissingField { field: &'static str },
+    #[error("{field} exceeds {max_chars} characters after redaction")]
+    FieldTooLong {
+        field: &'static str,
+        max_chars: usize,
+    },
+    #[error("priority must be between 1 and 5, got {0}")]
+    InvalidPriority(u8),
+}
+
+pub type Result<T> = std::result::Result<T, DesignInsightError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesignInsightSource {
+    UserIdea,
+    ReviewFinding,
+    ToolFriction,
+    Incident,
+    Research,
+}
+
+impl DesignInsightSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::UserIdea => "user_idea",
+            Self::ReviewFinding => "review_finding",
+            Self::ToolFriction => "tool_friction",
+            Self::Incident => "incident",
+            Self::Research => "research",
+        }
+    }
+}
+
+impl FromStr for DesignInsightSource {
+    type Err = DesignInsightError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match normalize_slug(value).as_str() {
+            "user_idea" => Ok(Self::UserIdea),
+            "review_finding" => Ok(Self::ReviewFinding),
+            "tool_friction" => Ok(Self::ToolFriction),
+            "incident" => Ok(Self::Incident),
+            "research" => Ok(Self::Research),
+            _ => Err(DesignInsightError::InvalidEnum {
+                kind: "design insight source",
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesignInsightScope {
+    Project,
+    CrossProject,
+    Repo,
+    Issue,
+}
+
+impl DesignInsightScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::CrossProject => "cross_project",
+            Self::Repo => "repo",
+            Self::Issue => "issue",
+        }
+    }
+}
+
+impl FromStr for DesignInsightScope {
+    type Err = DesignInsightError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match normalize_slug(value).as_str() {
+            "project" => Ok(Self::Project),
+            "cross_project" => Ok(Self::CrossProject),
+            "repo" => Ok(Self::Repo),
+            "issue" => Ok(Self::Issue),
+            _ => Err(DesignInsightError::InvalidEnum {
+                kind: "design insight scope",
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesignInsightTargetArtifact {
+    Memory,
+    Skill,
+    AgentsRule,
+    AgentsRulesRef,
+    CodexSkill,
+    GithubIssue,
+    MempalKnowledge,
+}
+
+impl DesignInsightTargetArtifact {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Skill => "skill",
+            Self::AgentsRule => "agents_rule",
+            Self::AgentsRulesRef => "agents_rules_ref",
+            Self::CodexSkill => "codex_skill",
+            Self::GithubIssue => "github_issue",
+            Self::MempalKnowledge => "mempal_knowledge",
+        }
+    }
+}
+
+impl FromStr for DesignInsightTargetArtifact {
+    type Err = DesignInsightError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match normalize_slug(value).as_str() {
+            "memory" => Ok(Self::Memory),
+            "skill" => Ok(Self::Skill),
+            "agents_rule" | "agent_rule" => Ok(Self::AgentsRule),
+            "agents_rules_ref" | "agents_ref" | "rules_ref" => Ok(Self::AgentsRulesRef),
+            "codex_skill" | "codex_skills" => Ok(Self::CodexSkill),
+            "github_issue" | "issue" => Ok(Self::GithubIssue),
+            "mempal_knowledge" | "knowledge" => Ok(Self::MempalKnowledge),
+            _ => Err(DesignInsightError::InvalidEnum {
+                kind: "design insight target artifact",
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DesignInsightStatus {
+    Open,
+    Resolved,
+}
+
+impl DesignInsightStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Resolved => "resolved",
+        }
+    }
+}
+
+impl FromStr for DesignInsightStatus {
+    type Err = DesignInsightError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match normalize_slug(value).as_str() {
+            "open" => Ok(Self::Open),
+            "resolved" => Ok(Self::Resolved),
+            _ => Err(DesignInsightError::InvalidEnum {
+                kind: "design insight status",
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDesignInsight<'a> {
+    pub source: DesignInsightSource,
+    pub scope: DesignInsightScope,
+    pub target_artifact: DesignInsightTargetArtifact,
+    pub evidence_ref: &'a str,
+    pub summary: &'a str,
+    pub rule_text: Option<&'a str>,
+    pub priority: u8,
+    pub project_id: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DesignInsightFilters {
+    pub status: Option<DesignInsightStatus>,
+    pub source: Option<DesignInsightSource>,
+    pub scope: Option<DesignInsightScope>,
+    pub target_artifact: Option<DesignInsightTargetArtifact>,
+    pub min_priority: Option<u8>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DesignInsight {
+    pub id: String,
+    pub source: DesignInsightSource,
+    pub scope: DesignInsightScope,
+    pub target_artifact: DesignInsightTargetArtifact,
+    pub evidence_ref: String,
+    pub summary: String,
+    pub rule_text: Option<String>,
+    pub priority: u8,
+    pub status: DesignInsightStatus,
+    pub created_at: String,
+    pub resolved_at: Option<String>,
+    pub resolved_by: Option<String>,
+    pub resolution_note: Option<String>,
+    pub redaction_count: u32,
+    pub project_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DesignInsightSummary {
+    pub open_total: u64,
+    pub high_value_open: u64,
+    pub open_by_target: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedactedText {
+    pub content: String,
+    pub redaction_count: u32,
+}
+
+pub fn design_insights_table_exists(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='design_insights')",
+        [],
+        |row| row.get::<_, i64>(0),
+    )
+    .unwrap_or(0)
+        == 1
+}
+
+pub fn record_design_insight(
+    conn: &Connection,
+    input: &NewDesignInsight<'_>,
+) -> Result<DesignInsight> {
+    validate_priority(input.priority)?;
+    let evidence =
+        sanitize_required_field("evidence_ref", input.evidence_ref, MAX_EVIDENCE_REF_CHARS)?;
+    let summary = sanitize_required_field("summary", input.summary, MAX_SUMMARY_CHARS)?;
+    let rule_text = input
+        .rule_text
+        .map(|value| sanitize_optional_field("rule_text", value, MAX_RULE_TEXT_CHARS))
+        .transpose()?
+        .flatten();
+    let project_id = input
+        .project_id
+        .map(|value| sanitize_optional_field("project_id", value, MAX_EVIDENCE_REF_CHARS))
+        .transpose()?
+        .flatten();
+    let redaction_count = evidence.redaction_count
+        + summary.redaction_count
+        + rule_text
+            .as_ref()
+            .map(|value| value.redaction_count)
+            .unwrap_or(0)
+        + project_id
+            .as_ref()
+            .map(|value| value.redaction_count)
+            .unwrap_or(0);
+    let rule_content = rule_text.as_ref().map(|value| value.content.as_str());
+    let project_content = project_id.as_ref().map(|value| value.content.as_str());
+    let created_at = iso_timestamp();
+    let id = build_design_insight_id(input, &created_at);
+
+    conn.execute(
+        r#"
+        INSERT INTO design_insights (
+            id, source, scope, target_artifact, evidence_ref, summary, rule_text,
+            priority, status, created_at, redaction_count, project_id
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'open', ?9, ?10, ?11)
+        "#,
+        params![
+            id,
+            input.source.as_str(),
+            input.scope.as_str(),
+            input.target_artifact.as_str(),
+            evidence.content,
+            summary.content,
+            rule_content,
+            input.priority,
+            created_at,
+            redaction_count,
+            project_content,
+        ],
+    )?;
+
+    get_design_insight(conn, &id)?.ok_or(rusqlite::Error::QueryReturnedNoRows.into())
+}
+
+pub fn list_design_insights(
+    conn: &Connection,
+    filters: &DesignInsightFilters,
+) -> Result<Vec<DesignInsight>> {
+    if !design_insights_table_exists(conn) {
+        return Ok(Vec::new());
+    }
+    if let Some(priority) = filters.min_priority {
+        validate_priority(priority)?;
+    }
+    let status = filters.status.map(DesignInsightStatus::as_str);
+    let source = filters.source.map(DesignInsightSource::as_str);
+    let scope = filters.scope.map(DesignInsightScope::as_str);
+    let target = filters
+        .target_artifact
+        .map(DesignInsightTargetArtifact::as_str);
+    let min_priority = i64::from(filters.min_priority.unwrap_or(1));
+    let limit = filters.limit.unwrap_or(100).min(1_000) as i64;
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT id, source, scope, target_artifact, evidence_ref, summary, rule_text,
+               priority, status, created_at, resolved_at, resolved_by, resolution_note,
+               redaction_count, project_id
+        FROM design_insights
+        WHERE (?1 IS NULL OR status = ?1)
+          AND (?2 IS NULL OR source = ?2)
+          AND (?3 IS NULL OR scope = ?3)
+          AND (?4 IS NULL OR target_artifact = ?4)
+          AND priority >= ?5
+        ORDER BY
+          CASE status WHEN 'open' THEN 0 ELSE 1 END,
+          priority DESC,
+          created_at DESC,
+          id ASC
+        LIMIT ?6
+        "#,
+    )?;
+    let rows = stmt
+        .query_map(
+            params![status, source, scope, target, min_priority, limit],
+            design_insight_from_row,
+        )?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    rows.into_iter().collect()
+}
+
+pub fn get_design_insight(conn: &Connection, id: &str) -> Result<Option<DesignInsight>> {
+    if !design_insights_table_exists(conn) {
+        return Ok(None);
+    }
+    let row = conn
+        .query_row(
+            r#"
+            SELECT id, source, scope, target_artifact, evidence_ref, summary, rule_text,
+                   priority, status, created_at, resolved_at, resolved_by, resolution_note,
+                   redaction_count, project_id
+            FROM design_insights
+            WHERE id = ?1
+            "#,
+            [id],
+            design_insight_from_row,
+        )
+        .optional()?;
+    row.transpose()
+}
+
+pub fn resolve_design_insight(
+    conn: &Connection,
+    id: &str,
+    actor: Option<&str>,
+    note: Option<&str>,
+) -> Result<bool> {
+    if !design_insights_table_exists(conn) {
+        return Ok(false);
+    }
+    let actor = actor
+        .map(|value| sanitize_optional_field("actor", value, MAX_EVIDENCE_REF_CHARS))
+        .transpose()?
+        .flatten();
+    let note = note
+        .map(|value| sanitize_optional_field("resolution_note", value, MAX_RULE_TEXT_CHARS))
+        .transpose()?
+        .flatten();
+    let changed = conn.execute(
+        r#"
+        UPDATE design_insights
+        SET status = 'resolved',
+            resolved_at = ?2,
+            resolved_by = ?3,
+            resolution_note = ?4,
+            redaction_count = redaction_count + ?5
+        WHERE id = ?1 AND status = 'open'
+        "#,
+        params![
+            id,
+            iso_timestamp(),
+            actor.as_ref().map(|value| value.content.as_str()),
+            note.as_ref().map(|value| value.content.as_str()),
+            actor
+                .as_ref()
+                .map(|value| value.redaction_count)
+                .unwrap_or(0)
+                + note
+                    .as_ref()
+                    .map(|value| value.redaction_count)
+                    .unwrap_or(0),
+        ],
+    )?;
+    Ok(changed > 0)
+}
+
+pub fn unresolved_design_insight_summary(conn: &Connection) -> Result<DesignInsightSummary> {
+    if !design_insights_table_exists(conn) {
+        return Ok(DesignInsightSummary::default());
+    }
+    let (open_total, high_value_open) = conn.query_row(
+        r#"
+        SELECT
+            COUNT(*),
+            COALESCE(SUM(CASE WHEN priority >= ?1 THEN 1 ELSE 0 END), 0)
+        FROM design_insights
+        WHERE status = 'open'
+        "#,
+        [HIGH_VALUE_PRIORITY],
+        |row| Ok((row.get::<_, u64>(0)?, row.get::<_, u64>(1)?)),
+    )?;
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT target_artifact, COUNT(*)
+        FROM design_insights
+        WHERE status = 'open'
+        GROUP BY target_artifact
+        ORDER BY target_artifact
+        "#,
+    )?;
+    let open_by_target = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, u64>(1)?))
+        })?
+        .collect::<std::result::Result<BTreeMap<_, _>, _>>()?;
+
+    Ok(DesignInsightSummary {
+        open_total,
+        high_value_open,
+        open_by_target,
+    })
+}
+
+pub fn sanitize_design_insight_text(input: &str) -> RedactedText {
+    let mut content = input.trim().to_string();
+    let mut redaction_count = 0u32;
+
+    for (regex, replacement) in [
+        (private_key_re(), "<redacted-private-key>"),
+        (prompt_block_re(), "<redacted-prompt>"),
+        (auth_header_re(), "Authorization: <redacted>"),
+        (bearer_re(), "Bearer <redacted>"),
+        (url_userinfo_re(), "$1<redacted>@"),
+        (url_secret_query_re(), "$1<redacted>"),
+    ] {
+        let count = regex.find_iter(&content).count() as u32;
+        if count > 0 {
+            content = regex.replace_all(&content, replacement).into_owned();
+            redaction_count += count;
+        }
+    }
+
+    let count = key_value_secret_re().find_iter(&content).count() as u32;
+    if count > 0 {
+        content = key_value_secret_re()
+            .replace_all(&content, |captures: &Captures<'_>| {
+                redact_captured_value(captures, "<redacted>")
+            })
+            .into_owned();
+        redaction_count += count;
+    }
+
+    let count = quoted_prompt_field_re().find_iter(&content).count() as u32;
+    if count > 0 {
+        content = quoted_prompt_field_re()
+            .replace_all(&content, |captures: &Captures<'_>| {
+                redact_captured_value(captures, "<redacted-prompt>")
+            })
+            .into_owned();
+        redaction_count += count;
+    }
+
+    let count = prompt_line_re().find_iter(&content).count() as u32;
+    if count > 0 {
+        content = prompt_line_re()
+            .replace_all(&content, |captures: &Captures<'_>| {
+                format!("{}<redacted-prompt>", &captures[1])
+            })
+            .into_owned();
+        redaction_count += count;
+    }
+
+    RedactedText {
+        content,
+        redaction_count,
+    }
+}
+
+fn sanitize_required_field(
+    field: &'static str,
+    value: &str,
+    max_chars: usize,
+) -> Result<RedactedText> {
+    let redacted = sanitize_optional_field(field, value, max_chars)?
+        .ok_or(DesignInsightError::MissingField { field })?;
+    Ok(redacted)
+}
+
+fn sanitize_optional_field(
+    field: &'static str,
+    value: &str,
+    max_chars: usize,
+) -> Result<Option<RedactedText>> {
+    let redacted = sanitize_design_insight_text(value);
+    if redacted.content.trim().is_empty() {
+        return Ok(None);
+    }
+    if redacted.content.chars().count() > max_chars {
+        return Err(DesignInsightError::FieldTooLong { field, max_chars });
+    }
+    Ok(Some(redacted))
+}
+
+fn validate_priority(priority: u8) -> Result<()> {
+    if (1..=5).contains(&priority) {
+        Ok(())
+    } else {
+        Err(DesignInsightError::InvalidPriority(priority))
+    }
+}
+
+fn design_insight_from_row(row: &Row<'_>) -> rusqlite::Result<Result<DesignInsight>> {
+    let priority = row.get::<_, i64>(7)? as u8;
+    let redaction_count = row.get::<_, i64>(13)? as u32;
+    let source = match row.get::<_, String>(1)?.parse::<DesignInsightSource>() {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    let scope = match row.get::<_, String>(2)?.parse::<DesignInsightScope>() {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    let target_artifact = match row
+        .get::<_, String>(3)?
+        .parse::<DesignInsightTargetArtifact>()
+    {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    let status = match row.get::<_, String>(8)?.parse::<DesignInsightStatus>() {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    Ok(Ok(DesignInsight {
+        id: row.get(0)?,
+        source,
+        scope,
+        target_artifact,
+        evidence_ref: row.get(4)?,
+        summary: row.get(5)?,
+        rule_text: row.get(6)?,
+        priority,
+        status,
+        created_at: row.get(9)?,
+        resolved_at: row.get(10)?,
+        resolved_by: row.get(11)?,
+        resolution_note: row.get(12)?,
+        redaction_count,
+        project_id: row.get(14)?,
+    }))
+}
+
+fn build_design_insight_id(input: &NewDesignInsight<'_>, created_at: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seed = format!(
+        "{}:{}:{}:{}:{}:{}",
+        nanos,
+        created_at,
+        input.source.as_str(),
+        input.scope.as_str(),
+        input.target_artifact.as_str(),
+        input.evidence_ref
+    );
+    let digest = blake3::hash(seed.as_bytes()).to_hex().to_string();
+    format!("insight_{}", &digest[..16])
+}
+
+fn normalize_slug(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .chars()
+        .map(|ch| match ch {
+            '-' | ' ' | '.' | '/' => '_',
+            _ => ch,
+        })
+        .collect()
+}
+
+fn private_key_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+        )
+        .expect("static private key regex")
+    })
+}
+
+fn prompt_block_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?is)<prompt\b[^>]*>.*?</prompt>").expect("static prompt regex"))
+}
+
+fn auth_header_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?im)^\s*authorization\s*:\s*.+$").expect("static auth header regex")
+    })
+}
+
+fn bearer_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}").expect("static bearer regex")
+    })
+}
+
+fn url_userinfo_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(https?://)[^/\s:@]+:[^@\s/]+@").expect("static url userinfo regex")
+    })
+}
+
+fn url_secret_query_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)([?&](?:api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|password|key)=)[^&#\s]+",
+        )
+        .expect("static url secret query regex")
+    })
+}
+
+fn key_value_secret_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?ix)
+            (?P<prefix>
+                "(?:[A-Z0-9]+[-_.])*(?:api[-_]?key|access[-_]?token|refresh[-_]?token|secret[-_]?access[-_]?key|secret[-_]?key|private[-_]?key|token|secret|password|passwd|pwd)"\s*:\s*
+                |
+                \b(?:[A-Z0-9]+[-_.])*(?:api[-_]?key|access[-_]?token|refresh[-_]?token|secret[-_]?access[-_]?key|secret[-_]?key|private[-_]?key|token|secret|password|passwd|pwd)\b\s*[:=]\s*
+            )
+            (?P<value>"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,"';&]+)
+            "#,
+        )
+        .expect("static key value secret regex")
+    })
+}
+
+fn quoted_prompt_field_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?ix)
+            (?P<prefix>"(?:raw[-_\s]?prompt|user[-_\s]?prompt|prompt)"\s*:\s*)
+            (?P<value>"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s,"';&]+)
+            "#,
+        )
+        .expect("static quoted prompt field regex")
+    })
+}
+
+fn redact_captured_value(captures: &Captures<'_>, placeholder: &str) -> String {
+    let prefix = captures
+        .name("prefix")
+        .map(|match_| match_.as_str())
+        .unwrap_or_default();
+    let value = captures
+        .name("value")
+        .map(|match_| match_.as_str())
+        .unwrap_or_default();
+    match value.chars().next() {
+        Some(quote @ ('\'' | '"')) => format!("{prefix}{quote}{placeholder}{quote}"),
+        _ => format!("{prefix}{placeholder}"),
+    }
+}
+
+fn prompt_line_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?im)^(\s*(?:raw\s+prompt|prompt|user\s+prompt)\s*:\s*).*$")
+            .expect("static prompt line regex")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::Database;
+
+    #[test]
+    fn record_list_and_resolve_design_insight() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db = Database::open(&tempdir.path().join("palace.db")).expect("open db");
+
+        let insight = record_design_insight(
+            db.conn(),
+            &NewDesignInsight {
+                source: DesignInsightSource::ReviewFinding,
+                scope: DesignInsightScope::Issue,
+                target_artifact: DesignInsightTargetArtifact::GithubIssue,
+                evidence_ref: "https://github.com/RyderFreeman4Logos/mempal/issues/415",
+                summary: "Capture reusable review findings as drainable design records.",
+                rule_text: Some("Every non-trivial issue gets a design-opportunity pass."),
+                priority: 5,
+                project_id: Some("mempal"),
+            },
+        )
+        .expect("record insight");
+
+        let listed = list_design_insights(
+            db.conn(),
+            &DesignInsightFilters {
+                status: Some(DesignInsightStatus::Open),
+                min_priority: Some(4),
+                ..DesignInsightFilters::default()
+            },
+        )
+        .expect("list insights");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, insight.id);
+        assert_eq!(listed[0].priority, 5);
+
+        let summary = unresolved_design_insight_summary(db.conn()).expect("summary");
+        assert_eq!(summary.open_total, 1);
+        assert_eq!(summary.high_value_open, 1);
+        assert_eq!(summary.open_by_target["github_issue"], 1);
+
+        assert!(
+            resolve_design_insight(db.conn(), &insight.id, Some("codex"), Some("filed issue"))
+                .expect("resolve")
+        );
+        let summary = unresolved_design_insight_summary(db.conn()).expect("summary");
+        assert_eq!(summary.open_total, 0);
+        assert_eq!(summary.high_value_open, 0);
+    }
+
+    #[test]
+    fn redacts_sensitive_design_insight_content() {
+        let input = "\
+Authorization: Bearer fixturebearertoken
+POST https://user:pass@example.test/path?token=abc123&safe=1
+api_key=\"abc123\"
+OPENAI_API_KEY=providerfixture12345
+GITHUB_TOKEN=githubfixture12345
+DJANGO_SECRET_KEY=secretkeyfixture12345
+JWT_SECRET_KEY=jwtsecretfixture12345
+<prompt>raw user prompt body</prompt>
+-----BEGIN PRIVATE KEY-----
+abc
+-----END PRIVATE KEY-----";
+
+        let redacted = sanitize_design_insight_text(input);
+
+        assert!(redacted.redaction_count >= 5);
+        assert!(!redacted.content.contains("fixturebearertoken"));
+        assert!(!redacted.content.contains("abc123"));
+        assert!(!redacted.content.contains("providerfixture12345"));
+        assert!(!redacted.content.contains("githubfixture12345"));
+        assert!(!redacted.content.contains("secretkeyfixture12345"));
+        assert!(!redacted.content.contains("jwtsecretfixture12345"));
+        assert!(!redacted.content.contains("user:pass"));
+        assert!(!redacted.content.contains("raw user prompt body"));
+        assert!(!redacted.content.contains("PRIVATE KEY-----\nabc"));
+        assert!(redacted.content.contains("<redacted>"));
+    }
+
+    #[test]
+    fn redacts_quoted_json_secret_and_prompt_fields() {
+        let input = r#"provider body {"OPENAI_API_KEY":"providerfixture12345","JWT_SECRET_KEY":"secretkeyfixture12345 with spaces","GITHUB_TOKEN":"githubfixture12345","prompt":"promptfixture12345 with spaces","user_prompt":"userpromptfixture12345 with spaces"}"#;
+
+        let redacted = sanitize_design_insight_text(input);
+
+        assert!(redacted.redaction_count >= 5);
+        assert!(!redacted.content.contains("providerfixture12345"));
+        assert!(!redacted.content.contains("secretkeyfixture12345"));
+        assert!(!redacted.content.contains("githubfixture12345"));
+        assert!(!redacted.content.contains("promptfixture12345"));
+        assert!(!redacted.content.contains("userpromptfixture12345"));
+        assert!(
+            redacted
+                .content
+                .contains(r#""OPENAI_API_KEY":"<redacted>""#)
+        );
+        assert!(
+            redacted
+                .content
+                .contains(r#""JWT_SECRET_KEY":"<redacted>""#)
+        );
+        assert!(redacted.content.contains(r#""GITHUB_TOKEN":"<redacted>""#));
+        assert!(redacted.content.contains(r#""prompt":"<redacted-prompt>""#));
+        assert!(
+            redacted
+                .content
+                .contains(r#""user_prompt":"<redacted-prompt>""#)
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod db;
 pub use async_db::AsyncDb;
 pub mod decay;
+pub mod design_insights;
 pub mod hot_reload;
 pub mod patterns;
 pub mod phase3;

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -391,7 +391,7 @@ pub const DEFAULT_IDENTITY_HINT: &str = "(identity not set — create ~/.mempal/
 
 #[cfg(test)]
 mod tests {
-    use crate::core::db::Database;
+    use crate::core::db::{CURRENT_SCHEMA_VERSION, Database};
 
     use super::MEMORY_PROTOCOL;
 
@@ -661,6 +661,9 @@ mod tests {
         let tempdir = tempfile::tempdir().expect("create temp dir");
         let db_path = tempdir.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
-        assert_eq!(db.schema_version().expect("schema version"), 17);
+        assert_eq!(
+            db.schema_version().expect("schema version"),
+            CURRENT_SCHEMA_VERSION
+        );
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -8,6 +8,9 @@ use serde::Serialize;
 
 use crate::core::config::{Config, ConfigHandle};
 use crate::core::db::CURRENT_SCHEMA_VERSION;
+use crate::core::design_insights::{
+    design_insights_table_exists, unresolved_design_insight_summary,
+};
 use crate::core::queue::{QueueStats, queue_stats_readonly};
 use crate::process_diagnostics::{DbHolderReport, inspect_db_holders};
 
@@ -78,6 +81,7 @@ pub struct DoctorReport {
     pub db_holders: DbHolderReport,
     pub install: DoctorInstallReport,
     pub embedding: DoctorEmbeddingReport,
+    pub design_insights: DoctorDesignInsightReport,
     pub restart_required_config_changes: Vec<String>,
     pub warnings: Vec<String>,
     pub recommendations: Vec<String>,
@@ -115,6 +119,14 @@ pub struct DoctorEmbeddingQueueReport {
     pub pending: u64,
     pub claimed: u64,
     pub failed: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DoctorDesignInsightReport {
+    pub schema_available: bool,
+    pub open_total: u64,
+    pub high_value_open: u64,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -174,6 +186,7 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     let install = inspect_install();
     let config = Config::load().ok();
     let embedding = build_embedding_report(config.as_ref(), db_path);
+    let design_insights = inspect_design_insights(db_path);
     let restart_required_config_changes = ConfigHandle::restart_required_pending();
     let mut warnings = Vec::new();
     let mut recommendations = vec![
@@ -192,6 +205,17 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
     }
     if let Some(error) = db.error.as_deref() {
         warnings.push(format!("database schema could not be inspected: {error}"));
+    }
+    if design_insights.high_value_open > 0 {
+        warnings.push(format!(
+            "{} unresolved high-value design insight(s) need draining",
+            design_insights.high_value_open
+        ));
+        recommendations
+            .push("Run `mempal insight list --status open --min-priority 4`.".to_string());
+    }
+    if let Some(error) = design_insights.error.as_deref() {
+        warnings.push(format!("design insights could not be inspected: {error}"));
     }
     for change in &restart_required_config_changes {
         warnings.push(format!("config change pending restart: {change}"));
@@ -214,9 +238,41 @@ pub fn build_doctor_report(db_path: &Path) -> DoctorReport {
         db_holders,
         install,
         embedding,
+        design_insights,
         restart_required_config_changes,
         warnings,
         recommendations,
+    }
+}
+
+fn inspect_design_insights(db_path: &Path) -> DoctorDesignInsightReport {
+    if !db_path.exists() {
+        return DoctorDesignInsightReport::default();
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(error) => {
+            return DoctorDesignInsightReport {
+                error: Some(error.to_string()),
+                ..DoctorDesignInsightReport::default()
+            };
+        }
+    };
+    if !design_insights_table_exists(&conn) {
+        return DoctorDesignInsightReport::default();
+    }
+    match unresolved_design_insight_summary(&conn) {
+        Ok(summary) => DoctorDesignInsightReport {
+            schema_available: true,
+            open_total: summary.open_total,
+            high_value_open: summary.high_value_open,
+            error: None,
+        },
+        Err(error) => DoctorDesignInsightReport {
+            schema_available: true,
+            error: Some(error.to_string()),
+            ..DoctorDesignInsightReport::default()
+        },
     }
 }
 

--- a/src/insights.rs
+++ b/src/insights.rs
@@ -1,0 +1,363 @@
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+use serde::Serialize;
+
+use mempal::core::{
+    db::Database,
+    design_insights::{
+        DesignInsight, DesignInsightFilters, DesignInsightScope, DesignInsightSource,
+        DesignInsightStatus, DesignInsightTargetArtifact, NewDesignInsight, list_design_insights,
+        record_design_insight, resolve_design_insight,
+    },
+};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum InsightCommands {
+    /// Record a content-free, redacted design insight for later draining.
+    Record {
+        /// user-idea, review-finding, tool-friction, incident, or research.
+        #[arg(long)]
+        source: String,
+        /// project, cross-project, repo, or issue.
+        #[arg(long)]
+        scope: String,
+        /// memory, skill, agents-rule, agents-rules-ref, codex-skill, github-issue, or mempal-knowledge.
+        #[arg(long = "target", alias = "target-artifact")]
+        target_artifact: String,
+        /// Content-free evidence reference: issue URL, session id, review id, or incident id.
+        #[arg(long)]
+        evidence: String,
+        /// Redacted, content-free summary of the reusable design insight.
+        #[arg(long)]
+        summary: String,
+        /// Proposed acceptance criteria or reusable rule text.
+        #[arg(long = "rule", alias = "acceptance", alias = "acceptance-criteria")]
+        rule_text: Option<String>,
+        /// Value/priority from 1 to 5. Values 4-5 surface in status/doctor reminders.
+        #[arg(long, default_value_t = 3)]
+        priority: u8,
+        /// Optional project id for filtering/audit context.
+        #[arg(long)]
+        project: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List design insights, open by default, for autonomous drain workflows.
+    List {
+        /// open, resolved, or all.
+        #[arg(long, default_value = "open")]
+        status: String,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long)]
+        scope: Option<String>,
+        #[arg(long = "target", alias = "target-artifact")]
+        target_artifact: Option<String>,
+        /// Minimum priority to show.
+        #[arg(long, default_value_t = 1)]
+        min_priority: u8,
+        /// Maximum number of rows to print.
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Mark an insight as drained into its target artifact.
+    Resolve {
+        /// Insight ID returned by `mempal insight record` or `list`.
+        insight_id: String,
+        /// Optional resolving actor/tool id.
+        #[arg(long)]
+        actor: Option<String>,
+        /// Optional content-free resolution note.
+        #[arg(long)]
+        note: Option<String>,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print the design-opportunity pass workflow for dev2merge/issue-drain.
+    Runbook {
+        #[arg(long, default_value = "plain")]
+        format: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct ResolveOutput<'a> {
+    insight_id: &'a str,
+    resolved: bool,
+}
+
+pub fn run_command(db: &Database, command: InsightCommands) -> Result<()> {
+    match command {
+        InsightCommands::Record {
+            source,
+            scope,
+            target_artifact,
+            evidence,
+            summary,
+            rule_text,
+            priority,
+            project,
+            json,
+        } => cmd_record(
+            db,
+            RecordArgs {
+                source,
+                scope,
+                target_artifact,
+                evidence,
+                summary,
+                rule_text,
+                priority,
+                project,
+                json,
+            },
+        ),
+        InsightCommands::List {
+            status,
+            source,
+            scope,
+            target_artifact,
+            min_priority,
+            limit,
+            json,
+        } => cmd_list(
+            db,
+            ListArgs {
+                status,
+                source,
+                scope,
+                target_artifact,
+                min_priority,
+                limit,
+                json,
+            },
+        ),
+        InsightCommands::Resolve {
+            insight_id,
+            actor,
+            note,
+            json,
+        } => cmd_resolve(db, &insight_id, actor.as_deref(), note.as_deref(), json),
+        InsightCommands::Runbook { format } => cmd_runbook(&format),
+    }
+}
+
+struct RecordArgs {
+    source: String,
+    scope: String,
+    target_artifact: String,
+    evidence: String,
+    summary: String,
+    rule_text: Option<String>,
+    priority: u8,
+    project: Option<String>,
+    json: bool,
+}
+
+fn cmd_record(db: &Database, args: RecordArgs) -> Result<()> {
+    let source = parse_source(&args.source)?;
+    let scope = parse_scope(&args.scope)?;
+    let target_artifact = parse_target(&args.target_artifact)?;
+    let insight = record_design_insight(
+        db.conn(),
+        &NewDesignInsight {
+            source,
+            scope,
+            target_artifact,
+            evidence_ref: &args.evidence,
+            summary: &args.summary,
+            rule_text: args.rule_text.as_deref(),
+            priority: args.priority,
+            project_id: args.project.as_deref(),
+        },
+    )
+    .context("failed to record design insight")?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&insight)?);
+    } else {
+        println!("insight_id={}", insight.id);
+        println!(
+            "status={} priority={} redactions={}",
+            insight.status.as_str(),
+            insight.priority,
+            insight.redaction_count
+        );
+    }
+    Ok(())
+}
+
+struct ListArgs {
+    status: String,
+    source: Option<String>,
+    scope: Option<String>,
+    target_artifact: Option<String>,
+    min_priority: u8,
+    limit: usize,
+    json: bool,
+}
+
+fn cmd_list(db: &Database, args: ListArgs) -> Result<()> {
+    let filters = DesignInsightFilters {
+        status: parse_status_filter(&args.status)?,
+        source: args.source.as_deref().map(parse_source).transpose()?,
+        scope: args.scope.as_deref().map(parse_scope).transpose()?,
+        target_artifact: args
+            .target_artifact
+            .as_deref()
+            .map(parse_target)
+            .transpose()?,
+        min_priority: Some(args.min_priority),
+        limit: Some(args.limit),
+    };
+    let insights =
+        list_design_insights(db.conn(), &filters).context("failed to list design insights")?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&insights)?);
+        return Ok(());
+    }
+    print_insight_table(&insights);
+    Ok(())
+}
+
+fn cmd_resolve(
+    db: &Database,
+    insight_id: &str,
+    actor: Option<&str>,
+    note: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let resolved = resolve_design_insight(db.conn(), insight_id, actor, note)
+        .context("failed to resolve design insight")?;
+    if !resolved {
+        bail!("design insight not found or already resolved: {insight_id}");
+    }
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&ResolveOutput {
+                insight_id,
+                resolved
+            })?
+        );
+    } else {
+        println!("resolved insight_id={insight_id}");
+    }
+    Ok(())
+}
+
+fn cmd_runbook(format: &str) -> Result<()> {
+    const TITLE: &str = "Design Insight Learning Loop";
+    const STEPS: &[(&str, &str)] = &[
+        (
+            "Design-opportunity pass",
+            "For every non-trivial dev2merge/issue-drain issue, ask whether the user idea, review finding, incident, tool friction, or research result should become a durable artifact.",
+        ),
+        (
+            "Record",
+            "mempal insight record --source review-finding --scope issue --target github-issue --evidence <issue-or-session-ref> --summary <content-free-insight> --rule <acceptance-or-reusable-rule> --priority 4",
+        ),
+        (
+            "Drain",
+            "mempal insight list --status open --min-priority 4",
+        ),
+        (
+            "Resolve",
+            "mempal insight resolve <insight_id> --actor <agent-or-human> --note <target-artifact-ref>",
+        ),
+    ];
+    match format {
+        "plain" => {
+            println!("{TITLE}");
+            println!();
+            for (label, detail) in STEPS {
+                println!("{label}:");
+                println!("  {detail}");
+            }
+            Ok(())
+        }
+        "json" => {
+            let value = serde_json::json!({
+                "title": TITLE,
+                "steps": STEPS
+                    .iter()
+                    .map(|(label, detail)| serde_json::json!({
+                        "label": label,
+                        "detail": detail,
+                    }))
+                    .collect::<Vec<_>>(),
+            });
+            println!("{}", serde_json::to_string_pretty(&value)?);
+            Ok(())
+        }
+        other => bail!("unsupported insight runbook format: {other}"),
+    }
+}
+
+fn print_insight_table(insights: &[DesignInsight]) {
+    if insights.is_empty() {
+        println!("no design insights found");
+        return;
+    }
+    println!(
+        "{:<25} {:<8} {:<15} {:<14} {:<18} {:>3}  SUMMARY",
+        "INSIGHT_ID", "STATUS", "SOURCE", "SCOPE", "TARGET", "PRI"
+    );
+    println!("{}", "-".repeat(112));
+    for insight in insights {
+        println!(
+            "{:<25} {:<8} {:<15} {:<14} {:<18} {:>3}  {}",
+            insight.id,
+            insight.status.as_str(),
+            insight.source.as_str(),
+            insight.scope.as_str(),
+            insight.target_artifact.as_str(),
+            insight.priority,
+            inline_preview(&insight.summary, 96)
+        );
+    }
+}
+
+fn parse_source(value: &str) -> Result<DesignInsightSource> {
+    value
+        .parse()
+        .with_context(|| format!("invalid design insight source: {value}"))
+}
+
+fn parse_scope(value: &str) -> Result<DesignInsightScope> {
+    value
+        .parse()
+        .with_context(|| format!("invalid design insight scope: {value}"))
+}
+
+fn parse_target(value: &str) -> Result<DesignInsightTargetArtifact> {
+    value
+        .parse()
+        .with_context(|| format!("invalid design insight target artifact: {value}"))
+}
+
+fn parse_status_filter(value: &str) -> Result<Option<DesignInsightStatus>> {
+    let normalized = value.trim().to_ascii_lowercase().replace('-', "_");
+    if normalized == "all" {
+        return Ok(None);
+    }
+    Ok(Some(value.parse().with_context(|| {
+        format!("invalid design insight status: {value}")
+    })?))
+}
+
+fn inline_preview(value: &str, max_chars: usize) -> String {
+    let one_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut chars = one_line.chars();
+    let mut preview = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+mod insights;
 mod longmemeval;
 mod patterns;
 #[path = "cli/prime.rs"]
@@ -604,6 +605,11 @@ enum Commands {
     Phase3 {
         #[command(subcommand)]
         command: Phase3Commands,
+    },
+    /// Capture and drain reusable design insights from dev workflows.
+    Insight {
+        #[command(subcommand)]
+        command: insights::InsightCommands,
     },
     /// Manage explicit tunnels between memory scopes.
     Tunnels {
@@ -3537,6 +3543,7 @@ fn run() -> Result<()> {
         Commands::Phase3 { command } => {
             block_on_result(phase3_command(&db, config.as_ref(), command))
         }
+        Commands::Insight { command } => insights::run_command(&db, command),
         Commands::Tunnels { command } => tunnels_command(&db, command),
         Commands::Taxonomy { command } => taxonomy_command(&db, command),
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
@@ -10006,6 +10013,19 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     let last_crystallization_at = db
         .last_crystallization_at()
         .context("failed to read last crystallization timestamp")?;
+    let design_insight_summary =
+        mempal::core::design_insights::unresolved_design_insight_summary(db.conn())
+            .context("failed to summarize design insights")?;
+    if design_insight_summary.high_value_open > 0 {
+        runtime_warnings.push(mempal::core::config::RuntimeWarning {
+            level: "warn",
+            source: "design_insights",
+            message: format!(
+                "{} unresolved high-value design insight(s) need draining; run `mempal insight list --status open --min-priority 4`.",
+                design_insight_summary.high_value_open
+            ),
+        });
+    }
     let daemon_pid = read_daemon_pid(db.path())?;
     let daemon_running = daemon_pid
         .map(process_is_running)
@@ -10098,6 +10118,23 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     match last_crystallization_at.as_deref() {
         Some(last) => println!("  last_crystallization_at: {last}"),
         None => println!("  last_crystallization_at: none"),
+    }
+    println!("Design Insights:");
+    println!("  open_total: {}", design_insight_summary.open_total);
+    println!(
+        "  high_value_open: {}",
+        design_insight_summary.high_value_open
+    );
+    if design_insight_summary.open_by_target.is_empty() {
+        println!("  open_by_target: none");
+    } else {
+        let targets = design_insight_summary
+            .open_by_target
+            .iter()
+            .map(|(target, count)| format!("{target}={count}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  open_by_target: {targets}");
     }
     let triple_count = db.triple_count().context("failed to count triples")?;
     println!("taxonomy_entries: {taxonomy_count}");
@@ -13080,9 +13117,11 @@ Mempal Maintenance Runbook
 2. Ingest research plan: mempal phase3 research-ingest-plan <report.json>
 3. Knowledge distill: mempal knowledge distill
 4. Check adoption events: mempal phase3 adoption review
-5. Capture handoff: mempal cowork-capture --cwd <path> --summary-source handoff
-6. Run runtime adoption analytics: mempal phase3 adoption analytics
-7. Doctor check: mempal doctor";
+5. Design-opportunity pass: mempal insight runbook
+6. Drain high-value design insights: mempal insight list --status open --min-priority 4
+7. Capture handoff: mempal cowork-capture --cwd <path> --summary-source handoff
+8. Run runtime adoption analytics: mempal phase3 adoption analytics
+9. Doctor check: mempal doctor";
     match format.as_str() {
         "plain" => {
             println!("{RUNBOOK_CONTENT}");
@@ -13177,6 +13216,11 @@ fn maintenance_guided_run_command(format: String) -> Result<()> {
         MaintenanceStep {
             command: "mempal cowork-doctor --cwd .".to_string(),
             description: "Health check the multi-agent cowork bus registry".to_string(),
+        },
+        MaintenanceStep {
+            command: "mempal insight list --status open --min-priority 4".to_string(),
+            description: "Drain unresolved high-value design insights before or after issue work"
+                .to_string(),
         },
         MaintenanceStep {
             command: "mempal cowork-capture --cwd . --summary-source handoff".to_string(),
@@ -16788,6 +16832,15 @@ fn doctor_command(format: String) -> Result<()> {
                 report.embedding.queue.claimed,
                 report.embedding.queue.failed
             );
+            println!(
+                "design_insights=schema_available:{} open:{} high_value_open:{}",
+                report.design_insights.schema_available,
+                report.design_insights.open_total,
+                report.design_insights.high_value_open
+            );
+            if let Some(error) = report.design_insights.error.as_deref() {
+                println!("design_insights_error={error}");
+            }
             if report.embedding.endpoints.is_empty() {
                 println!("embedding_endpoints=none");
             } else {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -100,26 +100,27 @@ use super::tools::{
     CoworkBusHandoffDto, CoworkBusHandoffFiltersDto, CoworkBusMessageDto, CoworkBusRequest,
     CoworkBusResponse, CoworkBusSessionDto, CoworkBusTmuxPeekDto, CoworkBusTmuxProbeDto,
     CoworkPushRequest, CoworkPushResponse, DatabaseDiagnosticDto, DeleteRequest, DeleteResponse,
-    DoctorMcpDto, DoctorRequest, DoctorResponse, DoctorToolDto, DuplicateWarning,
-    EmbedEndpointStatusDto, EmbedStatusDto, EmbedderCircuitDto, EndpointHealthDto,
-    FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto, FieldTaxonomyResponse,
-    GatingRuntimeStatusDto, IngestControls, IngestOperationState, IngestRequest, IngestResponse,
-    IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
-    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
-    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
-    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
-    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
-    LeaseInfoDto, LeaseRequest, LeaseResponse, LlmEndpointStatusDto, LlmStatusDto,
-    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
-    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
-    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
-    QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse,
-    ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto, RollbackRequest,
-    RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto,
-    SearchRequest, SearchResponse, SearchResultDto, SkillDto, SkillRequest, SkillResponse,
-    SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest, StatusResponse, StatusScope,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
-    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    DesignInsightStatusDto, DoctorMcpDto, DoctorRequest, DoctorResponse, DoctorToolDto,
+    DuplicateWarning, EmbedEndpointStatusDto, EmbedStatusDto, EmbedderCircuitDto,
+    EndpointHealthDto, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
+    FieldTaxonomyResponse, GatingRuntimeStatusDto, IngestControls, IngestOperationState,
+    IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto,
+    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
+    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
+    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
+    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
+    KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest, LeaseResponse,
+    LlmEndpointStatusDto, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
+    OperationStatusRequest, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto,
+    Phase3Request, Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
+    PinnedFactsResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
+    ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievedKnowledgeCardDto,
+    RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto,
+    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto,
+    SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, StatusDetail, StatusRequest,
+    StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto, TaxonomyRequest,
+    TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto, TunnelsRequest,
+    TunnelsResponse, TurnStorageStatusDto,
 };
 
 fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool {
@@ -613,6 +614,8 @@ impl MempalMcpServer {
                 let consolidation_stats = db.consolidation_stats()?;
                 let pending_card_count = db.pending_auto_generated_knowledge_card_count()?;
                 let last_crystallization_at = db.last_crystallization_at()?;
+                let design_insight_summary =
+                    crate::core::design_insights::unresolved_design_insight_summary(db.conn())?;
                 let raw_turn_count = count_raw_turn_drawers(db, &turns_config)?;
                 let null_project_backfill_pending = db.null_project_backfill_pending_count()?;
                 let taxonomy_count = db.taxonomy_count()?;
@@ -657,6 +660,7 @@ impl MempalMcpServer {
                     sleep_conflicts_resolved: consolidation_stats.sleep_conflicts_resolved,
                     pending_card_count,
                     last_crystallization_at,
+                    design_insight_summary,
                     raw_turn_count,
                     null_project_backfill_pending,
                     taxonomy_count,
@@ -1398,6 +1402,7 @@ struct StatusDbSnapshot {
     sleep_conflicts_resolved: u64,
     pending_card_count: i64,
     last_crystallization_at: Option<String>,
+    design_insight_summary: crate::core::design_insights::DesignInsightSummary,
     raw_turn_count: i64,
     null_project_backfill_pending: i64,
     taxonomy_count: i64,
@@ -2238,6 +2243,16 @@ impl MempalMcpServer {
                 source: "vector_index".to_string(),
             });
         }
+        if db_snapshot.design_insight_summary.high_value_open > 0 {
+            system_warnings.push(SystemWarning {
+                level: "warn".to_string(),
+                message: format!(
+                    "{} unresolved high-value design insight(s) need draining; run `mempal insight list --status open --min-priority 4`",
+                    db_snapshot.design_insight_summary.high_value_open
+                ),
+                source: "design_insights".to_string(),
+            });
+        }
         if unresolved_project_scope && config.search.strict_project_isolation {
             system_warnings.push(SystemWarning {
                 level: "warn".to_string(),
@@ -2321,6 +2336,11 @@ impl MempalMcpServer {
             sleep_conflicts_resolved: db_snapshot.sleep_conflicts_resolved,
             pending_card_count: db_snapshot.pending_card_count,
             last_crystallization_at: db_snapshot.last_crystallization_at,
+            design_insights: DesignInsightStatusDto {
+                open_total: db_snapshot.design_insight_summary.open_total,
+                high_value_open: db_snapshot.design_insight_summary.high_value_open,
+                open_by_target: db_snapshot.design_insight_summary.open_by_target,
+            },
             taxonomy_count: db_snapshot.taxonomy_count,
             db_size_bytes: db_snapshot.db_size_bytes,
             diary_rollup_days: db_snapshot.diary_rollup_days,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1903,6 +1903,7 @@ pub struct StatusResponse {
     pub sleep_conflicts_resolved: u64,
     pub pending_card_count: i64,
     pub last_crystallization_at: Option<String>,
+    pub design_insights: DesignInsightStatusDto,
     pub taxonomy_count: i64,
     pub db_size_bytes: u64,
     pub config_version: String,
@@ -1939,6 +1940,13 @@ pub struct StatusResponse {
     pub database_diagnostic: Option<DatabaseDiagnosticDto>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub struct DesignInsightStatusDto {
+    pub open_total: u64,
+    pub high_value_open: u64,
+    pub open_by_target: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/tests/context_assembler.rs
+++ b/tests/context_assembler.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use mempal::context::{ContextRequest, assemble_context};
 use mempal::core::anchor;
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{
     AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
     KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType, TriggerHints,
@@ -1175,10 +1175,10 @@ async fn test_context_assembler_returns_typed_pack() {
 #[test]
 fn test_context_assembler_does_not_bump_schema() {
     let (tmp, db) = setup_cli_home();
-    assert_eq!(db.schema_version().expect("schema"), 17);
+    assert_eq!(db.schema_version().expect("schema"), CURRENT_SCHEMA_VERSION);
     let before_tables = table_names(&db);
     let _ = run_context_plain(tmp.path(), "debug", &[]);
-    assert_eq!(db.schema_version().expect("schema"), 17);
+    assert_eq!(db.schema_version().expect("schema"), CURRENT_SCHEMA_VERSION);
     assert_eq!(table_names(&db), before_tables);
 }
 

--- a/tests/design_insights.rs
+++ b/tests/design_insights.rs
@@ -1,0 +1,229 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use mempal::core::db::Database;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn palace_db_path(home: &TempDir) -> PathBuf {
+    home.path().join(".mempal/palace.db")
+}
+
+fn setup_home() -> TempDir {
+    let home = TempDir::new().expect("home");
+    Database::open(&palace_db_path(&home)).expect("open db");
+    home
+}
+
+fn run_mempal(home: &Path, args: &[&str]) -> Output {
+    Command::new(mempal_bin())
+        .env("HOME", home)
+        .env("MEMPAL_EMBED_BACKEND", "stub")
+        .args(args)
+        .output()
+        .expect("run mempal")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+#[test]
+fn test_cli_design_insight_record_list_resolve_and_redact() {
+    let home = setup_home();
+    let secret = "supersecret12345";
+    let provider_secret = "providerfixture12345";
+    let secret_key_fixture = "secretkeyfixture12345";
+    let json_provider_secret = "jsonproviderfixture54321";
+    let json_github_token = "jsongithubfixture54321";
+    let json_jwt_secret = "jsonjwtfixture54321";
+    let json_prompt = "jsonpromptfixture54321";
+    let json_user_prompt = "jsonuserpromptfixture54321";
+    let evidence = format!("https://user:pass@example.test/session?token={secret}");
+    let summary = format!(
+        r#"Endpoint outage should produce a reusable retry rule without storing Bearer {secret}; provider body {{"OPENAI_API_KEY":"{json_provider_secret}","prompt":"{json_prompt} with spaces"}}."#
+    );
+    let rule = format!(
+        r#"password={secret}
+raw prompt: copy the user's full request
+provider body {{"JWT_SECRET_KEY":"{json_jwt_secret} with spaces","user_prompt":"{json_user_prompt} with spaces"}}"#
+    );
+    let project = format!(
+        r#"OPENAI_API_KEY={provider_secret} DJANGO_SECRET_KEY={secret_key_fixture} {{"GITHUB_TOKEN":"{json_github_token}"}}"#
+    );
+
+    let record = run_mempal(
+        home.path(),
+        &[
+            "insight",
+            "record",
+            "--source",
+            "user-idea",
+            "--scope",
+            "issue",
+            "--target",
+            "github-issue",
+            "--evidence",
+            &evidence,
+            "--summary",
+            &summary,
+            "--rule",
+            &rule,
+            "--project",
+            &project,
+            "--priority",
+            "5",
+            "--json",
+        ],
+    );
+    assert_success(&record);
+    let record_stdout = stdout(&record);
+    assert!(!record_stdout.contains(secret), "{record_stdout}");
+    assert!(!record_stdout.contains(provider_secret), "{record_stdout}");
+    assert!(
+        !record_stdout.contains(secret_key_fixture),
+        "{record_stdout}"
+    );
+    for leaked in [
+        json_provider_secret,
+        json_github_token,
+        json_jwt_secret,
+        json_prompt,
+        json_user_prompt,
+    ] {
+        assert!(!record_stdout.contains(leaked));
+    }
+    assert!(!record_stdout.contains("user:pass"), "{record_stdout}");
+    assert!(
+        !record_stdout.contains("copy the user's full request"),
+        "{record_stdout}"
+    );
+    let record_value: Value = serde_json::from_str(&record_stdout).expect("record json");
+    let insight_id = record_value["id"].as_str().expect("insight id").to_string();
+    assert!(insight_id.starts_with("insight_"));
+    assert_eq!(record_value["status"], "open");
+    assert_eq!(record_value["priority"], 5);
+    assert_eq!(
+        record_value["project_id"],
+        r#"OPENAI_API_KEY=<redacted> DJANGO_SECRET_KEY=<redacted> {"GITHUB_TOKEN":"<redacted>"}"#
+    );
+    assert!(record_value["redaction_count"].as_u64().unwrap_or(0) >= 12);
+
+    let db = Database::open(&palace_db_path(&home)).expect("reopen db");
+    let stored: (String, String, Option<String>, Option<String>) = db
+        .conn()
+        .query_row(
+            "SELECT evidence_ref, summary, rule_text, project_id FROM design_insights WHERE id = ?1",
+            [insight_id.as_str()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("stored insight");
+    let stored_text = format!(
+        "{} {} {} {}",
+        stored.0,
+        stored.1,
+        stored.2.as_deref().unwrap_or_default(),
+        stored.3.as_deref().unwrap_or_default()
+    );
+    for leaked in [
+        secret,
+        provider_secret,
+        secret_key_fixture,
+        json_provider_secret,
+        json_github_token,
+        json_jwt_secret,
+        json_prompt,
+        json_user_prompt,
+    ] {
+        assert!(!stored_text.contains(leaked));
+    }
+
+    let list = run_mempal(
+        home.path(),
+        &["insight", "list", "--status", "open", "--json"],
+    );
+    assert_success(&list);
+    let list_stdout = stdout(&list);
+    assert!(!list_stdout.contains(secret), "{list_stdout}");
+    assert!(!list_stdout.contains(provider_secret), "{list_stdout}");
+    assert!(!list_stdout.contains(secret_key_fixture), "{list_stdout}");
+    for leaked in [
+        json_provider_secret,
+        json_github_token,
+        json_jwt_secret,
+        json_prompt,
+        json_user_prompt,
+    ] {
+        assert!(!list_stdout.contains(leaked));
+    }
+    let rows: Value = serde_json::from_str(&list_stdout).expect("list json");
+    assert_eq!(rows.as_array().expect("rows").len(), 1);
+    assert_eq!(rows[0]["id"], insight_id);
+
+    let status = run_mempal(home.path(), &["status"]);
+    assert_success(&status);
+    let status_stdout = stdout(&status);
+    assert!(
+        status_stdout.contains("Design Insights:") && status_stdout.contains("high_value_open: 1"),
+        "{status_stdout}"
+    );
+
+    let doctor = run_mempal(home.path(), &["doctor", "--format", "json"]);
+    assert_success(&doctor);
+    let doctor_value: Value = serde_json::from_str(&stdout(&doctor)).expect("doctor json");
+    assert_eq!(doctor_value["design_insights"]["open_total"], 1);
+    assert_eq!(doctor_value["design_insights"]["high_value_open"], 1);
+    assert!(
+        doctor_value["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .unwrap_or_default()
+                .contains("design insight")),
+        "{doctor_value:#}"
+    );
+
+    let resolve = run_mempal(
+        home.path(),
+        &[
+            "insight",
+            "resolve",
+            &insight_id,
+            "--actor",
+            "codex",
+            "--note",
+            "drained into issue acceptance criteria",
+            "--json",
+        ],
+    );
+    assert_success(&resolve);
+    let resolve_value: Value = serde_json::from_str(&stdout(&resolve)).expect("resolve json");
+    assert_eq!(resolve_value["resolved"], true);
+
+    let list_after = run_mempal(
+        home.path(),
+        &["insight", "list", "--status", "open", "--json"],
+    );
+    assert_success(&list_after);
+    let rows_after: Value = serde_json::from_str(&stdout(&list_after)).expect("list json");
+    assert_eq!(rows_after.as_array().expect("rows").len(), 0);
+}

--- a/tests/knowledge_card_schema.rs
+++ b/tests/knowledge_card_schema.rs
@@ -1,4 +1,4 @@
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use rusqlite::{Connection, params};
 use tempfile::TempDir;
@@ -259,10 +259,13 @@ fn insert_event(
 }
 
 #[test]
-fn test_new_database_schema_version_is_17() {
+fn test_new_database_schema_version_is_current() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
     for table in [
         "knowledge_cards",
         "knowledge_evidence_links",
@@ -291,7 +294,10 @@ fn test_migration_v7_to_v10_adds_phase2_phase3_and_validity_without_data_loss() 
 
     let db = Database::open(&db_path).expect("migrate v7 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let taxonomy_count: i64 = db

--- a/tests/mind_model_bootstrap.rs
+++ b/tests/mind_model_bootstrap.rs
@@ -19,7 +19,11 @@ use mempal::core::types::{
     KnowledgeTier, MemoryDomain, MemoryKind, Provenance, SourceType, TriggerHints,
 };
 use mempal::core::utils::{build_bootstrap_drawer_id_from_parts, build_drawer_id};
-use mempal::core::{anchor, db::Database, protocol::MEMORY_PROTOCOL};
+use mempal::core::{
+    anchor,
+    db::{CURRENT_SCHEMA_VERSION, Database},
+    protocol::MEMORY_PROTOCOL,
+};
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::ingest::{IngestOptions, ingest_file_with_options};
 use mempal::mcp::MempalMcpServer;
@@ -564,7 +568,10 @@ fn test_migration_backfills_legacy_drawers_with_bootstrap_defaults() {
     }
 
     let db = Database::open(&db_path).expect("migrate db to latest");
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
 
     let drawer = db
         .get_drawer("drawer_legacy_001")

--- a/tests/normalize_version.rs
+++ b/tests/normalize_version.rs
@@ -1,4 +1,4 @@
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::ingest::lock::{acquire_source_lock, source_key};
@@ -377,7 +377,10 @@ fn test_migration_v6_to_v7_stamps_normalize_version_1() {
 
     let db = Database::open(&db_path).expect("migrate v6 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
     assert_eq!(db.drawer_count().expect("drawer count"), 20);
     assert_eq!(count_normalize_version(&db, 1), 20);
 }

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 use std::thread;
 
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{
     AnchorKind, Drawer, KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
     KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance, RuntimeAdoptionEvent,
@@ -291,7 +291,10 @@ fn read_include_cards_default(home: &TempDir) -> bool {
 fn test_runtime_adoption_event_roundtrip_db() {
     let tmp = TempDir::new().expect("tempdir");
     let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
 
     let event = RuntimeAdoptionEvent {
         id: "adoption_test".to_string(),

--- a/tests/search_neighbors.rs
+++ b/tests/search_neighbors.rs
@@ -1,4 +1,4 @@
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::ingest::{IngestOptions, ingest_file_with_options};
@@ -293,7 +293,10 @@ async fn test_neighbors_limited_to_same_wing() {
 fn test_current_schema_has_chunk_index() {
     let (_tmp, db) = new_db();
 
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
     let exists: bool = db
         .conn()
         .query_row(

--- a/tests/tunnels_explicit.rs
+++ b/tests/tunnels_explicit.rs
@@ -1,4 +1,4 @@
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType, TunnelEndpoint};
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::mcp::MempalMcpServer;
@@ -204,7 +204,10 @@ fn test_schema_v5_to_v6_migration_preserves_data() {
 
     let db = Database::open(&db_path).expect("migrate v5 db");
 
-    assert_eq!(db.schema_version().expect("schema version"), 17);
+    assert_eq!(
+        db.schema_version().expect("schema version"),
+        CURRENT_SCHEMA_VERSION
+    );
     assert_eq!(db.drawer_count().expect("drawer count"), 2);
     assert_eq!(db.triple_count().expect("triple count"), 1);
     let tunnels_count: i64 = db

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3024209d4f6d0d38a5718c4b8f005cd868a3b360"
+commit = "e54244658fdfcca7a812c668e2ac35e28ff58335"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add a schema-v18 `design_insights` store for content-safe design opportunities.
- Add `mempal insight record/list/resolve/runbook` for dev2merge design-insight capture and draining.
- Surface unresolved high-value design insights through status, doctor, and MCP status warnings without exposing insight content.
- Harden design-insight redaction before persistence/output for credentials, provider/env key-value forms, quoted JSON/provider bodies, prompt fields, URL secrets, private keys, and raw prompt text.

## Validation

- `timeout 240s mise exec rust@stable -- cargo test -j1 design_insight`
- `timeout 240s mise exec rust@stable -- cargo check -j1 --all-targets`
- `mise exec rust@stable -- cargo fmt --check`
- `git diff --check`
- hook-enabled amend: branch-protection, quality-gates (`just clippy` + full `cargo test`), quick-format-check
- Native full-diff review of exact head `71acfb2`: PASS/CLEAN

## Notes

- CSA/Codex repeatedly terminated with signal 143 during this issue, so the final implementation/review gate used native subagents and local hooks instead.
- No real forget/rejudge execute was run.
- GitHub CI was not watched; local hooks/tests plus exact-head native review were used as the gate.

Closes #415
