### PR TITLE
fix(status): split llm control-plane and generation health

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,6 +27,7 @@ const DEFAULT_EMBED_MAX_CONCURRENT: usize = 16;
 const DEFAULT_EMBED_ENDPOINT_PRIORITY: i32 = 0;
 const DEFAULT_LLM_BACKEND: &str = "openai_compat";
 const DEFAULT_LLM_REQUEST_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_LLM_HEALTH_PROBE_TIMEOUT_SECS: u64 = 3;
 const DEFAULT_LLM_RETRY_INTERVAL_SECS: u64 = 2;
 const DEFAULT_LLM_MAX_CONCURRENT: usize = 16;
 const DEFAULT_LLM_ENDPOINT_PRIORITY: i32 = 0;
@@ -1557,6 +1558,7 @@ pub struct LlmConfig {
     pub endpoints: Vec<LlmEndpointConfig>,
     #[serde(alias = "timeout_secs")]
     pub request_timeout_secs: u64,
+    pub health_probe_timeout_secs: u64,
     pub retry_interval_secs: u64,
     pub max_concurrent: usize,
     pub enabled_for: Vec<String>,
@@ -1574,6 +1576,7 @@ impl Default for LlmConfig {
             extra_body: None,
             endpoints: Vec::new(),
             request_timeout_secs: DEFAULT_LLM_REQUEST_TIMEOUT_SECS,
+            health_probe_timeout_secs: DEFAULT_LLM_HEALTH_PROBE_TIMEOUT_SECS,
             retry_interval_secs: DEFAULT_LLM_RETRY_INTERVAL_SECS,
             max_concurrent: DEFAULT_LLM_MAX_CONCURRENT,
             enabled_for: vec!["gating".to_string()],
@@ -1595,6 +1598,7 @@ pub struct LlmEndpointConfig {
     pub priority: Option<i32>,
     #[serde(alias = "timeout_secs")]
     pub request_timeout_secs: Option<u64>,
+    pub health_probe_timeout_secs: Option<u64>,
     pub retry_interval_secs: Option<u64>,
     pub max_concurrent: Option<usize>,
 }
@@ -1609,6 +1613,7 @@ pub struct EffectiveLlmEndpoint {
     pub extra_body: Option<serde_json::Value>,
     pub priority: i32,
     pub request_timeout_secs: u64,
+    pub health_probe_timeout_secs: u64,
     pub retry_interval_secs: u64,
     pub max_concurrent: usize,
 }
@@ -1662,6 +1667,10 @@ impl LlmConfig {
                     request_timeout_secs: endpoint
                         .request_timeout_secs
                         .unwrap_or(self.request_timeout_secs),
+                    health_probe_timeout_secs: endpoint
+                        .health_probe_timeout_secs
+                        .unwrap_or(self.health_probe_timeout_secs)
+                        .max(1),
                     retry_interval_secs: endpoint
                         .retry_interval_secs
                         .unwrap_or(self.retry_interval_secs)
@@ -1760,6 +1769,7 @@ impl LlmConfig {
             extra_body: self.extra_body.clone(),
             priority: DEFAULT_LLM_ENDPOINT_PRIORITY,
             request_timeout_secs: self.request_timeout_secs,
+            health_probe_timeout_secs: self.health_probe_timeout_secs.max(1),
             retry_interval_secs: self.retry_interval_secs.max(1),
             max_concurrent: self.max_concurrent.max(1),
         }))

--- a/src/endpoint_health.rs
+++ b/src/endpoint_health.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde_json::Value;
 use tokio::time::timeout;
 
 use crate::core::config::{Config, EffectiveEmbedEndpoint, EffectiveLlmEndpoint};
@@ -11,7 +12,12 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EndpointHealthSnapshot {
     pub embedding: ProbeStatus,
+    /// Backward-compatible alias for LLM generation health.
     pub llm: ProbeStatus,
+    /// Shallow control-plane probe (`/models`) for LLM endpoints.
+    pub llm_control_plane: ProbeStatus,
+    /// Deep generation probe (`/chat/completions`) for LLM endpoints.
+    pub llm_generation: ProbeStatus,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,8 +57,14 @@ impl ProbeStatus {
 }
 
 pub async fn probe_endpoints(config: &Config) -> EndpointHealthSnapshot {
-    let (embedding, llm) = tokio::join!(probe_embedding(config), probe_llm(config));
-    EndpointHealthSnapshot { embedding, llm }
+    let (embedding, (llm_control_plane, llm_generation)) =
+        tokio::join!(probe_embedding(config), probe_llm(config));
+    EndpointHealthSnapshot {
+        embedding,
+        llm: llm_generation.clone(),
+        llm_control_plane,
+        llm_generation,
+    }
 }
 
 pub fn probe_endpoints_blocking(config: &Config) -> Result<EndpointHealthSnapshot> {
@@ -93,7 +105,7 @@ async fn probe_embedding_endpoints(endpoints: &[EffectiveEmbedEndpoint]) -> Prob
     ProbeStatus::unreachable(failures.join("; "))
 }
 
-async fn probe_llm(config: &Config) -> ProbeStatus {
+async fn probe_llm(config: &Config) -> (ProbeStatus, ProbeStatus) {
     let effective_llm = if config.memory_intelligence.mode.uses_llm()
         && config
             .memory_intelligence
@@ -104,17 +116,32 @@ async fn probe_llm(config: &Config) -> ProbeStatus {
         config.llm.clone()
     };
     if !effective_llm.enabled {
-        return ProbeStatus::unreachable("disabled".to_string());
+        let disabled = ProbeStatus::unreachable("disabled".to_string());
+        return (disabled.clone(), disabled);
     }
     let endpoints = match effective_llm.effective_endpoints() {
         Ok(endpoints) if !endpoints.is_empty() => endpoints,
-        Ok(_) => return ProbeStatus::unreachable("missing base_url".to_string()),
-        Err(error) => return ProbeStatus::unreachable(error.to_string()),
+        Ok(_) => {
+            let missing = ProbeStatus::unreachable("missing base_url".to_string());
+            return (missing.clone(), missing);
+        }
+        Err(error) => {
+            let failure = ProbeStatus::unreachable(error.to_string());
+            return (failure.clone(), failure);
+        }
     };
     probe_llm_endpoints(&endpoints).await
 }
 
-async fn probe_llm_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> ProbeStatus {
+async fn probe_llm_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> (ProbeStatus, ProbeStatus) {
+    let (control_plane, generation) = tokio::join!(
+        probe_llm_control_plane_endpoints(endpoints),
+        probe_llm_generation_endpoints(endpoints)
+    );
+    (control_plane, generation)
+}
+
+async fn probe_llm_control_plane_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> ProbeStatus {
     let mut failures = Vec::new();
     for endpoint in endpoints {
         let status = probe_models_endpoint(
@@ -134,6 +161,21 @@ async fn probe_llm_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> ProbeStatus 
     ProbeStatus::unreachable(failures.join("; "))
 }
 
+async fn probe_llm_generation_endpoints(endpoints: &[EffectiveLlmEndpoint]) -> ProbeStatus {
+    let mut failures = Vec::new();
+    for endpoint in endpoints {
+        let status = probe_chat_completion_endpoint(endpoint).await;
+        if status.reachable {
+            return ProbeStatus::reachable(
+                status.latency_ms,
+                format!("generation probe via {}", endpoint.id),
+            );
+        }
+        failures.push(format!("{}: {}", endpoint.id, status.detail));
+    }
+    ProbeStatus::unreachable(failures.join("; "))
+}
+
 async fn probe_models_endpoint(
     base_url: &str,
     api_key_env: Option<&str>,
@@ -141,7 +183,7 @@ async fn probe_models_endpoint(
 ) -> ProbeStatus {
     let endpoint = format!("{}/models", base_url.trim_end_matches('/'));
     match timeout(PROBE_TIMEOUT, async {
-        let client = build_http_client(api_key_env, direct_api_key)?;
+        let client = build_http_client(api_key_env, direct_api_key, PROBE_TIMEOUT)?;
         let started = Instant::now();
         let response = client
             .get(&endpoint)
@@ -163,9 +205,76 @@ async fn probe_models_endpoint(
     }
 }
 
+async fn probe_chat_completion_endpoint(endpoint: &EffectiveLlmEndpoint) -> ProbeStatus {
+    let probe_timeout = Duration::from_secs(endpoint.health_probe_timeout_secs.max(1));
+    let request = match build_chat_probe_body(endpoint) {
+        Ok(request) => request,
+        Err(error) => return ProbeStatus::unreachable(format!("{error:#}")),
+    };
+    let url = format!(
+        "{}/chat/completions",
+        endpoint.base_url.trim_end_matches('/')
+    );
+    match timeout(probe_timeout, async {
+        let client = build_http_client(
+            endpoint.api_key_env.as_deref(),
+            endpoint.api_key.as_deref(),
+            probe_timeout,
+        )?;
+        let started = Instant::now();
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .with_context(|| format!("request failed for {url}"))?;
+        response
+            .error_for_status_ref()
+            .with_context(|| format!("generation probe returned {}", response.status()))?;
+        Ok::<u64, anyhow::Error>(started.elapsed().as_millis() as u64)
+    })
+    .await
+    {
+        Ok(Ok(latency_ms)) => {
+            ProbeStatus::reachable(Some(latency_ms), "generation probe".to_string())
+        }
+        Ok(Err(error)) => ProbeStatus::unreachable(format!("{error:#}")),
+        Err(_) => {
+            ProbeStatus::unreachable(format!("timeout after {}ms", probe_timeout.as_millis()))
+        }
+    }
+}
+
+fn build_chat_probe_body(endpoint: &EffectiveLlmEndpoint) -> Result<Value> {
+    let mut body = serde_json::Map::new();
+    body.insert("model".to_string(), Value::String(endpoint.model.clone()));
+    body.insert(
+        "messages".to_string(),
+        serde_json::json!([{ "role": "user", "content": "ping" }]),
+    );
+    body.insert("temperature".to_string(), serde_json::json!(0.0));
+    body.insert("max_tokens".to_string(), serde_json::json!(1));
+    if let Some(extra_body) = endpoint.extra_body.as_ref() {
+        let Value::Object(extra) = extra_body else {
+            anyhow::bail!("llm.extra_body must be a JSON object");
+        };
+        for (key, value) in extra {
+            if matches!(
+                key.as_str(),
+                "model" | "messages" | "temperature" | "max_tokens"
+            ) {
+                continue;
+            }
+            body.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(Value::Object(body))
+}
+
 fn build_http_client(
     api_key_env: Option<&str>,
     direct_api_key: Option<&str>,
+    request_timeout: Duration,
 ) -> Result<reqwest::Client> {
     let mut headers = HeaderMap::new();
     if let Some(api_key) = resolve_api_key(api_key_env, direct_api_key)? {
@@ -175,7 +284,7 @@ fn build_http_client(
     }
     reqwest::Client::builder()
         .default_headers(headers)
-        .timeout(PROBE_TIMEOUT)
+        .timeout(request_timeout)
         .build()
         .context("failed to build health probe client")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9923,6 +9923,10 @@ fn config_intelligence_command(config: &Config) -> Result<()> {
     }
     println!("  timeout_secs: {}", effective_llm.request_timeout_secs);
     println!(
+        "  health_probe_timeout_secs: {}",
+        effective_llm.health_probe_timeout_secs
+    );
+    println!(
         "  extra_body: {}",
         if effective_llm.extra_body.is_some() {
             "configured"
@@ -10232,7 +10236,11 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         Some(health) => {
             println!("Endpoints:");
             println!("  embedding: {}", health.embedding.display());
-            println!("  llm: {}", health.llm.display());
+            println!(
+                "  llm_control_plane: {}",
+                health.llm_control_plane.display()
+            );
+            println!("  llm_generation: {}", health.llm_generation.display());
             push_model_backend_runtime_warnings(
                 &mut runtime_warnings,
                 config,
@@ -10474,8 +10482,8 @@ fn push_model_backend_runtime_warnings(
     {
         warnings.push(mempal::core::config::RuntimeWarning {
             level: "error",
-            source: "llm",
-            message: "LLM memory judge is configured but no judge endpoint is reachable; memory quality gating is unavailable until an endpoint recovers.".to_string(),
+            source: "llm_generation",
+            message: "LLM memory judge is configured but no chat-completion endpoint is reachable; memory quality gating is unavailable until generation recovers.".to_string(),
         });
     }
     if queue_stats.pending > 0 && !endpoint_health.embedding.reachable {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2362,6 +2362,12 @@ impl MempalMcpServer {
                 embedding_latency_ms: endpoint_health.embedding.latency_ms,
                 llm_reachable: endpoint_health.llm.reachable,
                 llm_latency_ms: endpoint_health.llm.latency_ms,
+                llm_control_plane_reachable: endpoint_health.llm_control_plane.reachable,
+                llm_control_plane_latency_ms: endpoint_health.llm_control_plane.latency_ms,
+                llm_control_plane_detail: endpoint_health.llm_control_plane.detail.clone(),
+                llm_generation_reachable: endpoint_health.llm_generation.reachable,
+                llm_generation_latency_ms: endpoint_health.llm_generation.latency_ms,
+                llm_generation_detail: endpoint_health.llm_generation.detail.clone(),
             },
             embed_status: EmbedStatusDto {
                 backend: config.embed.backend.clone(),
@@ -7736,8 +7742,8 @@ fn push_model_backend_warnings(
     {
         system_warnings.push(SystemWarning {
             level: "error".to_string(),
-            message: "LLM memory judge is configured but no judge endpoint is reachable; memory quality gating is unavailable until an endpoint recovers.".to_string(),
-            source: "llm".to_string(),
+            message: "LLM memory judge is configured but no chat-completion endpoint is reachable; memory quality gating is unavailable until generation recovers.".to_string(),
+            source: "llm_generation".to_string(),
         });
     }
     if queue_stats.pending > 0 && !endpoint_health.embedding.reachable {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1975,9 +1975,18 @@ pub struct EndpointHealthDto {
     pub embedding_reachable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding_latency_ms: Option<u64>,
+    /// Backward-compatible alias for LLM generation health.
     pub llm_reachable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub llm_latency_ms: Option<u64>,
+    pub llm_control_plane_reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_control_plane_latency_ms: Option<u64>,
+    pub llm_control_plane_detail: String,
+    pub llm_generation_reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub llm_generation_latency_ms: Option<u64>,
+    pub llm_generation_detail: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]

--- a/tests/endpoint_health.rs
+++ b/tests/endpoint_health.rs
@@ -1,6 +1,45 @@
+use axum::{
+    Json, Router,
+    routing::{get, post},
+};
 use mempal::core::config::Config;
 use mempal::endpoint_health::probe_endpoints;
 use mockito::Server;
+use serde_json::json;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+async fn spawn_llm_health_server(
+    chat_delay: Duration,
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { Json(json!({ "object": "list", "data": [] })) }),
+        )
+        .route(
+            "/v1/chat/completions",
+            post(move || async move {
+                tokio::time::sleep(chat_delay).await;
+                Json(json!({
+                    "model": "probe-model",
+                    "choices": [{
+                        "message": {"role": "assistant", "content": "ok"}
+                    }]
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind LLM health server");
+    let addr = listener.local_addr().expect("health server addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve LLM health server");
+    });
+    (addr, handle)
+}
 
 #[tokio::test]
 async fn test_endpoint_health_probes_llm_endpoint_pool() {
@@ -16,6 +55,18 @@ async fn test_endpoint_health_probes_llm_endpoint_pool() {
         .mock("GET", "/v1/models")
         .with_status(200)
         .with_body(r#"{"object":"list","data":[]}"#)
+        .create_async()
+        .await;
+    let primary_generation_mock = primary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(500)
+        .with_body("primary generation unavailable")
+        .create_async()
+        .await;
+    let secondary_generation_mock = secondary
+        .mock("POST", "/v1/chat/completions")
+        .with_status(200)
+        .with_body(r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}]}"#)
         .create_async()
         .await;
     let config = Config::parse(&format!(
@@ -42,8 +93,42 @@ model = "secondary-model"
 
     primary_mock.assert_async().await;
     secondary_mock.assert_async().await;
+    primary_generation_mock.assert_async().await;
+    secondary_generation_mock.assert_async().await;
     assert!(health.llm.reachable, "{health:#?}");
-    assert_eq!(health.llm.detail, "http probe via secondary");
+    assert_eq!(health.llm_control_plane.detail, "http probe via secondary");
+    assert_eq!(
+        health.llm_generation.detail,
+        "generation probe via secondary"
+    );
+    assert_eq!(health.llm.detail, health.llm_generation.detail);
+}
+
+#[tokio::test]
+async fn test_endpoint_health_distinguishes_llm_models_from_generation_timeout() {
+    let (addr, handle) = spawn_llm_health_server(Duration::from_secs(5)).await;
+    let config = Config::parse(&format!(
+        r#"
+[llm]
+enabled = true
+base_url = "http://{addr}/v1"
+model = "probe-model"
+health_probe_timeout_secs = 1
+"#
+    ))
+    .expect("parse LLM health config");
+
+    let health = probe_endpoints(&config).await;
+    handle.abort();
+    let _ = handle.await;
+
+    assert!(health.llm_control_plane.reachable, "{health:#?}");
+    assert!(!health.llm_generation.reachable, "{health:#?}");
+    assert!(
+        health.llm_generation.detail.contains("timeout")
+            || health.llm_generation.detail.contains("timed out"),
+        "{health:#?}"
+    );
 }
 
 #[tokio::test]

--- a/tests/llm_config.rs
+++ b/tests/llm_config.rs
@@ -7,6 +7,7 @@ fn test_llm_config_default_disabled() {
     assert!(!config.enabled);
     assert_eq!(config.backend, "openai_compat");
     assert_eq!(config.request_timeout_secs, 30);
+    assert_eq!(config.health_probe_timeout_secs, 3);
     assert_eq!(config.retry_interval_secs, 2);
     assert_eq!(config.max_concurrent, 16);
     assert_eq!(config.enabled_for, vec!["gating".to_string()]);
@@ -30,6 +31,7 @@ base_url = "http://localhost:8317/v1"
 model = "qwen35-35b-a3b"
 api_key_env = "LOCAL_ROUTER_API_KEY"
 request_timeout_secs = 45
+health_probe_timeout_secs = 5
 retry_interval_secs = 3
 max_concurrent = 8
 enabled_for = ["gating", "distill", "compress"]
@@ -49,6 +51,7 @@ enabled_for = ["gating", "distill", "compress"]
         Some("LOCAL_ROUTER_API_KEY")
     );
     assert_eq!(config.llm.request_timeout_secs, 45);
+    assert_eq!(config.llm.health_probe_timeout_secs, 5);
     assert_eq!(config.llm.retry_interval_secs, 3);
     assert_eq!(config.llm.max_concurrent, 8);
     assert_eq!(
@@ -71,6 +74,7 @@ base_url = "http://localhost:8317/v1"
 model = "qwen35-35b-a3b"
 api_key_env = "LOCAL_ROUTER_API_KEY"
 request_timeout_secs = 45
+health_probe_timeout_secs = 6
 max_concurrent = 8
 "#,
     )
@@ -90,6 +94,7 @@ max_concurrent = 8
         Some("LOCAL_ROUTER_API_KEY")
     );
     assert_eq!(endpoints[0].request_timeout_secs, 45);
+    assert_eq!(endpoints[0].health_probe_timeout_secs, 6);
     assert_eq!(endpoints[0].max_concurrent, 8);
 }
 
@@ -111,6 +116,7 @@ base_url = "http://backup.local:8317/v1"
 model = "backup-model"
 priority = 20
 request_timeout_secs = 12
+health_probe_timeout_secs = 4
 retry_interval_secs = 4
 max_concurrent = 3
 "#,
@@ -128,11 +134,13 @@ max_concurrent = 3
     assert_eq!(endpoints[0].model, "primary-model");
     assert_eq!(endpoints[0].priority, 10);
     assert_eq!(endpoints[0].request_timeout_secs, 30);
+    assert_eq!(endpoints[0].health_probe_timeout_secs, 3);
     assert_eq!(endpoints[0].retry_interval_secs, 2);
     assert_eq!(endpoints[0].max_concurrent, 16);
     assert_eq!(endpoints[1].id, "lan.backup-1");
     assert_eq!(endpoints[1].priority, 20);
     assert_eq!(endpoints[1].request_timeout_secs, 12);
+    assert_eq!(endpoints[1].health_probe_timeout_secs, 4);
     assert_eq!(endpoints[1].retry_interval_secs, 4);
     assert_eq!(endpoints[1].max_concurrent, 3);
     assert_eq!(config.llm.pool_capacity(), 19);

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -7,7 +7,10 @@ use std::path::{Path, PathBuf};
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
 
 #[cfg(feature = "integration")]
-use axum::{Json, Router, routing::get};
+use axum::{
+    Json, Router,
+    routing::{get, post},
+};
 #[cfg(feature = "integration")]
 use common::harness::McpStdio;
 use mempal::core::compaction::merge_cluster;
@@ -134,7 +137,10 @@ enabled = true
     assert_eq!(response.llm_status.max_concurrent, 5);
     assert!(
         response.system_warnings.iter().any(|warning| {
-            warning.source == "llm" && warning.message.contains("no judge endpoint is reachable")
+            warning.source == "llm_generation"
+                && warning
+                    .message
+                    .contains("no chat-completion endpoint is reachable")
         }),
         "{:?}",
         response.system_warnings
@@ -203,10 +209,21 @@ retry_interval_secs = 5
 
 #[cfg(feature = "integration")]
 async fn spawn_models_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
-    let app = Router::new().route(
-        "/v1/models",
-        get(|| async { Json(json!({ "object": "list", "data": [] })) }),
-    );
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { Json(json!({ "object": "list", "data": [] })) }),
+        )
+        .route(
+            "/v1/chat/completions",
+            post(|| async {
+                Json(json!({
+                    "id": "health-probe",
+                    "object": "chat.completion",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                }))
+            }),
+        );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind");
@@ -467,6 +484,30 @@ async fn test_mcp_status_surfaces_endpoint_health() {
         response["endpoint_health"]["llm_latency_ms"]
             .as_u64()
             .is_some(),
+        "{response:#?}"
+    );
+    assert!(
+        response["endpoint_health"]["llm_control_plane_reachable"]
+            .as_bool()
+            .expect("llm_control_plane_reachable bool"),
+        "{response:#?}"
+    );
+    assert!(
+        response["endpoint_health"]["llm_generation_reachable"]
+            .as_bool()
+            .expect("llm_generation_reachable bool"),
+        "{response:#?}"
+    );
+    assert!(
+        response["endpoint_health"]["llm_control_plane_detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
+        "{response:#?}"
+    );
+    assert!(
+        response["endpoint_health"]["llm_generation_detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
         "{response:#?}"
     );
 

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -125,7 +125,7 @@ fn test_status_command_shows_endpoint_health() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     let handle = thread::spawn(move || {
-        for _ in 0..2 {
+        for _ in 0..3 {
             let (mut stream, _) = listener.accept().expect("accept");
             let mut buf = [0_u8; 1024];
             let _ = stream.read(&mut buf);
@@ -140,6 +140,7 @@ fn test_status_command_shows_endpoint_health() {
     let (home, _db_path) = setup_home_with_status_endpoints(&format!("http://{addr}/v1"));
     let output = Command::new(mempal_bin())
         .arg("status")
+        .arg("--full")
         .env("HOME", home.path())
         .output()
         .expect("run mempal status");
@@ -148,7 +149,11 @@ fn test_status_command_shows_endpoint_health() {
     let stdout = String::from_utf8(output.stdout).expect("status stdout utf8");
     assert!(stdout.contains("Endpoints:"), "{stdout}");
     assert!(stdout.contains("embedding: reachable ("), "{stdout}");
-    assert!(stdout.contains("llm: reachable ("), "{stdout}");
+    assert!(
+        stdout.contains("llm_control_plane: reachable ("),
+        "{stdout}"
+    );
+    assert!(stdout.contains("llm_generation: reachable ("), "{stdout}");
 
     handle.join().expect("server join");
 }


### PR DESCRIPTION
## Summary
- Split LLM endpoint health into shallow control-plane `/models` reachability and deep chat-completion generation health.
- Keep the existing `llm_reachable` compatibility field tied to generation health so status warnings do not treat a healthy `/models` endpoint as production chat availability.
- Add `health_probe_timeout_secs` for short health probes, separate from production `request_timeout_secs`.
- Update CLI/MCP status output and integration fixtures/tests for the new generation probe.

## Verification
- `cargo test --features integration --test queue_stats test_status_command_shows_endpoint_health -- --nocapture`
- `cargo test --features integration --test mcp_status_queue_stats test_mcp_status_surfaces_endpoint_health -- --nocapture`
- `cargo test --test endpoint_health -- --nocapture`
- `cargo test --test mcp_status_queue_stats -- --nocapture`
- `cargo test --test llm_config -- --nocapture`
- `cargo test --test llm_router -- --nocapture`
- `just pre-commit`
- Independent review: PASS/CLEAN after fixing two integration fixture findings

## Review note
CSA review command is currently blocked by cli-sub-agent infrastructure issue RyderFreeman4Logos/cli-sub-agent#2213. This branch used native independent review fallback and recorded the pre-push review-check bypass reason for the exact reviewed SHA.

Closes #422
