### PR TITLE
fix(mcp): drain async ingest operations safely

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -234,6 +234,19 @@ impl AsyncPendingMessageStore {
             .await
     }
 
+    pub async fn claim_by_id_and_kind(
+        &self,
+        worker_id: String,
+        claim_ttl_secs: i64,
+        id: String,
+        kind_filter: String,
+    ) -> Result<Option<ClaimedMessage>> {
+        self.run(move |store| {
+            store.claim_by_id_and_kind(&worker_id, claim_ttl_secs, &id, &kind_filter)
+        })
+        .await
+    }
+
     pub async fn confirm(&self, claim: ClaimedMessage) -> Result<()> {
         self.run(move |store| store.confirm(&claim)).await
     }
@@ -601,6 +614,80 @@ impl PendingMessageStore {
             WHERE id = ?1 AND status = 'pending'
             "#,
             params![id, claim_token, now],
+        )?;
+        if updated == 0 {
+            tx.commit()?;
+            return Ok(None);
+        }
+
+        tx.commit()?;
+        Ok(Some(ClaimedMessage {
+            id,
+            kind,
+            payload,
+            retry_count,
+            claim_token,
+            source_hash,
+            created_at,
+            claimed_at: now,
+        }))
+    }
+
+    pub fn claim_by_id_and_kind(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+        id_filter: &str,
+        kind_filter: &str,
+    ) -> Result<Option<ClaimedMessage>> {
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        reclaim_stale_tx(&tx, saturating_cutoff(now_secs(), claim_ttl_secs))?;
+
+        let now = now_secs();
+        let row = tx
+            .query_row(
+                r#"
+                SELECT id, kind, payload, retry_count, source_hash, created_at
+                FROM pending_messages
+                WHERE id = ?1
+                  AND status = 'pending'
+                  AND next_attempt_at <= ?2
+                  AND kind = ?3
+                LIMIT 1
+                "#,
+                params![id_filter, now, kind_filter],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let Some((id, kind, payload, retry_count_i64, source_hash, created_at)) = row else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let retry_count = u32::try_from(retry_count_i64)
+            .map_err(|_| QueueError::RetryCountOverflow { id: id.clone() })?;
+        let claim_token = format!("{worker_id}:{}", next_id("claim"));
+        let updated = tx.execute(
+            r#"
+            UPDATE pending_messages
+            SET status = 'claimed',
+                claim_token = ?2,
+                claimed_at = ?3,
+                heartbeat_at = ?3,
+                op_state = 'running'
+            WHERE id = ?1 AND status = 'pending' AND kind = ?4
+            "#,
+            params![id, claim_token, now, kind_filter],
         )?;
         if updated == 0 {
             tx.commit()?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -83,7 +83,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         let db = context.db.lock().await;
         db.path().to_path_buf()
     };
-    global_embed_status().set_audit_db_path(Some(db_path));
+    global_embed_status().set_audit_db_path(Some(db_path.clone()));
     {
         let db = context.db.lock().await;
         db.prune_expired_audit_logs()
@@ -205,6 +205,8 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .await
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
+    spawn_daemon_ingest_drain_worker(context, &db_path)
+        .context("failed to start daemon async ingest worker")?;
     let stall_watchdog_handle = spawn_stall_watchdog(
         context.write_observer.clone(),
         context.store.clone(),
@@ -343,6 +345,20 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         tracing::info!("released {released} claimed messages back to pending on shutdown");
     }
 
+    Ok(())
+}
+
+fn spawn_daemon_ingest_drain_worker(context: &DaemonContext, db_path: &Path) -> Result<()> {
+    let config = context.config.as_ref().clone();
+    let server = crate::mcp::MempalMcpServer::new_with_factory_and_config(
+        db_path.to_path_buf(),
+        config.clone(),
+        Arc::new(crate::embed::ConfiguredEmbedderFactory::new_for_daemon(
+            config,
+        )),
+    )?;
+    server.ensure_ingest_drain_worker_started();
+    tracing::info!("daemon async ingest worker started");
     Ok(())
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -205,7 +205,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .await
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
-    spawn_daemon_ingest_drain_worker(context, &db_path)
+    let ingest_drain_worker = spawn_daemon_ingest_drain_worker(context, &db_path)
         .context("failed to start daemon async ingest worker")?;
     let stall_watchdog_handle = spawn_stall_watchdog(
         context.write_observer.clone(),
@@ -301,6 +301,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         );
         wait_for_hook_worker_or_tick(&mut hook_workers, poll_interval).await;
     }
+    ingest_drain_worker.request_shutdown();
 
     #[cfg(unix)]
     hook_ipc_service.shutdown().await;
@@ -331,6 +332,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     let _ = stall_watchdog_handle.await;
     endpoint_requeue_handle.abort();
     let _ = endpoint_requeue_handle.await;
+    ingest_drain_worker.shutdown_and_drain().await;
 
     // Release any tasks still claimed by workers that were aborted or did not finish.
     let released = context
@@ -348,7 +350,10 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     Ok(())
 }
 
-fn spawn_daemon_ingest_drain_worker(context: &DaemonContext, db_path: &Path) -> Result<()> {
+fn spawn_daemon_ingest_drain_worker(
+    context: &DaemonContext,
+    db_path: &Path,
+) -> Result<crate::mcp::IngestDrainWorkerHandle> {
     let config = context.config.as_ref().clone();
     let server = crate::mcp::MempalMcpServer::new_with_factory_and_config(
         db_path.to_path_buf(),
@@ -357,9 +362,9 @@ fn spawn_daemon_ingest_drain_worker(context: &DaemonContext, db_path: &Path) -> 
             config,
         )),
     )?;
-    server.ensure_ingest_drain_worker_started();
+    let handle = server.spawn_scoped_ingest_drain_worker();
     tracing::info!("daemon async ingest worker started");
-    Ok(())
+    Ok(handle)
 }
 
 #[derive(Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5201,51 +5201,6 @@ fn ingest_stdin_wait_stats_from_response(response: &IngestResponse) -> IngestSta
     stats
 }
 
