### PR TITLE
fix(rest): redact schema-skew write failures

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::core::{
     anchor,
     config::ConfigHandle,
-    db::Database,
+    db::{Database, DbError},
     project::{ProjectSearchScope, resolve_project_id},
     remote_calls::{
         RemoteCallService, blocked_remote_endpoint_error, endpoint_policy_display_label,
@@ -29,6 +29,7 @@ use crate::core::{
 use crate::embed::global_embed_status;
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
+use crate::process_diagnostics::inspect_process_memory;
 use crate::search::{
     SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
     bm25_fallback_warning_dimension_mismatch, bm25_fallback_warning_embed_error,
@@ -54,6 +55,8 @@ pub const DEFAULT_REST_ADDR: &str = "127.0.0.1:3080";
 const HERMES_COMPAT_VERSION: &str = "mempal-hermes-compat/1";
 const REST_SEARCH_WARNING_HEADER: &str = "mempal-warnings";
 const STATUS_DB_SNAPSHOT_DEADLINE: Duration = Duration::from_secs(1);
+const REST_WRITE_RESTART_HINT: &str = "Restart the mempal daemon after upgrading so REST writes use a binary that supports this palace.db schema.";
+static REST_WRITE_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub async fn serve(listener: tokio::net::TcpListener, state: ApiState) -> std::io::Result<()> {
     serve_with_shutdown(listener, state, shutdown_signal()).await
@@ -1080,6 +1083,7 @@ async fn ingest_handler(
     State(state): State<ApiState>,
     Json(request): Json<IngestRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
+    validate_rest_write_runtime(&state.db_path)?;
     validate_ingest_request(&request)?;
     if global_embed_status().should_block_writes() {
         return Err(ApiError::new(
@@ -1102,9 +1106,9 @@ async fn process_ingest_request(
             "mempal embed backend degraded; writes are paused until recovery. Read operations remain available.",
         ));
     }
+    let db = open_rest_write_database(&db_path)?;
     let embedder: Box<dyn crate::embed::Embedder> =
         embedder_factory.build().await.map_err(internal_error)?;
-    let db = Database::open(&db_path).map_err(internal_error)?;
     let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
     let validated = validate_ingest_request(&request)?;
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
@@ -1462,9 +1466,16 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
         ),
         Err(error) => (
             StatusDbSnapshot::default(),
-            vec![status_database_snapshot_error_warning(error)],
+            vec![status_database_snapshot_error_warning(&error)],
         ),
     };
+    let mut status_warnings = status_warnings;
+    if current_executable_deleted() {
+        status_warnings.push(
+            "daemon binary has been deleted or replaced; run `mempal daemon restart` after upgrade"
+                .to_string(),
+        );
+    }
 
     Ok(Json(StatusResponse {
         drawer_count: db_snapshot.drawer_count,
@@ -1544,7 +1555,14 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
     }))
 }
 
-fn status_database_snapshot_error_warning(error: impl std::fmt::Display) -> String {
+fn status_database_snapshot_error_warning(error: &anyhow::Error) -> String {
+    if let Some(DbError::UnsupportedSchemaVersion { current, supported }) =
+        error.downcast_ref::<DbError>()
+    {
+        return format!(
+            "status database snapshot unavailable because palace.db schema {current} is newer than this daemon supports ({supported}); run `mempal daemon restart` after upgrading or install a mempal binary that supports this schema"
+        );
+    }
     let detail = crate::core::config::scrub_sensitive_text(&error.to_string());
     format!("status database snapshot unavailable; returning partial status: {detail}")
 }
@@ -1563,6 +1581,9 @@ fn current_embedding_status(snapshot: &crate::embed::EmbedHealthSnapshot) -> &'s
 struct ApiError {
     status: StatusCode,
     message: String,
+    kind: &'static str,
+    schema_skew: Option<SchemaSkew>,
+    recovery_hint: Option<&'static str>,
 }
 
 impl ApiError {
@@ -1570,19 +1591,59 @@ impl ApiError {
         Self {
             status,
             message: message.into(),
+            kind: "http_error",
+            schema_skew: None,
+            recovery_hint: None,
+        }
+    }
+
+    fn schema_skew(current: u32, supported: u32) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: format!(
+                "database schema version {current} is newer than this mempal daemon supports ({supported}); restart or upgrade the daemon before retrying REST writes"
+            ),
+            kind: "schema_skew",
+            schema_skew: Some(SchemaSkew { current, supported }),
+            recovery_hint: Some(REST_WRITE_RESTART_HINT),
+        }
+    }
+
+    fn stale_daemon() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: "mempal daemon binary has been deleted or replaced; restart the daemon before retrying REST writes".to_string(),
+            kind: "stale_daemon",
+            schema_skew: None,
+            recovery_hint: Some(REST_WRITE_RESTART_HINT),
         }
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SchemaSkew {
+    current: u32,
+    supported: u32,
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        let mut error = json!({
+            "message": self.message,
+            "status": self.status.as_u16(),
+            "kind": self.kind,
+        });
+        if let Some(schema_skew) = self.schema_skew {
+            error["schema_version"] = json!(schema_skew.current);
+            error["supported_schema_version"] = json!(schema_skew.supported);
+        }
+        if let Some(recovery_hint) = self.recovery_hint {
+            error["recovery_hint"] = json!(recovery_hint);
+        }
         (
             self.status,
             Json(json!({
-                "error": {
-                    "message": self.message,
-                    "status": self.status.as_u16(),
-                },
+                "error": error,
             })),
         )
             .into_response()
@@ -1613,6 +1674,7 @@ struct WriteQueueCounters {
 }
 
 struct WriteJob {
+    request_id: u64,
     request: IngestRequest,
     respond_to: oneshot::Sender<Result<IngestResponse, ApiError>>,
 }
@@ -1659,6 +1721,7 @@ impl WriteQueue {
 
         let (respond_to, response_rx) = oneshot::channel();
         let job = WriteJob {
+            request_id: next_rest_write_request_id(),
             request,
             respond_to,
         };
@@ -1721,7 +1784,7 @@ async fn write_worker(
     drained: Arc<Notify>,
 ) {
     while let Some(job) = receiver.recv().await {
-        let recovery_content = job.request.content.clone();
+        let log_metadata = RestWriteLogMetadata::from_request(job.request_id, &job.request);
         let result =
             process_ingest_request(db_path.clone(), Arc::clone(&embedder_factory), job.request)
                 .await;
@@ -1731,11 +1794,7 @@ async fn write_worker(
             }
             Err(error) => {
                 stats.failed.fetch_add(1, Ordering::SeqCst);
-                tracing::error!(
-                    error = %error.message,
-                    drawer_content = %recovery_content,
-                    "REST write failed; drawer content logged for manual recovery"
-                );
+                log_rest_write_failure(&log_metadata, error);
             }
         }
         stats.pending.fetch_sub(1, Ordering::SeqCst);
@@ -1744,8 +1803,96 @@ async fn write_worker(
     }
 }
 
+fn validate_rest_write_runtime(db_path: &std::path::Path) -> Result<(), ApiError> {
+    open_rest_write_database(db_path).map(|_| ())
+}
+
+fn open_rest_write_database(db_path: &std::path::Path) -> Result<Database, ApiError> {
+    if current_executable_deleted() {
+        return Err(ApiError::stale_daemon());
+    }
+    Database::open(db_path).map_err(db_error_to_api_error)
+}
+
+fn current_executable_deleted() -> bool {
+    let Ok(pid) = i32::try_from(std::process::id()) else {
+        return false;
+    };
+    inspect_process_memory(pid).exe_deleted
+}
+
+fn next_rest_write_request_id() -> u64 {
+    REST_WRITE_REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+#[derive(Debug)]
+struct RestWriteLogMetadata {
+    request_id: u64,
+    content_len: usize,
+    content_hash_prefix: String,
+    source_type: &'static str,
+}
+
+impl RestWriteLogMetadata {
+    fn from_request(request_id: u64, request: &IngestRequest) -> Self {
+        Self {
+            request_id,
+            content_len: request.content.len(),
+            content_hash_prefix: blake3::hash(request.content.as_bytes()).to_hex()[..12]
+                .to_string(),
+            source_type: request.source_type_label(),
+        }
+    }
+}
+
+impl IngestRequest {
+    fn source_type_label(&self) -> &'static str {
+        match self.source_type.as_deref() {
+            Some("user_explicit") => "user_explicit",
+            Some("agent_observation") => "agent_observation",
+            Some("agent_inference") => "agent_inference",
+            Some("system_generated") => "system_generated",
+            Some(_) => "invalid",
+            None => "unspecified",
+        }
+    }
+}
+
+fn log_rest_write_failure(metadata: &RestWriteLogMetadata, error: &ApiError) {
+    let (schema_current, schema_supported) = error
+        .schema_skew
+        .map(|schema| (Some(schema.current), Some(schema.supported)))
+        .unwrap_or((None, None));
+    tracing::error!(
+        request_id = metadata.request_id,
+        route = "/api/ingest",
+        source_type = metadata.source_type,
+        content_len = metadata.content_len,
+        content_hash_prefix = %metadata.content_hash_prefix,
+        http_status = error.status.as_u16(),
+        error_kind = error.kind,
+        schema_version = schema_current,
+        supported_schema_version = schema_supported,
+        stale_binary = current_executable_deleted(),
+        recovery_hint = error.recovery_hint.unwrap_or("inspect REST daemon logs and retry after fixing the write path"),
+        "REST write failed"
+    );
+}
+
+fn db_error_to_api_error(error: DbError) -> ApiError {
+    match error {
+        DbError::UnsupportedSchemaVersion { current, supported } => {
+            ApiError::schema_skew(current, supported)
+        }
+        other => internal_error(other),
+    }
+}
+
 fn internal_error(error: impl std::fmt::Display) -> ApiError {
-    ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+    ApiError::new(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        crate::core::config::scrub_sensitive_text(&error.to_string()),
+    )
 }
 
 fn replacement_error(error: crate::core::db::DbError) -> ApiError {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,6 +5,7 @@ use std::{env, fs, io};
 
 use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
+use serde_json::Value;
 
 use crate::core::config::{Config, ConfigHandle};
 use crate::core::db::CURRENT_SCHEMA_VERSION;
@@ -184,6 +185,8 @@ pub struct RestRouteReport {
     pub available: bool,
     pub http_status: Option<u16>,
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub degraded_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -384,6 +387,10 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
         .iter()
         .filter_map(unhealthy_rest_route_detail)
         .collect::<Vec<_>>();
+    let degraded_reasons = routes
+        .iter()
+        .flat_map(|route| route.degraded_reasons.iter().cloned())
+        .collect::<Vec<_>>();
 
     let mut warnings = Vec::new();
     let mut recommendations = Vec::new();
@@ -444,7 +451,22 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
         recommendations.push(
             "Inspect the REST daemon logs and fix the failing route handler or database/profile configuration."
                 .to_string(),
-        );
+            );
+    }
+    if endpoint_reachable && !degraded_reasons.is_empty() {
+        warnings.push(format!(
+            "REST endpoint reports degraded status: {}",
+            degraded_reasons.join("; ")
+        ));
+        if degraded_reasons
+            .iter()
+            .any(|reason| reason.starts_with("schema_skew:") || reason.starts_with("stale_daemon:"))
+        {
+            recommendations.push(
+                "Restart or upgrade the mempal daemon serving this REST endpoint, then rerun `mempal doctor rest`."
+                    .to_string(),
+            );
+        }
     }
 
     if let (Some(db_path), Some(port)) = (db_path, &port)
@@ -476,6 +498,8 @@ pub async fn build_rest_doctor_report(endpoint: &str, db_path: Option<&Path>) ->
         "routes_unhealthy"
     } else if !missing_routes.is_empty() {
         "routes_missing"
+    } else if !degraded_reasons.is_empty() {
+        "degraded"
     } else {
         "ok"
     };
@@ -683,6 +707,7 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
                     available: false,
                     http_status: None,
                     error: Some(error.to_string()),
+                    degraded_reasons: Vec::new(),
                 })
                 .collect();
         }
@@ -701,6 +726,7 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
                     available: false,
                     http_status: None,
                     error: Some("unsupported route probe method".to_string()),
+                    degraded_reasons: Vec::new(),
                 });
                 continue;
             }
