### PR TITLE
feat: auto ingest Hermes sessions and rerank recall

### DIFF
--- a/contrib/hermes-agent-plugin/mempal-hooks/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal-hooks/__init__.py
@@ -67,6 +67,20 @@ def _load_config(hermes_home: str = "") -> dict:
     return config
 
 
+def _rest_query_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value
+
+
+def _encode_query_params(params: Dict[str, Any]) -> str:
+    import urllib.parse
+
+    return urllib.parse.urlencode(
+        {k: _rest_query_value(v) for k, v in params.items() if v is not None}
+    )
+
+
 class _MempalHooks:
     def __init__(self) -> None:
         self._base_url = "http://127.0.0.1:3080"
@@ -114,14 +128,11 @@ class _MempalHooks:
             )
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
-        import urllib.parse
         import urllib.request
 
         url = self._base_url + path
         if params:
-            url += "?" + urllib.parse.urlencode(
-                {k: v for k, v in params.items() if v is not None}
-            )
+            url += "?" + _encode_query_params(params)
         with urllib.request.urlopen(url, timeout=10) as resp:
             return json.loads(resp.read().decode())
 

--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -128,6 +128,20 @@ def _strip_none(d: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in d.items() if v is not None}
 
 
+def _rest_query_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value
+
+
+def _encode_query_params(params: Dict[str, Any]) -> str:
+    import urllib.parse
+
+    return urllib.parse.urlencode(
+        {k: _rest_query_value(v) for k, v in params.items() if v is not None}
+    )
+
+
 def _bounded_int(value: Any, default: int, minimum: int, maximum: int) -> int:
     try:
         parsed = int(value)
@@ -668,10 +682,10 @@ class MempalMemoryProvider:
             logger.warning("mempal circuit breaker tripped after %d failures. Pausing %ds.", self._consecutive_failures, _BREAKER_COOLDOWN_SECS)
 
     def _get(self, path, params=None):
-        import urllib.parse, urllib.request
+        import urllib.request
         url = self._base_url + path
         if params:
-            url += "?" + urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
+            url += "?" + _encode_query_params(params)
         with urllib.request.urlopen(url, timeout=10) as resp:
             return json.loads(resp.read().decode())
 

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -1,4 +1,5 @@
 import json
+import importlib.util
 import os
 import sys
 import tempfile
@@ -11,7 +12,12 @@ PLUGIN_DIR = os.path.dirname(__file__)
 if PLUGIN_DIR not in sys.path:
     sys.path.insert(0, PLUGIN_DIR)
 
-from mempal import MempalMemoryProvider, _LLMClient, _IntelligenceEnhancer  # noqa: E402
+from mempal import (  # noqa: E402
+    MempalMemoryProvider,
+    _LLMClient,
+    _IntelligenceEnhancer,
+    _encode_query_params,
+)
 
 
 class DiscoveryTests(unittest.TestCase):
@@ -22,6 +28,25 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertIn("register_memory_provider", scan_window)
         self.assertIn("MemoryProvider", scan_window)
+
+    def test_rest_query_encoding_uses_serde_compatible_booleans(self) -> None:
+        encoded = _encode_query_params({"include_raw_turns": False, "active": True})
+
+        self.assertIn("include_raw_turns=false", encoded)
+        self.assertIn("active=true", encoded)
+
+    def test_hooks_rest_query_encoding_uses_serde_compatible_booleans(self) -> None:
+        hooks_path = os.path.join(PLUGIN_DIR, "mempal-hooks", "__init__.py")
+        spec = importlib.util.spec_from_file_location("mempal_hooks_for_test", hooks_path)
+        if spec is None or spec.loader is None:
+            self.fail("failed to load mempal-hooks plugin module")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        encoded = module._encode_query_params({"include_raw_turns": False, "active": True})
+
+        self.assertIn("include_raw_turns=false", encoded)
+        self.assertIn("active=true", encoded)
 
 
 class RecordingProvider(MempalMemoryProvider):

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1115,9 +1115,14 @@ pub struct HooksSessionEndConfig {
     pub trailing_messages: usize,
     pub min_length: usize,
     pub wing: String,
-    /// Deprecated (P16): SessionEnd auto-ingest was removed. Field kept for config
-    /// compat; set to false in your config to suppress the deprecation warning.
+    /// Automatically ingest the matching Hermes session into xurl when a SessionEnd
+    /// hook is processed. Automatic ingest is gated before any conversation turn is
+    /// written, so rejected/noisy turns never enter `conversation_turns` or vectors.
     pub auto_ingest_conversation: bool,
+    /// Hermes profile to ingest when `auto_ingest_conversation` is enabled.
+    pub hermes_profile: String,
+    /// Optional Hermes home override. Defaults to `HERMES_HOME` or `~/.hermes`.
+    pub hermes_home: Option<PathBuf>,
 }
 
 impl Default for HooksSessionEndConfig {
@@ -1128,6 +1133,8 @@ impl Default for HooksSessionEndConfig {
             min_length: DEFAULT_SESSION_REVIEW_MIN_LENGTH,
             wing: DEFAULT_SESSION_REVIEW_WING.to_string(),
             auto_ingest_conversation: false,
+            hermes_profile: "default".to_string(),
+            hermes_home: None,
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -87,14 +87,6 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     install_shutdown_handlers()?;
     tracing::info!("daemon log path: {}", context.log_path.display());
 
-    if context.config.hooks.session_end.auto_ingest_conversation {
-        tracing::warn!(
-            "config.hooks.session_end.auto_ingest_conversation is set to true but was \
-             removed in P16. Use `mempal xurl ingest` instead. \
-             Set auto_ingest_conversation = false to suppress this warning."
-        );
-    }
-
     // Start REST API before the hooks check so the API remains available
     // even when hooks are disabled.
     #[cfg(feature = "rest")]
@@ -1010,6 +1002,20 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
         last_drawer_id = Some(drawer_id);
     }
 
+    if let Some(stats) =
+        auto_ingest_hermes_session_end(db, store, worker_id, message, embedder, &context, &envelope)
+            .await?
+    {
+        tracing::info!(
+            turns_parsed = stats.turns_parsed,
+            turns_inserted = stats.turns_inserted,
+            turns_skipped = stats.turns_skipped,
+            turns_updated = stats.turns_updated,
+            vectors_created = stats.vectors_created,
+            "auto-ingested gated Hermes session turns"
+        );
+    }
+
     Ok(last_drawer_id.unwrap_or_else(|| message.id.clone()))
 }
 