-async fn wait_for_operation_status_with_progress(
-    server: &MempalMcpServer,
-    operation_id: &str,
-    timeout: std::time::Duration,
-    poll_interval: std::time::Duration,
-) -> Result<Option<IngestResponse>> {
-    let deadline = std::time::Instant::now() + clamp_wait_timeout(timeout);
-    loop {
-        let response = server
-            .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
-                OperationStatusRequest {
-                    operation_id: operation_id.to_string(),
-                },
-            ))
-            .await
-            .context("failed to load operation status")?
-            .0;
-        if response
-            .state
-            .map(IngestOperationState::is_terminal)
-            .unwrap_or(false)
-        {
-            return Ok(Some(response));
-        }
-        if timeout.is_zero() || std::time::Instant::now() >= deadline {
-            return Ok(None);
-        }
-        eprintln!(
-            "waiting operation_id={} state={}",
-            operation_id,
-            response
-                .state
-                .map(|state| state.as_str())
-                .unwrap_or("unknown")
-        );
-        tokio::time::sleep(poll_interval).await;
-    }
-}
-
-const MAX_WAIT_TIMEOUT_SECS: u64 = 86_400;
-
-fn clamp_wait_timeout(timeout: std::time::Duration) -> std::time::Duration {
-    timeout.min(std::time::Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
-}
-
 fn finish_operation_wait_response(response: IngestResponse, operation_id: &str) -> Result<()> {
     print_operation_response(&response)?;
     match response.state {
@@ -5278,20 +5233,43 @@ async fn operation_command(
             operation_id,
             timeout_secs,
         } => {
-            let ingest_drain_worker = server.spawn_scoped_ingest_drain_worker();
             eprintln!(
                 "waiting for operation_id={} timeout_secs={timeout_secs}",
                 operation_id
             );
-            let wait_result = wait_for_operation_status_with_progress(
-                &server,
-                &operation_id,
-                std::time::Duration::from_secs(timeout_secs),
-                std::time::Duration::from_millis(150),
-            )
-            .await;
-            ingest_drain_worker.shutdown_and_drain().await;
-            match wait_result? {
+            let initial_status = server
+                .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
+                    OperationStatusRequest {
+                        operation_id: operation_id.clone(),
+                    },
+                ))
+                .await
+                .context("failed to load initial operation status")?
+                .0;
+            eprintln!(
+                "waiting operation_id={} state={}",
+                operation_id,
+                initial_status
+                    .state
+                    .map(|state| state.as_str())
+                    .unwrap_or("unknown")
+            );
+            if initial_status
+                .state
+                .map(IngestOperationState::is_terminal)
+                .unwrap_or(false)
+            {
+                return finish_operation_wait_response(initial_status, &operation_id);
+            }
+            let wait_result = server
+                .wait_for_operation_status_with_scoped_worker(
+                    &operation_id,
+                    std::time::Duration::from_secs(timeout_secs),
+                    std::time::Duration::from_millis(150),
+                )
+                .await
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            match wait_result {
                 Some(response) => finish_operation_wait_response(response, &operation_id),
                 None => {
                     let mut response = server

--- a/src/main.rs
+++ b/src/main.rs
@@ -4880,7 +4880,7 @@ async fn ingest_stdin_command(
         };
         let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone())?;
         let response = server
-            .mempal_ingest_with_controls(wait_request, controls)
+            .mempal_ingest_with_controls_scoped_worker(wait_request, controls)
             .await
             .map(|response| response.0)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5268,6 +5268,7 @@ async fn operation_command(
             operation_id,
             timeout_secs,
         } => {
+            server.ensure_ingest_drain_worker_started();
             eprintln!(
                 "waiting for operation_id={} timeout_secs={timeout_secs}",
                 operation_id

--- a/src/main.rs
+++ b/src/main.rs
@@ -5246,6 +5246,16 @@ fn clamp_wait_timeout(timeout: std::time::Duration) -> std::time::Duration {
     timeout.min(std::time::Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
 }
 
+fn finish_operation_wait_response(response: IngestResponse, operation_id: &str) -> Result<()> {
+    print_operation_response(&response)?;
+    match response.state {
+        Some(IngestOperationState::Completed) => Ok(()),
+        Some(IngestOperationState::Rejected) => bail!("operation {operation_id} was rejected"),
+        Some(IngestOperationState::Failed) => bail!("operation {operation_id} failed"),
+        _ => Ok(()),
+    }
+}
+
 async fn operation_command(
     db: &Database,
     config: &Config,
@@ -5268,32 +5278,21 @@ async fn operation_command(
             operation_id,
             timeout_secs,
         } => {
-            server.ensure_ingest_drain_worker_started();
+            let ingest_drain_worker = server.spawn_scoped_ingest_drain_worker();
             eprintln!(
                 "waiting for operation_id={} timeout_secs={timeout_secs}",
                 operation_id
             );
-            match wait_for_operation_status_with_progress(
+            let wait_result = wait_for_operation_status_with_progress(
                 &server,
                 &operation_id,
                 std::time::Duration::from_secs(timeout_secs),
                 std::time::Duration::from_millis(150),
             )
-            .await?
-            {
-                Some(response) => {
-                    print_operation_response(&response)?;
-                    match response.state {
-                        Some(IngestOperationState::Completed) => Ok(()),
-                        Some(IngestOperationState::Rejected) => {
-                            bail!("operation {operation_id} was rejected")
-                        }
-                        Some(IngestOperationState::Failed) => {
-                            bail!("operation {operation_id} failed")
-                        }
-                        _ => Ok(()),
-                    }
-                }
+            .await;
+            ingest_drain_worker.shutdown_and_drain().await;
+            match wait_result? {
+                Some(response) => finish_operation_wait_response(response, &operation_id),
                 None => {
                     let mut response = server
                         .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
@@ -5304,6 +5303,13 @@ async fn operation_command(
                         .await
                         .context("failed to load timed-out operation status")?
                         .0;
+                    if response
+                        .state
+                        .map(IngestOperationState::is_terminal)
+                        .unwrap_or(false)
+                    {
+                        return finish_operation_wait_response(response, &operation_id);
+                    }
                     response.timed_out = true;
                     print_operation_response(&response)?;
                     bail!("timed out waiting for operation {operation_id}")

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -5,7 +5,7 @@ mod server;
 mod timeline;
 mod tools;
 
-pub use server::MempalMcpServer;
+pub use server::{IngestDrainWorkerHandle, MempalMcpServer};
 pub use timeline::{TimelineRequest, TimelineResponse};
 pub use tools::{
     IngestControls, IngestOperationState, IngestRequest, IngestResponse,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -534,26 +534,8 @@ impl MempalMcpServer {
             }
         };
 
-        let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
-        let heartbeat_queue = queue.clone();
-        let heartbeat_id = claim.id.clone();
-        let heartbeat_worker_id = worker_id.to_string();
-        let heartbeat = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(INGEST_HEARTBEAT_INTERVAL);
-            interval.tick().await;
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        if let Err(error) = heartbeat_queue.refresh_heartbeat(heartbeat_id.clone(), heartbeat_worker_id.clone()).await {
-                            tracing::warn!(error = %error, claim_id = %heartbeat_id, "failed to refresh async ingest heartbeat");
-                            break;
-                        }
-                    }
-                    _ = &mut stop_rx => break,
-                }
-            }
-        });
-
+        let (stop_tx, heartbeat) =
+            Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
         let outcome = match self
             .run_prepared_ingest_off_runtime(prepared.request.clone(), prepared.controls)
             .await
@@ -563,9 +545,49 @@ impl MempalMcpServer {
             Err(error) => Err(error.to_string()),
         };
 
-        let _ = stop_tx.send(());
-        let _ = heartbeat.await;
+        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+        self.complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .await
+    }
 
+    async fn process_ingest_claim_inline(
+        &self,
+        queue: &AsyncPendingMessageStore,
+        worker_id: &str,
+        claim: ClaimedMessage,
+    ) -> anyhow::Result<()> {
+        let queue_wait_ms = queue_wait_ms(claim.created_at, claim.claimed_at);
+        let prepared: PreparedIngestOperation = match serde_json::from_str(&claim.payload) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let detail = format!("failed to decode ingest operation {}: {error}", claim.id);
+                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
+                return Ok(());
+            }
+        };
+
+        let (stop_tx, heartbeat) =
+            Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
+        let outcome = match self
+            .mempal_ingest_sync(prepared.request.clone(), prepared.controls)
+            .await
+        {
+            Ok(response) => Ok(response.0),
+            Err(error) => Err(error.to_string()),
+        };
+
+        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+        self.complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .await
+    }
+
+    async fn complete_ingest_claim_outcome(
+        &self,
+        queue: &AsyncPendingMessageStore,
+        claim: &ClaimedMessage,
+        queue_wait_ms: u64,
+        outcome: std::result::Result<IngestResponse, String>,
+    ) -> anyhow::Result<()> {
         match outcome {
             Ok(mut response) => {
                 let rejected_reason = response
@@ -615,11 +637,47 @@ impl MempalMcpServer {
                     })?;
             }
             Err(detail) => {
-                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
+                complete_failed_ingest_claim(queue, claim, queue_wait_ms, detail).await?;
             }
         }
 
         Ok(())
+    }
+
+    fn spawn_ingest_claim_heartbeat(
+        queue: AsyncPendingMessageStore,
+        claim_id: String,
+        worker_id: &str,
+    ) -> (
+        tokio::sync::oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let heartbeat_worker_id = worker_id.to_string();
+        let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let heartbeat = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(INGEST_HEARTBEAT_INTERVAL);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        if let Err(error) = queue.refresh_heartbeat(claim_id.clone(), heartbeat_worker_id.clone()).await {
+                            tracing::warn!(error = %error, claim_id = %claim_id, "failed to refresh async ingest heartbeat");
+                            break;
+                        }
+                    }
+                    _ = &mut stop_rx => break,
+                }
+            }
+        });
+        (stop_tx, heartbeat)
+    }
+
+    async fn stop_ingest_claim_heartbeat(
+        stop_tx: tokio::sync::oneshot::Sender<()>,
+        heartbeat: tokio::task::JoinHandle<()>,
+    ) {
+        let _ = stop_tx.send(());
+        let _ = heartbeat.await;
     }
 
     async fn run_prepared_ingest_off_runtime(
@@ -846,6 +904,96 @@ impl MempalMcpServer {
                 return Ok(None);
             }
             tokio::time::sleep(poll_interval).await;
+        }
+    }
+
+    #[doc(hidden)]
+    pub async fn wait_for_operation_status_with_scoped_worker(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+        poll_interval: Duration,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        let timeout = clamp_wait_timeout(timeout);
+        let deadline = Instant::now() + timeout;
+        let worker_id = format!(
+            "mcp-ingest-scoped-wait-{:x}-{:x}",
+            std::process::id(),
+            Arc::as_ptr(&self.ingest_worker_started) as usize
+        );
+        let queue = self.async_queue.clone();
+
+        loop {
+            let response = self.operation_status_json_for_test(operation_id).await?;
+            if response
+                .state
+                .map(IngestOperationState::is_terminal)
+                .unwrap_or(false)
+            {
+                return Ok(Some(response));
+            }
+            if timeout.is_zero() || Instant::now() >= deadline {
+                return Ok(None);
+            }
+
+            match queue
+                .claim_by_id_and_kind(
+                    worker_id.clone(),
+                    INGEST_CLAIM_TTL_SECS,
+                    operation_id.to_string(),
+                    INGEST_ASYNC_KIND.to_string(),
+                )
+                .await
+            {
+                Ok(Some(claim)) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        queue.release_claim(claim).await.map_err(|error| {
+                            ErrorData::internal_error(
+                                format!("failed to release timed-out scoped ingest claim: {error}"),
+                                None,
+                            )
+                        })?;
+                        return Ok(None);
+                    }
+
+                    let process =
+                        self.process_ingest_claim_inline(&queue, &worker_id, claim.clone());
+                    tokio::pin!(process);
+                    tokio::select! {
+                        result = &mut process => {
+                            result.map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("scoped async ingest worker failed: {error}"),
+                                    None,
+                                )
+                            })?;
+                        }
+                        _ = tokio::time::sleep(remaining) => {
+                            queue.release_claim(claim).await.map_err(|error| {
+                                ErrorData::internal_error(
+                                    format!("failed to release timed-out scoped ingest claim: {error}"),
+                                    None,
+                                )
+                            })?;
+                            return Ok(None);
+                        }
+                    }
+                }
+                Ok(None) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Ok(None);
+                    }
+                    tokio::time::sleep(poll_interval.min(remaining)).await;
+                }
+                Err(error) => {
+                    return Err(ErrorData::internal_error(
+                        format!("scoped async ingest worker claim failed: {error}"),
+                        None,
+                    ));
+                }
+            }
         }
     }
 
