### PR TITLE
fix(mcp): explain schema mismatch recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Next session (any agent) → mempal search → finds the decision with source ci
 > `cargo install --git <fork-url> --branch main --force mempal` may report success while actually
 > skipping the rebuild (cargo's source cache returns a stale ref despite `--force`, which only
 > forces *installation* not *re-fetch*). After a `CURRENT_SCHEMA_VERSION` bump in `src/core/db.rs`,
-> the resulting binary will fail with `database schema version N is newer than supported version N-1`.
+> the resulting binary will fail with a schema mismatch error that tells you to update the mempal
+> binary and, for MCP servers, verify the MCP client command/path configuration.
 > See [#76](https://github.com/RyderFreeman4Logos/mempal/issues/76).
 >
 > For fork builds, prefer the `--path` route below (clones a fresh checkout, builds locally).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,8 @@ Before using the CLI, keep four nouns straight:
 > `cargo install --git <fork-url> --branch main --force mempal` may report success while actually
 > skipping the rebuild (cargo's source cache returns a stale ref despite `--force`, which only
 > forces *installation* not *re-fetch*). After a `CURRENT_SCHEMA_VERSION` bump in `src/core/db.rs`,
-> the resulting binary will fail with `database schema version N is newer than supported version N-1`.
+> the resulting binary will fail with a schema mismatch error that tells you to update the mempal
+> binary and, for MCP servers, verify the MCP client command/path configuration.
 > See [#76](https://github.com/RyderFreeman4Logos/mempal/issues/76).
 >
 > For fork builds, prefer the `--path` route below (clones a fresh checkout, builds locally).

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -4,8 +4,9 @@
 # Why this script exists: `cargo install --git <fork> --branch main --force mempal`
 # is unreliable. `--force` only forces *installation*, not source re-fetch, so cargo's
 # git source cache can return a stale ref and silently skip the rebuild ("0 deps compiled").
-# After a CURRENT_SCHEMA_VERSION bump, the resulting binary will fail with
-# `database schema version N is newer than supported version N-1`.
+# After a CURRENT_SCHEMA_VERSION bump, the resulting binary will fail with a
+# schema mismatch error that tells you to update the mempal binary and, for MCP
+# servers, verify the MCP client command/path configuration.
 # See https://github.com/RyderFreeman4Logos/mempal/issues/76.
 #
 # This script always pulls fresh source and uses --path, which forces a real rebuild.

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -204,7 +204,9 @@ pub enum DbError {
     InvalidTunnel(String),
     #[error("failed to register sqlite-vec auto extension: {0}")]
     RegisterVec(String),
-    #[error("database schema version {current} is newer than supported version {supported}")]
+    #[error(
+        "database schema version {current} is newer than supported version {supported}; update the mempal binary that opens this database (for example, run `cargo install mempal` or reinstall from this source checkout). If this error comes from an MCP server, check the MCP client configuration and ensure its command/path points at the updated mempal binary."
+    )]
     UnsupportedSchemaVersion { current: u32, supported: u32 },
     #[error("supersedes and replace_text are mutually exclusive")]
     ReplacementTargetConflict,
@@ -6940,6 +6942,30 @@ mod tests {
     fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
         db.insert_drawer_with_project(&test_drawer(id, content), project_id)
             .expect("insert drawer");
+    }
+
+    #[test]
+    fn unsupported_schema_version_error_guides_binary_update_and_mcp_config() {
+        let conn = Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch(&format!(
+            "PRAGMA user_version = {};",
+            CURRENT_SCHEMA_VERSION + 1
+        ))
+        .expect("set future schema version");
+
+        let err = apply_migrations(&conn).expect_err("future schema should be unsupported");
+        let message = err.to_string();
+
+        assert!(message.contains(&format!(
+            "database schema version {} is newer than supported version {}",
+            CURRENT_SCHEMA_VERSION + 1,
+            CURRENT_SCHEMA_VERSION
+        )));
+        assert!(message.contains("update the mempal binary"));
+        assert!(message.contains("cargo install mempal"));
+        assert!(message.contains("MCP server"));
+        assert!(message.contains("MCP client configuration"));
+        assert!(message.contains("command/path"));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "e54244658fdfcca7a812c668e2ac35e28ff58335"
+commit = "7cceeea92493f367f8d289b56fb0ec2895c53095"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Clarifies the unsupported database schema error so stale mempal binaries tell operators to update the binary.
- Adds explicit MCP guidance to verify the MCP client command/path points at the updated mempal binary.
- Updates installation/docs wording to match the new actionable schema mismatch recovery message.

## Validation
- `cargo fmt --check`
- `cargo test unsupported_schema_version_error_guides_binary_update_and_mcp_config`
- `just pre-commit`
- `csa review --diff --sa-mode true --tool gemini-cli --tier tier-4-critical` → PASS
- `csa review --range main...HEAD --sa-mode true --tool gemini-cli --tier tier-4-critical` → PASS

Closes #424