@@ -1056,6 +1062,425 @@ async fn embed_text_with_heartbeat<E: Embedder + ?Sized>(
         .into_iter()
         .next()
         .ok_or_else(|| EmbedError::Runtime("embedder returned no vectors".to_string()))
+}
+
+async fn auto_ingest_hermes_session_end<E: Embedder + ?Sized>(
+    db: &AsyncDb,
+    store: &AsyncPendingMessageStore,
+    worker_id: &str,
+    message: &ClaimedMessage,
+    embedder: &E,
+    context: &DaemonIngestContext<'_>,
+    envelope: &CapturedHookEnvelope,
+) -> Result<Option<crate::xurl::ingest::IngestStats>> {
+    if envelope.event != crate::hook::HookEvent::SessionEnd.display_name()
+        || !context.config.hooks.session_end.auto_ingest_conversation
+    {
+        return Ok(None);
+    }
+    if !context.config.ingest_gating.enabled {
+        tracing::warn!(
+            "SessionEnd Hermes auto-ingest skipped because ingest_gating.enabled is false; \
+             automatic conversation import requires a pre-insert gate"
+        );
+        return Ok(Some(crate::xurl::ingest::IngestStats::default()));
+    }
+
+    let Some(session_id) = hermes_session_id_from_envelope(envelope) else {
+        tracing::warn!(
+            event = %envelope.event,
+            agent = %envelope.agent,
+            "SessionEnd Hermes auto-ingest skipped because payload has no session_id"
+        );
+        return Ok(Some(crate::xurl::ingest::IngestStats::default()));
+    };
+    let profile = context.config.hooks.session_end.hermes_profile.trim();
+    let profile = if profile.is_empty() {
+        "default"
+    } else {
+        profile
+    };
+    let hermes_db = crate::xurl::ingest::default_hermes_db_path(
+        profile,
+        context.config.hooks.session_end.hermes_home.as_deref(),
+    );
+    if !hermes_db.exists() {
+        tracing::warn!(
+            hermes_db = %hermes_db.display(),
+            hermes_profile = profile,
+            "SessionEnd Hermes auto-ingest skipped because state.db was not found"
+        );
+        return Ok(Some(crate::xurl::ingest::IngestStats::default()));
+    }
+
+    let mut parse_options =
+        crate::xurl::parser::hermes::HermesParseOptions::new(&session_id, profile, false);
+    parse_options.session_id_filter = Some(session_id.clone());
+    parse_options.cwd = Some(envelope.claude_cwd.clone());
+    let parse_db = hermes_db.clone();
+    let parsed_turns = tokio::task::spawn_blocking(move || {
+        crate::xurl::parser::hermes::parse_hermes_db_with_options(&parse_db, &parse_options)
+    })
+    .await
+    .context("Hermes auto-ingest parser task failed")?
+    .with_context(|| format!("failed to parse Hermes state.db {}", hermes_db.display()))?;
+    let turns_parsed = parsed_turns.len();
+
+    let heartbeat_store = store.clone();
+    let heartbeat_message_id = message.id.clone();
+    let heartbeat_worker_id = worker_id.to_string();
+    let embed_heartbeat = move || -> crate::embed::Result<()> {
+        let store = heartbeat_store.clone();
+        let message_id = heartbeat_message_id.clone();
+        let worker_id = heartbeat_worker_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = store.refresh_heartbeat(message_id.clone(), worker_id).await {
+                tracing::warn!(
+                    ?error,
+                    message_id,
+                    "failed to refresh Hermes auto-ingest embed heartbeat"
+                );
+            }
+        });
+        Ok(())
+    };
+    let llm_heartbeat_store = store.clone();
+    let llm_heartbeat_message_id = message.id.clone();
+    let llm_heartbeat_worker_id = worker_id.to_string();
+    let llm_heartbeat = move || -> std::result::Result<(), crate::llm::LlmError> {
+        let store = llm_heartbeat_store.clone();
+        let message_id = llm_heartbeat_message_id.clone();
+        let worker_id = llm_heartbeat_worker_id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = store.refresh_heartbeat(message_id.clone(), worker_id).await {
+                tracing::warn!(
+                    ?error,
+                    message_id,
+                    "failed to refresh Hermes auto-ingest LLM heartbeat"
+                );
+            }
+        });
+        Ok(())
+    };
+
+    let project_id = resolve_hook_project_id(envelope, context.config)?;
+    let mut kept_turns = Vec::new();
+    for mut turn in parsed_turns {
+        turn.content = context.config.scrub_content(&turn.content);
+        if turn.content.trim().is_empty() {
+            continue;
+        }
+        let candidate_hash = crate::xurl::store::turn_id_for(&turn);
+        if gate_automatic_hermes_turn(
+            db,
+            embedder,
+            context,
+            AutomaticHermesTurnGateInput {
+                turn: &turn,
+                candidate_hash: &candidate_hash,
+                project_id: project_id.as_deref(),
+                embed_heartbeat: Some(&embed_heartbeat),
+                llm_heartbeat: Some(&llm_heartbeat),
+            },
+        )
+        .await?
+        {
+            kept_turns.push(turn);
+        }
+    }
+
+    if kept_turns.is_empty() {
+        return Ok(Some(crate::xurl::ingest::IngestStats {
+            turns_parsed,
+            turns_inserted: 0,
+            turns_skipped: 0,
+            turns_updated: 0,
+            vectors_created: 0,
+        }));
+    }
+
+    let insert_stats = db
+        .run_write_anyhow(move |db| {
+            crate::xurl::store::insert_turns(db.conn(), &kept_turns)
+                .context("failed to insert gated Hermes turns")
+        })
+        .await?;
+    let turn_ids = insert_stats.turn_ids.clone();
+    let vector_fingerprint = context
+        .config
+        .embed
+        .current_vector_embedder_fingerprint(embedder.dimensions());
+    let vectors_created = embed_and_write_hermes_turn_vectors(
+        db,
+        embedder,
+        &turn_ids,
+        &vector_fingerprint,
+        context.config,
+        Some(&embed_heartbeat),
+    )
+    .await
+    .context("failed to embed gated Hermes turns")?;
+
+    Ok(Some(crate::xurl::ingest::IngestStats {
+        turns_parsed,
+        turns_inserted: insert_stats.inserted,
+        turns_skipped: insert_stats.skipped,
+        turns_updated: insert_stats.updated,
+        vectors_created,
+    }))
+}
+
+async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
+    db: &AsyncDb,
+    embedder: &E,
+    turn_ids: &[String],
+    fingerprint: &str,
+    config: &crate::core::config::Config,
+    heartbeat: Option<&HeartbeatCallback>,
+) -> Result<usize> {
+    let mut embedded = 0usize;
+    for batch in turn_ids.chunks(500) {
+        let batch_ids = batch.to_vec();
+        let candidates = db
+            .run_read_anyhow(move |db| {
+                if batch_ids.is_empty() {
+                    return Ok(Vec::<(String, String)>::new());
+                }
+                let placeholders = (0..batch_ids.len())
+                    .map(|index| format!("?{}", index + 1))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT ct.id, ct.content \
+                     FROM conversation_turns ct \
+                     LEFT JOIN conversation_turn_vectors ctv \
+                       ON ctv.turn_id = ct.id AND ctv.chunk_index = 0 \
+                     WHERE ct.id IN ({placeholders}) AND ctv.turn_id IS NULL"
+                );
+                let mut stmt = db.conn().prepare(&sql)?;
+                let rows = stmt.query_map(rusqlite::params_from_iter(batch_ids.iter()), |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                let mut out = Vec::new();
+                for row in rows {
+                    out.push(row?);
+                }
+                Ok(out)
+            })
+            .await?;
+        if candidates.is_empty() {
+            continue;
+        }
+
+        let mut vector_rows = Vec::<(String, i64, Vec<u8>)>::new();
+        for (turn_id, content) in candidates {
+            let chunks = crate::ingest::chunk::chunk_text_token_aware(
+                &content,
+                &config.chunker,
+                embedder,
+                Some(&format!("xurl:auto-hermes:{turn_id}")),
+            );
+            for (chunk_index, chunk) in chunks.iter().enumerate() {
+                let vector = embed_text_with_heartbeat(embedder, chunk, heartbeat).await?;
+                vector_rows.push((
+                    turn_id.clone(),
+                    chunk_index as i64,
+                    serialize_f32_vector(&vector),
+                ));
+            }
+        }
+        if vector_rows.is_empty() {
+            continue;
+        }
+
+        let fingerprint = fingerprint.to_string();
+        let dim = i64::try_from(embedder.dimensions()).unwrap_or(i64::MAX);
+        let rows_written = db
+            .run_write_anyhow(move |db| {
+                let conn = db.conn();
+                conn.execute_batch("BEGIN IMMEDIATE")?;
+                let write = (|| -> rusqlite::Result<usize> {
+                    let mut rows_written = 0usize;
+                    for (turn_id, chunk_index, blob) in &vector_rows {
+                        rows_written += conn.execute(
+                            "INSERT INTO conversation_turn_vectors \
+                             (turn_id, chunk_index, vector, embedder_fingerprint, dim, index_version) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                             ON CONFLICT(turn_id, chunk_index) DO NOTHING",
+                            rusqlite::params![
+                                turn_id,
+                                chunk_index,
+                                blob,
+                                &fingerprint,
+                                dim,
+                                crate::core::db::CURRENT_VECTOR_INDEX_VERSION,
+                            ],
+                        )?;
+                    }
+                    Ok(rows_written)
+                })();
+                match write {
+                    Ok(rows_written) => {
+                        conn.execute_batch("COMMIT")?;
+                        Ok(rows_written)
+                    }
+                    Err(error) => {
+                        let _ = conn.execute_batch("ROLLBACK");
+                        Err(error.into())
+                    }
+                }
+            })
+            .await?;
+        embedded += rows_written;
+    }
+    Ok(embedded)
+}
+
+fn serialize_f32_vector(vector: &[f32]) -> Vec<u8> {
+    vector
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+struct AutomaticHermesTurnGateInput<'a> {
+    turn: &'a crate::xurl::model::RawTurn,
+    candidate_hash: &'a str,
+    project_id: Option<&'a str>,
+    embed_heartbeat: Option<&'a HeartbeatCallback>,
+    llm_heartbeat: Option<&'a crate::llm::retry::HeartbeatCallback>,
+}
+
+async fn gate_automatic_hermes_turn<E: Embedder + ?Sized>(
+    db: &AsyncDb,
+    embedder: &E,
+    context: &DaemonIngestContext<'_>,
+    input: AutomaticHermesTurnGateInput<'_>,
+) -> Result<bool> {
+    let candidate = IngestCandidate {
+        content: input.turn.content.clone(),
+        event: Some("HermesSessionTurn".to_string()),
+        tool_name: input.turn.metadata.tool_name.clone(),
+        exit_code: None,
+    };
+    let mut gating_decision = evaluate_tier1(&candidate, &context.config.ingest_gating);
+    if gating_decision.is_none()
+        && context.config.ingest_gating.enabled
+        && !tier2_enabled(&context.config.ingest_gating)
+    {
+        gating_decision = Some(GatingDecision::accepted(
+            0,
+            Some("tier2_disabled".to_string()),
+            None,
+        ));
+    }
+    if let Some(decision) = gating_decision.as_ref()
+        && decision.is_rejected()
+        && should_drop_reject_before_automatic_hook_llm_gate(context.config, decision)
+    {
+        record_gating_audit_async(
+            db,
+            input.candidate_hash,
+            decision,
+            input.project_id.map(ToOwned::to_owned),
+            None,
+        )
+        .await?;
+        return Ok(false);
+    }
+
+    if gating_decision.is_none() && tier2_enabled(&context.config.ingest_gating) {
+        let classifier = context.prototype_classifier.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Hermes auto-ingest requires prototype classifier but it is not available"
+            )
+        })?;
+        let candidate_vector = embed_text_with_heartbeat(
+            embedder,
+            analysis_content(&candidate.content),
+            input.embed_heartbeat,
+        )
+        .await?;
+        let decision = classifier.decide(
+            &candidate_vector,
+            context.config.ingest_gating.embedding_classifier.threshold,
+        );
+        if decision.is_rejected()
+            && should_drop_reject_before_automatic_hook_llm_gate(context.config, &decision)
+        {
+            record_gating_audit_async(
+                db,
+                input.candidate_hash,
+                &decision,
+                input.project_id.map(ToOwned::to_owned),
+                None,
+            )
+            .await?;
+            return Ok(false);
+        }
+        gating_decision = Some(decision);
+    }
+
+    if automatic_hook_llm_gate_required(context.config) {
+        let classifier_decision = gating_decision.clone();
+        let llm_decision = judge_automatic_content_llm_gate(
+            context.llm_gate,
+            context.config,
+            input.candidate_hash,
+            &candidate.content,
+            input.llm_heartbeat,
+        )
+        .await?;
+        let audit_decision = classifier_decision
+            .as_ref()
+            .map(|decision| audit_decision_with_llm_outcome(decision, &llm_decision))
+            .unwrap_or_else(|| llm_decision.clone());
+        record_gating_audit_async(
+            db,
+            input.candidate_hash,
+            &audit_decision,
+            input.project_id.map(ToOwned::to_owned),
+            (!audit_decision.is_rejected()).then_some(candidate.content.as_str()),
+        )
+        .await?;
+        record_llm_verdict_async(db, input.candidate_hash, &llm_decision).await?;
+        return Ok(!llm_decision.is_rejected());
+    }
+
+    let decision = gating_decision.unwrap_or_else(|| {
+        GatingDecision::accepted(0, Some("gating_default_keep".to_string()), None)
+    });
+    let keep = !decision.is_rejected();
+    record_gating_audit_async(
+        db,
+        input.candidate_hash,
+        &decision,
+        input.project_id.map(ToOwned::to_owned),
+        keep.then_some(candidate.content.as_str()),
+    )
+    .await?;
+    Ok(keep)
+}
+
+fn hermes_session_id_from_envelope(envelope: &CapturedHookEnvelope) -> Option<String> {
+    let payload = envelope.payload.as_deref()?;
+    let value = serde_json::from_str::<Value>(payload).ok()?;
+    json_string_at(&value, &["session_id"])
+        .or_else(|| json_string_at(&value, &["sessionId"]))
+        .or_else(|| json_string_at(&value, &["session", "id"]))
+        .or_else(|| json_string_at(&value, &["session", "session_id"]))
+}
+
+fn json_string_at(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn queue_failure_disposition(error: &anyhow::Error) -> QueueFailureDisposition {
@@ -1860,25 +2285,40 @@ async fn judge_automatic_hook_llm_gate(
     content: &str,
     heartbeat: Option<&crate::llm::retry::HeartbeatCallback>,
 ) -> Result<GatingDecision> {
-    let gate = context.daemon.llm_gate.ok_or_else(|| {
+    judge_automatic_content_llm_gate(
+        context.daemon.llm_gate,
+        context.daemon.config,
+        drawer_id,
+        content,
+        heartbeat,
+    )
+    .await
+}
+
+async fn judge_automatic_content_llm_gate(
+    gate: Option<&HookLlmGateRuntime>,
+    config: &crate::core::config::Config,
+    candidate_hash: &str,
+    content: &str,
+    heartbeat: Option<&crate::llm::retry::HeartbeatCallback>,
+) -> Result<GatingDecision> {
+    let gate = gate.ok_or_else(|| {
         anyhow::anyhow!(
             "LLM gating is required for automatic hook writes but no LLM gate runtime is available"
         )
     })?;
     let task = crate::llm::LlmTaskPayload {
         task_type: "gating".to_string(),
-        drawer_id: drawer_id.to_string(),
-        drawer_ids: vec![drawer_id.to_string()],
+        drawer_id: candidate_hash.to_string(),
+        drawer_ids: vec![candidate_hash.to_string()],
         content: content.to_string(),
-        system_prompt: context
-            .daemon
-            .config
+        system_prompt: config
             .ingest_gating
             .llm_judge
             .as_ref()
             .and_then(|judge| judge.system_prompt.clone()),
     };
-    let outcome = match gate.judge(context.daemon.config, &task, heartbeat).await {
+    let outcome = match gate.judge(config, &task, heartbeat).await {
         Ok(outcome) => outcome,
         Err(error) => {
             let error_chain = format!("{error:#}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10865,6 +10865,7 @@ async fn xurl_ingest_command(db: &Database, config: &Config, command: XurlComman
                     include_csa,
                     include_agent_prompts,
                     min_score: Some(min_score),
+                    reranker: Some(config.search.reranker.clone()),
                 },
             )
             .await
@@ -11309,6 +11310,7 @@ async fn hermes_query_command(db: &Database, config: &Config, args: HermesQueryA
             include_csa: args.include_csa,
             include_agent_prompts: args.include_agent_prompts,
             min_score: Some(args.min_score),
+            reranker: Some(config.search.reranker.clone()),
         },
     )
     .await

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -24,6 +24,28 @@ pub struct RerankOutcome {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexRerankOutcome {
+    pub order: Vec<usize>,
+    pub warnings: Vec<String>,
+}
+
+impl IndexRerankOutcome {
+    fn unchanged(len: usize) -> Self {
+        Self {
+            order: (0..len).collect(),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn fallback(len: usize, error: RerankError) -> Self {
+        Self {
+            order: (0..len).collect(),
+            warnings: vec![reranker_fallback_warning(&error)],
+        }
+    }
+}
+
 impl RerankOutcome {
     fn unchanged(results: Vec<SearchResult>) -> Self {
         Self {
@@ -125,26 +147,21 @@ impl HttpReranker {
             model,
         })
     }
-}
 
-#[async_trait::async_trait]
-impl Reranker for HttpReranker {
-    async fn try_rerank(
+    pub async fn try_rerank_indices(
         &self,
         query: &str,
-        results: Vec<SearchResult>,
-    ) -> Result<Vec<SearchResult>, RerankError> {
-        if results.len() <= 1 {
-            return Ok(results);
+        documents: Vec<&str>,
+    ) -> Result<Vec<usize>, RerankError> {
+        if documents.len() <= 1 {
+            return Ok((0..documents.len()).collect());
         }
+        let document_count = documents.len();
         let request = RerankRequest {
             model: &self.model,
             query,
-            documents: results
-                .iter()
-                .map(|result| result.content.as_str())
-                .collect(),
-            top_n: results.len(),
+            documents,
+            top_n: document_count,
         };
         let response = self
             .client
@@ -161,7 +178,26 @@ impl Reranker for HttpReranker {
         let body = read_limited_response_body(response).await?;
         let response = serde_json::from_slice::<RerankResponse>(&body)
             .map_err(|source| RerankError::DecodeResponse(source.to_string()))?;
-        reorder_results(results, response.items())
+        reorder_indices(document_count, response.items())
+    }
+}
+
+#[async_trait::async_trait]
+impl Reranker for HttpReranker {
+    async fn try_rerank(
+        &self,
+        query: &str,
+        results: Vec<SearchResult>,
+    ) -> Result<Vec<SearchResult>, RerankError> {
+        let documents = results
+            .iter()
+            .map(|result| result.content.as_str())
+            .collect();
+        let order = self.try_rerank_indices(query, documents).await?;
+        Ok(order
+            .into_iter()
+            .map(|index| results[index].clone())
+            .collect())
     }
 }
 
@@ -244,6 +280,33 @@ pub async fn maybe_rerank_with_config(
     }
 }
 
+pub async fn maybe_rerank_indices_with_config(
+    config: &SearchRerankerConfig,
+    query: &str,
+    documents: Vec<&str>,
+) -> IndexRerankOutcome {
+    if !config.enabled || documents.len() <= 1 {
+        return IndexRerankOutcome::unchanged(documents.len());
+    }
+
+    let candidate_count = config.top_k.min(documents.len());
+    let candidates = documents[..candidate_count].to_vec();
+    let reranker = match HttpReranker::from_config(config) {
+        Ok(reranker) => reranker,
+        Err(error) => return IndexRerankOutcome::fallback(documents.len(), error),
+    };
+    match reranker.try_rerank_indices(query, candidates).await {
+        Ok(mut order) => {
+            order.extend(candidate_count..documents.len());
+            IndexRerankOutcome {
+                order,
+                warnings: Vec::new(),
+            }
+        }
+        Err(error) => IndexRerankOutcome::fallback(documents.len(), error),
+    }
+}
+
 fn reranker_fallback_warning(error: &RerankError) -> String {
     format!(
         "reranker unavailable; using original search ranking: {}",
@@ -284,21 +347,28 @@ struct RerankItem {
     score: Option<f32>,
 }
 
+#[cfg(test)]
 fn reorder_results(
     results: Vec<SearchResult>,
     items: Vec<RerankItem>,
 ) -> Result<Vec<SearchResult>, RerankError> {
+    let order = reorder_indices(results.len(), items)?;
+    Ok(order
+        .into_iter()
+        .map(|index| results[index].clone())
+        .collect())
+}
+
+fn reorder_indices(len: usize, items: Vec<RerankItem>) -> Result<Vec<usize>, RerankError> {
     if items.is_empty() {
         return Err(RerankError::InvalidResponse(
             "missing results or data array".to_string(),
         ));
     }
-
-    let original = results;
     let mut ranked = items
         .into_iter()
         .filter_map(|item| {
-            if item.index >= original.len() {
+            if item.index >= len {
                 return None;
             }
             let score = item.score?;
@@ -321,15 +391,15 @@ fn reorder_results(
     });
 
     let mut seen = HashSet::new();
-    let mut ordered = Vec::with_capacity(original.len());
+    let mut ordered = Vec::with_capacity(len);
     for (index, _) in ranked {
         if seen.insert(index) {
-            ordered.push(original[index].clone());
+            ordered.push(index);
         }
     }
-    for (index, result) in original.into_iter().enumerate() {
+    for index in 0..len {
         if seen.insert(index) {
-            ordered.push(result);
+            ordered.push(index);
         }
     }
     Ok(ordered)

--- a/src/xurl/search.rs
+++ b/src/xurl/search.rs
@@ -21,12 +21,13 @@ struct TurnBestEntry {
     next_message_id: Option<String>,
 }
 
+use crate::core::config::SearchRerankerConfig;
 use crate::core::db::Database;
 use crate::embed::Embedder;
 use crate::xurl::store::{TurnFilter, push_filter_conditions};
 use crate::xurl::{XurlError, XurlResult};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SearchHit {
     pub turn_id: String,
     pub session_id: String,
@@ -58,6 +59,8 @@ pub struct SearchResult {
     pub total_candidates: usize,
     /// The min-score threshold that was applied, if any.
     pub min_score_floor: Option<f32>,
+    /// Non-sensitive diagnostics for optional retrieval stages such as reranking.
+    pub warnings: Vec<String>,
 }
 
 /// Deserialize a raw f32 little-endian BLOB into a vector.
@@ -95,6 +98,8 @@ pub struct SearchOptions {
     pub include_agent_prompts: bool,
     /// Exclude hits scoring below this threshold.
     pub min_score: Option<f32>,
+    /// Optional top-K reranker. `None` keeps xurl search fully local and preserves vector order.
+    pub reranker: Option<SearchRerankerConfig>,
 }
 
 /// Semantic search over `conversation_turn_vectors` using brute-force cosine similarity.
@@ -118,6 +123,7 @@ pub async fn search<E: Embedder + ?Sized>(
         include_csa,
         include_agent_prompts,
         min_score,
+        reranker,
     } = opts;
     if limit == 0 {
         return Ok(SearchResult {
@@ -126,6 +132,7 @@ pub async fn search<E: Embedder + ?Sized>(
             best_score_below_floor: None,
             total_candidates: 0,
             min_score_floor: min_score,
+            warnings: Vec::new(),
         });
     }
 
@@ -307,6 +314,26 @@ pub async fn search<E: Embedder + ?Sized>(
     let best_score_below_floor = below_floor.into_iter().next().map(|h| h.score);
 
     let passing_total = passing.len();
+    let mut passing = passing;
+    let mut warnings = Vec::new();
+    if let Some(reranker_config) = reranker {
+        let documents = passing
+            .iter()
+            .map(|hit| hit.content.as_str())
+            .collect::<Vec<_>>();
+        let outcome = crate::search::rerank::maybe_rerank_indices_with_config(
+            &reranker_config,
+            query,
+            documents,
+        )
+        .await;
+        warnings.extend(outcome.warnings);
+        passing = outcome
+            .order
+            .into_iter()
+            .filter_map(|index| passing.get(index).cloned())
+            .collect();
+    }
     let hits = passing.into_iter().skip(offset).take(limit).collect();
 
     Ok(SearchResult {
@@ -315,6 +342,7 @@ pub async fn search<E: Embedder + ?Sized>(
         best_score_below_floor,
         total_candidates,
         min_score_floor: min_score,
+        warnings,
     })
 }
 

--- a/tests/hermes_auto_ingest.rs
+++ b/tests/hermes_auto_ingest.rs
@@ -1,0 +1,295 @@
+#![cfg(feature = "integration")]
+
+use async_trait::async_trait;
+use mempal::core::AsyncDb;
+use mempal::core::config::Config;
+use mempal::core::db::Database;
+use mempal::core::queue::{AsyncPendingMessageStore, PendingMessageStore};
+use mempal::daemon::{DaemonIngestContext, process_claimed_message_with_embedder};
+use mempal::embed::{EmbedError, Embedder};
+use mempal::hook::{CapturedHookEnvelope, HookEvent};
+use mempal::xurl::model::Tool;
+use mempal::xurl::store::{self, TurnFilter};
+use rusqlite::{Connection, params};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+#[derive(Clone)]
+struct DeterministicEmbedder {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl Embedder for DeterministicEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn name(&self) -> &str {
+        "deterministic"
+    }
+}
+
+struct AutoIngestEnv {
+    _tmp: TempDir,
+    db_path: PathBuf,
+    mempal_home: PathBuf,
+    project_dir: PathBuf,
+    config: Config,
+    store: PendingMessageStore,
+}
+
+impl AutoIngestEnv {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let mempal_home = tmp.path().join(".mempal");
+        let hermes_home = tmp.path().join(".hermes");
+        let project_dir = tmp.path().join("workspace/project-alpha");
+        fs::create_dir_all(&mempal_home).expect("create mempal home");
+        fs::create_dir_all(&hermes_home).expect("create hermes home");
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        let db_path = mempal_home.join("palace.db");
+        Database::open(&db_path).expect("open mempal db");
+        write_hermes_state_db(&hermes_home.join("state.db"), &project_dir);
+
+        let config_text = format!(
+            r#"
+db_path = "{}"
+
+[project]
+id = "project-alpha"
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 100
+
+[hooks.session_end]
+auto_ingest_conversation = true
+hermes_profile = "default"
+hermes_home = "{}"
+
+[privacy]
+enabled = false
+
+[ingest_gating]
+enabled = true
+
+[[ingest_gating.rules]]
+action = "reject"
+content_contains = "drop-noise"
+
+[search]
+strict_project_isolation = true
+progressive_disclosure = true
+preview_chars = 48
+"#,
+            db_path.display(),
+            hermes_home.display(),
+        );
+        let config = Config::parse(&config_text).expect("parse config");
+        let store = PendingMessageStore::new(&db_path).expect("open pending store");
+        Self {
+            _tmp: tmp,
+            db_path,
+            mempal_home,
+            project_dir,
+            config,
+            store,
+        }
+    }
+
+    fn enqueue_session_end(&self) {
+        let payload = serde_json::json!({
+            "session_id": "hermes-auto-session",
+            "agent": "hermes"
+        });
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::SessionEnd.display_name().to_string(),
+            kind: HookEvent::SessionEnd.queue_kind().to_string(),
+            agent: "hermes".to_string(),
+            captured_at: "1713000000".to_string(),
+            claude_cwd: self.project_dir.display().to_string(),
+            payload: Some(payload.to_string()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: payload.to_string().len(),
+            truncated: false,
+        };
+        let serialized = serde_json::to_string(&envelope).expect("serialize envelope");
+        self.store
+            .enqueue(HookEvent::SessionEnd.queue_kind(), &serialized)
+            .expect("enqueue session end");
+    }
+
+    async fn process_once(&self) {
+        let claimed = self
+            .store
+            .claim_next("worker-hermes-auto", 120)
+            .expect("claim next")
+            .expect("claimed message");
+        let db = AsyncDb::open(&self.db_path, 4).expect("open async db");
+        let async_store = AsyncPendingMessageStore::from_store(self.store.clone());
+        let embedder = DeterministicEmbedder {
+            vector: vec![0.2, 0.8, 0.4],
+        };
+        process_claimed_message_with_embedder(
+            &db,
+            &async_store,
+            "worker-hermes-auto",
+            &claimed,
+            &embedder,
+            DaemonIngestContext {
+                prototype_classifier: None,
+                llm_gate: None,
+                config: &self.config,
+                mempal_home: &self.mempal_home,
+            },
+        )
+        .await
+        .expect("process hook message");
+    }
+}
+
+fn write_hermes_state_db(path: &Path, project_dir: &Path) {
+    let conn = Connection::open(path).expect("open hermes state db");
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            source TEXT,
+            cwd TEXT
+        );
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            timestamp REAL NOT NULL,
+            cwd TEXT
+        );",
+    )
+    .expect("create hermes schema");
+    conn.execute(
+        "INSERT INTO sessions (id, title, source, cwd) VALUES (?1, ?2, ?3, ?4)",
+        params![
+            "hermes-auto-session",
+            "Auto ingest regression",
+            "hermes-test",
+            project_dir.display().to_string()
+        ],
+    )
+    .expect("insert session");
+    let messages = [
+        (
+            "msg-keep-1",
+            "user",
+            "keep durable Hermes decision about automatic gated session import",
+            1.0,
+        ),
+        (
+            "msg-drop-1",
+            "assistant",
+            "drop-noise transient spinner output that must not be stored",
+            2.0,
+        ),
+        (
+            "msg-keep-2",
+            "assistant",
+            "keep follow-up implementation note for automatic Hermes ingest",
+            3.0,
+        ),
+    ];
+    for (id, role, content, timestamp) in messages {
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, cwd) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                "hermes-auto-session",
+                role,
+                content,
+                timestamp,
+                project_dir.display().to_string(),
+            ],
+        )
+        .expect("insert message");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_end_auto_ingests_hermes_turns_after_gate() {
+    let env = AutoIngestEnv::new();
+    env.enqueue_session_end();
+    env.process_once().await;
+
+    let db = Database::open(&env.db_path).expect("open db");
+    let turns = store::get_turns_filtered(
+        db.conn(),
+        TurnFilter {
+            tool: Some(Tool::Hermes),
+            session_id: Some("hermes-auto-session".to_string()),
+            hermes_profile: Some("default".to_string()),
+            limit: 10,
+            ..Default::default()
+        },
+        true,
+        true,
+    )
+    .expect("query hermes turns");
+    let contents = turns
+        .iter()
+        .map(|turn| turn.content.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(contents.len(), 2);
+    assert!(
+        contents
+            .iter()
+            .any(|content| content.contains("durable Hermes decision"))
+    );
+    assert!(
+        contents
+            .iter()
+            .any(|content| content.contains("implementation note"))
+    );
+    assert!(
+        contents
+            .iter()
+            .all(|content| !content.contains("drop-noise"))
+    );
+
+    let vector_count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM conversation_turn_vectors WHERE turn_id IN (
+                SELECT id FROM conversation_turns WHERE tool = 'hermes' AND session_id = 'hermes-auto-session'
+            )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count vectors");
+    assert_eq!(vector_count, 2);
+
+    let skipped_audit_rows: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM gating_audit WHERE decision = 'skip'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count skip audit rows");
+    assert_eq!(skipped_audit_rows, 1);
+
+    let skipped_previews_with_content: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM gating_audit WHERE decision = 'skip' AND content_preview IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count skip audit previews");
+    assert_eq!(skipped_previews_with_content, 0);
+}

--- a/tests/xurl_search.rs
+++ b/tests/xurl_search.rs
@@ -1,3 +1,4 @@
+use mempal::core::config::SearchRerankerConfig;
 use mempal::core::db::Database;
 use mempal::embed::Embedder;
 use mempal::xurl::model::{Provenance, RawTurn, Role, Tool, TurnMetadata};
@@ -328,6 +329,64 @@ async fn search_paginates_ranked_results_with_filter_offset() {
 }
 
 #[tokio::test]
+async fn search_optionally_reranks_configured_top_k_hits() {
+    let db = open_temp_db();
+    let embedder = AxisEmbedder;
+    let ids = [
+        seed_scored_turn(&db, 0, 0.99),
+        seed_scored_turn(&db, 1, 0.90),
+        seed_scored_turn(&db, 2, 0.80),
+    ];
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/v1/rerank")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "model": "test-reranker",
+            "query": "needle",
+            "top_n": 2
+        })))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"results":[{"index":1,"relevance_score":0.98},{"index":0,"relevance_score":0.12}]}"#,
+        )
+        .create_async()
+        .await;
+
+    let result = search::search(
+        &db.inner,
+        &embedder,
+        "needle",
+        SearchOptions {
+            limit: 3,
+            min_score: Some(0.0),
+            reranker: Some(SearchRerankerConfig {
+                enabled: true,
+                endpoint: Some(server.url()),
+                model: Some("test-reranker".to_string()),
+                timeout_secs: 2,
+                top_k: 2,
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    mock.assert_async().await;
+    let hit_ids = result
+        .hits
+        .iter()
+        .map(|hit| hit.turn_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        hit_ids,
+        vec![ids[1].as_str(), ids[0].as_str(), ids[2].as_str()]
+    );
+    assert!(result.warnings.is_empty());
+}
+
+#[tokio::test]
 async fn search_with_tool_filter() {
     let db = open_temp_db();
     let embedder = SemanticEmbedder::new(16);
@@ -608,6 +667,7 @@ fn markdown_reports_sub_floor_candidates_when_floor_hides_all_hits() {
         best_score_below_floor: Some(0.645),
         total_candidates: 3,
         min_score_floor: Some(0.70),
+        warnings: Vec::new(),
     });
 
     assert!(
@@ -632,6 +692,7 @@ fn markdown_derives_sub_floor_hint_from_low_best_score() {
         best_score_below_floor: Some(0.350),
         total_candidates: 3,
         min_score_floor: Some(0.70),
+        warnings: Vec::new(),
     });
 
     assert!(
@@ -673,6 +734,7 @@ fn markdown_keeps_confident_match_output_free_of_sub_floor_hint() {
         best_score_below_floor: Some(0.645),
         total_candidates: 2,
         min_score_floor: Some(0.70),
+        warnings: Vec::new(),
     });
 
     assert!(
@@ -697,6 +759,7 @@ fn markdown_reports_no_more_results_for_empty_page_with_passing_matches() {
         best_score_below_floor: Some(0.55),
         total_candidates: 2,
         min_score_floor: Some(0.70),
+        warnings: Vec::new(),
     });
 
     assert!(


### PR DESCRIPTION
## Summary

- Restore automatic gated Hermes SessionEnd conversation ingestion without relying on manual `mempal hermes ingest`.
- Reuse optional `[search.reranker]` config for xurl/Hermes recall search so long-context recall can use the gb10 reranker while remaining fail-open.
- Fix Hermes plugin REST query encoding so Python booleans are sent as serde-compatible lowercase `true`/`false`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test hermes_auto_ingest --features integration -- --nocapture`
- `cargo test --test xurl_search -- --nocapture`
- `cargo test reranker -- --nocapture`
- `python3 -m unittest contrib/hermes-agent-plugin/test_mempal_provider.py -v`
- CSA review PASS/CLEAN: session `01KV5WDFHGV2R7C60WZQMRZ463` at HEAD `2b1d4f03bd6`
- Pre-push review-check passed for HEAD `2b1d4f03bd6`

## Notes

- The global Hermes plugin files under `~/.hermes/plugins/` were updated separately for the current machine; restart Hermes to load them.
- CSA Codex review attempt hit memory soft-limit and was reported upstream: RyderFreeman4Logos/cli-sub-agent#2249.