@@ -4158,25 +4306,26 @@ impl MempalMcpServer {
         };
 
         if wait {
-            let scoped_worker =
+            let operation_id = queued_response
+                .operation_id
+                .as_deref()
+                .expect("queued receipt must include operation id");
+            let wait_result =
                 if matches!(worker_mode, IngestWaitWorkerMode::Scoped) && wait_timeout_secs > 0 {
-                    Some(self.spawn_scoped_ingest_drain_worker())
+                    self.wait_for_operation_status_with_scoped_worker(
+                        operation_id,
+                        Duration::from_secs(wait_timeout_secs),
+                        Duration::from_millis(150),
+                    )
+                    .await
                 } else {
-                    None
+                    self.wait_for_operation_status(
+                        operation_id,
+                        Duration::from_secs(wait_timeout_secs),
+                        Duration::from_millis(150),
+                    )
+                    .await
                 };
-            let wait_result = self
-                .wait_for_operation_status(
-                    queued_response
-                        .operation_id
-                        .as_deref()
-                        .expect("queued receipt must include operation id"),
-                    Duration::from_secs(wait_timeout_secs),
-                    Duration::from_millis(150),
-                )
-                .await;
-            if let Some(worker) = scoped_worker {
-                worker.shutdown_and_drain().await;
-            }
             if let Some(final_response) = wait_result? {
                 return Ok(Json(final_response));
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -387,6 +387,21 @@ impl MempalMcpServer {
         self.spawn_ingest_drain_worker();
     }
 
+    #[doc(hidden)]
+    pub fn spawn_scoped_ingest_drain_worker(&self) -> IngestDrainWorkerHandle {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let worker = self.clone();
+        let handle = tokio::spawn(async move {
+            worker
+                .run_ingest_drain_worker_until_shutdown(shutdown_rx)
+                .await;
+        });
+        IngestDrainWorkerHandle {
+            shutdown_tx,
+            handle,
+        }
+    }
+
     async fn supervise_ingest_drain_worker(self) {
         let mut restart_backoff_ms = INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS;
         loop {
@@ -415,6 +430,60 @@ impl MempalMcpServer {
             restart_backoff_ms = restart_backoff_ms
                 .saturating_mul(2)
                 .min(INGEST_DRAIN_RESTART_BACKOFF_MAX_MS);
+        }
+    }
+
+    async fn run_ingest_drain_worker_until_shutdown(
+        self,
+        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ) {
+        let worker_id = format!(
+            "mcp-ingest-scoped-worker-{:x}-{:x}",
+            std::process::id(),
+            Arc::as_ptr(&self.ingest_worker_started) as usize
+        );
+        let queue = self.async_queue.clone();
+
+        loop {
+            if *shutdown_rx.borrow() {
+                break;
+            }
+
+            match queue
+                .claim_next_by_kind(
+                    worker_id.clone(),
+                    INGEST_CLAIM_TTL_SECS,
+                    INGEST_ASYNC_KIND.to_string(),
+                )
+                .await
+            {
+                Ok(Some(claim)) => {
+                    if let Err(error) = self.process_ingest_claim(&queue, &worker_id, claim).await {
+                        tracing::warn!(error = %error, "scoped async ingest worker failed to process op");
+                    }
+                }
+                Ok(None) => {
+                    tokio::select! {
+                        result = shutdown_rx.changed() => {
+                            if result.is_err() || *shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
+                        _ = tokio::time::sleep(INGEST_POLL_INTERVAL) => {}
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "scoped async ingest worker claim failed");
+                    tokio::select! {
+                        result = shutdown_rx.changed() => {
+                            if result.is_err() || *shutdown_rx.borrow() {
+                                break;
+                            }
+                        }
+                        _ = tokio::time::sleep(INGEST_POLL_INTERVAL) => {}
+                    }
+                }
+            }
         }
     }
 
@@ -1425,6 +1494,27 @@ const INGEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const INGEST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS: u64 = 250;
 const INGEST_DRAIN_RESTART_BACKOFF_MAX_MS: u64 = 5_000;
+
+#[doc(hidden)]
+pub struct IngestDrainWorkerHandle {
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl IngestDrainWorkerHandle {
+    #[doc(hidden)]
+    pub fn request_shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    #[doc(hidden)]
+    pub async fn shutdown_and_drain(self) {
+        self.request_shutdown();
+        if let Err(error) = self.handle.await {
+            tracing::warn!(error = %error, "scoped async ingest worker did not shut down cleanly");
+        }
+    }
+}
 
 struct IngestDrainWorkerStartedGuard {
     started: Arc<AtomicBool>,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -382,6 +382,11 @@ impl MempalMcpServer {
         });
     }
 
+    #[doc(hidden)]
+    pub fn ensure_ingest_drain_worker_started(&self) {
+        self.spawn_ingest_drain_worker();
+    }
+
     async fn supervise_ingest_drain_worker(self) {
         let mut restart_backoff_ms = INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS;
         loop {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1495,6 +1495,12 @@ const INGEST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS: u64 = 250;
 const INGEST_DRAIN_RESTART_BACKOFF_MAX_MS: u64 = 5_000;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IngestWaitWorkerMode {
+    Background,
+    Scoped,
+}
+
 #[doc(hidden)]
 pub struct IngestDrainWorkerHandle {
     shutdown_tx: tokio::sync::watch::Sender<bool>,
@@ -3986,6 +3992,30 @@ impl MempalMcpServer {
         request: IngestRequest,
         controls: IngestControls,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        self.mempal_ingest_with_controls_and_worker(
+            request,
+            controls,
+            IngestWaitWorkerMode::Background,
+        )
+        .await
+    }
+
+    #[doc(hidden)]
+    pub async fn mempal_ingest_with_controls_scoped_worker(
+        &self,
+        request: IngestRequest,
+        controls: IngestControls,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        self.mempal_ingest_with_controls_and_worker(request, controls, IngestWaitWorkerMode::Scoped)
+            .await
+    }
+
+    async fn mempal_ingest_with_controls_and_worker(
+        &self,
+        request: IngestRequest,
+        controls: IngestControls,
+        worker_mode: IngestWaitWorkerMode,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let dry_run = request.dry_run.unwrap_or(false);
         if !dry_run && global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
@@ -3997,7 +4027,6 @@ impl MempalMcpServer {
                 error.as_ref(),
             ));
         }
-        self.spawn_ingest_drain_worker();
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
         let room = request.room.as_deref();
         // Snapshot the request-wide warnings once so every early-return path reports a
@@ -4009,6 +4038,9 @@ impl MempalMcpServer {
             .await?;
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
+        if matches!(worker_mode, IngestWaitWorkerMode::Background) {
+            self.spawn_ingest_drain_worker();
+        }
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
@@ -4126,7 +4158,13 @@ impl MempalMcpServer {
         };
 
         if wait {
-            if let Some(final_response) = self
+            let scoped_worker =
+                if matches!(worker_mode, IngestWaitWorkerMode::Scoped) && wait_timeout_secs > 0 {
+                    Some(self.spawn_scoped_ingest_drain_worker())
+                } else {
+                    None
+                };
+            let wait_result = self
                 .wait_for_operation_status(
                     queued_response
                         .operation_id
@@ -4135,12 +4173,34 @@ impl MempalMcpServer {
                     Duration::from_secs(wait_timeout_secs),
                     Duration::from_millis(150),
                 )
-                .await?
-            {
+                .await;
+            if let Some(worker) = scoped_worker {
+                worker.shutdown_and_drain().await;
+            }
+            if let Some(final_response) = wait_result? {
                 return Ok(Json(final_response));
             }
 
-            let mut timed_out_response = queued_response;
+            let mut timed_out_response = if matches!(worker_mode, IngestWaitWorkerMode::Scoped) {
+                let refreshed = self
+                    .operation_status_json_for_test(
+                        queued_response
+                            .operation_id
+                            .as_deref()
+                            .expect("queued receipt must include operation id"),
+                    )
+                    .await?;
+                if refreshed
+                    .state
+                    .map(IngestOperationState::is_terminal)
+                    .unwrap_or(false)
+                {
+                    return Ok(Json(refreshed));
+                }
+                refreshed
+            } else {
+                queued_response
+            };
             timed_out_response.timed_out = true;
             return Ok(Json(timed_out_response));
         }

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -10,6 +10,7 @@ use mempal::core::queue::PendingMessageStore;
 use mempal::daemon_bootstrap::DaemonContext;
 use mempal::hook::{CapturedHookEnvelope, HookEvent};
 use mockito::Server;
+use serde_json::json;
 use tempfile::TempDir;
 
 fn mempal_bin() -> String {
@@ -45,6 +46,78 @@ log_path = "{}"
     )
     .expect("write config");
     (tmp, db_path, config_path)
+}
+
+fn prepared_ingest_payload(content: &str) -> String {
+    serde_json::to_string(&json!({
+        "request": {
+            "content": content,
+            "wing": "daemon",
+            "room": "ingest-async",
+            "source": "daemon-lifecycle-test",
+            "source_type": "user_explicit",
+            "confidence": 0.9,
+            "project_id": null,
+            "supersedes": null,
+            "replace_text": null,
+            "valid_from": null,
+            "valid_until": null,
+            "dry_run": false,
+            "wait": false,
+            "wait_timeout_secs": null,
+            "diary_rollup": false,
+            "importance": 0,
+            "memory_kind": "evidence",
+            "domain": "project",
+            "field": "general",
+            "is_pinned": false,
+            "provenance": null,
+            "statement": null,
+            "tier": null,
+            "status": null,
+            "supporting_refs": null,
+            "counterexample_refs": null,
+            "teaching_refs": null,
+            "verification_refs": null,
+            "scope_constraints": null,
+            "trigger_hints": null,
+            "anchor_kind": null,
+            "anchor_id": null,
+            "parent_anchor_id": null,
+            "cwd": null
+        },
+        "controls": {
+            "no_gate": false,
+            "bypass_novelty": false
+        },
+        "project_id": null,
+        "scrubbed_content": content,
+        "source_type": "user_explicit",
+        "confidence": 0.9,
+        "metadata": {
+            "memory_kind": "evidence",
+            "domain": "project",
+            "field": "general",
+            "is_pinned": false,
+            "anchor_kind": "global",
+            "anchor_id": "general",
+            "parent_anchor_id": null,
+            "provenance": null,
+            "statement": null,
+            "tier": null,
+            "status": null,
+            "supporting_refs": [],
+            "counterexample_refs": [],
+            "teaching_refs": [],
+            "verification_refs": [],
+            "scope_constraints": null,
+            "trigger_hints": null
+        },
+        "superseded_drawer_id": null,
+        "raw_turn": false,
+        "drawer_importance": 0
+    }))
+    .expect("serialize prepared ingest payload")
 }
 
 #[cfg(unix)]
@@ -448,6 +521,60 @@ fn test_daemon_reap_keeps_single_pidfile_process() -> Result<()> {
     child.kill()?;
     child.wait()?;
     Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn test_daemon_processes_ingest_async_queue_rows() {
+    let (tmp, db_path, _config_path) = setup_daemon_home();
+    let _cleanup = DaemonHomeCleanup {
+        db_path: db_path.clone(),
+    };
+    let store = PendingMessageStore::new(&db_path).expect("store");
+    let operation_id = store
+        .enqueue(
+            "ingest_async",
+            &prepared_ingest_payload("daemon consumes queued ingest_async row"),
+        )
+        .expect("enqueue async ingest");
+
+    let mut child = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut completed = false;
+    while Instant::now() < deadline {
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation status")
+            .expect("operation record exists");
+        if record.op_state == "completed" {
+            completed = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+    assert_eq!(rc, 0, "failed to send SIGTERM");
+    let status = child.wait().expect("wait child");
+    assert!(
+        status.success(),
+        "daemon must exit cleanly after SIGTERM: {status:?}"
+    );
+
+    assert!(
+        completed,
+        "daemon must claim and complete ingest_async operations"
+    );
+    let db = Database::open(&db_path).expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
 }
 
 #[cfg(unix)]

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -1,9 +1,12 @@
+mod common;
+
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use common::harness::embed_mock::start as start_embed_mock;
 use mempal::bootstrap_events::BootstrapEvent;
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
@@ -118,6 +121,44 @@ fn prepared_ingest_payload(content: &str) -> String {
         "drawer_importance": 0
     }))
     .expect("serialize prepared ingest payload")
+}
+
+fn write_openai_daemon_config(
+    config_path: &std::path::Path,
+    db_path: &std::path::Path,
+    log_path: &std::path::Path,
+    base_url: &str,
+) {
+    fs::write(
+        config_path,
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "openai_compat"
+api_model = "test-embed"
+base_url = "{base_url}"
+dim = 4
+
+[embed.openai_compat]
+base_url = "{base_url}"
+model = "test-embed"
+dim = 4
+request_timeout_secs = 5
+
+[hooks]
+enabled = true
+daemon_poll_interval_ms = 100
+
+[daemon]
+log_path = "{}"
+"#,
+            db_path.display(),
+            log_path.display()
+        ),
+    )
+    .expect("write openai daemon config");
 }
 
 #[cfg(unix)]
@@ -561,6 +602,7 @@ fn test_daemon_processes_ingest_async_queue_rows() {
         std::thread::sleep(Duration::from_millis(100));
     }
 
+    // SAFETY: this test owns the foreground daemon child process.
     let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
     assert_eq!(rc, 0, "failed to send SIGTERM");
     let status = child.wait().expect("wait child");
@@ -575,6 +617,105 @@ fn test_daemon_processes_ingest_async_queue_rows() {
     );
     let db = Database::open(&db_path).expect("open db");
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_daemon_sigterm_drains_running_ingest_async_before_reclaim() {
+    let (tmp, db_path, config_path) = setup_daemon_home();
+    let _cleanup = DaemonHomeCleanup {
+        db_path: db_path.clone(),
+    };
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    handle.pause();
+    write_openai_daemon_config(
+        &config_path,
+        &db_path,
+        &tmp.path().join(".mempal/daemon.log"),
+        &format!("http://{addr}/v1"),
+    );
+
+    let store = PendingMessageStore::new(&db_path).expect("store");
+    let operation_id = store
+        .enqueue(
+            "ingest_async",
+            &prepared_ingest_payload("daemon drains active ingest_async row"),
+        )
+        .expect("enqueue async ingest");
+
+    let mut child = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation status")
+            .expect("operation record exists");
+        if record.op_state == "running" {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let running = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load running status")
+        .expect("operation record exists");
+    assert_eq!(running.op_state, "running");
+
+    // SAFETY: this test owns the foreground daemon child process.
+    let rc = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+    assert_eq!(rc, 0, "failed to send SIGTERM");
+    assert!(
+        !wait_for_child_exit(&mut child, Duration::from_millis(300)),
+        "daemon must not exit while the active ingest_async claim is mid-ingest"
+    );
+
+    handle.resume();
+    let status = child.wait().expect("wait child");
+    handle.shutdown().await;
+    assert!(
+        status.success(),
+        "daemon must exit cleanly after draining active ingest: {status:?}"
+    );
+
+    let completed = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load completed status")
+        .expect("operation record exists");
+    assert_eq!(completed.op_state, "completed");
+    let db = Database::open(&db_path).expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
+
+    let mut restarted = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("restart daemon");
+    std::thread::sleep(Duration::from_millis(300));
+    // SAFETY: this test owns the restarted foreground daemon child process.
+    let rc = unsafe { libc::kill(restarted.id() as i32, libc::SIGTERM) };
+    assert_eq!(rc, 0, "failed to stop restarted daemon");
+    let restart_status = restarted.wait().expect("wait restarted daemon");
+    assert!(
+        restart_status.success(),
+        "restarted daemon must exit cleanly: {restart_status:?}"
+    );
+    let db = Database::open(&db_path).expect("open db after restart");
+    assert_eq!(
+        db.drawer_count().expect("drawer count after restart"),
+        1,
+        "completed async ingest must not be reprocessed after restart"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -107,6 +107,50 @@ fn test_enqueue_then_claim_returns_same_payload() {
 }
 
 #[test]
+fn test_claim_by_id_and_kind_claims_only_target_message() {
+    let (_tmp, _db_path, store) = new_store();
+
+    let hook_id = store
+        .enqueue("hook_event", r#"{"tool":"Bash"}"#)
+        .expect("enqueue hook");
+    let first_ingest_id = store
+        .enqueue("ingest_async", r#"{"content":"first"}"#)
+        .expect("enqueue first ingest");
+    let second_ingest_id = store
+        .enqueue("ingest_async", r#"{"content":"second"}"#)
+        .expect("enqueue second ingest");
+
+    assert!(
+        store
+            .claim_by_id_and_kind("worker-wrong-kind", 60, &hook_id, "ingest_async")
+            .expect("wrong-kind target claim")
+            .is_none(),
+        "targeted claim must not claim a row with a different kind"
+    );
+
+    let targeted = store
+        .claim_by_id_and_kind("worker-target", 60, &second_ingest_id, "ingest_async")
+        .expect("targeted claim")
+        .expect("targeted message");
+    assert_eq!(targeted.id, second_ingest_id);
+    assert_eq!(targeted.kind, "ingest_async");
+    assert_eq!(targeted.payload, r#"{"content":"second"}"#);
+
+    let next_ingest = store
+        .claim_next_by_kind("worker-next", 60, "ingest_async")
+        .expect("claim next ingest")
+        .expect("remaining ingest");
+    assert_eq!(next_ingest.id, first_ingest_id);
+
+    let next_any = store
+        .claim_next("worker-any", 60)
+        .expect("claim next")
+        .expect("remaining hook");
+    assert_eq!(next_any.id, hook_id);
+    assert_eq!(next_any.kind, "hook_event");
+}
+
+#[test]
 fn test_confirm_deletes_row() {
     let (_tmp, db_path, store) = new_store();
     let id = store

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -122,6 +122,27 @@ fn spawn_cli(home: &Path, args: &[&str]) -> Child {
         .expect("spawn mempal")
 }
 
+fn wait_child_output_timeout(mut child: Child, timeout: Duration) -> Output {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if child.try_wait().expect("poll child").is_some() {
+            return child.wait_with_output().expect("collect child output");
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .expect("collect timed-out child output");
+            panic!(
+                "child did not exit within {timeout:?}; stdout={}, stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
 fn prepared_ingest_payload(content: &str, wing: &str, room: Option<&str>) -> String {
     serde_json::to_string(&json!({
         "request": {
@@ -505,7 +526,7 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_wait_json_timeout_drains_active_scoped_worker_before_exit() {
+async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let _config = write_config(home.path(), &format!("http://{addr}/v1"));
@@ -566,26 +587,57 @@ async fn test_ingest_wait_json_timeout_drains_active_scoped_worker_before_exit()
         .expect("operation record exists");
     assert_eq!(running.op_state, "running");
 
-    tokio::time::sleep(Duration::from_millis(1300)).await;
+    let output = wait_child_output_timeout(child, Duration::from_secs(4));
     assert!(
-        child.try_wait().expect("poll ingest wait").is_none(),
-        "ingest --stdin --wait must not exit while its scoped worker is mid-ingest"
-    );
-
-    handle.resume();
-    let output = child.wait_with_output().expect("wait ingest child");
-    handle.shutdown().await;
-
-    assert!(
-        output.status.success(),
+        !output.status.success(),
         "stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let stdout: Value = serde_json::from_slice(&output.stdout).expect("completed ingest JSON");
-    assert_eq!(stdout["stats"]["files"], 1);
-    assert_eq!(stdout["stats"]["chunks"], 1);
-    assert_eq!(stdout["stats"]["skipped"], 0);
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("timed-out ingest JSON");
+    assert_eq!(stdout["operation_id"], operation_id);
+    assert_eq!(stdout["state"], "queued");
+    assert_eq!(stdout["timed_out"], true);
+    assert_eq!(stdout["drawer_id"], "");
+    assert!(
+        !stdout
+            .as_object()
+            .expect("ingest receipt object")
+            .contains_key("drawer_ids"),
+        "timed-out receipt must not report drawer ids: {stdout}"
+    );
+    let queued = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load queued status")
+        .expect("operation record exists");
+    assert_eq!(queued.op_state, "queued");
+
+    handle.resume();
+    let recovery = run_cli(
+        home.path(),
+        &["operation", "wait", &operation_id, "--timeout-secs", "10"],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        recovery.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&recovery.stdout),
+        String::from_utf8_lossy(&recovery.stderr)
+    );
+    let (recovery_stdout, recovery_stderr) = print_lines(&recovery);
+    assert!(
+        recovery_stdout.contains("state=completed"),
+        "{recovery_stdout}"
+    );
+    assert!(
+        recovery_stdout.contains("timed_out=false"),
+        "{recovery_stdout}"
+    );
+    assert!(
+        recovery_stderr.contains("waiting for operation_id="),
+        "{recovery_stderr}"
+    );
     let completed = PendingMessageStore::new_without_reclaim(&db_path)
         .operation_status(&operation_id)
         .expect("load completed status")
@@ -1147,7 +1199,7 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_operation_wait_timeout_drains_active_scoped_worker_before_exit() {
+async fn test_operation_wait_timeout_returns_receipt_and_requeues_claim() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
@@ -1162,7 +1214,7 @@ async fn test_operation_wait_timeout_drains_active_scoped_worker_before_exit() {
     );
 
     handle.pause();
-    let mut child = spawn_cli(
+    let child = spawn_cli(
         home.path(),
         &["operation", "wait", &operation_id, "--timeout-secs", "1"],
     );
@@ -1184,26 +1236,51 @@ async fn test_operation_wait_timeout_drains_active_scoped_worker_before_exit() {
         .expect("operation record exists");
     assert_eq!(running.op_state, "running");
 
-    tokio::time::sleep(Duration::from_millis(1300)).await;
+    let output = wait_child_output_timeout(child, Duration::from_secs(4));
     assert!(
-        child.try_wait().expect("poll operation wait").is_none(),
-        "operation wait must not exit while its scoped worker is mid-ingest"
-    );
-
-    handle.resume();
-    let output = child.wait_with_output().expect("wait operation child");
-    handle.shutdown().await;
-
-    assert!(
-        output.status.success(),
+        !output.status.success(),
         "stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     let (stdout, stderr) = print_lines(&output);
-    assert!(stdout.contains("state=completed"), "{stdout}");
-    assert!(stdout.contains("timed_out=false"), "{stdout}");
+    assert!(stdout.contains("operation_id="), "{stdout}");
+    assert!(stdout.contains("state=queued"), "{stdout}");
+    assert!(stdout.contains("timed_out=true"), "{stdout}");
+    assert!(stdout.contains("drawer_id="), "{stdout}");
     assert!(stderr.contains("waiting for operation_id="), "{stderr}");
+    let queued = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load queued status")
+        .expect("operation record exists");
+    assert_eq!(queued.op_state, "queued");
+
+    handle.resume();
+    let recovery = run_cli(
+        home.path(),
+        &["operation", "wait", &operation_id, "--timeout-secs", "10"],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        recovery.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&recovery.stdout),
+        String::from_utf8_lossy(&recovery.stderr)
+    );
+    let (recovery_stdout, recovery_stderr) = print_lines(&recovery);
+    assert!(
+        recovery_stdout.contains("state=completed"),
+        "{recovery_stdout}"
+    );
+    assert!(
+        recovery_stdout.contains("timed_out=false"),
+        "{recovery_stdout}"
+    );
+    assert!(
+        recovery_stderr.contains("waiting for operation_id="),
+        "{recovery_stderr}"
+    );
 
     let db = Database::open(&db_path).expect("open db");
     assert_eq!(db.drawer_count().expect("drawer count"), 1);

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -1092,9 +1092,7 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
     let _guard = ConfigOverrideGuard::install(&config_path);
-    let config = Config::load_from(&config_path).expect("load config");
     let db_path = home.path().join(".mempal/palace.db");
-    let server = MempalMcpServer::new(db_path.clone(), config).expect("create MCP server");
 
     let operation_id =
         enqueue_prepared_operation(&db_path, "wait cli content", "mcp", Some("wait"));
@@ -1113,12 +1111,10 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
     );
     tokio::time::sleep(Duration::from_millis(150)).await;
 
-    let warmup = start_worker(server.clone());
     tokio::time::sleep(Duration::from_millis(150)).await;
     handle.resume();
 
     let output = child.wait_with_output().expect("wait operation child");
-    warmup.await.expect("warmup join");
     handle.shutdown().await;
 
     assert!(

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -1137,3 +1137,66 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
         "{stderr}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_operation_wait_timeout_drains_active_scoped_worker_before_exit() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
+    let _guard = ConfigOverrideGuard::install(&config_path);
+    let db_path = home.path().join(".mempal/palace.db");
+
+    let operation_id = enqueue_prepared_operation(
+        &db_path,
+        "wait timeout drains active worker",
+        "mcp",
+        Some("wait-timeout"),
+    );
+
+    handle.pause();
+    let mut child = spawn_cli(
+        home.path(),
+        &["operation", "wait", &operation_id, "--timeout-secs", "1"],
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation status")
+            .expect("operation record exists");
+        if record.op_state == "running" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let running = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load running status")
+        .expect("operation record exists");
+    assert_eq!(running.op_state, "running");
+
+    tokio::time::sleep(Duration::from_millis(1300)).await;
+    assert!(
+        child.try_wait().expect("poll operation wait").is_none(),
+        "operation wait must not exit while its scoped worker is mid-ingest"
+    );
+
+    handle.resume();
+    let output = child.wait_with_output().expect("wait operation child");
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let (stdout, stderr) = print_lines(&output);
+    assert!(stdout.contains("state=completed"), "{stdout}");
+    assert!(stdout.contains("timed_out=false"), "{stdout}");
+    assert!(stderr.contains("waiting for operation_id="), "{stderr}");
+
+    let db = Database::open(&db_path).expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
+}

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -5,7 +5,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Mutex, MutexGuard};
-use std::thread;
 use std::time::Duration;
 
 use common::harness::embed_mock::start as start_embed_mock;
@@ -16,7 +15,7 @@ use mempal::core::types::Triple;
 use mempal::core::utils::build_triple_id;
 use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 use serde_json::json;
 use tempfile::TempDir;
@@ -111,48 +110,6 @@ fn run_cli_with_stdin(home: &Path, args: &[&str], payload: &[u8]) -> Output {
         stdin.write_all(payload).expect("write stdin payload");
     }
     child.wait_with_output().expect("wait mempal")
-}
-
-fn run_cli_with_stdin_timeout(
-    home: &Path,
-    args: &[&str],
-    payload: &[u8],
-    timeout: Duration,
-) -> Output {
-    use std::io::Write as _;
-
-    let mut child = Command::new(mempal_bin())
-        .args(args)
-        .env("HOME", home)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn mempal");
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(payload).expect("write stdin payload");
-    }
-
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_status)) => return child.wait_with_output().expect("wait mempal"),
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let output = child.wait_with_output().expect("wait killed mempal");
-                    panic!(
-                        "mempal command timed out after {:?}: args={args:?} stdout={} stderr={}",
-                        timeout,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                }
-                thread::sleep(Duration::from_millis(25));
-            }
-            Err(error) => panic!("poll mempal child failed: {error}"),
-        }
-    }
 }
 
 fn spawn_cli(home: &Path, args: &[&str]) -> Child {
@@ -267,6 +224,18 @@ fn novelty_audit_count(home: &Path) -> i64 {
             row.get::<_, i64>(0)
         })
         .expect("count novelty audit")
+}
+
+fn first_ingest_async_operation(db_path: &Path) -> Option<(String, String)> {
+    Connection::open(db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT id, op_state FROM pending_messages WHERE kind = 'ingest_async' ORDER BY created_at ASC LIMIT 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .expect("query ingest async operation")
 }
 
 fn assert_bootstrap_stderr(output: &Output) {
@@ -536,10 +505,11 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_wait_json_timeout_exits_after_receipt() {
+async fn test_ingest_wait_json_timeout_drains_active_scoped_worker_before_exit() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let _config = write_config(home.path(), &format!("http://{addr}/v1"));
+    let db_path = home.path().join(".mempal/palace.db");
     handle.pause();
 
     let payload = serde_json::json!({
@@ -548,9 +518,8 @@ async fn test_ingest_wait_json_timeout_exits_after_receipt() {
     })
     .to_string();
 
-    let output = run_cli_with_stdin_timeout(
-        home.path(),
-        &[
+    let mut child = Command::new(mempal_bin())
+        .args([
             "ingest",
             "--stdin",
             "--project",
@@ -562,29 +531,68 @@ async fn test_ingest_wait_json_timeout_exits_after_receipt() {
             "--wait-timeout-secs",
             "1",
             "--json",
-        ],
-        payload.as_bytes(),
-        Duration::from_secs(4),
+        ])
+        .env("HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn mempal");
+    {
+        use std::io::Write as _;
+
+        let mut stdin = child.stdin.take().expect("child stdin");
+        stdin
+            .write_all(payload.as_bytes())
+            .expect("write stdin payload");
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let operation_id = loop {
+        if let Some((operation_id, state)) = first_ingest_async_operation(&db_path)
+            && state == "running"
+        {
+            break operation_id;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "ingest wait worker did not claim operation"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    let running = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load running status")
+        .expect("operation record exists");
+    assert_eq!(running.op_state, "running");
+
+    tokio::time::sleep(Duration::from_millis(1300)).await;
+    assert!(
+        child.try_wait().expect("poll ingest wait").is_none(),
+        "ingest --stdin --wait must not exit while its scoped worker is mid-ingest"
     );
+
     handle.resume();
+    let output = child.wait_with_output().expect("wait ingest child");
     handle.shutdown().await;
 
     assert!(
-        !output.status.success(),
-        "timeout must preserve non-zero CLI status: stdout={}, stderr={}",
+        output.status.success(),
+        "stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let receipt: Value =
-        serde_json::from_slice(&output.stdout).expect("timed-out receipt must be JSON");
-    assert!(receipt["operation_id"].as_str().is_some());
-    assert_eq!(receipt["state"], "queued");
-    assert_eq!(receipt["timed_out"], true);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("timed out waiting for ingest operation"),
-        "{stderr}"
-    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("completed ingest JSON");
+    assert_eq!(stdout["stats"]["files"], 1);
+    assert_eq!(stdout["stats"]["chunks"], 1);
+    assert_eq!(stdout["stats"]["skipped"], 0);
+    let completed = PendingMessageStore::new_without_reclaim(&db_path)
+        .operation_status(&operation_id)
+        .expect("load completed status")
+        .expect("operation record exists");
+    assert_eq!(completed.op_state, "completed");
+    let db = Database::open(&db_path).expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- keep generic hook workers from claiming ingest_async rows
- drain ingest_async rows with explicit lifecycle ownership
- preserve bounded CLI wait timeout semantics without abandoning active claims

## Verification

- local pre-push gates passed (just/lefthook local-gates)
- exact-head CSA/Codex review PASS: 01KVJQS512K5WAGEC8BSGK54QH
- review-check passed for main...HEAD at 32559c79e7d

Fixes #494