### PR TITLE
fix: avoid false unhealthy REST doctor search probe

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -689,7 +689,9 @@ fn unhealthy_rest_route_detail(route: &RestRouteReport) -> Option<String> {
 
 fn route_probe_url(endpoint: &str, path: &str) -> String {
     match path {
-        "/api/search" => format!("{endpoint}{path}?q=mempal-doctor-rest&top_k=1"),
+        "/api/search" => format!(
+            "{endpoint}{path}?q=mempal-doctor-rest&wing=hermes-user%2Fhermes-user%2Fdefault&include_raw_turns=false&top_k=0"
+        ),
         "/api/timeline" | "/api/pinned_facts" => format!("{endpoint}{path}?limit=1"),
         _ => format!("{endpoint}{path}"),
     }

--- a/tests/doctor_rest.rs
+++ b/tests/doctor_rest.rs
@@ -146,6 +146,66 @@ fn test_doctor_rest_accepts_axum_ingest_validation_response() {
 }
 
 #[test]
+fn test_doctor_rest_uses_scoped_cheap_search_probe() {
+    let home = temp_home();
+    let mut server = Server::new();
+    let _status = server
+        .mock("GET", "/api/status")
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let _search = server
+        .mock("GET", "/api/search")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("q".into(), "mempal-doctor-rest".into()),
+            Matcher::UrlEncoded("wing".into(), "hermes-user/hermes-user/default".into()),
+            Matcher::UrlEncoded("include_raw_turns".into(), "false".into()),
+            Matcher::UrlEncoded("top_k".into(), "0".into()),
+        ]))
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _ingest = server
+        .mock("POST", "/api/ingest")
+        .match_body(Matcher::PartialJson(serde_json::json!({})))
+        .with_status(422)
+        .with_body(r#"{\"error\":\"missing field `content`\"}"#)
+        .create();
+    let _timeline = server
+        .mock("GET", "/api/timeline")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _pinned = server
+        .mock("GET", "/api/pinned_facts")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+
+    let output = run_doctor_rest(&home, &["--addr", &server.url(), "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "ok");
+    }
+    let search_route = report["routes"]
+        .as_array()
+        .expect("routes")
+        .iter()
+        .find(|route| route["method"] == "GET" && route["path"] == "/api/search")
+        .expect("search route");
+    assert_eq!(search_route["available"], true);
+}
+
+#[test]
 fn test_doctor_rest_reports_server_error_routes_as_unhealthy() {
     let home = temp_home();
     let mut server = Server::new();


### PR DESCRIPTION
## Summary

- Fixes `mempal doctor rest` false unhealthy reports for `/api/search` on large/slow local memories.
- Changes the REST doctor search probe to a scoped metadata-only query with `include_raw_turns=false` and `top_k=0`.
- Adds a regression test proving the doctor uses the cheap scoped search probe while preserving existing route classification behavior.

Closes #446

## Test Plan

- `cargo test --test doctor_rest test_doctor_rest_uses_scoped_cheap_search_probe --features rest -- --nocapture`
- `cargo test --test doctor_rest --features rest -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets --features rest -- -D warnings`
- `./target/debug/mempal doctor rest --addr 127.0.0.1:3080` → `status=ok`, `/api/search available=true http_status=200`

## Review

- CSA Codex review unavailable due memory soft-limit; diagnostic issue filed: RyderFreeman4Logos/cli-sub-agent#2250
- CSA Gemini review PASS/CLEAN: `01KV66ZJ801C44AM5DCREGC4YF`
- Reviewed head: `7d8c646feea`
