### PR TITLE
refactor(endpoint): share model endpoint pool runtime

### DIFF
--- a/src/embed/openai_compat.rs
+++ b/src/embed/openai_compat.rs
@@ -12,7 +12,6 @@ use crate::core::config::{Config, EffectiveEmbedEndpoint};
 
 use super::{EmbedError, Embedder, Result};
 
-pub(crate) const MAX_REMOTE_RETRY_HINT: Duration = Duration::from_secs(60);
 const MAX_REMOTE_RETRY_HINT_SECS: u64 = 60;
 
 #[derive(Debug, Clone)]

--- a/src/embed/router.rs
+++ b/src/embed/router.rs
@@ -1,12 +1,13 @@
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use reqwest::StatusCode;
-use tokio::sync::Mutex;
 
 use crate::core::config::{EffectiveEmbedEndpoint, EmbedConfig};
+use crate::endpoint_pool::{
+    EndpointPool, EndpointPoolEndpoint, EndpointPoolEntry, EndpointPoolItem, EndpointPoolStrategy,
+};
 
-use super::openai_compat::{MAX_REMOTE_RETRY_HINT, OpenAiCompatibleEmbedder};
+use super::openai_compat::OpenAiCompatibleEmbedder;
 use super::retry::HeartbeatCallback;
 use super::{EmbedError, Embedder, Result};
 
@@ -17,16 +18,9 @@ pub struct RoutedEmbeddingResponse {
     pub vectors: Vec<Vec<f32>>,
 }
 
