### PR TITLE
fix(queue): auto-requeue recovered model failures

### DIFF
--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 21;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 22;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -111,6 +111,15 @@ CREATE INDEX IF NOT EXISTS idx_ct_hermes_profile
 CREATE INDEX IF NOT EXISTS idx_ct_session_source
     ON conversation_turns(session_source, timestamp_epoch DESC)
     WHERE session_source IS NOT NULL;
+"#;
+
+pub const FORK_EXT_V22_SCHEMA_SQL: &str = r#"
+CREATE INDEX IF NOT EXISTS idx_pending_failed_failure_class
+    ON pending_messages(status, failure_class, kind);
+
+INSERT INTO fork_ext_meta (key, value)
+VALUES ('queue.auto_requeue.last_at_unix_ms', '0')
+ON CONFLICT(key) DO NOTHING;
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -439,6 +448,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 21,
             up: apply_v21,
         },
+        Migration {
+            version: 22,
+            up: apply_v22,
+        },
     ]
 }
 
@@ -633,6 +646,58 @@ fn apply_v21(conn: &Connection) -> rusqlite::Result<()> {
     ensure_nullable_column(conn, "conversation_turns", "previous_message_id", "TEXT")?;
     ensure_nullable_column(conn, "conversation_turns", "next_message_id", "TEXT")?;
     conn.execute_batch(FORK_EXT_V21_SCHEMA_SQL)
+}
+
+fn apply_v22(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_nullable_column(conn, "pending_messages", "failure_class", "TEXT")?;
+    conn.execute_batch(
+        r#"
+        UPDATE pending_messages
+        SET failure_class = CASE
+            WHEN status != 'failed' THEN NULL
+            WHEN lower(COALESCE(last_error, '')) LIKE '%decode%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%unknown llm task%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%invalid%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%unsupported%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%missing%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%configuration%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%config%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%dimension%' THEN 'terminal'
+            WHEN lower(COALESCE(last_error, '')) LIKE '%no vectors%' THEN 'terminal'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%408%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%429%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%500%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%502%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%503%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%504%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%timeout%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%timed out%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%too many requests%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%rate limit%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%cooldown%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%connection refused%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%connection reset%' THEN 'retryable_model'
+            WHEN kind IN ('llm_task', 'ingest_async', 'hook_event', 'hook_post_tool', 'hook_user_prompt', 'hook_session_start', 'hook_session_end', 'hook:post-tool-use', 'hook:user-prompt-submit', 'hook:session-start', 'hook:session-end')
+                AND lower(COALESCE(last_error, '')) LIKE '%remote disconnected%' THEN 'retryable_model'
+            ELSE 'terminal'
+        END
+        WHERE failure_class IS NULL;
+        "#,
+    )?;
+    conn.execute_batch(FORK_EXT_V22_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -28,6 +28,8 @@ pub enum QueueError {
     RetryCountOverflow { id: String },
     #[error("blocking queue task failed: {0}")]
     BlockingTaskFailed(String),
+    #[error("unsupported model task kind for auto-requeue: {0}")]
+    UnsupportedModelTaskKind(String),
 }
 
 pub type Result<T> = std::result::Result<T, QueueError>;
@@ -63,6 +65,11 @@ pub struct QueueStats {
     pub pending: u64,
     pub claimed: u64,
     pub failed: u64,
+    pub failed_retryable: u64,
+    pub failed_terminal: u64,
+    pub failed_retryable_embed: u64,
+    pub failed_retryable_llm: u64,
+    pub last_auto_requeue_at_unix_ms: Option<u64>,
     pub oldest_pending_age_secs: Option<u64>,
     pub rate_per_min: f64,
     pub avg_processing_ms: Option<u64>,
@@ -269,6 +276,11 @@ impl AsyncPendingMessageStore {
         disposition: QueueFailureDisposition,
     ) -> Result<()> {
         self.run(move |store| store.mark_failed_with_disposition(&claim, &error, disposition))
+            .await
+    }
+
+    pub async fn auto_requeue_failed_model_tasks(&self, model_kind: String) -> Result<u64> {
+        self.run(move |store| store.auto_requeue_failed_model_tasks(&model_kind))
             .await
     }
 
@@ -718,6 +730,7 @@ impl PendingMessageStore {
                 next_attempt_at = ?4,
                 status = ?5,
                 op_state = CASE WHEN ?5 = 'failed' THEN 'failed' ELSE 'queued' END,
+                failure_class = CASE WHEN ?5 = 'failed' THEN 'terminal' ELSE NULL END,
                 claim_token = NULL,
                 claimed_at = NULL,
                 heartbeat_at = NULL,
@@ -740,6 +753,57 @@ impl PendingMessageStore {
 
         tx.commit()?;
         Ok(())
+    }
+
+    /// Mark a model-backed task as failed but retryable once the corresponding endpoint recovers.
+    pub fn mark_model_task_failed_retryable(&self, id: &str, error: &str) -> Result<()> {
+        let now = now_secs();
+        let redacted_error = sanitize_last_error(error);
+        let conn = self.open_connection()?;
+        let updated = conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'failed',
+                retry_count = 0,
+                retry_backoff_ms = 0,
+                next_attempt_at = ?2,
+                claim_token = NULL,
+                claimed_at = NULL,
+                heartbeat_at = NULL,
+                last_error = ?3,
+                op_state = 'failed',
+                failure_class = 'retryable_model'
+            WHERE id = ?1
+            "#,
+            params![id, now, redacted_error],
+        )?;
+        if updated == 0 {
+            return Err(QueueError::MessageNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Requeue retryable failed model tasks for the recovered model family.
+    pub fn auto_requeue_failed_model_tasks(&self, model_kind: &str) -> Result<u64> {
+        let now = now_secs();
+        let conn = self.open_connection()?;
+        let updated = match model_kind {
+            "embedding" => requeue_failed_model_tasks(&conn, now, "embedding")?,
+            "llm" => requeue_failed_model_tasks(&conn, now, "llm")?,
+            other => return Err(QueueError::UnsupportedModelTaskKind(other.to_string())),
+        };
+        if updated > 0 {
+            let now_ms = now_millis().to_string();
+            conn.execute(
+                r#"
+                INSERT INTO fork_ext_meta (key, value)
+                VALUES ('queue.auto_requeue.last_at_unix_ms', ?1)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                "#,
+                [now_ms],
+            )?;
+        }
+        Ok(updated)
     }
 
     /// Return dead-lettered embed-queue messages to pending for a targeted retry.
@@ -884,6 +948,50 @@ impl PendingMessageStore {
             .saturating_mul(multiplier)
             .min(self.config.max_delay_ms)
     }
+}
+
+fn requeue_failed_model_tasks(conn: &Connection, now: i64, model_kind: &str) -> Result<u64> {
+    let kind_predicate = match model_kind {
+        "embedding" => "kind != 'llm_task'",
+        "llm" => "kind = 'llm_task'",
+        other => return Err(QueueError::UnsupportedModelTaskKind(other.to_string())),
+    };
+    let sql = format!(
+        r#"
+        UPDATE pending_messages
+        SET status = 'pending',
+            retry_count = 0,
+            retry_backoff_ms = 0,
+            next_attempt_at = MIN(created_at, ?1),
+            claim_token = NULL,
+            claimed_at = NULL,
+            heartbeat_at = NULL,
+            last_error = NULL,
+            op_state = 'queued',
+            failure_class = NULL,
+            result_drawer_id = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_drawer_id
+            END,
+            rejected_reason = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE rejected_reason
+            END,
+            failure_detail = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE failure_detail
+            END,
+            result_json = CASE
+                WHEN kind = 'ingest_async' THEN NULL
+                ELSE result_json
+            END
+        WHERE status = 'failed'
+          AND failure_class = 'retryable_model'
+          AND {kind_predicate}
+        "#
+    );
+    let updated = conn.execute(&sql, [now])?;
+    Ok(updated as u64)
 }
 
 fn confirm_in_tx(
@@ -1107,6 +1215,67 @@ fn compute_queue_stats(conn: &Connection) -> Result<QueueStats> {
         }
     }
 
+    let has_failure_class = column_exists(conn, "pending_messages", "failure_class")?;
+    let (failed_retryable, failed_terminal, failed_retryable_embed, failed_retryable_llm) =
+        if has_failure_class {
+            let failed_retryable = conn.query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM pending_messages
+                WHERE status = 'failed'
+                  AND failure_class = 'retryable_model'
+                "#,
+                [],
+                |row| row.get::<_, i64>(0),
+            )?;
+            let failed_retryable_embed = conn.query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM pending_messages
+                WHERE status = 'failed'
+                  AND failure_class = 'retryable_model'
+                  AND kind != 'llm_task'
+                "#,
+                [],
+                |row| row.get::<_, i64>(0),
+            )?;
+            let failed_retryable_llm = conn.query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM pending_messages
+                WHERE status = 'failed'
+                  AND failure_class = 'retryable_model'
+                  AND kind = 'llm_task'
+                "#,
+                [],
+                |row| row.get::<_, i64>(0),
+            )?;
+            (
+                failed_retryable,
+                failed.saturating_sub(failed_retryable),
+                failed_retryable_embed,
+                failed_retryable_llm,
+            )
+        } else {
+            (0, failed, 0, 0)
+        };
+    let last_auto_requeue_at_unix_ms = if table_exists(conn, "fork_ext_meta")? {
+        conn.query_row(
+            r#"
+            SELECT value
+            FROM fork_ext_meta
+            WHERE key = 'queue.auto_requeue.last_at_unix_ms'
+            "#,
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+    } else {
+        None
+    };
+
     let oldest_pending_created_at = conn
         .query_row(
             "SELECT MIN(created_at) FROM pending_messages WHERE status = 'pending'",
@@ -1148,6 +1317,11 @@ fn compute_queue_stats(conn: &Connection) -> Result<QueueStats> {
         pending: pending_u64,
         claimed: i64_to_u64(claimed),
         failed: i64_to_u64(failed),
+        failed_retryable: i64_to_u64(failed_retryable),
+        failed_terminal: i64_to_u64(failed_terminal),
+        failed_retryable_embed: i64_to_u64(failed_retryable_embed),
+        failed_retryable_llm: i64_to_u64(failed_retryable_llm),
+        last_auto_requeue_at_unix_ms,
         oldest_pending_age_secs,
         rate_per_min,
         avg_processing_ms,
@@ -1300,6 +1474,18 @@ fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
         |row| row.get::<_, i64>(0),
     )?;
     Ok(count > 0)
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    let escaped_table = table.replace('"', "\"\"");
+    let mut statement = conn.prepare(&format!("PRAGMA table_info(\"{escaped_table}\")"))?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+    for row in rows {
+        if row? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn sanitize_last_error(error: &str) -> String {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -46,6 +46,7 @@ const SESSION_REVIEW_REJECTED_TOTAL_KEY: &str = "session_review.rejected.total";
 /// Coupled to the orphan reaper grace period in `src/main.rs`.
 pub const DAEMON_DRAIN_BUDGET: Duration = Duration::from_secs(30);
 const DAEMON_HOOK_WORKER_LIMIT: usize = 4;
+const ENDPOINT_RECOVERY_REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     run_command_with_bootstrap_events(config_path, foreground, None)
@@ -203,6 +204,11 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         context.store.clone(),
         Duration::from_secs(60),
     );
+    let endpoint_requeue_handle = spawn_endpoint_recovery_requeue_worker(
+        context.store.clone(),
+        Arc::new(crate::core::config::ConfigHandle::current),
+        ENDPOINT_RECOVERY_REQUEUE_INTERVAL,
+    );
 
     let llm_worker_handles: Vec<tokio::task::JoinHandle<_>> = if context.config.llm.enabled {
         let llm_client_runtime = crate::llm::worker::LlmClientRuntime::new(&context.config.llm);
@@ -304,6 +310,8 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     tracing::info!("LLM workers stopped");
     stall_watchdog_handle.abort();
     let _ = stall_watchdog_handle.await;
+    endpoint_requeue_handle.abort();
+    let _ = endpoint_requeue_handle.await;
 
     // Release any tasks still claimed by workers that were aborted or did not finish.
     let released = context
@@ -553,6 +561,155 @@ fn spawn_stall_watchdog(
             observer.maybe_log_stall(&store).await;
         }
     })
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct EndpointRecoveryRequeuePlan {
+    embedding: bool,
+    llm: bool,
+}
+
+impl EndpointRecoveryRequeuePlan {
+    fn is_empty(self) -> bool {
+        !self.embedding && !self.llm
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct EndpointRecoveryRequeueState {
+    embedding_reachable: bool,
+    llm_generation_reachable: bool,
+}
+
+impl EndpointRecoveryRequeueState {
+    fn plan(
+        &self,
+        health: &crate::endpoint_health::EndpointHealthSnapshot,
+    ) -> EndpointRecoveryRequeuePlan {
+        EndpointRecoveryRequeuePlan {
+            embedding: health.embedding.reachable && !self.embedding_reachable,
+            llm: health.llm_generation.reachable && !self.llm_generation_reachable,
+        }
+    }
+
+    fn commit_successes(
+        &mut self,
+        health: &crate::endpoint_health::EndpointHealthSnapshot,
+        completed: EndpointRecoveryRequeuePlan,
+    ) {
+        if health.embedding.reachable {
+            self.embedding_reachable = self.embedding_reachable || completed.embedding;
+        } else {
+            self.embedding_reachable = false;
+        }
+        if health.llm_generation.reachable {
+            self.llm_generation_reachable = self.llm_generation_reachable || completed.llm;
+        } else {
+            self.llm_generation_reachable = false;
+        }
+    }
+}
+
+type EndpointRecoveryConfigProvider =
+    Arc<dyn Fn() -> Arc<crate::core::config::Config> + Send + Sync>;
+
+fn endpoint_recovery_probe_config(
+    config_provider: &EndpointRecoveryConfigProvider,
+) -> Arc<crate::core::config::Config> {
+    config_provider()
+}
+
+fn spawn_endpoint_recovery_requeue_worker(
+    store: AsyncPendingMessageStore,
+    config_provider: EndpointRecoveryConfigProvider,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut state = EndpointRecoveryRequeueState::default();
+        loop {
+            ticker.tick().await;
+            if shutdown_requested() {
+                break;
+            }
+            let config = endpoint_recovery_probe_config(&config_provider);
+            let (health, daemon_llm_generation) = tokio::join!(
+                crate::endpoint_health::probe_endpoints(config.as_ref()),
+                crate::endpoint_health::probe_daemon_llm_generation(config.as_ref())
+            );
+            let health = crate::endpoint_health::EndpointHealthSnapshot {
+                llm: daemon_llm_generation.clone(),
+                llm_generation: daemon_llm_generation,
+                ..health
+            };
+            if let Err(error) =
+                requeue_failed_model_tasks_after_recovery(&store, &mut state, &health).await
+            {
+                tracing::warn!(
+                    ?error,
+                    "failed to auto-requeue model tasks after endpoint recovery"
+                );
+            }
+        }
+    })
+}
+
+async fn requeue_failed_model_tasks_after_recovery(
+    store: &AsyncPendingMessageStore,
+    state: &mut EndpointRecoveryRequeueState,
+    health: &crate::endpoint_health::EndpointHealthSnapshot,
+) -> crate::core::queue::Result<EndpointRecoveryRequeuePlan> {
+    let plan = state.plan(health);
+    if plan.is_empty() {
+        state.commit_successes(health, EndpointRecoveryRequeuePlan::default());
+        return Ok(plan);
+    }
+    let mut completed = EndpointRecoveryRequeuePlan::default();
+    let mut error = None;
+    if plan.embedding {
+        match store
+            .auto_requeue_failed_model_tasks("embedding".to_string())
+            .await
+        {
+            Ok(requeued) => {
+                completed.embedding = true;
+                if requeued > 0 {
+                    tracing::info!(
+                        requeued,
+                        "auto-requeued failed embedding tasks after endpoint recovery"
+                    );
+                }
+            }
+            Err(requeue_error) => {
+                error.get_or_insert(requeue_error);
+            }
+        }
+    }
+    if plan.llm {
+        match store
+            .auto_requeue_failed_model_tasks("llm".to_string())
+            .await
+        {
+            Ok(requeued) => {
+                completed.llm = true;
+                if requeued > 0 {
+                    tracing::info!(
+                        requeued,
+                        "auto-requeued failed LLM tasks after endpoint recovery"
+                    );
+                }
+            }
+            Err(requeue_error) => {
+                error.get_or_insert(requeue_error);
+            }
+        }
+    }
+    state.commit_successes(health, completed);
+    if let Some(error) = error {
+        return Err(error);
+    }
+    Ok(plan)
 }
 
 #[cfg(unix)]
@@ -1981,18 +2138,24 @@ mod tests {
         AsyncDb,
         config::{Config, LlmJudgeConfig, TurnStorageMode},
         db::Database,
-        queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueError},
+        queue::{
+            AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueError,
+            QueueFailureDisposition,
+        },
         types::{Drawer, SourceType},
     };
     use crate::embed::{EmbedError, Embedder};
+    use crate::endpoint_health::{EndpointHealthSnapshot, ProbeStatus};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
     use arc_swap::ArcSwap;
     use std::pin::Pin;
 
     use super::{
-        ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext, HookWorkerState,
-        build_drawer_records, compile_classifier_from_embedder, llm_worker_claim_enabled,
-        poll_claim_next, process_claimed_message_with_embedder, run_hook_worker, wing_from_cwd,
+        ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext,
+        EndpointRecoveryConfigProvider, EndpointRecoveryRequeuePlan, EndpointRecoveryRequeueState,
+        HookWorkerState, build_drawer_records, compile_classifier_from_embedder,
+        llm_worker_claim_enabled, poll_claim_next, process_claimed_message_with_embedder,
+        run_hook_worker, wing_from_cwd,
     };
 
     struct StubClaimSource {
@@ -2005,6 +2168,222 @@ mod tests {
                 responses: Mutex::new(VecDeque::from(responses)),
             }
         }
+    }
+
+    fn endpoint_health_snapshot(
+        embedding_reachable: bool,
+        llm_generation_reachable: bool,
+    ) -> EndpointHealthSnapshot {
+        let embedding = ProbeStatus {
+            reachable: embedding_reachable,
+            latency_ms: None,
+            detail: "test embedding".to_string(),
+        };
+        let llm_generation = ProbeStatus {
+            reachable: llm_generation_reachable,
+            latency_ms: None,
+            detail: "test generation".to_string(),
+        };
+        EndpointHealthSnapshot {
+            embedding,
+            llm: llm_generation.clone(),
+            llm_control_plane: ProbeStatus {
+                reachable: llm_generation_reachable,
+                latency_ms: None,
+                detail: "test control plane".to_string(),
+            },
+            llm_generation,
+        }
+    }
+
+    #[test]
+    fn test_endpoint_recovery_probe_config_uses_current_provider_value() {
+        let mut old_config = crate::core::config::Config::default();
+        old_config.llm.model = Some("old-model".to_string());
+        let mut new_config = crate::core::config::Config::default();
+        new_config.llm.model = Some("new-model".to_string());
+
+        let current = Arc::new(ArcSwap::from_pointee(old_config));
+        let provider_current = Arc::clone(&current);
+        let provider: EndpointRecoveryConfigProvider =
+            Arc::new(move || provider_current.load_full());
+
+        assert_eq!(
+            super::endpoint_recovery_probe_config(&provider)
+                .llm
+                .model
+                .as_deref(),
+            Some("old-model")
+        );
+        current.store(Arc::new(new_config));
+        assert_eq!(
+            super::endpoint_recovery_probe_config(&provider)
+                .llm
+                .model
+                .as_deref(),
+            Some("new-model")
+        );
+    }
+
+    #[test]
+    fn test_endpoint_recovery_requeue_state_triggers_only_on_reachable_edges() {
+        let mut state = EndpointRecoveryRequeueState::default();
+
+        let down = endpoint_health_snapshot(false, false);
+        assert_eq!(
+            state.plan(&down),
+            EndpointRecoveryRequeuePlan {
+                embedding: false,
+                llm: false,
+            }
+        );
+        state.commit_successes(&down, EndpointRecoveryRequeuePlan::default());
+
+        let embedding_up = endpoint_health_snapshot(true, false);
+        let embedding_plan = EndpointRecoveryRequeuePlan {
+            embedding: true,
+            llm: false,
+        };
+        assert_eq!(state.plan(&embedding_up), embedding_plan);
+        state.commit_successes(&embedding_up, embedding_plan);
+        assert_eq!(
+            state.plan(&embedding_up),
+            EndpointRecoveryRequeuePlan {
+                embedding: false,
+                llm: false,
+            }
+        );
+
+        state.commit_successes(&down, EndpointRecoveryRequeuePlan::default());
+        let llm_up = endpoint_health_snapshot(false, true);
+        assert_eq!(
+            state.plan(&llm_up),
+            EndpointRecoveryRequeuePlan {
+                embedding: false,
+                llm: true,
+            }
+        );
+    }
+
+    #[test]
+    fn test_endpoint_recovery_requeue_state_commits_edges_only_after_success() {
+        let health = endpoint_health_snapshot(true, true);
+        let mut state = EndpointRecoveryRequeueState::default();
+
+        let first_plan = state.plan(&health);
+        assert_eq!(
+            first_plan,
+            EndpointRecoveryRequeuePlan {
+                embedding: true,
+                llm: true,
+            }
+        );
+        assert_eq!(state.plan(&health), first_plan);
+
+        state.commit_successes(
+            &health,
+            EndpointRecoveryRequeuePlan {
+                embedding: true,
+                llm: false,
+            },
+        );
+        assert_eq!(
+            state.plan(&health),
+            EndpointRecoveryRequeuePlan {
+                embedding: false,
+                llm: true,
+            }
+        );
+
+        state.commit_successes(
+            &health,
+            EndpointRecoveryRequeuePlan {
+                embedding: false,
+                llm: true,
+            },
+        );
+        assert!(state.plan(&health).is_empty());
+
+        let down = endpoint_health_snapshot(false, false);
+        state.commit_successes(&down, EndpointRecoveryRequeuePlan::default());
+        assert_eq!(state.plan(&health), first_plan);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_recovery_requeues_only_retryable_failed_model_tasks() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let sync_store = PendingMessageStore::new_without_reclaim(&db_path);
+        let async_store = AsyncPendingMessageStore::new_without_reclaim(&db_path);
+
+        let retryable_embedding_id = sync_store
+            .enqueue("hook_event", r#"{"n":1}"#)
+            .expect("enqueue retryable embedding");
+        let terminal_embedding_id = sync_store
+            .enqueue("hook_event", r#"{"n":2}"#)
+            .expect("enqueue terminal embedding");
+        let retryable_llm_id = sync_store
+            .enqueue("llm_task", r#"{"task_type":"gating","drawer_id":"d1"}"#)
+            .expect("enqueue retryable llm");
+
+        sync_store
+            .mark_model_task_failed_retryable(&retryable_embedding_id, "timeout")
+            .expect("mark retryable embedding failed");
+        let terminal_claim = sync_store
+            .claim_next("terminal-worker", 60)
+            .expect("claim terminal embedding")
+            .expect("terminal embedding row");
+        assert_eq!(terminal_claim.id, terminal_embedding_id);
+        sync_store
+            .mark_failed_with_disposition(
+                &terminal_claim,
+                "invalid payload",
+                QueueFailureDisposition::Terminal,
+            )
+            .expect("mark terminal embedding failed");
+        sync_store
+            .mark_model_task_failed_retryable(&retryable_llm_id, "429 Too Many Requests")
+            .expect("mark retryable llm failed");
+
+        let mut state = EndpointRecoveryRequeueState::default();
+        let plan = super::requeue_failed_model_tasks_after_recovery(
+            &async_store,
+            &mut state,
+            &endpoint_health_snapshot(true, true),
+        )
+        .await
+        .expect("requeue after recovery");
+        assert_eq!(
+            plan,
+            EndpointRecoveryRequeuePlan {
+                embedding: true,
+                llm: true,
+            }
+        );
+
+        let stats = sync_store.stats().expect("queue stats");
+        assert_eq!(stats.pending, 2);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_retryable, 0);
+        assert_eq!(stats.failed_terminal, 1);
+        assert_eq!(stats.failed_retryable_embed, 0);
+        assert_eq!(stats.failed_retryable_llm, 0);
+        assert!(stats.last_auto_requeue_at_unix_ms.is_some());
+
+        let repeated_plan = super::requeue_failed_model_tasks_after_recovery(
+            &async_store,
+            &mut state,
+            &endpoint_health_snapshot(true, true),
+        )
+        .await
+        .expect("second recovery check");
+        assert!(repeated_plan.is_empty());
+        let terminal_status = sync_store
+            .operation_status(&terminal_embedding_id)
+            .expect("terminal status")
+            .expect("terminal record");
+        assert_eq!(terminal_status.op_state, "failed");
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -119,6 +119,11 @@ pub struct DoctorEmbeddingQueueReport {
     pub pending: u64,
     pub claimed: u64,
     pub failed: u64,
+    pub failed_retryable: u64,
+    pub failed_terminal: u64,
+    pub failed_retryable_embed: u64,
+    pub failed_retryable_llm: u64,
+    pub last_auto_requeue_at_unix_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]
@@ -327,6 +332,11 @@ fn queue_report_from_stats(stats: QueueStats) -> DoctorEmbeddingQueueReport {
         pending: stats.pending,
         claimed: stats.claimed,
         failed: stats.failed,
+        failed_retryable: stats.failed_retryable,
+        failed_terminal: stats.failed_terminal,
+        failed_retryable_embed: stats.failed_retryable_embed,
+        failed_retryable_llm: stats.failed_retryable_llm,
+        last_auto_requeue_at_unix_ms: stats.last_auto_requeue_at_unix_ms,
     }
 }
 

--- a/src/endpoint_health.rs
+++ b/src/endpoint_health.rs
@@ -5,7 +5,7 @@ use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::Value;
 use tokio::time::timeout;
 
-use crate::core::config::{Config, EffectiveEmbedEndpoint, EffectiveLlmEndpoint};
+use crate::core::config::{Config, EffectiveEmbedEndpoint, EffectiveLlmEndpoint, LlmConfig};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -75,6 +75,17 @@ pub fn probe_endpoints_blocking(config: &Config) -> Result<EndpointHealthSnapsho
     Ok(runtime.block_on(probe_endpoints(config)))
 }
 
+/// Probe the LLM endpoint used by the daemon LLM worker.
+///
+/// `probe_endpoints` may report memory-intelligence LLM health when that
+/// subsystem has a distinct endpoint. Queue recovery for `llm_task` rows must
+/// instead follow `config.llm`, because that is the endpoint used to process
+/// daemon LLM work.
+pub async fn probe_daemon_llm_generation(config: &Config) -> ProbeStatus {
+    let (_, generation) = probe_llm_config(&config.llm).await;
+    generation
+}
+
 async fn probe_embedding(config: &Config) -> ProbeStatus {
     match config.embed.backend.as_str() {
         "openai_compat" | "api" => {
@@ -115,6 +126,10 @@ async fn probe_llm(config: &Config) -> (ProbeStatus, ProbeStatus) {
     } else {
         config.llm.clone()
     };
+    probe_llm_config(&effective_llm).await
+}
+
+async fn probe_llm_config(effective_llm: &LlmConfig) -> (ProbeStatus, ProbeStatus) {
     if !effective_llm.enabled {
         let disabled = ProbeStatus::unreachable("disabled".to_string());
         return (disabled.clone(), disabled);
@@ -305,5 +320,27 @@ fn resolve_api_key(
         Err(std::env::VarError::NotUnicode(_)) => {
             anyhow::bail!("api key env `{env_name}` is not valid unicode")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::Config;
+    use crate::core::types::IntelligenceMode;
+
+    #[tokio::test]
+    async fn daemon_llm_generation_probe_ignores_memory_intelligence_endpoint_when_worker_disabled()
+    {
+        let mut config = Config::default();
+        config.llm.enabled = false;
+        config.memory_intelligence.mode = IntelligenceMode::LocalLlm;
+        config.memory_intelligence.llm.base_url = Some("http://127.0.0.1:9/v1".to_string());
+        config.memory_intelligence.llm.model = Some("memory-intelligence-model".to_string());
+
+        let status = probe_daemon_llm_generation(&config).await;
+
+        assert!(!status.reachable);
+        assert_eq!(status.detail, "disabled");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10261,6 +10261,16 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     println!("  pending: {}", queue_stats.pending);
     println!("  claimed: {}", queue_stats.claimed);
     println!("  failed: {}", queue_stats.failed);
+    println!("  failed_retryable: {}", queue_stats.failed_retryable);
+    println!("  failed_terminal: {}", queue_stats.failed_terminal);
+    println!(
+        "  failed_retryable_model: embedding={} llm={}",
+        queue_stats.failed_retryable_embed, queue_stats.failed_retryable_llm
+    );
+    match queue_stats.last_auto_requeue_at_unix_ms {
+        Some(ts) => println!("  last_auto_requeue_at_unix_ms: {ts}"),
+        None => println!("  last_auto_requeue_at_unix_ms: none"),
+    }
     println!("  rate_per_min: {:.1}", queue_stats.rate_per_min);
     match queue_stats.oldest_pending_age_secs {
         Some(age) => println!("  oldest_pending_age_secs: {age}"),
@@ -10492,7 +10502,10 @@ fn push_model_backend_runtime_warnings(
         warnings.push(mempal::core::config::RuntimeWarning {
             level: "warn",
             source: "queue",
-            message: "queue has failed work; use `mempal reindex --failed` for failed embed-queue items, and resubmit any writes that were rejected before entering the queue.".to_string(),
+            message: format!(
+                "queue has failed work (retryable_model={}, terminal={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require manual action.",
+                queue_stats.failed_retryable, queue_stats.failed_terminal
+            ),
         });
     }
 }
@@ -16999,10 +17012,20 @@ fn doctor_command(format: String) -> Result<()> {
             );
             println!("embedding_pool_capacity={}", report.embedding.pool_capacity);
             println!(
-                "embedding_queue=pending:{} claimed:{} failed:{}",
+                "embedding_queue=pending:{} claimed:{} failed:{} retryable_model:{} terminal:{} retryable_embedding:{} retryable_llm:{} last_auto_requeue_at_unix_ms:{}",
                 report.embedding.queue.pending,
                 report.embedding.queue.claimed,
-                report.embedding.queue.failed
+                report.embedding.queue.failed,
+                report.embedding.queue.failed_retryable,
+                report.embedding.queue.failed_terminal,
+                report.embedding.queue.failed_retryable_embed,
+                report.embedding.queue.failed_retryable_llm,
+                report
+                    .embedding
+                    .queue
+                    .last_auto_requeue_at_unix_ms
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "none".to_string())
             );
             println!(
                 "design_insights=schema_available:{} open:{} high_value_open:{}",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1418,6 +1418,11 @@ fn default_queue_stats() -> crate::core::queue::QueueStats {
         pending: 0,
         claimed: 0,
         failed: 0,
+        failed_retryable: 0,
+        failed_terminal: 0,
+        failed_retryable_embed: 0,
+        failed_retryable_llm: 0,
+        last_auto_requeue_at_unix_ms: None,
         oldest_pending_age_secs: None,
         rate_per_min: 0.0,
         avg_processing_ms: None,
@@ -2431,6 +2436,11 @@ impl MempalMcpServer {
                 pending: queue_stats.pending,
                 claimed: queue_stats.claimed,
                 failed: queue_stats.failed,
+                failed_retryable: queue_stats.failed_retryable,
+                failed_terminal: queue_stats.failed_terminal,
+                failed_retryable_embed: queue_stats.failed_retryable_embed,
+                failed_retryable_llm: queue_stats.failed_retryable_llm,
+                last_auto_requeue_at_unix_ms: queue_stats.last_auto_requeue_at_unix_ms,
                 rate_per_min: queue_stats.rate_per_min,
                 oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
                 avg_processing_ms: queue_stats.avg_processing_ms,
@@ -7756,7 +7766,10 @@ fn push_model_backend_warnings(
     if queue_stats.failed > 0 {
         system_warnings.push(SystemWarning {
             level: "warn".to_string(),
-            message: "queue has failed work; use `mempal reindex --failed` for failed embed-queue items, and resubmit any writes that were rejected before entering the queue.".to_string(),
+            message: format!(
+                "queue has failed work (retryable_model={}, terminal={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require manual action.",
+                queue_stats.failed_retryable, queue_stats.failed_terminal
+            ),
             source: "queue".to_string(),
         });
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2150,6 +2150,12 @@ pub struct QueueStatsDto {
     pub pending: u64,
     pub claimed: u64,
     pub failed: u64,
+    pub failed_retryable: u64,
+    pub failed_terminal: u64,
+    pub failed_retryable_embed: u64,
+    pub failed_retryable_llm: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_auto_requeue_at_unix_ms: Option<u64>,
     pub rate_per_min: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_pending_age_secs: Option<u64>,

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -289,6 +289,11 @@ async fn test_mcp_status_surfaces_queue_stats() {
     assert_eq!(response.queue_stats.pending, 1);
     assert_eq!(response.queue_stats.claimed, 0);
     assert_eq!(response.queue_stats.failed, 0);
+    assert_eq!(response.queue_stats.failed_retryable, 0);
+    assert_eq!(response.queue_stats.failed_terminal, 0);
+    assert_eq!(response.queue_stats.failed_retryable_embed, 0);
+    assert_eq!(response.queue_stats.failed_retryable_llm, 0);
+    assert_eq!(response.queue_stats.last_auto_requeue_at_unix_ms, None);
     assert!((response.queue_stats.rate_per_min - 0.1).abs() < f64::EPSILON);
     assert!(response.queue_stats.avg_processing_ms.is_some());
     assert_eq!(response.queue_stats.eta_secs, Some(600));
@@ -308,7 +313,13 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
     )
     .expect("create store");
 
-    store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
+    let retryable = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue retryable");
+    store.enqueue("hook_event", r#"{"n":2}"#).expect("enqueue");
+    store
+        .mark_model_task_failed_retryable(&retryable, "temporary embed outage")
+        .expect("mark retryable model failed");
     let failed = store
         .claim_next("worker-failed", 60)
         .expect("claim")
@@ -320,13 +331,19 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
     let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
     let response = server.mempal_status().await.expect("status").0;
 
-    assert_eq!(response.queue_stats.failed, 1);
-    assert_eq!(response.embed_status.failed_count, 1);
-    assert_eq!(response.embed_status.fail_count, 1);
-    assert_eq!(response.embed_status.failure_count, 1);
+    assert_eq!(response.queue_stats.failed, 2);
+    assert_eq!(response.queue_stats.failed_retryable, 1);
+    assert_eq!(response.queue_stats.failed_terminal, 1);
+    assert_eq!(response.queue_stats.failed_retryable_embed, 1);
+    assert_eq!(response.queue_stats.failed_retryable_llm, 0);
+    assert_eq!(response.embed_status.failed_count, 2);
+    assert_eq!(response.embed_status.fail_count, 2);
+    assert_eq!(response.embed_status.failure_count, 2);
     assert!(
         response.system_warnings.iter().any(|warning| {
-            warning.source == "queue" && warning.message.contains("mempal reindex --failed")
+            warning.source == "queue"
+                && warning.message.contains("retryable_model=1")
+                && warning.message.contains("terminal=1")
         }),
         "{:?}",
         response.system_warnings

--- a/tests/ops_runtime.rs
+++ b/tests/ops_runtime.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
+use mempal::core::queue::{PendingMessageStore, QueueFailureDisposition};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -119,6 +120,59 @@ fn test_cli_doctor_json_reports_schema_and_path() {
             .expect("warnings")
             .iter()
             .any(|warning| warning.as_str().unwrap_or_default().contains("PATH"))
+    );
+}
+
+#[test]
+
+fn test_cli_doctor_reports_queue_failure_classes() {
+    let home = TempDir::new().expect("home");
+    fs::create_dir_all(home.path().join(".mempal")).expect("create mempal home");
+    let db_path = palace_db_path(&home);
+    Database::open(&db_path).expect("open db");
+    let store = PendingMessageStore::new_without_reclaim(&db_path);
+
+    let retryable = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue retryable row");
+    let terminal = store
+        .enqueue("hook_event", r#"{"n":2}"#)
+        .expect("enqueue terminal row");
+    store
+        .mark_model_task_failed_retryable(&retryable, "429 Too Many Requests")
+        .expect("mark retryable failed");
+    let terminal_claim = store
+        .claim_next("terminal-worker", 60)
+        .expect("claim terminal row")
+        .expect("terminal row claimed");
+    assert_eq!(terminal_claim.id, terminal);
+    store
+        .mark_failed_with_disposition(
+            &terminal_claim,
+            "invalid payload",
+            QueueFailureDisposition::Terminal,
+        )
+        .expect("mark terminal failed");
+
+    let json = run_mempal(&home, &["doctor", "--format", "json"]);
+    assert_success(&json);
+    let value: Value = serde_json::from_str(&stdout(&json)).expect("doctor json");
+    assert_eq!(value["embedding"]["queue"]["failed"], 2);
+    assert_eq!(value["embedding"]["queue"]["failed_retryable"], 1);
+    assert_eq!(value["embedding"]["queue"]["failed_terminal"], 1);
+    assert_eq!(value["embedding"]["queue"]["failed_retryable_embed"], 1);
+    assert_eq!(value["embedding"]["queue"]["failed_retryable_llm"], 0);
+    assert_eq!(
+        value["embedding"]["queue"]["last_auto_requeue_at_unix_ms"],
+        Value::Null
+    );
+
+    let plain = run_mempal(&home, &["doctor", "--format", "plain"]);
+    assert_success(&plain);
+    let out = stdout(&plain);
+    assert!(
+        out.contains("embedding_queue=pending:0 claimed:0 failed:2 retryable_model:1 terminal:1 retryable_embedding:1 retryable_llm:0 last_auto_requeue_at_unix_ms:none"),
+        "{out}"
     );
 }
 

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -205,6 +205,156 @@ fn test_fork_ext_migration_v0_to_v1_creates_pending_messages_table() {
 }
 
 #[test]
+fn test_queue_stats_readonly_handles_pre_v22_failure_class_schema() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let conn = Connection::open(&db_path).expect("open db");
+    conn.execute_batch(
+        r#"
+        CREATE TABLE fork_ext_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        INSERT INTO fork_ext_meta (key, value) VALUES ('fork_ext_version', '21');
+
+        CREATE TABLE pending_messages (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            source_hash TEXT NOT NULL,
+            status TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            last_error TEXT,
+            op_state TEXT NOT NULL
+        );
+        "#,
+    )
+    .expect("create v21 queue schema");
+    conn.execute(
+        r#"
+        INSERT INTO pending_messages (
+            id,
+            kind,
+            source_hash,
+            status,
+            payload,
+            created_at,
+            last_error,
+            op_state
+        )
+        VALUES ('legacy-v21-failed', 'hook_event', 'legacy-v21-failed', 'failed', '{}', 1700000000, 'legacy failure', 'failed')
+        "#,
+        [],
+    )
+    .expect("insert v21 failed row");
+    drop(conn);
+
+    let stats = mempal::core::queue::queue_stats_readonly(&db_path).expect("readonly stats");
+    assert_eq!(stats.failed, 1);
+    assert_eq!(stats.failed_retryable, 0);
+    assert_eq!(stats.failed_terminal, 1);
+    assert_eq!(stats.failed_retryable_embed, 0);
+    assert_eq!(stats.failed_retryable_llm, 0);
+    assert_eq!(stats.last_auto_requeue_at_unix_ms, None);
+}
+
+#[test]
+fn test_fork_ext_v22_classifies_legacy_failed_rows_conservatively() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    let conn = db.conn();
+    conn.execute(
+        "UPDATE fork_ext_meta SET value = '21' WHERE key = 'fork_ext_version'",
+        [],
+    )
+    .expect("rewind fork ext version for v22 fixture");
+
+    for (id, kind, last_error) in [
+        ("transient-timeout", "llm_task", "429 Too Many Requests"),
+        (
+            "transient-hook-post-tool",
+            "hook_post_tool",
+            "timeout contacting embedding endpoint",
+        ),
+        (
+            "transient-hook-user-prompt",
+            "hook_user_prompt",
+            "connection reset by peer",
+        ),
+        (
+            "transient-hook-session-start",
+            "hook_session_start",
+            "503 Service Unavailable",
+        ),
+        (
+            "transient-hook-session-end",
+            "hook_session_end",
+            "rate limit exceeded",
+        ),
+        ("terminal-invalid", "llm_task", "invalid json payload"),
+        ("terminal-unknown", "hook_event", "worker rejected row"),
+        (
+            "terminal-unknown-kind-timeout",
+            "future_model_task",
+            "timeout acquiring database lock",
+        ),
+    ] {
+        conn.execute(
+            r#"
+            INSERT INTO pending_messages (
+                id,
+                kind,
+                source_hash,
+                status,
+                payload,
+                created_at,
+                last_error,
+                op_state
+            )
+            VALUES (?1, ?2, ?3, 'failed', '{}', 1700000000, ?4, 'failed')
+            "#,
+            params![id, kind, id, last_error],
+        )
+        .expect("insert legacy failed row");
+    }
+
+    apply_fork_ext_migrations_to(conn, 22).expect("apply ext v22 migration");
+    let failure_class_for = |id: &str| -> String {
+        conn.query_row(
+            "SELECT failure_class FROM pending_messages WHERE id = ?1",
+            [id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("read failure_class")
+    };
+
+    assert_eq!(failure_class_for("transient-timeout"), "retryable_model");
+    assert_eq!(
+        failure_class_for("transient-hook-post-tool"),
+        "retryable_model"
+    );
+    assert_eq!(
+        failure_class_for("transient-hook-user-prompt"),
+        "retryable_model"
+    );
+    assert_eq!(
+        failure_class_for("transient-hook-session-start"),
+        "retryable_model"
+    );
+    assert_eq!(
+        failure_class_for("transient-hook-session-end"),
+        "retryable_model"
+    );
+    assert_eq!(failure_class_for("terminal-invalid"), "terminal");
+    assert_eq!(failure_class_for("terminal-unknown"), "terminal");
+    assert_eq!(
+        failure_class_for("terminal-unknown-kind-timeout"),
+        "terminal"
+    );
+}
+
+#[test]
 fn test_queue_stats_reflects_current_state() {
     let (_tmp, db_path, store) = new_store(QueueConfig {
         base_delay_ms: 0,
@@ -491,6 +641,128 @@ fn test_reindex_failed_requeues_only_failed_embed_queue_items() {
     assert_eq!(status_for(&failed_embed), ("pending".to_string(), 0));
     assert_eq!(status_for(&failed_llm), ("failed".to_string(), 4));
     assert_eq!(status_for(&pending_embed), ("pending".to_string(), 0));
+}
+
+#[test]
+fn test_queue_stats_split_failed_retryable_and_terminal_model_work() {
+    let (_tmp, _db_path, store) = new_store(QueueConfig::default());
+    let retryable_embed = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue retryable embed");
+    let retryable_llm = store
+        .enqueue("llm_task", r#"{"n":2}"#)
+        .expect("enqueue retryable llm");
+    let terminal_embed = store
+        .enqueue("hook_event", r#"{"n":3}"#)
+        .expect("enqueue terminal embed");
+
+    store
+        .mark_model_task_failed_retryable(&retryable_embed, "temporary embed outage")
+        .expect("mark retryable embed failed");
+    store
+        .mark_model_task_failed_retryable(&retryable_llm, "temporary llm outage")
+        .expect("mark retryable llm failed");
+    let terminal_claim = store
+        .claim_next("worker-terminal", 60)
+        .expect("claim")
+        .expect("terminal claim");
+    assert_eq!(terminal_claim.id, terminal_embed);
+    store
+        .mark_failed_with_disposition(
+            &terminal_claim,
+            "invalid configuration",
+            QueueFailureDisposition::Terminal,
+        )
+        .expect("mark terminal failed");
+
+    let stats = store.stats().expect("stats");
+    assert_eq!(stats.failed, 3);
+    assert_eq!(stats.failed_retryable, 2);
+    assert_eq!(stats.failed_terminal, 1);
+    assert_eq!(stats.failed_retryable_embed, 1);
+    assert_eq!(stats.failed_retryable_llm, 1);
+}
+
+#[test]
+fn test_auto_requeue_model_tasks_only_requeues_retryable_failed_kind() {
+    let (_tmp, db_path, store) = new_store(QueueConfig::default());
+    let retryable_embed = store
+        .enqueue("hook_event", r#"{"n":1}"#)
+        .expect("enqueue retryable embed");
+    let retryable_llm = store
+        .enqueue("llm_task", r#"{"n":2}"#)
+        .expect("enqueue retryable llm");
+    let terminal_embed = store
+        .enqueue("hook_event", r#"{"n":3}"#)
+        .expect("enqueue terminal embed");
+
+    store
+        .mark_model_task_failed_retryable(&retryable_embed, "temporary embed outage")
+        .expect("mark retryable embed failed");
+    store
+        .mark_model_task_failed_retryable(&retryable_llm, "temporary llm outage")
+        .expect("mark retryable llm failed");
+    let terminal_claim = store
+        .claim_next("worker-terminal", 60)
+        .expect("claim")
+        .expect("terminal claim");
+    assert_eq!(terminal_claim.id, terminal_embed);
+    store
+        .mark_failed_with_disposition(
+            &terminal_claim,
+            "invalid configuration",
+            QueueFailureDisposition::Terminal,
+        )
+        .expect("mark terminal failed");
+
+    let requeued = store
+        .auto_requeue_failed_model_tasks("embedding")
+        .expect("auto requeue embedding");
+
+    assert_eq!(requeued, 1);
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    let status_for = |id: &str| -> (String, i64, Option<String>) {
+        conn.query_row(
+            "SELECT status, retry_count, last_error FROM pending_messages WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read queue row")
+    };
+    assert_eq!(
+        status_for(&retryable_embed),
+        ("pending".to_string(), 0, None)
+    );
+    assert_eq!(
+        status_for(&retryable_llm),
+        (
+            "failed".to_string(),
+            0,
+            Some("temporary llm outage".to_string())
+        )
+    );
+    assert_eq!(
+        status_for(&terminal_embed),
+        (
+            "failed".to_string(),
+            1,
+            Some("invalid configuration".to_string())
+        )
+    );
+
+    let last_auto_requeue_at = conn
+        .query_row(
+            "SELECT value FROM fork_ext_meta WHERE key = 'queue.auto_requeue.last_at_unix_ms'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("last auto requeue timestamp");
+    assert!(
+        last_auto_requeue_at
+            .parse::<u64>()
+            .is_ok_and(|value| value > 0),
+        "{last_auto_requeue_at}"
+    );
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "3a16e4bf927d88f0a573195ce2585f531038809b"
+commit = "f8c2e2f1ab9f581c889693d998a1b84f2e69431a"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add durable `failure_class` tracking for retryable model failures vs terminal failed queue items.
- Auto-requeue only `retryable_model` failed embedding/LLM tasks when their endpoints recover.
- Surface retryable/terminal failed counters and last auto-requeue timestamp in CLI status, doctor, and MCP status.
- Add conservative fork-ext v22 migration for legacy failed rows, including current hook queue kinds while leaving unknown/permanent failures terminal.

## Validation
- `cargo test --test queue_stats test_fork_ext_v22_classifies_legacy_failed_rows_conservatively -- --nocapture`
- `cargo test --test queue_stats -- --nocapture` (13 passed)
- `cargo test --lib -- --nocapture` (501 passed)
- `cargo test --test mcp_status_queue_stats -- --nocapture` (7 passed)
- `cargo test --test ops_runtime -- --nocapture` (10 passed)
- `git diff --check`
- `cargo fmt --check`
- `just pre-commit` (exit 0; hook-enabled commit also passed)

## Review
- CSA review unavailable due cli-sub-agent infra issue: RyderFreeman4Logos/cli-sub-agent#2218.
- Native independent staged-diff review found blockers; fixed with regressions.
- Native exact-head review for `737b43d48a2e6a46e3621a28e94bc8c3cfd7ad2c` returned PASS/CLEAN.
- Push used documented narrow `CSA_SKIP_REVIEW_CHECK` override for the CSA review-check only; other pre-push hooks ran.

Closes #418