@@ -709,12 +735,19 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
             Ok(response) => {
                 let status = response.status();
                 let (available, error) = classify_rest_route_probe(method, path, status);
+                let body = if *path == "/api/status" {
+                    response.text().await.ok()
+                } else {
+                    None
+                };
+                let degraded_reasons = status_route_degraded_reasons(path, status, body.as_deref());
                 reports.push(RestRouteReport {
                     method: (*method).to_string(),
                     path: (*path).to_string(),
                     available,
                     http_status: Some(status.as_u16()),
                     error,
+                    degraded_reasons,
                 });
             }
             Err(error) => reports.push(RestRouteReport {
@@ -723,10 +756,50 @@ async fn probe_rest_routes(endpoint: &str) -> Vec<RestRouteReport> {
                 available: false,
                 http_status: None,
                 error: Some(error.to_string()),
+                degraded_reasons: Vec::new(),
             }),
         }
     }
     reports
+}
+
+fn status_route_degraded_reasons(
+    path: &str,
+    status: reqwest::StatusCode,
+    body: Option<&str>,
+) -> Vec<String> {
+    if path != "/api/status" || !status.is_success() {
+        return Vec::new();
+    }
+    let Some(body) = body else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return Vec::new();
+    };
+    value
+        .get("status_warnings")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(rest_degraded_reason_from_status_warning)
+        .collect()
+}
+
+fn rest_degraded_reason_from_status_warning(warning: &str) -> String {
+    let safe = crate::core::config::scrub_sensitive_text(warning);
+    let lower = safe.to_ascii_lowercase();
+    if lower.contains("schema") && lower.contains("newer than") {
+        format!("schema_skew: {safe}")
+    } else if lower.contains("daemon binary")
+        || lower.contains("deleted or replaced")
+        || lower.contains("stale daemon")
+    {
+        format!("stale_daemon: {safe}")
+    } else {
+        format!("status_warning: {safe}")
+    }
 }
 
 fn classify_rest_route_probe(

--- a/src/main.rs
+++ b/src/main.rs
@@ -19448,6 +19448,9 @@ fn print_rest_doctor_plain(report: &RestDoctorReport) {
         if let Some(error) = route.error.as_deref() {
             println!("    error={error}");
         }
+        for reason in &route.degraded_reasons {
+            println!("    degraded_reason={reason}");
+        }
     }
     for warning in &report.warnings {
         println!("warning: {warning}");

--- a/tests/doctor_rest.rs
+++ b/tests/doctor_rest.rs
@@ -276,6 +276,94 @@ fn test_doctor_rest_reports_server_error_routes_as_unhealthy() {
 }
 
 #[test]
+fn test_doctor_rest_surfaces_status_schema_skew_warning_as_degraded() {
+    let home = temp_home();
+    let mut server = Server::new();
+    let _status = server
+        .mock("GET", "/api/status")
+        .with_status(200)
+        .with_body(
+            r#"{"status_warnings":["status database snapshot unavailable because palace.db schema 20 is newer than this daemon supports (19); run `mempal daemon restart` after upgrading"]}"#,
+        )
+        .create();
+    let _search = server
+        .mock("GET", "/api/search")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _ingest = server
+        .mock("POST", "/api/ingest")
+        .match_body(Matcher::PartialJson(serde_json::json!({})))
+        .with_status(422)
+        .with_body(r#"{"error":"missing field `content`"}"#)
+        .create();
+    let _timeline = server
+        .mock("GET", "/api/timeline")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+    let _pinned = server
+        .mock("GET", "/api/pinned_facts")
+        .match_query(Matcher::Any)
+        .with_status(200)
+        .with_body("[]")
+        .create();
+
+    let output = run_doctor_rest(&home, &["--addr", &server.url(), "--format", "json"]);
+
+    assert!(
+        output.status.success(),
+        "doctor rest failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).expect("doctor rest json");
+    if cfg!(feature = "rest") {
+        assert_eq!(report["status"], "degraded");
+    }
+    assert_eq!(report["endpoint_reachable"], true);
+    let status_route = report["routes"]
+        .as_array()
+        .expect("routes")
+        .iter()
+        .find(|route| route["method"] == "GET" && route["path"] == "/api/status")
+        .expect("status route");
+    assert_eq!(status_route["available"], true);
+    assert!(
+        status_route["degraded_reasons"]
+            .as_array()
+            .expect("degraded reasons")
+            .iter()
+            .any(|reason| reason
+                .as_str()
+                .is_some_and(|reason| reason.starts_with("schema_skew:"))),
+        "status route should expose schema skew: {report:#}"
+    );
+    assert!(
+        report["warnings"]
+            .as_array()
+            .expect("warnings")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("schema_skew"))),
+        "warnings should mention schema skew: {report:#}"
+    );
+    assert!(
+        report["recommendations"]
+            .as_array()
+            .expect("recommendations")
+            .iter()
+            .any(|recommendation| recommendation
+                .as_str()
+                .is_some_and(|recommendation| recommendation.contains("Restart or upgrade"))),
+        "recommendations should point to restart/upgrade: {report:#}"
+    );
+}
+
+#[test]
 fn test_doctor_rest_distinguishes_daemon_not_running_from_missing_rest_feature() {
     let home = temp_home();
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "rest")]
 
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -13,7 +14,7 @@ use mempal::api::ApiState;
 #[cfg(feature = "db-test-seam")]
 use mempal::core::AsyncDb;
 use mempal::core::config::ConfigHandle;
-use mempal::core::db::Database;
+use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::core::utils::iso_timestamp;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
@@ -86,6 +87,12 @@ search_db_deadline_secs = {api_search_deadline_secs}
 
     fn db(&self) -> Database {
         Database::open(&self.db_path).expect("open db")
+    }
+
+    fn force_future_schema(&self) {
+        let conn = rusqlite::Connection::open(&self.db_path).expect("open raw sqlite");
+        conn.pragma_update(None, "user_version", CURRENT_SCHEMA_VERSION + 1)
+            .expect("set future schema version");
     }
 
     fn state(&self, factory: Arc<dyn EmbedderFactory>) -> ApiState {
@@ -166,6 +173,42 @@ impl EmbedderFactory for BuildFailFactory {
     async fn build(&self) -> Result<Box<dyn Embedder>, EmbedError> {
         Err(EmbedError::Runtime("embedder unavailable".to_string()))
     }
+}
+
+struct LogCapture {
+    buffer: Arc<StdMutex<Vec<u8>>>,
+}
+
+impl Write for LogCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("log mutex poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn install_log_capture() -> (Arc<StdMutex<Vec<u8>>>, tracing::dispatcher::DefaultGuard) {
+    let logs = Arc::new(StdMutex::new(Vec::new()));
+    let writer_logs = Arc::clone(&logs);
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_writer(move || LogCapture {
+            buffer: Arc::clone(&writer_logs),
+        })
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (logs, guard)
+}
+
+fn captured_logs(logs: &Arc<StdMutex<Vec<u8>>>) -> String {
+    String::from_utf8(logs.lock().expect("log mutex poisoned").clone()).expect("utf8 logs")
 }
 
 #[derive(Clone)]
@@ -256,6 +299,142 @@ async fn post_json(state: ApiState, uri: &str, body: Value) -> (StatusCode, Valu
         .expect("read body");
     let body = serde_json::from_slice(&bytes).expect("parse json");
     (status, body)
+}
+
+#[tokio::test]
+async fn test_ingest_rejects_future_schema_without_leaking_content() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    env.force_future_schema();
+    let (logs, _log_guard) = install_log_capture();
+    let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+    let secret = "REST_SCHEMA_SKEW_SECRET_503_DO_NOT_LEAK";
+
+    let (status, body) = post_json(
+        state,
+        "/api/ingest",
+        json!({
+            "content": format!("write should be rejected before queueing {secret}"),
+            "wing": "test",
+            "room": "schema",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "body={body}");
+    let rendered = serde_json::to_string(&body).expect("serialize body");
+    assert!(rendered.contains("schema_skew"), "{rendered}");
+    assert!(rendered.contains("restart"), "{rendered}");
+    assert!(rendered.contains("supported_schema_version"), "{rendered}");
+    assert!(!rendered.contains(secret), "{rendered}");
+    let logs = captured_logs(&logs);
+    assert!(!logs.contains(secret), "{logs}");
+    assert!(!logs.contains("drawer_content"), "{logs}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_worker_schema_skew_log_uses_metadata_not_drawer_content() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    let (logs, _log_guard) = install_log_capture();
+    let started = Arc::new(Notify::new());
+    let released = Arc::new(Notify::new());
+    let has_started = Arc::new(AtomicBool::new(false));
+    let state = env.state(Arc::new(BlockingEmbedderFactory {
+        started: Arc::clone(&started),
+        released: Arc::clone(&released),
+        has_started: Arc::clone(&has_started),
+    }));
+
+    let first = tokio::spawn({
+        let state = state.clone();
+        async move {
+            post_json(
+                state,
+                "/api/ingest",
+                json!({
+                    "content": "first queued write blocks the worker",
+                    "wing": "test",
+                    "room": "schema",
+                }),
+            )
+            .await
+        }
+    });
+
+    while !has_started.load(Ordering::SeqCst) {
+        started.notified().await;
+    }
+
+    let secret = "WORKER_SCHEMA_SKEW_SECRET_503_DO_NOT_LEAK";
+    let second = tokio::spawn({
+        let state = state.clone();
+        async move {
+            post_json(
+                state,
+                "/api/ingest",
+                json!({
+                    "content": format!("second write should fail after enqueue {secret}"),
+                    "wing": "test",
+                    "room": "schema",
+                }),
+            )
+            .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !second.is_finished(),
+        "second write should be queued behind the blocking first write"
+    );
+
+    env.force_future_schema();
+    released.notify_waiters();
+
+    let (first_status, first_body) = first.await.expect("join first write");
+    assert_eq!(first_status, StatusCode::CREATED, "body={first_body}");
+    let (second_status, second_body) = second.await.expect("join second write");
+    assert_eq!(
+        second_status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "body={second_body}"
+    );
+    let rendered = serde_json::to_string(&second_body).expect("serialize body");
+    assert!(rendered.contains("schema_skew"), "{rendered}");
+    assert!(!rendered.contains(secret), "{rendered}");
+
+    let logs = captured_logs(&logs);
+    assert!(logs.contains("REST write failed"), "{logs}");
+    assert!(logs.contains("content_len"), "{logs}");
+    assert!(logs.contains("content_hash_prefix"), "{logs}");
+    assert!(logs.contains("schema_skew"), "{logs}");
+    assert!(!logs.contains(secret), "{logs}");
+    assert!(!logs.contains("drawer_content"), "{logs}");
+    assert!(!logs.contains("manual recovery"), "{logs}");
+}
+
+#[tokio::test]
+async fn test_status_reports_schema_skew_restart_warning() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    env.force_future_schema();
+    let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+
+    let (status, _headers, body) = get_json(state, "/api/status").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let warnings = body["status_warnings"].as_array().expect("status warnings");
+    assert!(
+        warnings.iter().any(|warning| {
+            warning.as_str().is_some_and(|warning| {
+                warning.contains("palace.db schema")
+                    && warning.contains("newer than this daemon supports")
+                    && warning.contains("mempal daemon restart")
+            })
+        }),
+        "status warnings should surface schema skew: {body:#}"
+    );
+    assert_eq!(body["drawer_count"].as_i64(), Some(0));
 }
 
 fn insert_search_drawer(db: &Database) {

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "69e4ee298d6cb33dc8bdcafe51158ccf9294e986"
+commit = "c25cd80d42f0411eaa86efc00bee9c037de3e037"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- reject stale-daemon/schema-skew REST writes with restart-oriented guidance
- avoid logging raw drawer content on write failures
- surface degraded stale-daemon/schema-skew signals in status/doctor paths

## Verification

- local pre-push gates passed (just/lefthook local-gates)
- exact-head CSA/Codex review PASS: 01KVJZWZAN37QR25YH30CX2KHN
- review-check passed for main...HEAD at bea14c10ef3

Fixes #503