-#[derive(Debug)]
-struct RoutedEndpoint {
-    config: EffectiveEmbedEndpoint,
-    client: OpenAiCompatibleEmbedder,
-    unavailable_until: Mutex<Option<Instant>>,
-}
-
 #[derive(Debug, Clone)]
 pub struct EmbeddingRouter {
-    endpoints: Arc<Vec<Arc<RoutedEndpoint>>>,
+    pool: EndpointPool<OpenAiCompatibleEmbedder>,
     dimensions: usize,
     name: String,
     max_input_tokens: Option<usize>,
@@ -52,118 +46,46 @@ impl EmbeddingRouter {
             .iter()
             .filter_map(|endpoint| endpoint.max_input_tokens)
             .min();
-        let mut endpoints = endpoints.into_iter().enumerate().collect::<Vec<_>>();
-        endpoints.sort_by_key(|(index, endpoint)| (endpoint.priority, *index));
-        let routed = endpoints
+        let items = endpoints
             .into_iter()
-            .map(|(_, config)| {
+            .map(|config| {
                 let client = OpenAiCompatibleEmbedder::from_endpoint(&config)?;
-                Ok(Arc::new(RoutedEndpoint {
-                    config,
+                Ok(EndpointPoolItem::new(
+                    EndpointPoolEndpoint::new(
+                        config.id,
+                        config.model,
+                        config.priority,
+                        config.max_concurrent,
+                        Duration::from_secs(config.retry_interval_secs),
+                    ),
                     client,
-                    unavailable_until: Mutex::new(None),
-                }))
+                ))
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
-            endpoints: Arc::new(routed),
+            pool: EndpointPool::new(items),
             dimensions,
             name,
             max_input_tokens,
         })
     }
 
-    pub async fn embed_routed(
+    pub async fn embed_routed<'a>(
         &self,
-        texts: &[&str],
-        heartbeat: Option<&HeartbeatCallback>,
+        texts: &'a [&'a str],
+        heartbeat: Option<&'a HeartbeatCallback>,
     ) -> Result<RoutedEmbeddingResponse> {
-        let mut last_retryable = None;
-        let mut earliest_retry_after: Option<Duration> = None;
-        let mut first_saturated_endpoint: Option<Arc<RoutedEndpoint>> = None;
-
-        for endpoint in self.endpoints.iter() {
-            if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
-                earliest_retry_after = Some(match earliest_retry_after {
-                    Some(current) => current.min(retry_after),
-                    None => retry_after,
-                });
-                continue;
-            }
-            refresh_heartbeat(heartbeat)?;
-            match endpoint.client.try_embed(texts).await {
-                Ok(Some(vectors)) => {
-                    endpoint.mark_available().await;
-                    crate::embed::global_embed_status()
-                        .record_endpoint_success(&endpoint.config.id);
-                    return Ok(RoutedEmbeddingResponse {
-                        endpoint_id: endpoint.config.id.clone(),
-                        endpoint_model: endpoint.config.model.clone(),
-                        vectors,
-                    });
-                }
-                Ok(None) => {
-                    if first_saturated_endpoint.is_none() {
-                        first_saturated_endpoint = Some(Arc::clone(endpoint));
-                    }
-                }
-                Err(error) if should_try_next_endpoint(&error) => {
-                    if let Some(retry_after) = endpoint.retry_after_for_error(&error) {
-                        endpoint.mark_temporarily_unavailable(retry_after).await;
-                        crate::embed::global_embed_status().record_endpoint_cooldown(
-                            &endpoint.config.id,
-                            retry_after,
-                            &error,
-                        );
-                        earliest_retry_after = Some(match earliest_retry_after {
-                            Some(current) => current.min(retry_after),
-                            None => retry_after,
-                        });
-                    }
-                    last_retryable = Some(error);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-
-        if let Some(endpoint) = first_saturated_endpoint {
-            refresh_heartbeat(heartbeat)?;
-            let vectors = endpoint.client.embed_with_permit(texts).await?;
-            endpoint.mark_available().await;
-            crate::embed::global_embed_status().record_endpoint_success(&endpoint.config.id);
-            return Ok(RoutedEmbeddingResponse {
-                endpoint_id: endpoint.config.id.clone(),
-                endpoint_model: endpoint.config.model.clone(),
-                vectors,
-            });
-        }
-
-        match (last_retryable, earliest_retry_after) {
-            (None, Some(retry_after)) | (Some(_), Some(retry_after)) => {
-                Err(EmbedError::TemporarilyUnavailable {
-                    retry_after,
-                    reason: format!(
-                        "{} embedding endpoint(s) are cooling down after retryable failures",
-                        self.endpoints.len()
-                    ),
-                })
-            }
-            (Some(error), _) => Err(error),
-            (None, None) => Err(EmbedError::MissingConfiguration(
-                "no embedding endpoint is currently available".to_string(),
-            )),
-        }
+        self.pool
+            .route(&EmbeddingRoutingStrategy { texts, heartbeat })
+            .await
     }
 
     pub fn endpoint_count(&self) -> usize {
-        self.endpoints.len()
+        self.pool.endpoint_count()
     }
 
     pub fn pool_capacity(&self) -> usize {
-        self.endpoints
-            .iter()
-            .map(|endpoint| endpoint.config.max_concurrent.max(1))
-            .sum()
+        self.pool.pool_capacity()
     }
 }
 
@@ -188,56 +110,107 @@ impl Embedder for EmbeddingRouter {
     }
 }
 
-impl RoutedEndpoint {
-    async fn temporary_unavailable_remaining(&self) -> Option<Duration> {
-        let mut guard = self.unavailable_until.lock().await;
-        match *guard {
-            Some(until) if until > Instant::now() => {
-                Some(until.saturating_duration_since(Instant::now()))
+struct EmbeddingRoutingStrategy<'a> {
+    texts: &'a [&'a str],
+    heartbeat: Option<&'a HeartbeatCallback>,
+}
+
+#[async_trait::async_trait]
+impl EndpointPoolStrategy<OpenAiCompatibleEmbedder> for EmbeddingRoutingStrategy<'_> {
+    type Output = RoutedEmbeddingResponse;
+    type Error = EmbedError;
+
+    async fn try_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<OpenAiCompatibleEmbedder>,
+    ) -> std::result::Result<Option<Self::Output>, Self::Error> {
+        refresh_heartbeat(self.heartbeat)?;
+        match endpoint.client().try_embed(self.texts).await? {
+            Some(vectors) => {
+                crate::embed::global_embed_status()
+                    .record_endpoint_success(endpoint.endpoint().id());
+                Ok(Some(RoutedEmbeddingResponse {
+                    endpoint_id: endpoint.endpoint().id().to_string(),
+                    endpoint_model: endpoint.endpoint().model().to_string(),
+                    vectors,
+                }))
             }
-            Some(_) => {
-                *guard = None;
-                crate::embed::global_embed_status().clear_endpoint_cooldown(&self.config.id);
-                None
-            }
-            None => None,
+            None => Ok(None),
         }
     }
 
-    fn retry_after_for_error(&self, error: &EmbedError) -> Option<Duration> {
+    async fn wait_for_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<OpenAiCompatibleEmbedder>,
+    ) -> std::result::Result<Self::Output, Self::Error> {
+        refresh_heartbeat(self.heartbeat)?;
+        let vectors = endpoint.client().embed_with_permit(self.texts).await?;
+        crate::embed::global_embed_status().record_endpoint_success(endpoint.endpoint().id());
+        Ok(RoutedEmbeddingResponse {
+            endpoint_id: endpoint.endpoint().id().to_string(),
+            endpoint_model: endpoint.endpoint().model().to_string(),
+            vectors,
+        })
+    }
+
+    fn should_try_next(&self, error: &Self::Error) -> bool {
+        should_try_next_endpoint(error)
+    }
+
+    fn retry_after_for_error(
+        &self,
+        endpoint: &EndpointPoolEntry<OpenAiCompatibleEmbedder>,
+        error: &Self::Error,
+    ) -> Option<Duration> {
         match error {
             EmbedError::HttpStatus {
                 status: StatusCode::TOO_MANY_REQUESTS,
                 retry_after,
                 ..
-            } => Some(
-                retry_after.unwrap_or_else(|| Duration::from_secs(self.config.retry_interval_secs)),
-            ),
+            } => Some(retry_after.unwrap_or_else(|| endpoint.endpoint().retry_interval())),
             EmbedError::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
             EmbedError::HttpRequest { .. }
             | EmbedError::Runtime(_)
-            | EmbedError::WorkerPanic(_) => {
-                Some(Duration::from_secs(self.config.retry_interval_secs))
-            }
+            | EmbedError::WorkerPanic(_) => Some(endpoint.endpoint().retry_interval()),
             EmbedError::HttpStatus { status, .. } if status.is_server_error() => {
-                Some(Duration::from_secs(self.config.retry_interval_secs))
+                Some(endpoint.endpoint().retry_interval())
             }
             _ => None,
         }
     }
 
-    async fn mark_temporarily_unavailable(&self, retry_after: Duration) {
-        let mut guard = self.unavailable_until.lock().await;
-        let now = Instant::now();
-        *guard = Some(
-            now.checked_add(retry_after)
-                .unwrap_or_else(|| now + MAX_REMOTE_RETRY_HINT),
+    fn all_cooling_down_error(&self, endpoint_count: usize, retry_after: Duration) -> Self::Error {
+        EmbedError::TemporarilyUnavailable {
+            retry_after,
+            reason: format!(
+                "{endpoint_count} embedding endpoint(s) are cooling down after retryable failures"
+            ),
+        }
+    }
+
+    fn no_endpoint_available_error(&self) -> Self::Error {
+        EmbedError::MissingConfiguration("no embedding endpoint is currently available".to_string())
+    }
+
+    fn clear_cooldown_on_success(&self) -> bool {
+        true
+    }
+
+    fn on_cooldown_marked(
+        &self,
+        endpoint: &EndpointPoolEntry<OpenAiCompatibleEmbedder>,
+        retry_after: Duration,
+        error: &Self::Error,
+    ) {
+        crate::embed::global_embed_status().record_endpoint_cooldown(
+            endpoint.endpoint().id(),
+            retry_after,
+            error,
         );
     }
 
-    async fn mark_available(&self) {
-        let mut guard = self.unavailable_until.lock().await;
-        *guard = None;
+    fn on_cooldown_cleared(&self, endpoint: &EndpointPoolEntry<OpenAiCompatibleEmbedder>) {
+        crate::embed::global_embed_status().clear_endpoint_cooldown(endpoint.endpoint().id());
     }
 }
 

--- a/src/endpoint_pool.rs
+++ b/src/endpoint_pool.rs
@@ -1,0 +1,533 @@
+//! Shared model-endpoint scheduler for LLM and embedding providers.
+//!
+//! Provider-specific routers own request construction and error mapping. This
+//! module owns only stable scheduling concerns: priority ordering, per-endpoint
+//! cooldown, saturated-endpoint fallback, and aggregate pool capacity.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+/// Immutable routing metadata shared by all model-backed endpoint pools.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EndpointPoolEndpoint {
+    id: String,
+    model: String,
+    priority: i32,
+    max_concurrent: usize,
+    retry_interval: Duration,
+}
+
+impl EndpointPoolEndpoint {
+    pub(crate) fn new(
+        id: impl Into<String>,
+        model: impl Into<String>,
+        priority: i32,
+        max_concurrent: usize,
+        retry_interval: Duration,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            model: model.into(),
+            priority,
+            max_concurrent,
+            retry_interval,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub(crate) fn retry_interval(&self) -> Duration {
+        self.retry_interval
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EndpointPoolItem<C> {
+    endpoint: EndpointPoolEndpoint,
+    client: C,
+}
+
+impl<C> EndpointPoolItem<C> {
+    pub(crate) fn new(endpoint: EndpointPoolEndpoint, client: C) -> Self {
+        Self { endpoint, client }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EndpointPoolEntry<C> {
+    endpoint: EndpointPoolEndpoint,
+    client: C,
+    unavailable_until: Mutex<Option<Instant>>,
+}
+
+impl<C> EndpointPoolEntry<C> {
+    pub(crate) fn endpoint(&self) -> &EndpointPoolEndpoint {
+        &self.endpoint
+    }
+
+    pub(crate) fn client(&self) -> &C {
+        &self.client
+    }
+}
+
+const MAX_COOLDOWN_HINT: Duration = Duration::from_secs(60);
+
+#[derive(Debug)]
+pub(crate) struct EndpointPool<C> {
+    endpoints: Arc<Vec<Arc<EndpointPoolEntry<C>>>>,
+}
+
+impl<C> Clone for EndpointPool<C> {
+    fn clone(&self) -> Self {
+        Self {
+            endpoints: Arc::clone(&self.endpoints),
+        }
+    }
+}
+
+impl<C> EndpointPool<C>
+where
+    C: Send + Sync,
+{
+    pub(crate) fn new(items: Vec<EndpointPoolItem<C>>) -> Self {
+        let mut items = items.into_iter().enumerate().collect::<Vec<_>>();
+        items.sort_by_key(|(index, item)| (item.endpoint.priority, *index));
+        let endpoints = items
+            .into_iter()
+            .map(|(_, item)| {
+                Arc::new(EndpointPoolEntry {
+                    endpoint: item.endpoint,
+                    client: item.client,
+                    unavailable_until: Mutex::new(None),
+                })
+            })
+            .collect();
+        Self {
+            endpoints: Arc::new(endpoints),
+        }
+    }
+
+    pub(crate) async fn route<S>(&self, strategy: &S) -> Result<S::Output, S::Error>
+    where
+        S: EndpointPoolStrategy<C>,
+    {
+        let mut last_retryable = None;
+        let mut earliest_retry_after: Option<Duration> = None;
+        let mut first_saturated_endpoint: Option<Arc<EndpointPoolEntry<C>>> = None;
+
+        for endpoint in self.endpoints.iter() {
+            if let Some(retry_after) = endpoint.temporary_unavailable_remaining(strategy).await {
+                earliest_retry_after = Some(min_retry_after(earliest_retry_after, retry_after));
+                continue;
+            }
+
+            match strategy.try_endpoint(endpoint).await {
+                Ok(Some(output)) => {
+                    if strategy.clear_cooldown_on_success() {
+                        endpoint.mark_available(strategy).await;
+                    }
+                    return Ok(output);
+                }
+                Ok(None) => {
+                    if first_saturated_endpoint.is_none() {
+                        first_saturated_endpoint = Some(Arc::clone(endpoint));
+                    }
+                }
+                Err(error) if strategy.should_try_next(&error) => {
+                    if let Some(retry_after) = strategy.retry_after_for_error(endpoint, &error) {
+                        endpoint
+                            .mark_temporarily_unavailable(strategy, retry_after, &error)
+                            .await;
+                        earliest_retry_after =
+                            Some(min_retry_after(earliest_retry_after, retry_after));
+                    }
+                    last_retryable = Some(error);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        if let Some(endpoint) = first_saturated_endpoint {
+            let output = strategy.wait_for_endpoint(&endpoint).await?;
+            if strategy.clear_cooldown_on_success() {
+                endpoint.mark_available(strategy).await;
+            }
+            return Ok(output);
+        }
+
+        match (last_retryable, earliest_retry_after) {
+            (None, Some(retry_after)) | (Some(_), Some(retry_after)) => {
+                Err(strategy.all_cooling_down_error(self.endpoints.len(), retry_after))
+            }
+            (Some(error), None) => Err(error),
+            (None, None) => Err(strategy.no_endpoint_available_error()),
+        }
+    }
+
+    pub(crate) fn endpoint_count(&self) -> usize {
+        self.endpoints.len()
+    }
+
+    pub(crate) fn pool_capacity(&self) -> usize {
+        self.endpoints
+            .iter()
+            .map(|endpoint| endpoint.endpoint.max_concurrent.max(1))
+            .sum()
+    }
+}
+
+impl<C> EndpointPoolEntry<C> {
+    async fn temporary_unavailable_remaining<S>(&self, strategy: &S) -> Option<Duration>
+    where
+        C: Send + Sync,
+        S: EndpointPoolStrategy<C>,
+    {
+        let mut guard = self.unavailable_until.lock().await;
+        match *guard {
+            Some(until) if until > Instant::now() => {
+                Some(until.saturating_duration_since(Instant::now()))
+            }
+            Some(_) => {
+                *guard = None;
+                strategy.on_cooldown_cleared(self);
+                None
+            }
+            None => None,
+        }
+    }
+
+    async fn mark_temporarily_unavailable<S>(
+        &self,
+        strategy: &S,
+        retry_after: Duration,
+        error: &S::Error,
+    ) where
+        C: Send + Sync,
+        S: EndpointPoolStrategy<C>,
+    {
+        let mut guard = self.unavailable_until.lock().await;
+        let now = Instant::now();
+        *guard = Some(
+            now.checked_add(retry_after)
+                .unwrap_or_else(|| now + MAX_COOLDOWN_HINT),
+        );
+        strategy.on_cooldown_marked(self, retry_after, error);
+    }
+
+    async fn mark_available<S>(&self, strategy: &S)
+    where
+        C: Send + Sync,
+        S: EndpointPoolStrategy<C>,
+    {
+        let mut guard = self.unavailable_until.lock().await;
+        *guard = None;
+        strategy.on_cooldown_cleared(self);
+    }
+}
+
+#[async_trait::async_trait]
+pub(crate) trait EndpointPoolStrategy<C>: Sync
+where
+    C: Send + Sync,
+{
+    type Output: Send;
+    type Error: Send;
+
+    async fn try_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<C>,
+    ) -> Result<Option<Self::Output>, Self::Error>;
+
+    async fn wait_for_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<C>,
+    ) -> Result<Self::Output, Self::Error>;
+
+    fn should_try_next(&self, error: &Self::Error) -> bool;
+
+    fn retry_after_for_error(
+        &self,
+        endpoint: &EndpointPoolEntry<C>,
+        error: &Self::Error,
+    ) -> Option<Duration>;
+
+    fn all_cooling_down_error(&self, endpoint_count: usize, retry_after: Duration) -> Self::Error;
+
+    fn no_endpoint_available_error(&self) -> Self::Error;
+
+    fn clear_cooldown_on_success(&self) -> bool {
+        false
+    }
+
+    fn on_cooldown_marked(
+        &self,
+        _endpoint: &EndpointPoolEntry<C>,
+        _retry_after: Duration,
+        _error: &Self::Error,
+    ) {
+    }
+
+    fn on_cooldown_cleared(&self, _endpoint: &EndpointPoolEntry<C>) {}
+}
+
+fn min_retry_after(current: Option<Duration>, next: Duration) -> Duration {
+    match current {
+        Some(current) => current.min(next),
+        None => next,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+
+    #[derive(Debug)]
+    struct ScriptedClient {
+        id: &'static str,
+        attempts: Mutex<VecDeque<Attempt>>,
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[derive(Debug)]
+    enum Attempt {
+        Saturated,
+        Retryable(Duration),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ScriptError {
+        Retryable(Duration),
+        CoolingDown(Duration),
+        Missing,
+    }
+
+    struct ScriptedStrategy;
+
+    #[async_trait::async_trait]
+    impl EndpointPoolStrategy<ScriptedClient> for ScriptedStrategy {
+        type Output = String;
+        type Error = ScriptError;
+
+        async fn try_endpoint(
+            &self,
+            endpoint: &EndpointPoolEntry<ScriptedClient>,
+        ) -> Result<Option<Self::Output>, Self::Error> {
+            endpoint
+                .client()
+                .calls
+                .lock()
+                .expect("calls")
+                .push(format!("try:{}", endpoint.endpoint().id()));
+            match endpoint
+                .client()
+                .attempts
+                .lock()
+                .expect("attempts")
+                .pop_front()
+                .expect("scripted attempt")
+            {
+                Attempt::Saturated => Ok(None),
+                Attempt::Retryable(retry_after) => Err(ScriptError::Retryable(retry_after)),
+            }
+        }
+
+        async fn wait_for_endpoint(
+            &self,
+            endpoint: &EndpointPoolEntry<ScriptedClient>,
+        ) -> Result<Self::Output, Self::Error> {
+            endpoint
+                .client()
+                .calls
+                .lock()
+                .expect("calls")
+                .push(format!("wait:{}", endpoint.endpoint().id()));
+            Ok(endpoint.client().id.to_string())
+        }
+
+        fn should_try_next(&self, error: &Self::Error) -> bool {
+            matches!(error, ScriptError::Retryable(_))
+        }
+
+        fn retry_after_for_error(
+            &self,
+            _endpoint: &EndpointPoolEntry<ScriptedClient>,
+            error: &Self::Error,
+        ) -> Option<Duration> {
+            match error {
+                ScriptError::Retryable(retry_after) => Some(*retry_after),
+                ScriptError::CoolingDown(_) | ScriptError::Missing => None,
+            }
+        }
+
+        fn all_cooling_down_error(
+            &self,
+            _endpoint_count: usize,
+            retry_after: Duration,
+        ) -> Self::Error {
+            ScriptError::CoolingDown(retry_after)
+        }
+
+        fn no_endpoint_available_error(&self) -> Self::Error {
+            ScriptError::Missing
+        }
+    }
+
+    #[tokio::test]
+    async fn route_waits_for_saturated_higher_priority_before_returning_cooldown() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let pool = EndpointPool::new(vec![
+            EndpointPoolItem::new(
+                EndpointPoolEndpoint::new("primary", "primary-model", 0, 1, Duration::from_secs(2)),
+                ScriptedClient {
+                    id: "primary",
+                    attempts: Mutex::new(VecDeque::from([Attempt::Saturated])),
+                    calls: Arc::clone(&calls),
+                },
+            ),
+            EndpointPoolItem::new(
+                EndpointPoolEndpoint::new(
+                    "cooldown",
+                    "cooldown-model",
+                    10,
+                    1,
+                    Duration::from_secs(60),
+                ),
+                ScriptedClient {
+                    id: "cooldown",
+                    attempts: Mutex::new(VecDeque::from([Attempt::Retryable(
+                        Duration::from_secs(60),
+                    )])),
+                    calls: Arc::clone(&calls),
+                },
+            ),
+        ]);
+
+        let routed = pool.route(&ScriptedStrategy).await.expect("routed output");
+
+        assert_eq!(routed, "primary");
+        assert_eq!(
+            calls.lock().expect("calls").as_slice(),
+            ["try:primary", "try:cooldown", "wait:primary"]
+        );
+        assert_eq!(pool.endpoint_count(), 2);
+        assert_eq!(pool.pool_capacity(), 2);
+    }
+
+    struct ConcurrentSuccessAfterFailureStrategy {
+        calls: AtomicUsize,
+        first_started: Notify,
+        release_first: Notify,
+    }
+
+    #[async_trait::async_trait]
+    impl EndpointPoolStrategy<ScriptedClient> for ConcurrentSuccessAfterFailureStrategy {
+        type Output = String;
+        type Error = ScriptError;
+
+        async fn try_endpoint(
+            &self,
+            _endpoint: &EndpointPoolEntry<ScriptedClient>,
+        ) -> Result<Option<Self::Output>, Self::Error> {
+            match self.calls.fetch_add(1, Ordering::SeqCst) {
+                0 => {
+                    self.first_started.notify_waiters();
+                    self.release_first.notified().await;
+                    Ok(Some("success".to_string()))
+                }
+                1 => Err(ScriptError::Retryable(Duration::from_secs(60))),
+                _ => Ok(Some("unexpected-success-after-cooldown".to_string())),
+            }
+        }
+
+        async fn wait_for_endpoint(
+            &self,
+            _endpoint: &EndpointPoolEntry<ScriptedClient>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok("wait".to_string())
+        }
+
+        fn should_try_next(&self, error: &Self::Error) -> bool {
+            matches!(error, ScriptError::Retryable(_))
+        }
+
+        fn retry_after_for_error(
+            &self,
+            _endpoint: &EndpointPoolEntry<ScriptedClient>,
+            error: &Self::Error,
+        ) -> Option<Duration> {
+            match error {
+                ScriptError::Retryable(retry_after) => Some(*retry_after),
+                ScriptError::CoolingDown(_) | ScriptError::Missing => None,
+            }
+        }
+
+        fn all_cooling_down_error(
+            &self,
+            _endpoint_count: usize,
+            retry_after: Duration,
+        ) -> Self::Error {
+            ScriptError::CoolingDown(retry_after)
+        }
+
+        fn no_endpoint_available_error(&self) -> Self::Error {
+            ScriptError::Missing
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_success_does_not_clear_newer_cooldown_by_default() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let pool = EndpointPool::new(vec![EndpointPoolItem::new(
+            EndpointPoolEndpoint::new("primary", "model", 0, 2, Duration::from_secs(2)),
+            ScriptedClient {
+                id: "primary",
+                attempts: Mutex::new(VecDeque::new()),
+                calls,
+            },
+        )]);
+        let strategy = Arc::new(ConcurrentSuccessAfterFailureStrategy {
+            calls: AtomicUsize::new(0),
+            first_started: Notify::new(),
+            release_first: Notify::new(),
+        });
+
+        let first_pool = pool.clone();
+        let first_strategy = Arc::clone(&strategy);
+        let first = tokio::spawn(async move { first_pool.route(first_strategy.as_ref()).await });
+        strategy.first_started.notified().await;
+
+        let second = pool
+            .route(strategy.as_ref())
+            .await
+            .expect_err("second concurrent failure should cool down endpoint");
+        strategy.release_first.notify_waiters();
+        let first = first
+            .await
+            .expect("join first route")
+            .expect("first success");
+        let third = pool
+            .route(strategy.as_ref())
+            .await
+            .expect_err("newer cooldown should survive older success");
+
+        assert_eq!(first, "success");
+        assert_eq!(second, ScriptError::CoolingDown(Duration::from_secs(60)));
+        assert!(matches!(
+            third,
+            ScriptError::CoolingDown(retry_after) if retry_after <= Duration::from_secs(60)
+        ));
+        assert_eq!(strategy.calls.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod db_path_identity;
 pub mod doctor;
 pub mod embed;
 pub mod endpoint_health;
+pub(crate) mod endpoint_pool;
 pub mod factcheck;
 pub mod field_taxonomy;
 pub mod hook;

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -11,7 +11,6 @@ use tokio::sync::{Mutex, Semaphore};
 
 use crate::core::config::{EffectiveLlmEndpoint, LlmConfig, validate_llm_base_url};
 
-pub(crate) const MAX_REMOTE_RETRY_HINT: Duration = Duration::from_secs(60);
 const MAX_REMOTE_RETRY_HINT_SECS: u64 = 60;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/llm/router.rs
+++ b/src/llm/router.rs
@@ -1,12 +1,13 @@
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use reqwest::StatusCode;
-use tokio::sync::Mutex;
 
 use crate::core::config::{EffectiveLlmEndpoint, LlmConfig};
+use crate::endpoint_pool::{
+    EndpointPool, EndpointPoolEndpoint, EndpointPoolEntry, EndpointPoolItem, EndpointPoolStrategy,
+};
 
-use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse, MAX_REMOTE_RETRY_HINT};
+use super::client::{LlmClient, LlmError, LlmRequest, LlmResponse};
 use super::retry::HeartbeatCallback;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,16 +17,9 @@ pub struct RoutedLlmResponse {
     pub response: LlmResponse,
 }
 
-#[derive(Debug)]
-struct RoutedEndpoint {
-    config: EffectiveLlmEndpoint,
-    client: LlmClient,
-    unavailable_until: Mutex<Option<Instant>>,
-}
-
 #[derive(Debug, Clone)]
 pub struct LlmRouter {
-    endpoints: Arc<Vec<Arc<RoutedEndpoint>>>,
+    pool: EndpointPool<LlmClient>,
 }
 
 impl LlmRouter {
@@ -42,21 +36,24 @@ impl LlmRouter {
                 "llm endpoints must not be empty".to_string(),
             ));
         }
-        let mut endpoints = endpoints.into_iter().enumerate().collect::<Vec<_>>();
-        endpoints.sort_by_key(|(index, endpoint)| (endpoint.priority, *index));
-        let routed = endpoints
+        let items = endpoints
             .into_iter()
-            .map(|(_, config)| {
+            .map(|config| {
                 let client = LlmClient::from_endpoint(&config)?;
-                Ok(Arc::new(RoutedEndpoint {
-                    config,
+                Ok(EndpointPoolItem::new(
+                    EndpointPoolEndpoint::new(
+                        config.id,
+                        config.model,
+                        config.priority,
+                        config.max_concurrent,
+                        Duration::from_secs(config.retry_interval_secs),
+                    ),
                     client,
-                    unavailable_until: Mutex::new(None),
-                }))
+                ))
             })
             .collect::<Result<Vec<_>, LlmError>>()?;
         Ok(Self {
-            endpoints: Arc::new(routed),
+            pool: EndpointPool::new(items),
         })
     }
 
@@ -65,120 +62,79 @@ impl LlmRouter {
         request: &LlmRequest,
         heartbeat: Option<&HeartbeatCallback>,
     ) -> Result<RoutedLlmResponse, LlmError> {
-        let mut last_retryable = None;
-        let mut earliest_retry_after: Option<Duration> = None;
-        let mut first_saturated_endpoint: Option<Arc<RoutedEndpoint>> = None;
-
-        for endpoint in self.endpoints.iter() {
-            if let Some(retry_after) = endpoint.temporary_unavailable_remaining().await {
-                earliest_retry_after = Some(match earliest_retry_after {
-                    Some(current) => current.min(retry_after),
-                    None => retry_after,
-                });
-                continue;
-            }
-            refresh_heartbeat(heartbeat)?;
-            match endpoint.client.try_chat_completion(request).await {
-                Ok(Some(response)) => {
-                    return Ok(RoutedLlmResponse {
-                        endpoint_id: endpoint.config.id.clone(),
-                        endpoint_model: endpoint.config.model.clone(),
-                        response,
-                    });
-                }
-                Ok(None) => {
-                    if first_saturated_endpoint.is_none() {
-                        first_saturated_endpoint = Some(Arc::clone(endpoint));
-                    }
-                }
-                Err(error) if should_try_next_endpoint(&error) => {
-                    if let Some(retry_after) = endpoint.retry_after_for_error(&error) {
-                        endpoint.mark_temporarily_unavailable(retry_after).await;
-                        earliest_retry_after = Some(match earliest_retry_after {
-                            Some(current) => current.min(retry_after),
-                            None => retry_after,
-                        });
-                    }
-                    last_retryable = Some(error);
-                }
-                Err(error) => return Err(error),
-            }
-        }
-
-        if let Some(endpoint) = first_saturated_endpoint {
-            refresh_heartbeat(heartbeat)?;
-            let response = endpoint.client.chat_completion(request).await?;
-            return Ok(RoutedLlmResponse {
-                endpoint_id: endpoint.config.id.clone(),
-                endpoint_model: endpoint.config.model.clone(),
-                response,
-            });
-        }
-
-        match (last_retryable, earliest_retry_after) {
-            (None, Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
-                retry_after,
-                reason: format!(
-                    "{} endpoint(s) are cooling down after retryable failures",
-                    self.endpoints.len()
-                ),
-            }),
-            (Some(_error), Some(retry_after)) => Err(LlmError::TemporarilyUnavailable {
-                retry_after,
-                reason: format!(
-                    "{} endpoint(s) are cooling down after retryable failures",
-                    self.endpoints.len()
-                ),
-            }),
-            (Some(error), _) => Err(error),
-            (None, None) => Err(LlmError::MissingConfiguration(
-                "no LLM endpoint is currently available".to_string(),
-            )),
-        }
+        self.pool
+            .route(&LlmRoutingStrategy { request, heartbeat })
+            .await
     }
 
     pub fn endpoint_count(&self) -> usize {
-        self.endpoints.len()
+        self.pool.endpoint_count()
     }
 
     pub fn pool_capacity(&self) -> usize {
-        self.endpoints
-            .iter()
-            .map(|endpoint| endpoint.config.max_concurrent.max(1))
-            .sum()
+        self.pool.pool_capacity()
     }
 }
 
-impl RoutedEndpoint {
-    async fn temporary_unavailable_remaining(&self) -> Option<Duration> {
-        let mut guard = self.unavailable_until.lock().await;
-        match *guard {
-            Some(until) if until > Instant::now() => {
-                Some(until.saturating_duration_since(Instant::now()))
-            }
-            Some(_) => {
-                *guard = None;
-                None
-            }
-            None => None,
+struct LlmRoutingStrategy<'a> {
+    request: &'a LlmRequest,
+    heartbeat: Option<&'a HeartbeatCallback>,
+}
+
+#[async_trait::async_trait]
+impl EndpointPoolStrategy<LlmClient> for LlmRoutingStrategy<'_> {
+    type Output = RoutedLlmResponse;
+    type Error = LlmError;
+
+    async fn try_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<LlmClient>,
+    ) -> Result<Option<Self::Output>, Self::Error> {
+        refresh_heartbeat(self.heartbeat)?;
+        match endpoint.client().try_chat_completion(self.request).await? {
+            Some(response) => Ok(Some(RoutedLlmResponse {
+                endpoint_id: endpoint.endpoint().id().to_string(),
+                endpoint_model: endpoint.endpoint().model().to_string(),
+                response,
+            })),
+            None => Ok(None),
         }
     }
 
-    fn retry_after_for_error(&self, error: &LlmError) -> Option<Duration> {
+    async fn wait_for_endpoint(
+        &self,
+        endpoint: &EndpointPoolEntry<LlmClient>,
+    ) -> Result<Self::Output, Self::Error> {
+        refresh_heartbeat(self.heartbeat)?;
+        let response = endpoint.client().chat_completion(self.request).await?;
+        Ok(RoutedLlmResponse {
+            endpoint_id: endpoint.endpoint().id().to_string(),
+            endpoint_model: endpoint.endpoint().model().to_string(),
+            response,
+        })
+    }
+
+    fn should_try_next(&self, error: &Self::Error) -> bool {
+        should_try_next_endpoint(error)
+    }
+
+    fn retry_after_for_error(
+        &self,
+        endpoint: &EndpointPoolEntry<LlmClient>,
+        error: &Self::Error,
+    ) -> Option<Duration> {
         match error {
             LlmError::ClientError {
                 status: StatusCode::TOO_MANY_REQUESTS | StatusCode::REQUEST_TIMEOUT,
                 retry_after,
                 ..
-            } => Some(
-                retry_after.unwrap_or_else(|| Duration::from_secs(self.config.retry_interval_secs)),
-            ),
+            } => Some(retry_after.unwrap_or_else(|| endpoint.endpoint().retry_interval())),
             LlmError::TemporarilyUnavailable { retry_after, .. } => Some(*retry_after),
             LlmError::HttpRequest { .. } | LlmError::Timeout => {
-                Some(Duration::from_secs(self.config.retry_interval_secs))
+                Some(endpoint.endpoint().retry_interval())
             }
             LlmError::HttpStatus { status, .. } if status.is_server_error() => {
-                Some(Duration::from_secs(self.config.retry_interval_secs))
+                Some(endpoint.endpoint().retry_interval())
             }
             LlmError::HttpStatus { .. }
             | LlmError::ClientError { .. }
@@ -187,13 +143,17 @@ impl RoutedEndpoint {
         }
     }
 
-    async fn mark_temporarily_unavailable(&self, retry_after: Duration) {
-        let mut guard = self.unavailable_until.lock().await;
-        let now = Instant::now();
-        *guard = Some(
-            now.checked_add(retry_after)
-                .unwrap_or_else(|| now + MAX_REMOTE_RETRY_HINT),
-        );
+    fn all_cooling_down_error(&self, endpoint_count: usize, retry_after: Duration) -> Self::Error {
+        LlmError::TemporarilyUnavailable {
+            retry_after,
+            reason: format!(
+                "{endpoint_count} endpoint(s) are cooling down after retryable failures"
+            ),
+        }
+    }
+
+    fn no_endpoint_available_error(&self) -> Self::Error {
+        LlmError::MissingConfiguration("no LLM endpoint is currently available".to_string())
     }
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f8c2e2f1ab9f581c889693d998a1b84f2e69431a"
+commit = "2ff16a9778b51536643863ef9cc626755f2b7d63"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Extract shared crate-private `EndpointPool` runtime for model endpoint scheduling.
- Refactor LLM and embedding routers onto the shared scheduler while keeping provider-specific request, retry mapping, heartbeat, and status side effects in adapters.
- Preserve concurrency/cooldown semantics: LLM success does not clear newer concurrent cooldowns; embedding opts into its prior success-clear behavior.
- Include `weave.lock` cli-sub-agent pin update produced during the reviewed development workflow.

Fixes #421

## Tests
- `just pre-commit`
- `cargo test --lib -- --nocapture`
- `cargo test --test llm_router -- --nocapture`
- `cargo test --test embedder_router -- --nocapture`
- `cargo test --test endpoint_health -- --nocapture`
- `cargo test --test llm_config -- --nocapture`
- `cargo test --test intelligence -- --nocapture`
- `cargo test --test mcp_status_queue_stats -- --nocapture`

## Review
- Native staged review: CLEAN
- Native exact-head review: PASS/CLEAN for `d3ccb0bcf9525b1abbed8f99c6526f7c591f18ad`
- CSA exact-head review: PASS, session `01KV30F0ZJZ0SEZYZSXC70XG3V`
- CSA infra issue filed for earlier failed review session: RyderFreeman4Logos/cli-sub-agent#2221
