### PR TITLE
fix(daemon): enforce singleton writer leases

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -5085,6 +5085,24 @@ impl Database {
         Ok(renewed)
     }
 
+    pub fn runtime_writer_lease_is_active(
+        &self,
+        name: &str,
+        owner: &str,
+        session_id: &str,
+    ) -> Result<bool, DbError> {
+        self.runtime_writer_lease_cleanup_expired()?;
+        let active = self.conn.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM runtime_writer_leases
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3
+             )",
+            params![name, owner, session_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(active != 0)
+    }
+
     pub fn runtime_writer_lease_release(
         &self,
         name: &str,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -29,8 +29,8 @@ use super::{
         KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink, KnowledgeEvidenceRole,
         KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, NeighborChunk, Provenance,
         ReindexSource, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-        RuntimeAdoptionTrack, SleepStats, SourceType, TaxonomyEntry, Triple, TripleStats,
-        TunnelDrawer, TunnelEndpoint, TunnelFollowResult,
+        RuntimeAdoptionTrack, RuntimeWriterLease, SleepStats, SourceType, TaxonomyEntry, Triple,
+        TripleStats, TunnelDrawer, TunnelEndpoint, TunnelFollowResult,
     },
     utils::{
         build_drawer_id, build_scoped_drawer_id, build_tunnel_id, current_timestamp,
@@ -40,7 +40,7 @@ use super::{
 use crate::ingest::gating::GatingDecision;
 use crate::ingest::novelty::NoveltyAction;
 
-pub const CURRENT_SCHEMA_VERSION: u32 = 19;
+pub const CURRENT_SCHEMA_VERSION: u32 = 20;
 pub const CURRENT_VECTOR_INDEX_VERSION: &str = "v2";
 pub const VECTOR_DISTANCE_METRIC: &str = "cosine";
 /// SQLite page cache budget for issue #311's large-DB stale reindex path.
@@ -58,6 +58,35 @@ const CONTENT_HASH_BACKFILL_BATCH: usize = 1_000;
 
 fn content_hash_hex(content: &str) -> String {
     blake3::hash(content.as_bytes()).to_hex().to_string()
+}
+
+fn runtime_writer_session_id(name: &str, owner: &str) -> String {
+    let now_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(name.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(owner.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(std::process::id().to_string().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(now_nanos.to_string().as_bytes());
+    hasher.finalize().to_hex()[..16].to_string()
+}
+
+#[cfg(target_os = "linux")]
+fn runtime_boot_id() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn runtime_boot_id() -> Option<String> {
+    None
 }
 
 fn truncate_preview(content: &str, max_chars: usize) -> String {
@@ -4844,6 +4873,23 @@ impl Database {
         Ok(total)
     }
 
+    fn with_immediate_tx<T, F>(&self, work: F) -> Result<T, DbError>
+    where
+        F: FnOnce() -> Result<T, DbError>,
+    {
+        self.conn.execute_batch("BEGIN IMMEDIATE")?;
+        match work() {
+            Ok(value) => {
+                self.conn.execute_batch("COMMIT")?;
+                Ok(value)
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
     // --- Lease coordination ---
 
     pub fn lease_acquire(
@@ -4963,6 +5009,156 @@ impl Database {
     pub fn lease_cleanup_expired(&self) -> Result<usize, DbError> {
         let rows = self.conn.execute(
             "DELETE FROM leases WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now')",
+            [],
+        )?;
+        Ok(rows)
+    }
+
+    // --- Runtime writer lease coordination ---
+
+    pub fn runtime_writer_lease_acquire(
+        &self,
+        name: &str,
+        owner: &str,
+        mode: &str,
+        ttl_secs: u64,
+        metadata_json: Option<&str>,
+    ) -> Result<Option<RuntimeWriterLease>, DbError> {
+        let mut session_id = String::new();
+        let mut acquired = false;
+        self.with_immediate_tx(|| {
+            self.runtime_writer_lease_cleanup_expired_tx()?;
+            session_id = runtime_writer_session_id(name, owner);
+            let now = crate::cowork::peek::format_rfc3339(SystemTime::now());
+            let expires_at =
+                crate::cowork::peek::format_rfc3339(SystemTime::now() + std::time::Duration::from_secs(ttl_secs));
+            let rows = self.conn.execute(
+                "INSERT OR IGNORE INTO runtime_writer_leases \
+                 (name, owner, pid, boot_id, session_id, acquired_at, expires_at, heartbeat_at, mode, metadata_json) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?6, ?8, ?9)",
+                params![
+                    name,
+                    owner,
+                    std::process::id() as i64,
+                    runtime_boot_id(),
+                    &session_id,
+                    &now,
+                    &expires_at,
+                    mode,
+                    metadata_json
+                ],
+            )?;
+            acquired = rows > 0;
+            Ok(())
+        })?;
+        if acquired {
+            self.runtime_writer_lease_status(Some(name))
+                .map(|mut leases| leases.pop())
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn runtime_writer_lease_renew(
+        &self,
+        name: &str,
+        owner: &str,
+        session_id: &str,
+        ttl_secs: u64,
+    ) -> Result<bool, DbError> {
+        let mut renewed = false;
+        self.with_immediate_tx(|| {
+            self.runtime_writer_lease_cleanup_expired_tx()?;
+            let now = crate::cowork::peek::format_rfc3339(SystemTime::now());
+            let expires_at = crate::cowork::peek::format_rfc3339(
+                SystemTime::now() + std::time::Duration::from_secs(ttl_secs),
+            );
+            let rows = self.conn.execute(
+                "UPDATE runtime_writer_leases \
+                 SET expires_at = ?4, heartbeat_at = ?5 \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![name, owner, session_id, &expires_at, &now],
+            )?;
+            renewed = rows > 0;
+            Ok(())
+        })?;
+        Ok(renewed)
+    }
+
+    pub fn runtime_writer_lease_release(
+        &self,
+        name: &str,
+        owner: &str,
+        session_id: &str,
+    ) -> Result<bool, DbError> {
+        self.with_immediate_tx(|| {
+            let rows = self.conn.execute(
+                "DELETE FROM runtime_writer_leases \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![name, owner, session_id],
+            )?;
+            Ok(rows > 0)
+        })
+    }
+
+    pub fn runtime_writer_lease_status(
+        &self,
+        name: Option<&str>,
+    ) -> Result<Vec<RuntimeWriterLease>, DbError> {
+        self.runtime_writer_lease_cleanup_expired()?;
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0);
+        let collect_row = |row: &rusqlite::Row| -> rusqlite::Result<RuntimeWriterLease> {
+            let expires_at: String = row.get(6)?;
+            let remaining_secs = crate::cowork::peek::parse_rfc3339(&expires_at)
+                .map(|expires| (expires - now_secs).max(0))
+                .unwrap_or(0);
+            let pid_i64: i64 = row.get(2)?;
+            Ok(RuntimeWriterLease {
+                name: row.get(0)?,
+                owner: row.get(1)?,
+                pid: u32::try_from(pid_i64).unwrap_or(0),
+                boot_id: row.get(3)?,
+                session_id: row.get(4)?,
+                acquired_at: row.get(5)?,
+                expires_at,
+                heartbeat_at: row.get(7)?,
+                mode: row.get(8)?,
+                metadata_json: row.get(9)?,
+                remaining_secs,
+            })
+        };
+        let mut leases = Vec::new();
+        if let Some(name) = name {
+            let mut stmt = self.conn.prepare(
+                "SELECT name, owner, pid, boot_id, session_id, acquired_at, expires_at, heartbeat_at, mode, metadata_json \
+                 FROM runtime_writer_leases WHERE name = ?1",
+            )?;
+            for row in stmt.query_map([name], collect_row)? {
+                leases.push(row?);
+            }
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT name, owner, pid, boot_id, session_id, acquired_at, expires_at, heartbeat_at, mode, metadata_json \
+                 FROM runtime_writer_leases ORDER BY name ASC",
+            )?;
+            for row in stmt.query_map([], collect_row)? {
+                leases.push(row?);
+            }
+        }
+        Ok(leases)
+    }
+
+    pub fn runtime_writer_lease_cleanup_expired(&self) -> Result<usize, DbError> {
+        self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx())
+    }
+
+    fn runtime_writer_lease_cleanup_expired_tx(&self) -> Result<usize, DbError> {
+        let rows = self.conn.execute(
+            "DELETE FROM runtime_writer_leases \
+             WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now')",
             [],
         )?;
         Ok(rows)
@@ -6281,6 +6477,27 @@ CREATE INDEX IF NOT EXISTS idx_foresights_validity
     ON foresights(valid_from, valid_until);
 "#;
 
+const V20_MIGRATION_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS runtime_writer_leases (
+    name TEXT NOT NULL PRIMARY KEY,
+    owner TEXT NOT NULL,
+    pid INTEGER NOT NULL,
+    boot_id TEXT,
+    session_id TEXT NOT NULL,
+    acquired_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_at TEXT NOT NULL,
+    heartbeat_at TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    metadata_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_writer_leases_expires
+    ON runtime_writer_leases(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_runtime_writer_leases_mode
+    ON runtime_writer_leases(mode);
+"#;
+
 const V12_COMPACTION_SCHEMA_SQL: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_drawers_compacted_into
     ON drawers(compacted_into)
@@ -6439,6 +6656,10 @@ fn migrations() -> &'static [Migration] {
         Migration {
             version: 19,
             sql: V19_MIGRATION_SQL,
+        },
+        Migration {
+            version: 20,
+            sql: V20_MIGRATION_SQL,
         },
     ];
     MIGRATIONS

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -841,6 +841,22 @@ pub struct LeaseInfo {
     pub remaining_secs: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeWriterLease {
+    pub name: String,
+    pub owner: String,
+    pub pid: u32,
+    pub boot_id: Option<String>,
+    pub session_id: String,
+    pub acquired_at: String,
+    pub expires_at: String,
+    pub heartbeat_at: String,
+    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_json: Option<String>,
+    pub remaining_secs: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cowork/bus.rs
+++ b/src/cowork/bus.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use crate::core::{
     db::{Database, DbError},
-    types::{BootstrapEvidenceArgs, Drawer, SourceType},
+    types::{BootstrapEvidenceArgs, Drawer, RuntimeWriterLease, SourceType},
     utils::{build_bootstrap_evidence_drawer_id, current_timestamp},
 };
 
@@ -74,6 +74,21 @@ pub enum BusError {
     UnsupportedCaptureSource(String),
     #[error("capture execute requires an open database")]
     MissingCaptureDatabase,
+    #[error("capture execute requires an active SQLite writer lease")]
+    MissingCaptureWriterLease,
+    #[error("failed to verify SQLite writer lease `{lease_name}` before {operation}")]
+    CaptureWriterLeaseVerify {
+        operation: &'static str,
+        lease_name: String,
+        #[source]
+        source: DbError,
+    },
+    #[error("SQLite writer lease `{lease_name}` for {owner} was lost before {operation}")]
+    CaptureWriterLeaseLost {
+        operation: &'static str,
+        lease_name: String,
+        owner: String,
+    },
     #[error("invalid timestamp `{0}`: expected RFC3339")]
     InvalidTimestamp(String),
     #[error("unknown delivery message id `{0}`")]
@@ -1031,6 +1046,7 @@ pub fn build_handoff_summary(
 
 pub fn capture_handoff_to_memory(
     db: Option<&Database>,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     mempal_home: &Path,
     cwd: &Path,
     request: CoworkCaptureRequest,
@@ -1071,6 +1087,9 @@ pub fn capture_handoff_to_memory(
     );
     if request.execute {
         let db = db.ok_or(BusError::MissingCaptureDatabase)?;
+        let runtime_writer_lease =
+            runtime_writer_lease.ok_or(BusError::MissingCaptureWriterLease)?;
+        ensure_capture_writer_lease_active(db, runtime_writer_lease, "capture cowork handoff")?;
         let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
             id: drawer_id.clone(),
             content: content.clone(),
@@ -1093,6 +1112,29 @@ pub fn capture_handoff_to_memory(
         source: "handoff".to_string(),
         content,
     })
+}
+
+fn ensure_capture_writer_lease_active(
+    db: &Database,
+    lease: &RuntimeWriterLease,
+    operation: &'static str,
+) -> Result<(), BusError> {
+    let active = db
+        .runtime_writer_lease_is_active(&lease.name, &lease.owner, &lease.session_id)
+        .map_err(|source| BusError::CaptureWriterLeaseVerify {
+            operation,
+            lease_name: lease.name.clone(),
+            source,
+        })?;
+    if active {
+        Ok(())
+    } else {
+        Err(BusError::CaptureWriterLeaseLost {
+            operation,
+            lease_name: lease.name.clone(),
+            owner: lease.owner.clone(),
+        })
+    }
 }
 
 pub fn send(mempal_home: &Path, cwd: &Path, request: SendRequest) -> Result<SendReport, BusError> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -272,6 +272,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         config: Arc::clone(&context.config),
         mempal_home: context.mempal_home.clone(),
         write_observer: context.write_observer.clone(),
+        runtime_writer_lease: Some(writer_lease.lease().clone()),
         #[cfg(test)]
         idle_observer: None,
     };
@@ -492,6 +493,33 @@ fn format_runtime_writer_leases(leases: &[RuntimeWriterLease]) -> String {
         .join("; ")
 }
 
+fn ensure_daemon_runtime_writer_lease_active(
+    db: &Database,
+    lease: Option<&RuntimeWriterLease>,
+    operation: &'static str,
+) -> Result<()> {
+    let Some(lease) = lease else {
+        return Ok(());
+    };
+    let active = db
+        .runtime_writer_lease_is_active(&lease.name, &lease.owner, &lease.session_id)
+        .with_context(|| {
+            format!(
+                "failed to verify daemon writer lease `{}` before {operation}",
+                lease.name
+            )
+        })?;
+    if active {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "SQLite writer lease `{}` for {} was lost before {operation}",
+            lease.name,
+            lease.owner
+        )
+    }
+}
+
 fn spawn_daemon_ingest_drain_worker(
     context: &DaemonContext,
     db_path: &Path,
@@ -522,6 +550,7 @@ struct HookWorkerState {
     config: Arc<crate::core::config::Config>,
     mempal_home: PathBuf,
     write_observer: crate::daemon_bootstrap::DaemonWriteObserver,
+    runtime_writer_lease: Option<RuntimeWriterLease>,
     #[cfg(test)]
     idle_observer: Option<Arc<Notify>>,
 }
@@ -695,6 +724,7 @@ async fn process_hook_worker_message(
             llm_gate: state.llm_gate.as_ref(),
             config: state.config.as_ref(),
             mempal_home: &state.mempal_home,
+            runtime_writer_lease: state.runtime_writer_lease.as_ref(),
         },
     )
     .await;
@@ -1175,6 +1205,7 @@ pub struct DaemonIngestContext<'a> {
     pub llm_gate: Option<&'a HookLlmGateRuntime>,
     pub config: &'a crate::core::config::Config,
     pub mempal_home: &'a Path,
+    pub runtime_writer_lease: Option<&'a RuntimeWriterLease>,
 }
 
 struct DrawerIngestContext<'a, E: Embedder + ?Sized> {
@@ -1221,8 +1252,16 @@ pub async fn process_claimed_message_with_embedder<E: Embedder + ?Sized>(
         let envelope = envelope.clone();
         let config = (*context.config).clone();
         let mempal_home = context.mempal_home.to_path_buf();
-        db.run_write_anyhow(move |db| build_drawer_records(db, &envelope, &config, &mempal_home))
-            .await?
+        let runtime_writer_lease = context.runtime_writer_lease.cloned();
+        db.run_write_anyhow(move |db| {
+            ensure_daemon_runtime_writer_lease_active(
+                db,
+                runtime_writer_lease.as_ref(),
+                "build daemon hook drawer records",
+            )?;
+            build_drawer_records(db, &envelope, &config, &mempal_home)
+        })
+        .await?
     };
     let drawer_context = DrawerIngestContext {
         db,
@@ -1454,8 +1493,14 @@ async fn auto_ingest_hermes_session_end<E: Embedder + ?Sized>(
         }));
     }
 
+    let runtime_writer_lease = context.runtime_writer_lease.cloned();
     let insert_stats = db
         .run_write_anyhow(move |db| {
+            ensure_daemon_runtime_writer_lease_active(
+                db,
+                runtime_writer_lease.as_ref(),
+                "insert Hermes turns",
+            )?;
             crate::xurl::store::insert_turns(db.conn(), &kept_turns)
                 .context("failed to insert gated Hermes turns")
         })
@@ -1471,6 +1516,7 @@ async fn auto_ingest_hermes_session_end<E: Embedder + ?Sized>(
         &turn_ids,
         &vector_fingerprint,
         context.config,
+        context.runtime_writer_lease,
         Some(&embed_heartbeat),
     )
     .await
@@ -1491,6 +1537,7 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
     turn_ids: &[String],
     fingerprint: &str,
     config: &crate::core::config::Config,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     heartbeat: Option<&HeartbeatCallback>,
 ) -> Result<usize> {
     let mut embedded = 0usize;
@@ -1550,8 +1597,14 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
 
         let fingerprint = fingerprint.to_string();
         let dim = i64::try_from(embedder.dimensions()).unwrap_or(i64::MAX);
+        let runtime_writer_lease = runtime_writer_lease.cloned();
         let rows_written = db
             .run_write_anyhow(move |db| {
+                ensure_daemon_runtime_writer_lease_active(
+                    db,
+                    runtime_writer_lease.as_ref(),
+                    "insert Hermes turn vectors",
+                )?;
                 let conn = db.conn();
                 conn.execute_batch("BEGIN IMMEDIATE")?;
                 let write = (|| -> rusqlite::Result<usize> {
@@ -1635,6 +1688,7 @@ async fn gate_automatic_hermes_turn<E: Embedder + ?Sized>(
     {
         record_gating_audit_async(
             db,
+            context.runtime_writer_lease,
             input.candidate_hash,
             decision,
             input.project_id.map(ToOwned::to_owned),
@@ -1665,6 +1719,7 @@ async fn gate_automatic_hermes_turn<E: Embedder + ?Sized>(
         {
             record_gating_audit_async(
                 db,
+                context.runtime_writer_lease,
                 input.candidate_hash,
                 &decision,
                 input.project_id.map(ToOwned::to_owned),
@@ -1692,13 +1747,20 @@ async fn gate_automatic_hermes_turn<E: Embedder + ?Sized>(
             .unwrap_or_else(|| llm_decision.clone());
         record_gating_audit_async(
             db,
+            context.runtime_writer_lease,
             input.candidate_hash,
             &audit_decision,
             input.project_id.map(ToOwned::to_owned),
             (!audit_decision.is_rejected()).then_some(candidate.content.as_str()),
         )
         .await?;
-        record_llm_verdict_async(db, input.candidate_hash, &llm_decision).await?;
+        record_llm_verdict_async(
+            db,
+            context.runtime_writer_lease,
+            input.candidate_hash,
+            &llm_decision,
+        )
+        .await?;
         return Ok(!llm_decision.is_rejected());
     }
 
@@ -1708,6 +1770,7 @@ async fn gate_automatic_hermes_turn<E: Embedder + ?Sized>(
     let keep = !decision.is_rejected();
     record_gating_audit_async(
         db,
+        context.runtime_writer_lease,
         input.candidate_hash,
         &decision,
         input.project_id.map(ToOwned::to_owned),
@@ -2143,6 +2206,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     {
         record_gating_audit_async(
             context.db,
+            context.daemon.runtime_writer_lease,
             &drawer_id,
             decision,
             record.project_id.clone(),
@@ -2214,6 +2278,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         {
             record_gating_audit_async(
                 context.db,
+                context.daemon.runtime_writer_lease,
                 &drawer_id,
                 &decision,
                 record.project_id.clone(),
@@ -2240,13 +2305,20 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             .unwrap_or_else(|| llm_decision.clone());
         record_gating_audit_async(
             context.db,
+            context.daemon.runtime_writer_lease,
             &drawer_id,
             &audit_decision,
             record.project_id.clone(),
             (!audit_decision.is_rejected()).then_some(candidate.content.as_str()),
         )
         .await?;
-        record_llm_verdict_async(context.db, &drawer_id, &llm_decision).await?;
+        record_llm_verdict_async(
+            context.db,
+            context.daemon.runtime_writer_lease,
+            &drawer_id,
+            &llm_decision,
+        )
+        .await?;
         gating_audit_recorded = true;
         if llm_decision.is_rejected() {
             return Ok(drawer_id);
@@ -2256,6 +2328,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
     if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
         record_gating_audit_async(
             context.db,
+            context.daemon.runtime_writer_lease,
             &drawer_id,
             decision,
             record.project_id.clone(),
@@ -2276,12 +2349,19 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
         }
     };
     if record.bypass_novelty {
-        insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
-            .await?;
+        insert_drawer_with_vector_async(
+            context.db,
+            context.daemon.runtime_writer_lease,
+            &drawer_id,
+            record.clone(),
+            vector.clone(),
+        )
+        .await?;
         persist_deferred_raw_payload(&record)?;
         enqueue_llm_gating_after_durable_insert(
             context.db,
             context.store,
+            context.daemon.runtime_writer_lease,
             context.daemon.config,
             &gating_decision,
             &drawer_id,
@@ -2309,21 +2389,31 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             if novelty.should_audit {
                 record_novelty_audit_async(
                     context.db,
-                    &drawer_id,
-                    NoveltyAction::Insert,
-                    novelty.near_drawer_id.clone(),
-                    novelty.cosine,
-                    novelty.audit_decision.map(ToOwned::to_owned),
-                    record.project_id.clone(),
+                    context.daemon.runtime_writer_lease,
+                    DaemonNoveltyAudit {
+                        drawer_id: &drawer_id,
+                        action: NoveltyAction::Insert,
+                        near_drawer_id: novelty.near_drawer_id.as_deref(),
+                        cosine: novelty.cosine,
+                        audit_decision: novelty.audit_decision,
+                        project_id: record.project_id.as_deref(),
+                    },
                 )
                 .await?;
             }
-            insert_drawer_with_vector_async(context.db, &drawer_id, record.clone(), vector.clone())
-                .await?;
+            insert_drawer_with_vector_async(
+                context.db,
+                context.daemon.runtime_writer_lease,
+                &drawer_id,
+                record.clone(),
+                vector.clone(),
+            )
+            .await?;
             persist_deferred_raw_payload(&record)?;
             enqueue_llm_gating_after_durable_insert(
                 context.db,
                 context.store,
+                context.daemon.runtime_writer_lease,
                 context.daemon.config,
                 &gating_decision,
                 &drawer_id,
@@ -2336,12 +2426,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             if novelty.should_audit {
                 record_novelty_audit_async(
                     context.db,
-                    &drawer_id,
-                    NoveltyAction::Drop,
-                    novelty.near_drawer_id.clone(),
-                    novelty.cosine,
-                    novelty.audit_decision.map(ToOwned::to_owned),
-                    record.project_id.clone(),
+                    context.daemon.runtime_writer_lease,
+                    DaemonNoveltyAudit {
+                        drawer_id: &drawer_id,
+                        action: NoveltyAction::Drop,
+                        near_drawer_id: novelty.near_drawer_id.as_deref(),
+                        cosine: novelty.cosine,
+                        audit_decision: novelty.audit_decision,
+                        project_id: record.project_id.as_deref(),
+                    },
                 )
                 .await?;
             }
@@ -2399,16 +2492,20 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
             if capped {
                 record_novelty_audit_async(
                     context.db,
-                    &drawer_id,
-                    NoveltyAction::Insert,
-                    Some(target_id),
-                    novelty.cosine,
-                    Some("insert_due_to_merge_cap".to_string()),
-                    record.project_id.clone(),
+                    context.daemon.runtime_writer_lease,
+                    DaemonNoveltyAudit {
+                        drawer_id: &drawer_id,
+                        action: NoveltyAction::Insert,
+                        near_drawer_id: Some(target_id.as_str()),
+                        cosine: novelty.cosine,
+                        audit_decision: Some("insert_due_to_merge_cap"),
+                        project_id: record.project_id.as_deref(),
+                    },
                 )
                 .await?;
                 insert_drawer_with_vector_async(
                     context.db,
+                    context.daemon.runtime_writer_lease,
                     &drawer_id,
                     record.clone(),
                     vector.clone(),
@@ -2418,6 +2515,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                 enqueue_llm_gating_after_durable_insert(
                     context.db,
                     context.store,
+                    context.daemon.runtime_writer_lease,
                     context.daemon.config,
                     &gating_decision,
                     &drawer_id,
@@ -2443,16 +2541,20 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         );
                         record_novelty_audit_async(
                             context.db,
-                            &drawer_id,
-                            NoveltyAction::Insert,
-                            Some(target_id),
-                            novelty.cosine,
-                            Some("insert_due_to_embed_error".to_string()),
-                            record.project_id.clone(),
+                            context.daemon.runtime_writer_lease,
+                            DaemonNoveltyAudit {
+                                drawer_id: &drawer_id,
+                                action: NoveltyAction::Insert,
+                                near_drawer_id: Some(target_id.as_str()),
+                                cosine: novelty.cosine,
+                                audit_decision: Some("insert_due_to_embed_error"),
+                                project_id: record.project_id.as_deref(),
+                            },
                         )
                         .await?;
                         insert_drawer_with_vector_async(
                             context.db,
+                            context.daemon.runtime_writer_lease,
                             &drawer_id,
                             record.clone(),
                             vector.clone(),
@@ -2462,6 +2564,7 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                         enqueue_llm_gating_after_durable_insert(
                             context.db,
                             context.store,
+                            context.daemon.runtime_writer_lease,
                             context.daemon.config,
                             &gating_decision,
                             &drawer_id,
@@ -2475,9 +2578,15 @@ async fn ingest_drawer_record<E: Embedder + ?Sized>(
                 let target_id_for_merge = target_id.clone();
                 let audit_decision = novelty.audit_decision.map(ToOwned::to_owned);
                 let project_id = record.project_id.clone();
+                let runtime_writer_lease = context.daemon.runtime_writer_lease.cloned();
                 context
                     .db
                     .run_write_anyhow(move |db| {
+                        ensure_daemon_runtime_writer_lease_active(
+                            db,
+                            runtime_writer_lease.as_ref(),
+                            "merge daemon hook drawer",
+                        )?;
                         db.update_drawer_after_merge_and_record_novelty_audit(
                             &target_id_for_merge,
                             &merged_content,
@@ -2611,6 +2720,7 @@ fn audit_decision_with_llm_outcome(
 
 async fn record_llm_verdict_async(
     db: &AsyncDb,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     drawer_id: &str,
     decision: &GatingDecision,
 ) -> Result<()> {
@@ -2622,7 +2732,13 @@ async fn record_llm_verdict_async(
     }
     .to_string();
     let score = decision.score.map(f64::from);
+    let runtime_writer_lease = runtime_writer_lease.cloned();
     db.run_write_anyhow(move |db| {
+        ensure_daemon_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease.as_ref(),
+            "record daemon LLM verdict",
+        )?;
         db.upsert_llm_verdict_by_candidate_hash(&drawer_id, &verdict, score)
             .with_context(|| format!("failed to record LLM verdict {}", drawer_id))?;
         Ok(())
@@ -2631,8 +2747,9 @@ async fn record_llm_verdict_async(
 }
 
 async fn enqueue_llm_gating_after_durable_insert(
-    _db: &AsyncDb,
+    db: &AsyncDb,
     store: &AsyncPendingMessageStore,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     config: &crate::core::config::Config,
     gating_decision: &Option<GatingDecision>,
     drawer_id: &str,
@@ -2641,6 +2758,15 @@ async fn enqueue_llm_gating_after_durable_insert(
     if !should_enqueue_llm_gating(config, gating_decision) {
         return Ok(());
     }
+    let runtime_writer_lease = runtime_writer_lease.cloned();
+    db.run_write_anyhow(move |db| {
+        ensure_daemon_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease.as_ref(),
+            "enqueue daemon LLM gating task",
+        )
+    })
+    .await?;
 
     let system_prompt = config
         .ingest_gating
@@ -2670,6 +2796,7 @@ async fn enqueue_llm_gating_after_durable_insert(
 
 async fn record_gating_audit_async(
     db: &AsyncDb,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     drawer_id: &str,
     decision: &GatingDecision,
     project_id: Option<String>,
@@ -2678,7 +2805,13 @@ async fn record_gating_audit_async(
     let drawer_id = drawer_id.to_string();
     let decision = decision.clone();
     let content = content.map(str::to_string);
+    let runtime_writer_lease = runtime_writer_lease.cloned();
     db.run_write_anyhow(move |db| {
+        ensure_daemon_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease.as_ref(),
+            "record daemon gating audit",
+        )?;
         db.record_gating_audit(
             &drawer_id,
             &decision,
@@ -2691,17 +2824,33 @@ async fn record_gating_audit_async(
     .await
 }
 
+struct DaemonNoveltyAudit<'a> {
+    drawer_id: &'a str,
+    action: NoveltyAction,
+    near_drawer_id: Option<&'a str>,
+    cosine: Option<f32>,
+    audit_decision: Option<&'a str>,
+    project_id: Option<&'a str>,
+}
+
 async fn record_novelty_audit_async(
     db: &AsyncDb,
-    drawer_id: &str,
-    action: NoveltyAction,
-    near_drawer_id: Option<String>,
-    cosine: Option<f32>,
-    audit_decision: Option<String>,
-    project_id: Option<String>,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
+    audit: DaemonNoveltyAudit<'_>,
 ) -> Result<()> {
-    let drawer_id = drawer_id.to_string();
+    let drawer_id = audit.drawer_id.to_string();
+    let near_drawer_id = audit.near_drawer_id.map(str::to_string);
+    let audit_decision = audit.audit_decision.map(str::to_string);
+    let project_id = audit.project_id.map(str::to_string);
+    let action = audit.action;
+    let cosine = audit.cosine;
+    let runtime_writer_lease = runtime_writer_lease.cloned();
     db.run_write_anyhow(move |db| {
+        ensure_daemon_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease.as_ref(),
+            "record daemon novelty audit",
+        )?;
         db.record_novelty_audit(
             &drawer_id,
             action,
@@ -2718,13 +2867,22 @@ async fn record_novelty_audit_async(
 
 async fn insert_drawer_with_vector_async(
     db: &AsyncDb,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
     drawer_id: &str,
     record: DrawerRecord,
     vector: Vec<f32>,
 ) -> Result<()> {
     let drawer_id = drawer_id.to_string();
-    db.run_write_anyhow(move |db| insert_drawer_with_vector(db, &drawer_id, &record, &vector))
-        .await
+    let runtime_writer_lease = runtime_writer_lease.cloned();
+    db.run_write_anyhow(move |db| {
+        ensure_daemon_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease.as_ref(),
+            "insert daemon hook drawer",
+        )?;
+        insert_drawer_with_vector(db, &drawer_id, &record, &vector)
+    })
+    .await
 }
 
 fn insert_drawer_with_vector(
@@ -3995,6 +4153,7 @@ mod tests {
                 config: Arc::new(config),
                 mempal_home,
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: Some(Arc::clone(&idle_observer)),
             },
             60,
@@ -4080,6 +4239,131 @@ mod tests {
         fn name(&self) -> &str {
             "static-test"
         }
+    }
+
+    #[tokio::test]
+    async fn test_hook_worker_stops_before_drawer_write_after_writer_lease_loss() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let mempal_home = tmp.path().join(".mempal");
+        std::fs::create_dir_all(&mempal_home).expect("create mempal home");
+        let db = Database::open(&db_path).expect("open db");
+        let async_db = AsyncDb::open(&db_path, 4).expect("open async db");
+        let store = PendingMessageStore::new(&db_path).expect("store");
+        let async_store = AsyncPendingMessageStore::from_store(store.clone());
+        let lease = db
+            .runtime_writer_lease_acquire(
+                super::SQLITE_WRITER_LEASE_NAME,
+                "daemon-lease-loss-test",
+                "daemon",
+                300,
+                None,
+            )
+            .expect("acquire daemon writer lease")
+            .expect("lease acquired");
+
+        let hook_payload = serde_json::json!({
+            "tool_name": "Bash",
+            "input": "printf lease-lost",
+            "output": "this hook must not become durable",
+            "exit_code": 0
+        })
+        .to_string();
+        let envelope = CapturedHookEnvelope {
+            event: HookEvent::PostToolUse.display_name().to_string(),
+            kind: HookEvent::PostToolUse.queue_kind().to_string(),
+            agent: "codex".to_string(),
+            captured_at: "2026-05-01T12:34:56Z".to_string(),
+            claude_cwd: tmp.path().to_string_lossy().to_string(),
+            payload: Some(hook_payload.clone()),
+            payload_path: None,
+            payload_preview: None,
+            original_size_bytes: hook_payload.len(),
+            truncated: false,
+        };
+        let payload = serde_json::to_string(&envelope).expect("serialize envelope");
+        store
+            .enqueue(HookEvent::PostToolUse.queue_kind(), &payload)
+            .expect("enqueue hook envelope");
+        let message = async_store
+            .claim_next("lease-loss-worker".to_string(), 60)
+            .await
+            .expect("claim hook")
+            .expect("queued hook claimed");
+
+        assert!(
+            db.runtime_writer_lease_release(&lease.name, &lease.owner, &lease.session_id)
+                .expect("release daemon writer lease"),
+            "test must force the daemon writer lease to be lost"
+        );
+
+        super::process_hook_worker_message(
+            HookWorkerState {
+                async_db,
+                store: async_store,
+                worker_id: "lease-loss-worker".to_string(),
+                embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
+                    StaticEmbedder,
+                ))),
+                prototype_classifier: Arc::new(ArcSwap::from_pointee(None)),
+                llm_gate: None,
+                config: Arc::new(Config::default()),
+                mempal_home,
+                write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: Some(lease),
+                idle_observer: None,
+            },
+            message.clone(),
+            60,
+        )
+        .await;
+
+        let drawer_count: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM drawers", [], |row| row.get(0))
+            .expect("count drawers");
+        let vector_count: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'drawer_vectors'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("check drawer_vectors table");
+        let vector_count = if vector_count == 0 {
+            0
+        } else {
+            db.conn()
+                .query_row("SELECT COUNT(*) FROM drawer_vectors", [], |row| row.get(0))
+                .expect("count drawer vectors")
+        };
+        let gating_audit_count: i64 = db
+            .conn()
+            .query_row("SELECT COUNT(*) FROM gating_audit", [], |row| row.get(0))
+            .expect("count gating audit");
+        assert_eq!(drawer_count, 0, "lost lease must stop drawer writes");
+        assert_eq!(vector_count, 0, "lost lease must stop vector writes");
+        assert_eq!(
+            gating_audit_count, 0,
+            "lost lease must stop audit writes before drawer ingest"
+        );
+
+        let (status, retry_count, last_error): (String, i64, Option<String>) = db
+            .conn()
+            .query_row(
+                "SELECT status, retry_count, last_error FROM pending_messages WHERE id = ?1",
+                [message.id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("query queue row");
+        assert_eq!(status, "pending");
+        assert_eq!(retry_count, 1);
+        assert!(
+            last_error
+                .as_deref()
+                .is_some_and(|error| error.contains("lost before build daemon hook drawer records")),
+            "queue failure must record lease loss: {last_error:?}"
+        );
     }
 
     struct HeartbeatProbeEmbedder {
@@ -4232,6 +4516,7 @@ mod tests {
                 config: std::sync::Arc::new(config),
                 mempal_home,
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: None,
             },
             message,
@@ -4324,6 +4609,7 @@ mod tests {
                 config: Arc::new(config),
                 mempal_home,
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: None,
             },
             message,
@@ -4462,6 +4748,7 @@ mod tests {
                 config: Arc::new(config),
                 mempal_home,
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: None,
             },
             message,
@@ -4568,6 +4855,7 @@ mod tests {
                 llm_gate: None,
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -4640,6 +4928,7 @@ mod tests {
                 llm_gate: None,
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -4752,6 +5041,7 @@ mod tests {
                 llm_gate: Some(&llm_gate),
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -4887,6 +5177,7 @@ mod tests {
                 llm_gate: Some(&llm_gate),
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -4994,6 +5285,7 @@ mod tests {
                 config: std::sync::Arc::new(config),
                 mempal_home: tmp.path().to_path_buf(),
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: None,
             },
             message.clone(),
@@ -5112,6 +5404,7 @@ mod tests {
                 llm_gate: Some(&llm_gate),
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -5235,6 +5528,7 @@ mod tests {
                 config: Arc::new(config),
                 mempal_home: tmp.path().to_path_buf(),
                 write_observer: crate::daemon_bootstrap::DaemonWriteObserver::for_test(),
+                runtime_writer_lease: None,
                 idle_observer: None,
             },
             message,
@@ -5342,6 +5636,7 @@ mod tests {
                 llm_gate: Some(&llm_gate),
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -5452,6 +5747,7 @@ mod tests {
                 llm_gate: Some(&llm_gate),
                 config: &config,
                 mempal_home: tmp.path(),
+                runtime_writer_lease: None,
             },
         )
         .await

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,7 +18,7 @@ use crate::core::{
     project::resolve_project_id,
     queue::{AsyncPendingMessageStore, ClaimedMessage, QueueFailureDisposition},
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
-    types::{BootstrapEvidenceArgs, Drawer, SourceType},
+    types::{BootstrapEvidenceArgs, Drawer, RuntimeWriterLease, SourceType},
     utils::{current_timestamp, route_room_from_taxonomy, synthetic_source_file},
 };
 use crate::embed::{
@@ -53,6 +53,9 @@ const SESSION_REVIEW_REJECTED_TOTAL_KEY: &str = "session_review.rejected.total";
 pub const DAEMON_DRAIN_BUDGET: Duration = Duration::from_secs(30);
 const DAEMON_HOOK_WORKER_LIMIT: usize = 4;
 const ENDPOINT_RECOVERY_REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
+const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
+const DAEMON_WRITER_LEASE_TTL_SECS: u64 = 120;
+const DAEMON_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     run_command_with_bootstrap_events(config_path, foreground, None)
@@ -67,11 +70,11 @@ pub fn run_command_with_bootstrap_events(
     let context =
         match DaemonContext::bootstrap_with_events(config_path, foreground, bootstrap_events) {
             Ok(context) => context,
-            // A concurrent daemon already holds the singleton lock (#257): this is
-            // a clean no-op, not a failure. Exit success without daemonizing.
+            // A concurrent daemon already holds the singleton lock (#496):
+            // fail before daemonizing or starting any workers, with owner
+            // metadata in the error for operators and scripts.
             Err(error) if error.is::<crate::daemon_singleton::DaemonAlreadyRunning>() => {
-                eprintln!("daemon already running; exiting");
-                return Ok(());
+                return Err(error);
             }
             Err(error) => return Err(error),
         };
@@ -84,6 +87,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         db.path().to_path_buf()
     };
     global_embed_status().set_audit_db_path(Some(db_path.clone()));
+    let _writer_lease = acquire_daemon_writer_lease(context, &db_path).await?;
     {
         let db = context.db.lock().await;
         db.prune_expired_audit_logs()
@@ -350,6 +354,140 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
     Ok(())
 }
 
+struct RuntimeWriterLeaseHandle {
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+    heartbeat: tokio::task::JoinHandle<()>,
+}
+
+impl RuntimeWriterLeaseHandle {
+    fn new(db_path: PathBuf, lease: RuntimeWriterLease) -> Self {
+        let heartbeat = spawn_runtime_writer_lease_heartbeat(db_path.clone(), lease.clone());
+        Self {
+            db_path,
+            lease,
+            heartbeat,
+        }
+    }
+}
+
+impl Drop for RuntimeWriterLeaseHandle {
+    fn drop(&mut self) {
+        self.heartbeat.abort();
+        if let Ok(db) = Database::open(&self.db_path) {
+            let _ = db.runtime_writer_lease_release(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            );
+        }
+    }
+}
+
+async fn acquire_daemon_writer_lease(
+    context: &DaemonContext,
+    db_path: &Path,
+) -> Result<RuntimeWriterLeaseHandle> {
+    let owner = format!("mempal-daemon-{}", std::process::id());
+    let metadata = json!({
+        "command": "daemon",
+        "db_path": db_path.to_string_lossy(),
+    })
+    .to_string();
+    let lease = {
+        let db = context.db.lock().await;
+        db.runtime_writer_lease_acquire(
+            SQLITE_WRITER_LEASE_NAME,
+            &owner,
+            "daemon",
+            DAEMON_WRITER_LEASE_TTL_SECS,
+            Some(&metadata),
+        )
+        .context("failed to acquire daemon writer lease")?
+    };
+    match lease {
+        Some(lease) => Ok(RuntimeWriterLeaseHandle::new(db_path.to_path_buf(), lease)),
+        None => {
+            let active = {
+                let db = context.db.lock().await;
+                db.runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
+                    .unwrap_or_default()
+            };
+            Err(anyhow::anyhow!(
+                "SQLite writer lease `{}` is already held: {}",
+                SQLITE_WRITER_LEASE_NAME,
+                format_runtime_writer_leases(&active)
+            ))
+        }
+    }
+}
+
+fn spawn_runtime_writer_lease_heartbeat(
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(DAEMON_WRITER_LEASE_RENEW_INTERVAL);
+        loop {
+            interval.tick().await;
+            let db_path = db_path.clone();
+            let lease_for_renew = lease.clone();
+            let result = tokio::task::spawn_blocking(move || -> Result<bool> {
+                let db =
+                    Database::open(&db_path).context("failed to open DB for writer lease renew")?;
+                db.runtime_writer_lease_renew(
+                    &lease_for_renew.name,
+                    &lease_for_renew.owner,
+                    &lease_for_renew.session_id,
+                    DAEMON_WRITER_LEASE_TTL_SECS,
+                )
+                .context("failed to renew daemon writer lease")
+            })
+            .await;
+            match result {
+                Ok(Ok(true)) => {}
+                Ok(Ok(false)) => {
+                    tracing::error!(
+                        lease = %lease.name,
+                        owner = %lease.owner,
+                        "daemon writer lease was lost; requesting shutdown"
+                    );
+                    #[cfg(unix)]
+                    request_shutdown_and_notify();
+                    break;
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(error = %error, "failed to renew daemon writer lease");
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "writer lease heartbeat task failed");
+                }
+            }
+        }
+    })
+}
+
+fn format_runtime_writer_leases(leases: &[RuntimeWriterLease]) -> String {
+    if leases.is_empty() {
+        return "none visible".to_string();
+    }
+    leases
+        .iter()
+        .map(|lease| {
+            format!(
+                "name={} owner={} pid={} mode={} expires_at={} heartbeat_at={}",
+                lease.name,
+                lease.owner,
+                lease.pid,
+                lease.mode,
+                lease.expires_at,
+                lease.heartbeat_at
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 fn spawn_daemon_ingest_drain_worker(
     context: &DaemonContext,
     db_path: &Path,
@@ -361,7 +499,8 @@ fn spawn_daemon_ingest_drain_worker(
         Arc::new(crate::embed::ConfiguredEmbedderFactory::new_for_daemon(
             config,
         )),
-    )?;
+    )?
+    .with_external_ingest_writer_lease();
     let handle = server.spawn_scoped_ingest_drain_worker();
     tracing::info!("daemon async ingest worker started");
     Ok(handle)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -87,7 +87,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         db.path().to_path_buf()
     };
     global_embed_status().set_audit_db_path(Some(db_path.clone()));
-    let _writer_lease = acquire_daemon_writer_lease(context, &db_path).await?;
+    let writer_lease = acquire_daemon_writer_lease(context, &db_path).await?;
     {
         let db = context.db.lock().await;
         db.prune_expired_audit_logs()
@@ -209,7 +209,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
         .await
         .context("failed to reclaim stale daemon claims")?;
     tracing::info!("daemon startup reclaim_stale reclaimed={reclaimed}");
-    let ingest_drain_worker = spawn_daemon_ingest_drain_worker(context, &db_path)
+    let ingest_drain_worker = spawn_daemon_ingest_drain_worker(context, &db_path, &writer_lease)
         .context("failed to start daemon async ingest worker")?;
     let stall_watchdog_handle = spawn_stall_watchdog(
         context.write_observer.clone(),
@@ -369,6 +369,10 @@ impl RuntimeWriterLeaseHandle {
             heartbeat,
         }
     }
+
+    fn lease(&self) -> &RuntimeWriterLease {
+        &self.lease
+    }
 }
 
 impl Drop for RuntimeWriterLeaseHandle {
@@ -491,6 +495,7 @@ fn format_runtime_writer_leases(leases: &[RuntimeWriterLease]) -> String {
 fn spawn_daemon_ingest_drain_worker(
     context: &DaemonContext,
     db_path: &Path,
+    writer_lease: &RuntimeWriterLeaseHandle,
 ) -> Result<crate::mcp::IngestDrainWorkerHandle> {
     let config = context.config.as_ref().clone();
     let server = crate::mcp::MempalMcpServer::new_with_factory_and_config(
@@ -500,7 +505,7 @@ fn spawn_daemon_ingest_drain_worker(
             config,
         )),
     )?
-    .with_external_ingest_writer_lease();
+    .with_external_ingest_writer_lease(writer_lease.lease().clone());
     let handle = server.spawn_scoped_ingest_drain_worker();
     tracing::info!("daemon async ingest worker started");
     Ok(handle)

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -211,19 +211,19 @@ fn bootstrap_inner(
             .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
-    // Atomic singleton gate (#257): acquire the exclusive daemon lock BEFORE
+    // Atomic singleton gate (#496): acquire the DB-scoped exclusive daemon lock BEFORE
     // daemonizing. A race loser that cannot get the lock concludes a healthy
     // daemon already holds it and returns `DaemonAlreadyRunning` so the caller
     // can exit cleanly WITHOUT daemonizing. The lock's open file description
     // survives the double-fork in `perform_daemonize`, keeping the singleton
     // guarantee through the daemon's whole lifetime.
-    let lock_guard = match crate::daemon_singleton::try_acquire(&mempal_home)
+    let mut lock_guard = match crate::daemon_singleton::try_acquire(&db_path)
         .context("failed to acquire daemon singleton lock")?
     {
         crate::daemon_singleton::DaemonLockAcquisition::Acquired(guard) => guard,
-        crate::daemon_singleton::DaemonLockAcquisition::AlreadyHeld => {
+        crate::daemon_singleton::DaemonLockAcquisition::AlreadyHeld { owner, lock_path } => {
             return Err(anyhow::Error::new(
-                crate::daemon_singleton::DaemonAlreadyRunning,
+                crate::daemon_singleton::DaemonAlreadyRunning::new(owner, Some(lock_path)),
             ));
         }
     };
@@ -231,6 +231,9 @@ fn bootstrap_inner(
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::Daemonize);
     perform_daemonize(foreground, &mempal_home, &log_path)?;
+    lock_guard
+        .refresh_metadata()
+        .context("failed to refresh daemon singleton metadata")?;
 
     // harness-point: PR0
     emit_bootstrap_event(bootstrap_events.as_ref(), BootstrapEvent::RuntimeInit);

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -24,17 +24,24 @@
 //! and is released automatically when the process dies — even on `SIGKILL`,
 //! which is precisely how an orphaned daemon's lock frees up for its successor.
 
+use std::env;
 use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(target_os = "linux")]
 use crate::db_path_identity::DbPathIdentity;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// Lock file name, written next to `daemon.pid` inside `mempal_home`.
+/// Legacy lock file name used by pre-#496 daemon builds.
 pub const DAEMON_LOCK_FILE: &str = "daemon.lock";
+pub const MEMPAL_RUNTIME_DIR_ENV: &str = "MEMPAL_RUNTIME_DIR";
+pub const DAEMON_LOCK_SUFFIX: &str = ".daemon.lock";
+pub const DAEMON_METADATA_SUFFIX: &str = ".daemon.json";
+const XDG_RUNTIME_DIR_ENV: &str = "XDG_RUNTIME_DIR";
 const MEMPAL_DB_PATH_ENV: &[u8] = b"MEMPAL_DB_PATH=";
 
 /// Sentinel error meaning a healthy daemon already holds the singleton lock.
@@ -43,9 +50,48 @@ const MEMPAL_DB_PATH_ENV: &[u8] = b"MEMPAL_DB_PATH=";
 /// can be turned into a clean success exit at the single production call site
 /// without disturbing the `Result<DaemonContext>` signature the integration
 /// tests depend on. Downcast with [`anyhow::Error::is`].
-#[derive(Debug, Error)]
-#[error("daemon already running (singleton lock held)")]
-pub struct DaemonAlreadyRunning;
+#[derive(Debug)]
+pub struct DaemonAlreadyRunning {
+    pub owner: Option<DaemonLockMetadata>,
+    pub lock_path: Option<PathBuf>,
+}
+
+impl DaemonAlreadyRunning {
+    pub fn new(owner: Option<DaemonLockMetadata>, lock_path: Option<PathBuf>) -> Self {
+        Self { owner, lock_path }
+    }
+}
+
+impl std::fmt::Display for DaemonAlreadyRunning {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "daemon already running (singleton lock held")?;
+        if let Some(lock_path) = &self.lock_path {
+            write!(formatter, ", lock={}", lock_path.display())?;
+        }
+        if let Some(owner) = &self.owner {
+            write!(
+                formatter,
+                ", owner_pid={}, boot_id={}, version={}, db_fingerprint={}, started_at_unix_ms={}",
+                owner.pid,
+                owner.boot_id.as_deref().unwrap_or("unknown"),
+                owner.binary_version,
+                owner.db_fingerprint,
+                owner.started_at_unix_ms
+            )?;
+            if let Some(path) = &owner.executable_path {
+                write!(formatter, ", executable={path}")?;
+            }
+            if owner.executable_deleted {
+                write!(formatter, ", executable_deleted=true")?;
+            }
+        } else {
+            write!(formatter, ", owner_metadata=unavailable")?;
+        }
+        write!(formatter, ")")
+    }
+}
+
+impl std::error::Error for DaemonAlreadyRunning {}
 
 #[derive(Debug, Error)]
 pub enum DaemonLockError {
@@ -63,7 +109,32 @@ pub enum DaemonLockAcquisition {
     /// This process now exclusively owns the daemon lock.
     Acquired(DaemonLockGuard),
     /// A healthy daemon already holds the lock; the caller must NOT daemonize.
-    AlreadyHeld,
+    AlreadyHeld {
+        owner: Option<DaemonLockMetadata>,
+        lock_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonLockMetadata {
+    pub pid: u32,
+    pub boot_id: Option<String>,
+    pub binary_version: String,
+    pub db_path: String,
+    pub db_fingerprint: String,
+    pub profile: Option<String>,
+    pub started_at_unix_ms: u64,
+    pub executable_path: Option<String>,
+    pub executable_deleted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonLockPaths {
+    pub runtime_dir: PathBuf,
+    pub lock_path: PathBuf,
+    pub metadata_path: PathBuf,
+    pub db_path: PathBuf,
+    pub db_fingerprint: String,
 }
 
 /// RAII guard holding the daemon singleton lock for the process lifetime.
@@ -76,44 +147,296 @@ pub enum DaemonLockAcquisition {
 pub struct DaemonLockGuard {
     _file: File,
     path: PathBuf,
+    metadata_path: PathBuf,
+    metadata: DaemonLockMetadata,
 }
 
 impl DaemonLockGuard {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    pub fn metadata_path(&self) -> &Path {
+        &self.metadata_path
+    }
+
+    pub fn metadata(&self) -> &DaemonLockMetadata {
+        &self.metadata
+    }
+
+    pub fn refresh_metadata(&mut self) -> Result<(), DaemonLockError> {
+        let metadata = build_metadata(
+            &self.metadata.db_path,
+            self.metadata.db_fingerprint.clone(),
+            self.metadata.profile.clone(),
+        );
+        write_metadata_file(&self.metadata_path, &metadata)?;
+        self.metadata = metadata;
+        Ok(())
+    }
 }
 
-/// Try to acquire the daemon singleton lock at `<mempal_home>/daemon.lock`.
+impl Drop for DaemonLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.metadata_path);
+    }
+}
+
+/// Try to acquire the daemon singleton lock for a canonical database path.
 ///
 /// Non-blocking: on contention returns [`DaemonLockAcquisition::AlreadyHeld`]
 /// (no retry) so the race loser can exit instead of spinning. The open file
 /// description backing the returned guard survives `fork`/daemonize, so the
 /// lock persists into the final daemon process as long as the guard is held.
-pub fn try_acquire(mempal_home: &Path) -> Result<DaemonLockAcquisition, DaemonLockError> {
-    let lock_path = mempal_home.join(DAEMON_LOCK_FILE);
+pub fn try_acquire(db_path: &Path) -> Result<DaemonLockAcquisition, DaemonLockError> {
+    try_acquire_with_runtime_root(db_path, None, None)
+}
+
+#[doc(hidden)]
+pub fn try_acquire_for_test(
+    db_path: &Path,
+    runtime_root: &Path,
+) -> Result<DaemonLockAcquisition, DaemonLockError> {
+    try_acquire_with_runtime_root(db_path, None, Some(runtime_root))
+}
+
+fn try_acquire_with_runtime_root(
+    db_path: &Path,
+    profile: Option<&str>,
+    runtime_root: Option<&Path>,
+) -> Result<DaemonLockAcquisition, DaemonLockError> {
+    let paths = lock_paths_with_writable_runtime(db_path, profile, runtime_root)?;
     let file = OpenOptions::new()
         .create(true)
         .read(true)
         .truncate(false)
         .write(true)
-        .open(&lock_path)
+        .open(&paths.lock_path)
         .map_err(|source| DaemonLockError::Io {
-            path: lock_path.clone(),
+            path: paths.lock_path.clone(),
             source,
         })?;
 
     match imp::try_lock_exclusive(&file) {
-        Ok(true) => Ok(DaemonLockAcquisition::Acquired(DaemonLockGuard {
-            _file: file,
-            path: lock_path,
-        })),
-        Ok(false) => Ok(DaemonLockAcquisition::AlreadyHeld),
+        Ok(true) => {
+            let metadata = build_metadata(
+                &paths.db_path.to_string_lossy(),
+                paths.db_fingerprint.clone(),
+                profile.map(ToOwned::to_owned),
+            );
+            write_metadata_file(&paths.metadata_path, &metadata)?;
+            Ok(DaemonLockAcquisition::Acquired(DaemonLockGuard {
+                _file: file,
+                path: paths.lock_path,
+                metadata_path: paths.metadata_path,
+                metadata,
+            }))
+        }
+        Ok(false) => Ok(DaemonLockAcquisition::AlreadyHeld {
+            owner: read_metadata_file(&paths.metadata_path),
+            lock_path: paths.lock_path,
+        }),
         Err(source) => Err(DaemonLockError::Io {
-            path: lock_path,
+            path: paths.lock_path,
             source,
         }),
     }
+}
+
+fn lock_paths_with_writable_runtime(
+    db_path: &Path,
+    profile: Option<&str>,
+    runtime_root: Option<&Path>,
+) -> Result<DaemonLockPaths, DaemonLockError> {
+    let paths = daemon_lock_paths(db_path, profile, runtime_root)?;
+    match std::fs::create_dir_all(&paths.runtime_dir) {
+        Ok(()) => Ok(paths),
+        Err(source)
+            if runtime_root.is_none()
+                && env::var_os(MEMPAL_RUNTIME_DIR_ENV).is_none()
+                && env::var_os(XDG_RUNTIME_DIR_ENV).is_some() =>
+        {
+            let fallback_root = env::temp_dir().join("mempal-runtime");
+            let fallback_paths = daemon_lock_paths(db_path, profile, Some(&fallback_root))?;
+            std::fs::create_dir_all(&fallback_paths.runtime_dir).map_err(|fallback_source| {
+                DaemonLockError::Io {
+                    path: fallback_paths.runtime_dir.clone(),
+                    source: fallback_source,
+                }
+            })?;
+            tracing::warn!(
+                runtime_dir = %paths.runtime_dir.display(),
+                fallback_runtime_dir = %fallback_paths.runtime_dir.display(),
+                error = %source,
+                "daemon runtime directory is unavailable; using temp runtime directory"
+            );
+            Ok(fallback_paths)
+        }
+        Err(source) => Err(DaemonLockError::Io {
+            path: paths.runtime_dir,
+            source,
+        }),
+    }
+}
+
+#[doc(hidden)]
+pub fn daemon_lock_paths_for_test(
+    db_path: &Path,
+    runtime_root: &Path,
+) -> Result<DaemonLockPaths, DaemonLockError> {
+    daemon_lock_paths(db_path, None, Some(runtime_root))
+}
+
+fn daemon_lock_paths(
+    db_path: &Path,
+    profile: Option<&str>,
+    runtime_root: Option<&Path>,
+) -> Result<DaemonLockPaths, DaemonLockError> {
+    let db_path = canonical_db_scope_path(db_path).map_err(|source| DaemonLockError::Io {
+        path: db_path.to_path_buf(),
+        source,
+    })?;
+    let db_fingerprint = db_fingerprint(&db_path, profile);
+    let runtime_dir = runtime_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_runtime_dir)
+        .join("mempal");
+    let lock_path = runtime_dir.join(format!("{db_fingerprint}{DAEMON_LOCK_SUFFIX}"));
+    let metadata_path = runtime_dir.join(format!("{db_fingerprint}{DAEMON_METADATA_SUFFIX}"));
+    Ok(DaemonLockPaths {
+        runtime_dir,
+        lock_path,
+        metadata_path,
+        db_path,
+        db_fingerprint,
+    })
+}
+
+fn default_runtime_dir() -> PathBuf {
+    env::var_os(MEMPAL_RUNTIME_DIR_ENV)
+        .or_else(|| env::var_os(XDG_RUNTIME_DIR_ENV))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("mempal-runtime"))
+}
+
+fn canonical_db_scope_path(path: &Path) -> io::Result<PathBuf> {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return Ok(canonical);
+    }
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()?.join(path)
+    };
+    let Some(file_name) = absolute.file_name() else {
+        return Ok(absolute);
+    };
+    let parent = absolute
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    Ok(std::fs::canonicalize(parent)?.join(file_name))
+}
+
+fn db_fingerprint(path: &Path, profile: Option<&str>) -> String {
+    let mut hasher = blake3::Hasher::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        hasher.update(path.as_os_str().as_bytes());
+    }
+    #[cfg(not(unix))]
+    {
+        hasher.update(path.to_string_lossy().as_bytes());
+    }
+    if let Some(profile) = profile {
+        hasher.update(b"\0profile\0");
+        hasher.update(profile.as_bytes());
+    }
+    hasher.finalize().to_hex()[..16].to_string()
+}
+
+fn build_metadata(
+    db_path: &str,
+    db_fingerprint: String,
+    profile: Option<String>,
+) -> DaemonLockMetadata {
+    let executable_path = std::env::current_exe()
+        .ok()
+        .map(|path| path.to_string_lossy().into_owned());
+    let executable_deleted = executable_path
+        .as_deref()
+        .is_some_and(|path| path.ends_with(" (deleted)"));
+    DaemonLockMetadata {
+        pid: std::process::id(),
+        boot_id: boot_id(),
+        binary_version: env!("CARGO_PKG_VERSION").to_string(),
+        db_path: db_path.to_string(),
+        db_fingerprint,
+        profile,
+        started_at_unix_ms: unix_ms(),
+        executable_path,
+        executable_deleted,
+    }
+}
+
+fn write_metadata_file(
+    metadata_path: &Path,
+    metadata: &DaemonLockMetadata,
+) -> Result<(), DaemonLockError> {
+    let tmp_path = metadata_path.with_extension(format!("json.tmp.{}", std::process::id()));
+    let payload = serde_json::to_vec_pretty(metadata).map_err(|source| DaemonLockError::Io {
+        path: metadata_path.to_path_buf(),
+        source: io::Error::other(source),
+    })?;
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp_path)
+            .map_err(|source| DaemonLockError::Io {
+                path: tmp_path.clone(),
+                source,
+            })?;
+        file.write_all(&payload)
+            .and_then(|()| file.write_all(b"\n"))
+            .and_then(|()| file.sync_all())
+            .map_err(|source| DaemonLockError::Io {
+                path: tmp_path.clone(),
+                source,
+            })?;
+    }
+    std::fs::rename(&tmp_path, metadata_path).map_err(|source| DaemonLockError::Io {
+        path: metadata_path.to_path_buf(),
+        source,
+    })
+}
+
+fn read_metadata_file(metadata_path: &Path) -> Option<DaemonLockMetadata> {
+    let payload = std::fs::read(metadata_path).ok()?;
+    serde_json::from_slice(&payload).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn boot_id() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn boot_id() -> Option<String> {
+    None
+}
+
+fn unix_ms() -> u64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    u64::try_from(millis).unwrap_or(u64::MAX)
 }
 
 /// Basename of the currently running executable (e.g. `"mempal"`), used to
@@ -386,18 +709,38 @@ mod tests {
     #[test]
     fn test_second_acquire_blocked_until_first_dropped() {
         let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        File::create(&db_path).expect("db file");
+        let runtime = tmp.path().join("runtime");
 
-        let guard1 = match try_acquire(tmp.path()).expect("first acquire") {
+        let guard1 = match try_acquire_for_test(&db_path, &runtime).expect("first acquire") {
             DaemonLockAcquisition::Acquired(guard) => guard,
-            DaemonLockAcquisition::AlreadyHeld => panic!("first acquire should win"),
+            DaemonLockAcquisition::AlreadyHeld { .. } => panic!("first acquire should win"),
         };
-        assert!(guard1.path().ends_with(DAEMON_LOCK_FILE));
+        assert!(
+            guard1
+                .path()
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(DAEMON_LOCK_SUFFIX))
+        );
+        assert_eq!(guard1.metadata().pid, std::process::id());
+        assert!(guard1.metadata_path().exists());
 
         // A second acquisition while the first guard is held must observe the
         // lock as already held (distinct open file descriptions conflict under
         // flock even within the same process).
-        match try_acquire(tmp.path()).expect("second acquire attempt") {
-            DaemonLockAcquisition::AlreadyHeld => {}
+        match try_acquire_for_test(&db_path, &runtime).expect("second acquire attempt") {
+            DaemonLockAcquisition::AlreadyHeld {
+                owner: Some(owner),
+                lock_path,
+            } => {
+                assert_eq!(owner.pid, std::process::id());
+                assert_eq!(lock_path, guard1.path());
+            }
+            DaemonLockAcquisition::AlreadyHeld { owner: None, .. } => {
+                panic!("already-held result should include owner metadata")
+            }
             DaemonLockAcquisition::Acquired(_) => {
                 panic!("second acquire must not win while first guard is held")
             }
@@ -406,12 +749,64 @@ mod tests {
         drop(guard1);
 
         // After release the lock is acquirable again.
-        match try_acquire(tmp.path()).expect("third acquire after drop") {
+        match try_acquire_for_test(&db_path, &runtime).expect("third acquire after drop") {
             DaemonLockAcquisition::Acquired(_) => {}
-            DaemonLockAcquisition::AlreadyHeld => {
+            DaemonLockAcquisition::AlreadyHeld { .. } => {
                 panic!("acquire after drop should win")
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_lock_scope_is_canonical_db_not_shared_home() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = tmp.path().join("runtime");
+        let db_a = tmp.path().join("profile-a").join("palace.db");
+        let db_b = tmp.path().join("profile-b").join("palace.db");
+        std::fs::create_dir_all(db_a.parent().expect("db a parent")).expect("db a parent");
+        std::fs::create_dir_all(db_b.parent().expect("db b parent")).expect("db b parent");
+        File::create(&db_a).expect("db a");
+        File::create(&db_b).expect("db b");
+
+        let guard_a = match try_acquire_for_test(&db_a, &runtime).expect("acquire a") {
+            DaemonLockAcquisition::Acquired(guard) => guard,
+            DaemonLockAcquisition::AlreadyHeld { .. } => panic!("db a should acquire"),
+        };
+        let guard_b = match try_acquire_for_test(&db_b, &runtime).expect("acquire b") {
+            DaemonLockAcquisition::Acquired(guard) => guard,
+            DaemonLockAcquisition::AlreadyHeld { .. } => panic!("db b should acquire"),
+        };
+
+        assert_ne!(guard_a.path(), guard_b.path());
+        assert_ne!(
+            guard_a.metadata().db_fingerprint,
+            guard_b.metadata().db_fingerprint
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_stale_metadata_without_live_lock_is_recovered() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = tmp.path().join("runtime");
+        let db_path = tmp.path().join("palace.db");
+        File::create(&db_path).expect("db file");
+        let paths = daemon_lock_paths_for_test(&db_path, &runtime).expect("lock paths");
+        std::fs::create_dir_all(&paths.runtime_dir).expect("runtime dir");
+        std::fs::write(
+            &paths.metadata_path,
+            r#"{"pid":999999,"boot_id":"stale","binary_version":"old","db_path":"/stale","db_fingerprint":"stale","profile":null,"started_at_unix_ms":1,"executable_path":null,"executable_deleted":true}"#,
+        )
+        .expect("stale metadata");
+
+        let guard = match try_acquire_for_test(&db_path, &runtime).expect("acquire") {
+            DaemonLockAcquisition::Acquired(guard) => guard,
+            DaemonLockAcquisition::AlreadyHeld { .. } => panic!("stale metadata must not block"),
+        };
+
+        assert_eq!(guard.metadata().pid, std::process::id());
+        assert_eq!(guard.metadata().db_fingerprint, paths.db_fingerprint);
     }
 
     #[test]

--- a/src/daemon_singleton.rs
+++ b/src/daemon_singleton.rs
@@ -251,27 +251,6 @@ fn lock_paths_with_writable_runtime(
     let paths = daemon_lock_paths(db_path, profile, runtime_root)?;
     match std::fs::create_dir_all(&paths.runtime_dir) {
         Ok(()) => Ok(paths),
-        Err(source)
-            if runtime_root.is_none()
-                && env::var_os(MEMPAL_RUNTIME_DIR_ENV).is_none()
-                && env::var_os(XDG_RUNTIME_DIR_ENV).is_some() =>
-        {
-            let fallback_root = env::temp_dir().join("mempal-runtime");
-            let fallback_paths = daemon_lock_paths(db_path, profile, Some(&fallback_root))?;
-            std::fs::create_dir_all(&fallback_paths.runtime_dir).map_err(|fallback_source| {
-                DaemonLockError::Io {
-                    path: fallback_paths.runtime_dir.clone(),
-                    source: fallback_source,
-                }
-            })?;
-            tracing::warn!(
-                runtime_dir = %paths.runtime_dir.display(),
-                fallback_runtime_dir = %fallback_paths.runtime_dir.display(),
-                error = %source,
-                "daemon runtime directory is unavailable; using temp runtime directory"
-            );
-            Ok(fallback_paths)
-        }
         Err(source) => Err(DaemonLockError::Io {
             path: paths.runtime_dir,
             source,
@@ -701,6 +680,49 @@ mod imp {
 mod tests {
     use super::*;
 
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: daemon singleton tests serialize environment mutation with
+            // ENV_LOCK and restore the previous value when the guard is dropped.
+            unsafe {
+                env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+
+        fn set_path(key: &'static str, value: &Path) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: daemon singleton tests serialize environment mutation with
+            // ENV_LOCK and restore the previous value when the guard is dropped.
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: daemon singleton tests serialize environment mutation with
+            // ENV_LOCK and this drop restores the captured previous value.
+            unsafe {
+                if let Some(previous) = &self.previous {
+                    env::set_var(self.key, previous);
+                } else {
+                    env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(|s| s.to_string()).collect()
     }
@@ -755,6 +777,40 @@ mod tests {
                 panic!("acquire after drop should win")
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_xdg_runtime_creation_failure_does_not_fallback_to_temp() {
+        let _env_guard = ENV_LOCK.lock().expect("env lock");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        File::create(&db_path).expect("db file");
+        let runtime_file = tmp.path().join("runtime-file");
+        File::create(&runtime_file).expect("runtime file");
+        let fallback_root = env::temp_dir().join("mempal-runtime");
+        let fallback_paths =
+            daemon_lock_paths(&db_path, None, Some(&fallback_root)).expect("fallback paths");
+        let _ = std::fs::remove_file(&fallback_paths.lock_path);
+        let _ = std::fs::remove_file(&fallback_paths.metadata_path);
+
+        let _mempal_runtime_guard = EnvVarGuard::remove(MEMPAL_RUNTIME_DIR_ENV);
+        let _xdg_runtime_guard = EnvVarGuard::set_path(XDG_RUNTIME_DIR_ENV, &runtime_file);
+
+        let error = try_acquire(&db_path).expect_err("runtime dir failure must be fatal");
+        match error {
+            DaemonLockError::Io { path, .. } => {
+                assert_eq!(path, runtime_file.join("mempal"));
+            }
+        }
+        assert!(
+            !fallback_paths.lock_path.exists(),
+            "daemon singleton must not create a fallback temp lock"
+        );
+        assert!(
+            !fallback_paths.metadata_path.exists(),
+            "daemon singleton must not create fallback temp metadata"
+        );
     }
 
     #[cfg(unix)]

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -21,7 +21,8 @@ use crate::core::{
     db::Database,
     strata::{is_raw_turn, raw_turn_importance, should_store_raw_turns},
     types::{
-        BootstrapEvidenceArgs, Drawer, MemoryDomain, MemoryKind, SourceType, default_confidence,
+        BootstrapEvidenceArgs, Drawer, MemoryDomain, MemoryKind, RuntimeWriterLease, SourceType,
+        default_confidence,
     },
     utils::{
         build_bootstrap_evidence_drawer_id, build_drawer_id, iso_timestamp, link_superseded_drawer,
@@ -201,6 +202,40 @@ pub enum IngestError {
         #[source]
         source: std::io::Error,
     },
+    #[error("failed to verify runtime SQLite writer lease before {operation}")]
+    RuntimeWriterLeaseCheck {
+        operation: &'static str,
+        #[source]
+        source: crate::core::db::DbError,
+    },
+    #[error("runtime SQLite writer lease `{lease_name}` for {owner} was lost before {operation}")]
+    RuntimeWriterLeaseLost {
+        lease_name: String,
+        owner: String,
+        operation: &'static str,
+    },
+}
+
+fn ensure_runtime_writer_lease_active(
+    db: &Database,
+    lease: Option<&RuntimeWriterLease>,
+    operation: &'static str,
+) -> Result<()> {
+    let Some(lease) = lease else {
+        return Ok(());
+    };
+    let active = db
+        .runtime_writer_lease_is_active(&lease.name, &lease.owner, &lease.session_id)
+        .map_err(|source| IngestError::RuntimeWriterLeaseCheck { operation, source })?;
+    if active {
+        Ok(())
+    } else {
+        Err(IngestError::RuntimeWriterLeaseLost {
+            lease_name: lease.name.clone(),
+            owner: lease.owner.clone(),
+            operation,
+        })
+    }
 }
 
 /// Chunk content for embedding using the token-aware chunker.
@@ -267,6 +302,17 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
     wing: &str,
     options: IngestOptions<'_>,
 ) -> Result<IngestStats> {
+    ingest_file_with_options_and_writer_lease(db, embedder, path, wing, options, None).await
+}
+
+pub async fn ingest_file_with_options_and_writer_lease<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    path: &Path,
+    wing: &str,
+    options: IngestOptions<'_>,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
+) -> Result<IngestStats> {
     let bytes = tokio::fs::read(path)
         .await
         .map_err(|source| IngestError::ReadFile {
@@ -304,6 +350,9 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
 
     // Stage 3: Diary rollup early-return (upstream)
     if options.diary_rollup {
+        if !options.dry_run {
+            ensure_runtime_writer_lease_active(db, runtime_writer_lease, "diary rollup")?;
+        }
         let mut outcome = diary::ingest_diary_rollup(
             db,
             embedder,
@@ -413,6 +462,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         .confidence
         .unwrap_or_else(|| default_confidence(source_type));
     if options.replace_existing_source && !options.dry_run {
+        ensure_runtime_writer_lease_active(db, runtime_writer_lease, "source replacement")?;
         let replace_result = if options.replace_across_rooms {
             db.replace_active_source_drawers_across_rooms(
                 &source_file,
@@ -469,6 +519,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             .find(|summary| Some(summary.id.as_str()) != replacement_target_id);
         if let Some(existing) = exact_duplicate {
             if options.is_pinned {
+                ensure_runtime_writer_lease_active(
+                    db,
+                    runtime_writer_lease,
+                    "pin duplicate drawer",
+                )?;
                 db.pin_drawer(&existing.id, None)
                     .map_err(|source| IngestError::InsertDrawer {
                         drawer_id: existing.id.clone(),
@@ -530,6 +585,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
                 gating_decision = Some(tier2.decision);
             }
             if let Some(decision) = gating_decision.as_ref() {
+                ensure_runtime_writer_lease_active(
+                    db,
+                    runtime_writer_lease,
+                    "record gating audit",
+                )?;
                 db.record_gating_audit(&drawer_id, decision, options.project_id, Some(chunk))
                     .map_err(|source| IngestError::InsertDrawer {
                         drawer_id: drawer_id.clone(),
@@ -542,6 +602,14 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             }
 
             if !raw_turn
+                && {
+                    ensure_runtime_writer_lease_active(
+                        db,
+                        runtime_writer_lease,
+                        "record fact-check audit",
+                    )?;
+                    true
+                }
                 && let Some(outcome) = evaluate_fact_check_gate(
                     &drawer_id,
                     chunk,
@@ -568,6 +636,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
 
     if options.dry_run || pending.is_empty() {
         if !options.dry_run {
+            ensure_runtime_writer_lease_active(
+                db,
+                runtime_writer_lease,
+                "supersede replacement target",
+            )?;
             supersede_after_successful_replacement(db, replacement_target_id, &mut stats)?;
         }
         return Ok(stats);
@@ -616,6 +689,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
 
     // Stage 7: Storage with all fields from both sides
     for ((chunk_index, chunk, drawer_id), vector) in pending.into_iter().zip(vectors) {
+        ensure_runtime_writer_lease_active(db, runtime_writer_lease, "insert drawer")?;
         let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
             id: drawer_id.clone(),
             content: chunk.to_string(),
@@ -658,6 +732,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
             drawer_id: drawer.id.clone(),
             source,
         })?;
+        ensure_runtime_writer_lease_active(db, runtime_writer_lease, "insert vector")?;
         db.insert_vector_with_project(&drawer_id, &vector, options.project_id)
             .map_err(|source| IngestError::InsertVector {
                 drawer_id: drawer.id.clone(),
@@ -668,6 +743,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         {
             let config_snap = ConfigHandle::current();
             if config_snap.repair.enabled {
+                ensure_runtime_writer_lease_active(
+                    db,
+                    runtime_writer_lease,
+                    "record repair signal",
+                )?;
                 crate::repair::try_record_failure(
                     db.path(),
                     &drawer_id,
@@ -684,6 +764,11 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         {
             let config_snap = ConfigHandle::current();
             if config_snap.patterns.enabled {
+                ensure_runtime_writer_lease_active(
+                    db,
+                    runtime_writer_lease,
+                    "record pattern signal",
+                )?;
                 let model_id = config_snap.embed.model.clone().unwrap_or_else(|| {
                     if config_snap.embed.backend == "model2vec" {
                         "model2vec/potion-multilingual-128M".to_string()
@@ -714,6 +799,7 @@ pub async fn ingest_file_with_options<E: Embedder + ?Sized>(
         stats.chunks += 1;
     }
 
+    ensure_runtime_writer_lease_active(db, runtime_writer_lease, "supersede replacement target")?;
     supersede_after_successful_replacement(db, replacement_target_id, &mut stats)?;
 
     Ok(stats)
@@ -766,6 +852,17 @@ pub async fn ingest_dir_with_options<E: Embedder + ?Sized>(
     wing: &str,
     options: IngestOptions<'_>,
 ) -> Result<IngestStats> {
+    ingest_dir_with_options_and_writer_lease(db, embedder, dir, wing, options, None).await
+}
+
+pub async fn ingest_dir_with_options_and_writer_lease<E: Embedder + ?Sized>(
+    db: &Database,
+    embedder: &E,
+    dir: &Path,
+    wing: &str,
+    options: IngestOptions<'_>,
+    runtime_writer_lease: Option<&RuntimeWriterLease>,
+) -> Result<IngestStats> {
     let mut stats = IngestStats::default();
     let mut stack = vec![dir.to_path_buf()];
 
@@ -789,8 +886,15 @@ pub async fn ingest_dir_with_options<E: Embedder + ?Sized>(
             }
 
             if path.is_file() {
-                let file_stats =
-                    ingest_file_with_options(db, embedder, &path, wing, options).await?;
+                let file_stats = ingest_file_with_options_and_writer_lease(
+                    db,
+                    embedder,
+                    &path,
+                    wing,
+                    options,
+                    runtime_writer_lease,
+                )
+                .await?;
                 stats.files += file_stats.files;
                 stats.chunks += file_stats.chunks;
                 stats.skipped += file_stats.skipped;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(feature = "rest")]
 use std::sync::Arc;
+use std::sync::mpsc;
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -55,8 +56,8 @@ use mempal::core::{
         KnowledgeCardEvent, KnowledgeCardFilter, KnowledgeEventType, KnowledgeEvidenceLink,
         KnowledgeEvidenceRole, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind,
         Provenance, RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal,
-        RuntimeAdoptionTrack, SourceType, TaxonomyEntry, TriggerHints, TunnelEndpoint,
-        default_confidence,
+        RuntimeAdoptionTrack, RuntimeWriterLease, SourceType, TaxonomyEntry, TriggerHints,
+        TunnelEndpoint, default_confidence,
     },
     utils::{
         build_bootstrap_evidence_drawer_id, build_triple_id, current_timestamp,
@@ -2722,6 +2723,10 @@ const DEFAULT_HISTORICAL_REJUDGE_PAGE_SIZE: usize = 500;
 const DEFAULT_HISTORICAL_REJUDGE_LLM_CONCURRENCY: usize = 1;
 const HISTORICAL_REJUDGE_CHECKPOINT_KEY: &str = "maintenance.rejudge.checkpoint";
 const HISTORICAL_REJUDGE_WORK_TABLE: &str = "historical_rejudge_work_items";
+const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
+const MAINTENANCE_WRITER_LEASE_TTL_SECS: u64 = 120;
+const MAINTENANCE_WRITER_LEASE_RENEW_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
 const HISTORICAL_REJUDGE_SQLITE_BACKUP_HASH_FORMAT: &str = "sqlite_stream_v1";
 static HISTORICAL_REJUDGE_RUN_ID_SEQUENCE: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
@@ -4174,6 +4179,134 @@ where
         runtime.shutdown_timeout(std::time::Duration::from_millis(100));
     }
     result
+}
+
+struct MaintenanceWriterLeaseGuard {
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+    stop: Option<mpsc::Sender<()>>,
+    heartbeat: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for MaintenanceWriterLeaseGuard {
+    fn drop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(handle) = self.heartbeat.take() {
+            let _ = handle.join();
+        }
+        if let Ok(db) = Database::open(&self.db_path) {
+            let _ = db.runtime_writer_lease_release(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            );
+        }
+    }
+}
+
+fn acquire_maintenance_writer_lease(
+    db: &Database,
+    command: &str,
+) -> Result<MaintenanceWriterLeaseGuard> {
+    let owner = format!("mempal-maintenance-{command}-{}", std::process::id());
+    let metadata = serde_json::json!({
+        "command": command,
+        "db_path": db.path().to_string_lossy(),
+    })
+    .to_string();
+    let lease = db
+        .runtime_writer_lease_acquire(
+            SQLITE_WRITER_LEASE_NAME,
+            &owner,
+            "maintenance",
+            MAINTENANCE_WRITER_LEASE_TTL_SECS,
+            Some(&metadata),
+        )
+        .with_context(|| format!("failed to acquire writer lease for {command}"))?;
+    let lease = match lease {
+        Some(lease) => lease,
+        None => {
+            let active = db
+                .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
+                .unwrap_or_default();
+            bail!(
+                "SQLite writer lease `{}` is already held; refusing to run {command}: {}",
+                SQLITE_WRITER_LEASE_NAME,
+                format_runtime_writer_leases(&active)
+            );
+        }
+    };
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let heartbeat =
+        spawn_maintenance_writer_lease_heartbeat(db.path().to_path_buf(), lease.clone(), stop_rx);
+    Ok(MaintenanceWriterLeaseGuard {
+        db_path: db.path().to_path_buf(),
+        lease,
+        stop: Some(stop_tx),
+        heartbeat: Some(heartbeat),
+    })
+}
+
+fn spawn_maintenance_writer_lease_heartbeat(
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+    stop: mpsc::Receiver<()>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        loop {
+            match stop.recv_timeout(MAINTENANCE_WRITER_LEASE_RENEW_INTERVAL) {
+                Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
+            let result = Database::open(&db_path).and_then(|db| {
+                db.runtime_writer_lease_renew(
+                    &lease.name,
+                    &lease.owner,
+                    &lease.session_id,
+                    MAINTENANCE_WRITER_LEASE_TTL_SECS,
+                )
+            });
+            match result {
+                Ok(true) => {}
+                Ok(false) => {
+                    eprintln!(
+                        "warning: writer lease `{}` for {} was lost; stop this command before continuing writes",
+                        lease.name, lease.owner
+                    );
+                    break;
+                }
+                Err(error) => {
+                    eprintln!(
+                        "warning: failed to renew writer lease `{}` for {}: {error}",
+                        lease.name, lease.owner
+                    );
+                }
+            }
+        }
+    })
+}
+
+fn format_runtime_writer_leases(leases: &[RuntimeWriterLease]) -> String {
+    if leases.is_empty() {
+        return "none visible".to_string();
+    }
+    leases
+        .iter()
+        .map(|lease| {
+            format!(
+                "name={} owner={} pid={} mode={} expires_at={} heartbeat_at={}",
+                lease.name,
+                lease.owner,
+                lease.pid,
+                lease.mode,
+                lease.expires_at,
+                lease.heartbeat_at
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 async fn bench_command(config: &Config, command: BenchCommands) -> Result<()> {
@@ -6975,6 +7108,7 @@ fn recompute_importance_command(db: &Database, only_zero: bool) -> Result<()> {
             (d.id, s)
         })
         .collect();
+    let _writer_lease = acquire_maintenance_writer_lease(db, "recompute-importance")?;
     let updated = db
         .bulk_update_importance(&updates)
         .context("failed to apply importance scores")?;
@@ -6983,6 +7117,7 @@ fn recompute_importance_command(db: &Database, only_zero: bool) -> Result<()> {
 }
 
 fn reindex_failed_queue_command(db: &Database) -> Result<()> {
+    let _writer_lease = acquire_maintenance_writer_lease(db, "reindex-failed-queue")?;
     let store = mempal::core::queue::PendingMessageStore::new(db.path())
         .context("failed to open pending message queue")?;
     let retried = store
@@ -7076,6 +7211,7 @@ fn normalize_added_at_command(db: &Database) -> Result<()> {
         return Ok(());
     }
     println!("normalising {to_update} rows (batches of 1000)...");
+    let _writer_lease = acquire_maintenance_writer_lease(db, "normalize-added-at")?;
     let updated = db
         .bulk_update_added_at(&updates)
         .context("failed to apply added_at normalisation")?;
@@ -7104,6 +7240,7 @@ async fn reindex_command_by_embedder(
         println!("dry-run: no vectors were written");
         return Ok(());
     }
+    let _writer_lease = acquire_maintenance_writer_lease(db, "reindex-embedder")?;
     let embedder = build_specific_embedder(config, embedder_name).await?;
     let new_dim = embedder.dimensions();
     let current_dim = current_vector_dim(db).context("failed to read embedding dim")?;
@@ -7608,6 +7745,7 @@ async fn reindex_command_sources(
             .await
             .context("failed to plan reindex")?
     } else {
+        let _writer_lease = acquire_maintenance_writer_lease(db, "reindex-sources")?;
         let embedder = build_embedder(config).await?;
         println!("embedder: {} ({}d)", embedder.name(), embedder.dimensions());
         reindex_sources(db, &*embedder, options)
@@ -14336,6 +14474,11 @@ async fn maintenance_rejudge_command_with_runtime(
 ) -> Result<()> {
     validate_historical_rejudge_options(options)?;
     validate_historical_rejudge_runtime_options(runtime)?;
+    let _writer_lease = if options.execute {
+        Some(acquire_maintenance_writer_lease(db, "maintenance-rejudge")?)
+    } else {
+        None
+    };
     let current_dir = env::current_dir().ok();
     let project_id = if options.project.is_some() {
         resolve_project_id(options.project, config, current_dir.as_deref())
@@ -17558,6 +17701,14 @@ fn maintenance_rejudge_restore_command(
         skipped_active_count: 0,
         conflict_count: 0,
         audit_count: 0,
+    };
+    let _writer_lease = if execute {
+        Some(acquire_maintenance_writer_lease(
+            db,
+            "maintenance-rejudge-restore",
+        )?)
+    } else {
+        None
     };
 
     for item in &backup.items {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14407,8 +14407,17 @@ fn cowork_session_close_command(
         } else {
             None
         };
+        let writer_lease = if let Some(db) = db_opt.as_ref() {
+            Some(acquire_cli_content_writer_lease(
+                db,
+                "cowork-session-close-capture",
+            )?)
+        } else {
+            None
+        };
         let capture_report = capture_handoff_to_memory(
             db_opt.as_ref(),
+            writer_lease.as_ref().map(|lease| lease.lease()),
             &home,
             &cwd,
             CoworkCaptureRequest {
@@ -14488,8 +14497,14 @@ fn cowork_capture_command(
     } else {
         None
     };
+    let writer_lease = if let Some(db) = db_opt.as_ref() {
+        Some(acquire_cli_content_writer_lease(db, "cowork-capture")?)
+    } else {
+        None
+    };
     let report = capture_handoff_to_memory(
         db_opt.as_ref(),
+        writer_lease.as_ref().map(|lease| lease.lease()),
         &home,
         &cwd,
         CoworkCaptureRequest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,7 @@ use std::fs::{self, OpenOptions};
 use std::future::Future;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-#[cfg(feature = "rest")]
-use std::sync::Arc;
-use std::sync::mpsc;
+use std::sync::{Arc, mpsc};
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -80,7 +78,7 @@ use mempal::ingest::{
     IngestOptions, IngestStats,
     detect::detect_format,
     gating::{IngestCandidate, evaluate_fact_check_gate, evaluate_tier1, evaluate_tier2},
-    ingest_dir_with_options, ingest_file_with_options,
+    ingest_dir_with_options_and_writer_lease, ingest_file_with_options_and_writer_lease,
     normalize::{CURRENT_NORMALIZE_VERSION, NormalizeOptions, normalize_content_with_options},
     reindex::{ReindexMode, ReindexOptions, ReindexReport, reindex_sources},
 };
@@ -4184,8 +4182,62 @@ where
 struct MaintenanceWriterLeaseGuard {
     db_path: PathBuf,
     lease: RuntimeWriterLease,
+    active: Arc<std::sync::atomic::AtomicBool>,
     stop: Option<mpsc::Sender<()>>,
     heartbeat: Option<std::thread::JoinHandle<()>>,
+}
+
+impl MaintenanceWriterLeaseGuard {
+    fn lease(&self) -> &RuntimeWriterLease {
+        &self.lease
+    }
+
+    fn ensure_active(&self, operation: &'static str) -> Result<()> {
+        if !self.active.load(std::sync::atomic::Ordering::SeqCst) {
+            bail!(
+                "SQLite writer lease `{}` for {} was lost before {operation}",
+                self.lease.name,
+                self.lease.owner
+            );
+        }
+        let db = Database::open(&self.db_path).with_context(|| {
+            format!(
+                "failed to verify writer lease `{}` before {operation}",
+                self.lease.name
+            )
+        })?;
+        if db
+            .runtime_writer_lease_is_active(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            )
+            .with_context(|| {
+                format!(
+                    "failed to verify writer lease `{}` before {operation}",
+                    self.lease.name
+                )
+            })?
+        {
+            Ok(())
+        } else {
+            bail!(
+                "SQLite writer lease `{}` for {} was lost before {operation}",
+                self.lease.name,
+                self.lease.owner
+            )
+        }
+    }
+}
+
+fn ensure_maintenance_writer_lease_active(
+    lease: Option<&MaintenanceWriterLeaseGuard>,
+    operation: &'static str,
+) -> Result<()> {
+    if let Some(lease) = lease {
+        lease.ensure_active(operation)?;
+    }
+    Ok(())
 }
 
 impl Drop for MaintenanceWriterLeaseGuard {
@@ -4210,7 +4262,23 @@ fn acquire_maintenance_writer_lease(
     db: &Database,
     command: &str,
 ) -> Result<MaintenanceWriterLeaseGuard> {
-    let owner = format!("mempal-maintenance-{command}-{}", std::process::id());
+    acquire_runtime_writer_lease(db, command, "maintenance", "mempal-maintenance")
+}
+
+fn acquire_cli_ingest_writer_lease(
+    db: &Database,
+    command: &str,
+) -> Result<MaintenanceWriterLeaseGuard> {
+    acquire_runtime_writer_lease(db, command, "ingest", "mempal-ingest")
+}
+
+fn acquire_runtime_writer_lease(
+    db: &Database,
+    command: &str,
+    mode: &str,
+    owner_prefix: &str,
+) -> Result<MaintenanceWriterLeaseGuard> {
+    let owner = format!("{owner_prefix}-{command}-{}", std::process::id());
     let metadata = serde_json::json!({
         "command": command,
         "db_path": db.path().to_string_lossy(),
@@ -4220,7 +4288,7 @@ fn acquire_maintenance_writer_lease(
         .runtime_writer_lease_acquire(
             SQLITE_WRITER_LEASE_NAME,
             &owner,
-            "maintenance",
+            mode,
             MAINTENANCE_WRITER_LEASE_TTL_SECS,
             Some(&metadata),
         )
@@ -4239,11 +4307,17 @@ fn acquire_maintenance_writer_lease(
         }
     };
     let (stop_tx, stop_rx) = mpsc::channel();
-    let heartbeat =
-        spawn_maintenance_writer_lease_heartbeat(db.path().to_path_buf(), lease.clone(), stop_rx);
+    let active = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let heartbeat = spawn_maintenance_writer_lease_heartbeat(
+        db.path().to_path_buf(),
+        lease.clone(),
+        Arc::clone(&active),
+        stop_rx,
+    );
     Ok(MaintenanceWriterLeaseGuard {
         db_path: db.path().to_path_buf(),
         lease,
+        active,
         stop: Some(stop_tx),
         heartbeat: Some(heartbeat),
     })
@@ -4252,6 +4326,7 @@ fn acquire_maintenance_writer_lease(
 fn spawn_maintenance_writer_lease_heartbeat(
     db_path: PathBuf,
     lease: RuntimeWriterLease,
+    active: Arc<std::sync::atomic::AtomicBool>,
     stop: mpsc::Receiver<()>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
@@ -4271,6 +4346,7 @@ fn spawn_maintenance_writer_lease_heartbeat(
             match result {
                 Ok(true) => {}
                 Ok(false) => {
+                    active.store(false, std::sync::atomic::Ordering::SeqCst);
                     eprintln!(
                         "warning: writer lease `{}` for {} was lost; stop this command before continuing writes",
                         lease.name, lease.owner
@@ -4495,8 +4571,9 @@ async fn ingest_command(
     };
 
     let stats = if options.dry_run {
-        ingest_path_with_options(db, &NoopEmbedder, path, wing, base_options).await?
+        ingest_path_with_options(db, &NoopEmbedder, path, wing, base_options, None).await?
     } else {
+        let writer_lease = acquire_cli_ingest_writer_lease(db, "ingest")?;
         let prototype_classifier = if config.ingest_gating.enabled && !options.no_gate {
             compile_classifier_from_config(config)
                 .await
@@ -4530,7 +4607,15 @@ async fn ingest_command(
             valid_from,
             valid_until,
         };
-        ingest_path_with_options(db, &*embedder, path, wing, live_options).await?
+        ingest_path_with_options(
+            db,
+            &*embedder,
+            path,
+            wing,
+            live_options,
+            Some(writer_lease.lease()),
+        )
+        .await?
     };
 
     append_ingest_audit_log(
@@ -4992,6 +5077,7 @@ async fn ingest_stdin_command(
     // terminal stats/audit path as the direct stdin ingest instead of
     // queueing a receipt that would report different skip semantics.
     if options.wait && exact_duplicate.is_some() {
+        let _writer_lease = acquire_cli_ingest_writer_lease(db, "ingest-stdin")?;
         finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
             db,
             wing: &resolved.wing,
@@ -5055,7 +5141,10 @@ async fn ingest_stdin_command(
         }
     }
 
+    let writer_lease = acquire_cli_ingest_writer_lease(db, "ingest-stdin")?;
+
     if exact_duplicate.is_some() {
+        writer_lease.ensure_active("finalize duplicate stdin ingest")?;
         finalize_exact_duplicate_stdin_ingest(ExactDuplicateStdinIngest {
             db,
             wing: &resolved.wing,
@@ -5100,6 +5189,7 @@ async fn ingest_stdin_command(
             gating_decision = Some(tier2.decision);
         }
         if let Some(decision) = gating_decision.as_ref() {
+            writer_lease.ensure_active("record stdin gating audit")?;
             db.record_gating_audit(
                 &drawer_id,
                 decision,
@@ -5119,7 +5209,10 @@ async fn ingest_stdin_command(
 
         if !resolved.raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
-                &drawer_id,
+                {
+                    writer_lease.ensure_active("record stdin fact-check audit")?;
+                    &drawer_id
+                },
                 &resolved.content,
                 db,
                 resolved.project_id.as_deref(),
@@ -5180,6 +5273,7 @@ async fn ingest_stdin_command(
         link_superseded_drawer(&mut drawer, old_id);
     }
 
+    writer_lease.ensure_active("insert stdin drawer")?;
     db.insert_drawer_with_project_validity(
         &drawer,
         resolved.project_id.as_deref(),
@@ -5188,10 +5282,12 @@ async fn ingest_stdin_command(
         resolved.valid_until.as_deref(),
     )
     .with_context(|| format!("failed to insert drawer {}", drawer.id))?;
+    writer_lease.ensure_active("insert stdin vector")?;
     db.insert_vector_with_project(&drawer_id, &vector, resolved.project_id.as_deref())
         .with_context(|| format!("failed to insert vector for drawer {drawer_id}"))?;
 
     if let Some(old_id) = superseded_drawer_id.as_deref() {
+        writer_lease.ensure_active("supersede stdin replacement target")?;
         db.supersede_drawer(old_id, &format!("replaced by {drawer_id}"))
             .with_context(|| format!("failed to supersede drawer {old_id}"))?;
         stats.superseded_drawer_id = Some(old_id.to_string());
@@ -5201,6 +5297,7 @@ async fn ingest_stdin_command(
     {
         let config_snap = ConfigHandle::current();
         if config_snap.repair.enabled {
+            writer_lease.ensure_active("record stdin repair signal")?;
             mempal::repair::try_record_failure(
                 db.path(),
                 &drawer_id,
@@ -5707,11 +5804,28 @@ async fn ingest_path_with_options<'a, E: Embedder + ?Sized>(
     path: &'a Path,
     wing: &'a str,
     options: IngestOptions<'a>,
+    runtime_writer_lease: Option<&'a RuntimeWriterLease>,
 ) -> mempal::ingest::Result<IngestStats> {
     if path.is_file() {
-        ingest_file_with_options(db, embedder, path, wing, options).await
+        ingest_file_with_options_and_writer_lease(
+            db,
+            embedder,
+            path,
+            wing,
+            options,
+            runtime_writer_lease,
+        )
+        .await
     } else {
-        ingest_dir_with_options(db, embedder, path, wing, options).await
+        ingest_dir_with_options_and_writer_lease(
+            db,
+            embedder,
+            path,
+            wing,
+            options,
+            runtime_writer_lease,
+        )
+        .await
     }
 }
 
@@ -7240,7 +7354,7 @@ async fn reindex_command_by_embedder(
         println!("dry-run: no vectors were written");
         return Ok(());
     }
-    let _writer_lease = acquire_maintenance_writer_lease(db, "reindex-embedder")?;
+    let writer_lease = acquire_maintenance_writer_lease(db, "reindex-embedder")?;
     let embedder = build_specific_embedder(config, embedder_name).await?;
     let new_dim = embedder.dimensions();
     let current_dim = current_vector_dim(db).context("failed to read embedding dim")?;
@@ -7303,9 +7417,11 @@ async fn reindex_command_by_embedder(
             );
             resume_checkpoint = None;
         }
+        writer_lease.ensure_active("stash vectors before recreate")?;
         let stash = db
             .stash_vectors_before_recreate()
             .context("failed to stash existing vectors before recreate")?;
+        writer_lease.ensure_active("recreate vector table")?;
         println!("recreating drawer_vectors with {new_dim} dimensions...");
         db.recreate_vectors_table(new_dim)
             .context("failed to recreate vectors table")?;
@@ -7330,9 +7446,12 @@ async fn reindex_command_by_embedder(
             embedder.as_ref(),
             embedder_name,
             &target_fingerprint_for_reindex,
-            batch.batch_size,
             target,
-            policy,
+            StaleBatchExecution {
+                batch_size: batch.batch_size,
+                policy,
+                writer_lease: Some(&writer_lease),
+            },
         )
         .await;
     }
@@ -7378,11 +7497,14 @@ async fn reindex_command_by_embedder(
             .into_iter()
             .next()
             .ok_or_else(|| anyhow::anyhow!("embedder returned no vector during reindex"))?;
+        writer_lease.ensure_active("write reindex vector")?;
         db.conn()
             .execute("DELETE FROM drawer_vectors WHERE id = ?1", [&row.id])
             .with_context(|| format!("failed to clear existing vector for {}", row.id))?;
+        writer_lease.ensure_active("insert reindex vector")?;
         db.insert_vector_with_project(&row.id, &vector, row.project_id.as_deref())
             .with_context(|| format!("failed to insert vector for {}", row.id))?;
+        writer_lease.ensure_active("record reindex metadata")?;
         record_reindex_metadata(
             db,
             &row.id,
@@ -7390,6 +7512,7 @@ async fn reindex_command_by_embedder(
             &target_fingerprint_for_reindex,
         )
         .with_context(|| format!("failed to record reindex metadata for {}", row.id))?;
+        writer_lease.ensure_active("persist reindex checkpoint")?;
         progress_store_for_reindex
             .upsert_running(&row.source_path, Some(row.chunk_index), embedder_name)
             .context("failed to persist reindex checkpoint")?;
@@ -7539,6 +7662,12 @@ struct StaleBatchTuning {
     max_batch_retries: usize,
 }
 
+struct StaleBatchExecution<'a> {
+    batch_size: usize,
+    policy: BatchRetryPolicy,
+    writer_lease: Option<&'a MaintenanceWriterLeaseGuard>,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ReindexEmbedderMode {
     resume: bool,
@@ -7587,10 +7716,14 @@ async fn reindex_stale_batches(
     embedder: &dyn Embedder,
     embedder_name: &str,
     target_fingerprint: &str,
-    batch_size: usize,
     target: ReindexVectorTarget,
-    policy: BatchRetryPolicy,
+    execution: StaleBatchExecution<'_>,
 ) -> Result<()> {
+    let StaleBatchExecution {
+        batch_size,
+        policy,
+        writer_lease,
+    } = execution;
     if batch_size == 0 {
         bail!("--batch-size must be greater than 0");
     }
@@ -7627,10 +7760,13 @@ async fn reindex_stale_batches(
     // of an in-memory list expanded into `NOT IN (?, ?, ...)` placeholders,
     // whose bind-variable count would overflow SQLITE_MAX_VARIABLE_NUMBER
     // (32766) on a pathological run and crash the skip-continue (issue #304).
+    ensure_maintenance_writer_lease_active(writer_lease, "create stale reindex skip table")?;
     ensure_reindex_skipped_table(db).context("failed to create reindex skip table")?;
+    ensure_maintenance_writer_lease_active(writer_lease, "reset stale reindex skip table")?;
     db.conn()
         .execute_batch(&format!("DELETE FROM {REINDEX_SKIPPED_TABLE};"))
         .context("failed to reset reindex skip table")?;
+    ensure_maintenance_writer_lease_active(writer_lease, "snapshot stale reindex work")?;
     build_reindex_stale_pending_rows(db, target_fingerprint, &target)
         .context("failed to snapshot stale reindex work list")?;
     let mut batch_index = 0usize;
@@ -7665,11 +7801,23 @@ async fn reindex_stale_batches(
                 skipped_failed_batches += 1;
                 skipped_failed_drawers += rows.len();
                 let failed_ids: Vec<String> = rows.iter().map(|row| row.id.clone()).collect();
+                ensure_maintenance_writer_lease_active(
+                    writer_lease,
+                    "record skipped stale reindex ids",
+                )?;
                 stage_reindex_skipped_ids(db, &failed_ids)
                     .context("failed to record skipped drawer ids")?;
+                ensure_maintenance_writer_lease_active(
+                    writer_lease,
+                    "delete skipped stale reindex work",
+                )?;
                 delete_reindex_pending_ids(db, &failed_ids)
                     .context("failed to delete skipped stale reindex work")?;
                 for (source_path, chunk_index) in reindex_source_checkpoints(&rows) {
+                    ensure_maintenance_writer_lease_active(
+                        writer_lease,
+                        "record failed stale reindex checkpoint",
+                    )?;
                     progress_store
                         .mark_failed(&source_path, Some(chunk_index), embedder_name)
                         .context("failed to record failed reindex checkpoint")?;
@@ -7678,9 +7826,14 @@ async fn reindex_stale_batches(
                 continue;
             }
         };
+        ensure_maintenance_writer_lease_active(writer_lease, "write stale reindex vector batch")?;
         let stats = write_reindex_vector_batch(db, &rows, &vectors, target_fingerprint)
             .context("failed to write stale reindex batch")?;
         let pulled_ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+        ensure_maintenance_writer_lease_active(
+            writer_lease,
+            "delete completed stale reindex work",
+        )?;
         delete_reindex_pending_ids(db, &pulled_ids)
             .context("failed to delete completed stale reindex work")?;
         processed += stats.reindexed;
@@ -7697,6 +7850,10 @@ async fn reindex_stale_batches(
             );
         }
         for (source_path, chunk_index) in reindex_source_checkpoints(&rows) {
+            ensure_maintenance_writer_lease_active(
+                writer_lease,
+                "persist stale reindex checkpoint",
+            )?;
             let checkpoint = if failed_sources.contains(source_path.as_str()) {
                 progress_store.mark_failed(&source_path, Some(chunk_index), embedder_name)
             } else {
@@ -7705,6 +7862,7 @@ async fn reindex_stale_batches(
             checkpoint.context("failed to persist reindex checkpoint")?;
         }
     }
+    ensure_maintenance_writer_lease_active(writer_lease, "finalize stale reindex checkpoints")?;
     progress_store
         .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, target_fingerprint)
         .context("failed to finalize completed reindex sources")?;
@@ -19987,6 +20145,11 @@ api_model = "text-embedding-3-large"
         calls: AtomicUsize,
     }
 
+    struct LeaseDroppingEmbedder {
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+    }
+
     #[async_trait::async_trait]
     impl Embedder for FailFirstBatchEmbedder {
         async fn embed(
@@ -20008,6 +20171,37 @@ api_model = "text-embedding-3-large"
 
         fn name(&self) -> &str {
             "fail-first-test"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Embedder for LeaseDroppingEmbedder {
+        async fn embed(
+            &self,
+            texts: &[&str],
+        ) -> std::result::Result<Vec<Vec<f32>>, mempal::embed::EmbedError> {
+            let db = Database::open(&self.db_path).map_err(|error| {
+                mempal::embed::EmbedError::Runtime(format!("open db in test embedder: {error}"))
+            })?;
+            db.runtime_writer_lease_release(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            )
+            .map_err(|error| {
+                mempal::embed::EmbedError::Runtime(format!(
+                    "release writer lease in test embedder: {error}"
+                ))
+            })?;
+            Ok(texts.iter().map(|text| test_vector(text)).collect())
+        }
+
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        fn name(&self) -> &str {
+            "lease-dropping-test"
         }
     }
 
@@ -20150,11 +20344,14 @@ api_model = "text-embedding-3-large"
             &embedder,
             "recording-test",
             TEST_TARGET_FINGERPRINT,
-            2,
             empty_reindex_target(None),
-            BatchRetryPolicy {
-                interval: std::time::Duration::from_millis(0),
-                max_retries: 0,
+            StaleBatchExecution {
+                batch_size: 2,
+                policy: BatchRetryPolicy {
+                    interval: std::time::Duration::from_millis(0),
+                    max_retries: 0,
+                },
+                writer_lease: None,
             },
         )
         .await
@@ -20205,11 +20402,14 @@ api_model = "text-embedding-3-large"
             &embedder,
             "fail-first-test",
             TEST_TARGET_FINGERPRINT,
-            2,
             empty_reindex_target(None),
-            BatchRetryPolicy {
-                interval: std::time::Duration::from_millis(0),
-                max_retries: 0,
+            StaleBatchExecution {
+                batch_size: 2,
+                policy: BatchRetryPolicy {
+                    interval: std::time::Duration::from_millis(0),
+                    max_retries: 0,
+                },
+                writer_lease: None,
             },
         )
         .await
@@ -20238,6 +20438,62 @@ api_model = "text-embedding-3-large"
             reindex_vector_ids(&db).expect("vector ids"),
             vec!["d-2".to_string(), "d-3".to_string()],
             "later batches still complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_stale_batches_stops_before_write_after_writer_lease_loss() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        db.recreate_vectors_table(8).expect("create vector table");
+        for i in 0i64..2 {
+            insert_reindex_test_drawer(
+                &db,
+                &format!("d-{i}"),
+                &format!("content {i}"),
+                "fixtures/source.txt",
+                i,
+            );
+        }
+        let writer_lease =
+            acquire_maintenance_writer_lease(&db, "test-stale-lease-loss").expect("writer lease");
+        let embedder = LeaseDroppingEmbedder {
+            db_path: db.path().to_path_buf(),
+            lease: writer_lease.lease().clone(),
+        };
+
+        let error = reindex_stale_batches(
+            &db,
+            &embedder,
+            "lease-dropping-test",
+            TEST_TARGET_FINGERPRINT,
+            empty_reindex_target(None),
+            StaleBatchExecution {
+                batch_size: 2,
+                policy: BatchRetryPolicy {
+                    interval: std::time::Duration::from_millis(0),
+                    max_retries: 0,
+                },
+                writer_lease: Some(&writer_lease),
+            },
+        )
+        .await
+        .expect_err("lost writer lease must stop stale reindex");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("lost before write stale reindex vector batch"),
+            "{rendered}"
+        );
+        assert_eq!(
+            db.vector_row_count().expect("vector count"),
+            0,
+            "lease loss must stop before writing vectors"
+        );
+        assert_eq!(
+            reindex_pending_count(&db).expect("pending count"),
+            2,
+            "lease loss must not delete pending work"
         );
     }
 
@@ -20387,11 +20643,14 @@ api_model = "text-embedding-3-large"
             &embedder,
             "recording-test",
             TEST_TARGET_FINGERPRINT,
-            2,
             empty_reindex_target(Some(3)),
-            BatchRetryPolicy {
-                interval: std::time::Duration::from_millis(0),
-                max_retries: 0,
+            StaleBatchExecution {
+                batch_size: 2,
+                policy: BatchRetryPolicy {
+                    interval: std::time::Duration::from_millis(0),
+                    max_retries: 0,
+                },
+                writer_lease: None,
             },
         )
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -4473,9 +4473,11 @@ fn init_command(db: &Database, dir: &Path, dry_run: bool) -> Result<()> {
         .to_string();
     let rooms = detect_rooms(dir)?;
     if !dry_run {
+        let writer_lease = acquire_cli_content_writer_lease(db, "init")?;
         for room in &rooms {
             let keywords = serde_json::to_string(&vec![room.clone()])
                 .context("failed to serialize taxonomy keywords")?;
+            writer_lease.ensure_active("insert init taxonomy room")?;
             db.conn().execute("INSERT OR IGNORE INTO taxonomy (wing, room, display_name, keywords) VALUES (?1, ?2, ?3, ?4)", (&wing, room, room, keywords.as_str())).with_context(|| format!("failed to insert taxonomy room {room}"))?;
         }
     }
@@ -5568,6 +5570,7 @@ async fn checkpoint_command(
             let project_id = resolve_project_id(project.as_deref(), config, cwd.as_deref())
                 .context("failed to resolve checkpoint project id")?;
 
+            let writer_lease = acquire_cli_content_writer_lease(db, "checkpoint-save")?;
             let embedder = build_embedder(config).await?;
             let vectors = embedder
                 .embed(&[content.as_str()])
@@ -5594,8 +5597,10 @@ async fn checkpoint_command(
                 ..drawer
             };
 
+            writer_lease.ensure_active("insert checkpoint drawer")?;
             db.insert_drawer_with_project(&drawer, project_id.as_deref())
                 .with_context(|| format!("failed to insert checkpoint drawer {}", drawer.id))?;
+            writer_lease.ensure_active("insert checkpoint vector")?;
             db.insert_vector_with_project(&drawer_id, &vector, project_id.as_deref())
                 .with_context(|| format!("failed to insert vector for checkpoint {drawer_id}"))?;
 
@@ -5667,7 +5672,9 @@ async fn checkpoint_command(
                 )?;
                 println!("dry-run: would delete {count} checkpoints older than {cutoff_ts}");
             } else {
+                let writer_lease = acquire_cli_content_writer_lease(db, "checkpoint-cleanup")?;
                 let now_ts = iso_timestamp();
+                writer_lease.ensure_active("cleanup checkpoint drawers")?;
                 let affected = db.conn().execute(
                     "UPDATE drawers SET deleted_at = ?1 \
                      WHERE wing = 'session-checkpoint' AND deleted_at IS NULL \
@@ -6584,6 +6591,7 @@ fn effective_wake_up_text(drawer: &mempal::core::types::Drawer) -> &str {
 fn project_command(db: &Database, command: ProjectCommands) -> Result<()> {
     match command {
         ProjectCommands::Migrate { project, wing } => {
+            let _writer_lease = acquire_maintenance_writer_lease(db, "project-migrate")?;
             migrate_null_project_ids(db.path(), &project, wing.as_deref(), |event| match event {
                 ProjectMigrationEvent::Busy { delay_ms } => {
                     println!("batch busy, retrying in {delay_ms}ms");
@@ -6756,6 +6764,11 @@ fn consolidate_command(
     .context("failed to find similar drawer clusters")?;
 
     println!("clusters_found: {}", clusters.len());
+    let writer_lease = if options.dry_run {
+        None
+    } else {
+        Some(acquire_maintenance_writer_lease(db, "consolidate")?)
+    };
     let mut processed = 0usize;
     let mut drawers_merged = 0usize;
     for (index, cluster) in clusters.iter().take(limit).enumerate() {
@@ -6763,6 +6776,10 @@ fn consolidate_command(
             .iter()
             .map(|(drawer_id, _)| drawer_id.clone())
             .collect::<Vec<_>>();
+        ensure_maintenance_writer_lease_active(
+            writer_lease.as_ref(),
+            "merge consolidation cluster",
+        )?;
         let result = merge_cluster(db, &drawer_ids, strategy, options.dry_run)
             .context("failed to merge drawer cluster")?;
         processed += 1;
@@ -6808,6 +6825,11 @@ fn sleep_command(db: &Database, config: &Config, options: SleepCommandOptions) -
     let current_dir = env::current_dir().ok();
     let project_id = resolve_project_id(None, config, current_dir.as_deref())
         .context("failed to resolve project id for sleep cycle")?;
+    let _writer_lease = if options.dry_run {
+        None
+    } else {
+        Some(acquire_maintenance_writer_lease(db, "sleep")?)
+    };
     let summary = run_sleep_cycle(
         db,
         config,
@@ -6880,6 +6902,11 @@ async fn crystallize_command(
         Some(project) => Some(project),
         None => resolve_project_id(None, config, current_dir.as_deref())
             .context("failed to resolve project id for crystallization")?,
+    };
+    let _writer_lease = if options.dry_run {
+        None
+    } else {
+        Some(acquire_cli_content_writer_lease(db, "crystallize")?)
     };
     let summary = run_crystallization(
         db,
@@ -7292,6 +7319,8 @@ fn recompute_effective_importance_command(db: &Database) -> Result<()> {
         "recomputing effective_importance (decay_rate={}, floor={}, boost_cap={})...",
         imp.decay_rate, imp.floor, imp.boost_cap
     );
+    let writer_lease = acquire_maintenance_writer_lease(db, "recompute-effective-importance")?;
+    writer_lease.ensure_active("recompute effective_importance")?;
     let updated = db
         .recompute_all_effective_importance(now_ms, imp.decay_rate, imp.floor, imp.boost_cap)
         .context("failed to recompute effective_importance")?;
@@ -20287,6 +20316,102 @@ api_model = "text-embedding-3-large"
         vec![text.len() as f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
     }
 
+    fn new_temp_db() -> (tempfile::TempDir, Database) {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        (tmp, db)
+    }
+
+    fn hold_daemon_writer_lease(db: &Database) -> RuntimeWriterLease {
+        db.runtime_writer_lease_acquire(
+            SQLITE_WRITER_LEASE_NAME,
+            "test-daemon-writer",
+            "daemon",
+            MAINTENANCE_WRITER_LEASE_TTL_SECS,
+            None,
+        )
+        .expect("acquire daemon writer lease")
+        .expect("daemon writer lease")
+    }
+
+    fn assert_writer_lease_conflict(error: &anyhow::Error) {
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("SQLite writer lease `sqlite-writer` is already held"),
+            "{rendered}"
+        );
+    }
+
+    fn insert_checkpoint_drawer(db: &Database, id: &str, added_at: &str) {
+        let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+            id: id.to_string(),
+            content: "checkpoint content".to_string(),
+            wing: "session-checkpoint".to_string(),
+            room: Some("claude".to_string()),
+            source_file: Some("session-checkpoint".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: added_at.to_string(),
+            chunk_index: Some(0),
+            importance: 4,
+        });
+        db.insert_drawer(&drawer).expect("insert checkpoint drawer");
+    }
+
+    fn insert_cli_test_drawer(db: &Database, id: &str) {
+        let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+            id: id.to_string(),
+            content: "CLI writer lease regression drawer".to_string(),
+            wing: "lease-test".to_string(),
+            room: Some("cli".to_string()),
+            source_file: Some("tests://cli-writer-lease".to_string()),
+            source_type: SourceType::AgentInference,
+            added_at: "2026-01-01T00:00:00Z".to_string(),
+            chunk_index: Some(0),
+            importance: 3,
+        });
+        db.insert_drawer(&drawer).expect("insert CLI test drawer");
+    }
+
+    fn checkpoint_count(db: &Database) -> i64 {
+        db.conn()
+            .query_row(
+                "SELECT COUNT(*) FROM drawers WHERE wing = 'session-checkpoint'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .expect("count checkpoint drawers")
+    }
+
+    fn drawer_deleted_at(db: &Database, id: &str) -> Option<String> {
+        db.conn()
+            .query_row(
+                "SELECT deleted_at FROM drawers WHERE id = ?1",
+                [id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .expect("load drawer deleted_at")
+    }
+
+    fn drawer_project_id(db: &Database, id: &str) -> Option<String> {
+        db.conn()
+            .query_row(
+                "SELECT project_id FROM drawers WHERE id = ?1",
+                [id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .expect("load drawer project_id")
+    }
+
+    fn drawer_effective_importance(db: &Database, id: &str) -> f64 {
+        db.conn()
+            .query_row(
+                "SELECT effective_importance FROM drawers WHERE id = ?1",
+                [id],
+                |row| row.get::<_, f64>(0),
+            )
+            .expect("load drawer effective_importance")
+    }
+
     fn empty_reindex_target(limit: Option<usize>) -> ReindexVectorTarget {
         ReindexVectorTarget {
             drawer_ids: Vec::new(),
@@ -20399,6 +20524,178 @@ api_model = "text-embedding-3-large"
     fn char_safe_preview_returns_input_unchanged_when_short() {
         let content = "短文本"; // 3 chars, well under the limit
         assert_eq!(char_safe_preview(content, 300), content);
+    }
+
+    #[tokio::test]
+    async fn cli_checkpoint_writes_reject_existing_writer_lease() {
+        let (_tmp, db) = new_temp_db();
+        let config = Config::default();
+        insert_checkpoint_drawer(&db, "checkpoint-old", "2000-01-01T00:00:00Z");
+        let _daemon_lease = hold_daemon_writer_lease(&db);
+
+        let save_error = checkpoint_command(
+            &db,
+            &config,
+            CheckpointCommands::Save {
+                content: Some("new checkpoint content".to_string()),
+                project: Some("lease-project".to_string()),
+            },
+        )
+        .await
+        .expect_err("checkpoint save must reject under daemon writer lease");
+        assert_writer_lease_conflict(&save_error);
+
+        let cleanup_error = checkpoint_command(
+            &db,
+            &config,
+            CheckpointCommands::Cleanup {
+                max_age: "1h".to_string(),
+                dry_run: false,
+            },
+        )
+        .await
+        .expect_err("checkpoint cleanup must reject under daemon writer lease");
+        assert_writer_lease_conflict(&cleanup_error);
+
+        assert_eq!(
+            checkpoint_count(&db),
+            1,
+            "conflicting save must not insert a checkpoint drawer"
+        );
+        assert_eq!(
+            drawer_deleted_at(&db, "checkpoint-old"),
+            None,
+            "conflicting cleanup must not soft-delete checkpoint drawers"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_checkpoint_cleanup_succeeds_without_writer_conflict() {
+        let (_tmp, db) = new_temp_db();
+        let config = Config::default();
+        insert_checkpoint_drawer(&db, "checkpoint-cleanup", "2000-01-01T00:00:00Z");
+
+        checkpoint_command(
+            &db,
+            &config,
+            CheckpointCommands::Cleanup {
+                max_age: "1h".to_string(),
+                dry_run: false,
+            },
+        )
+        .await
+        .expect("checkpoint cleanup without writer conflict");
+
+        assert!(
+            drawer_deleted_at(&db, "checkpoint-cleanup").is_some(),
+            "checkpoint cleanup should soft-delete old checkpoint"
+        );
+    }
+
+    #[test]
+    fn cli_project_migrate_rejects_existing_writer_lease() {
+        let (_tmp, db) = new_temp_db();
+        insert_cli_test_drawer(&db, "project-migrate-conflict");
+        let _daemon_lease = hold_daemon_writer_lease(&db);
+
+        let error = project_command(
+            &db,
+            ProjectCommands::Migrate {
+                project: "lease-project".to_string(),
+                wing: None,
+            },
+        )
+        .expect_err("project migrate must reject under daemon writer lease");
+
+        assert_writer_lease_conflict(&error);
+        assert_eq!(
+            drawer_project_id(&db, "project-migrate-conflict"),
+            None,
+            "conflicting project migration must not update drawer project_id"
+        );
+    }
+
+    #[test]
+    fn cli_project_migrate_succeeds_without_writer_conflict() {
+        let (_tmp, db) = new_temp_db();
+        db.recreate_vectors_table(8).expect("create vector table");
+        insert_cli_test_drawer(&db, "project-migrate-success");
+
+        project_command(
+            &db,
+            ProjectCommands::Migrate {
+                project: "lease-project".to_string(),
+                wing: None,
+            },
+        )
+        .expect("project migrate without writer conflict");
+
+        assert_eq!(
+            drawer_project_id(&db, "project-migrate-success").as_deref(),
+            Some("lease-project")
+        );
+    }
+
+    #[test]
+    fn cli_effective_importance_recompute_rejects_existing_writer_lease() {
+        let (_tmp, db) = new_temp_db();
+        insert_cli_test_drawer(&db, "importance-conflict");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0 WHERE id = ?1",
+                ["importance-conflict"],
+            )
+            .expect("reset effective importance");
+        let _daemon_lease = hold_daemon_writer_lease(&db);
+
+        let error = recompute_effective_importance_command(&db)
+            .expect_err("effective importance recompute must reject under daemon writer lease");
+
+        assert_writer_lease_conflict(&error);
+        assert_eq!(
+            drawer_effective_importance(&db, "importance-conflict"),
+            0.0,
+            "conflicting recompute must not update effective_importance"
+        );
+    }
+
+    #[test]
+    fn cli_effective_importance_recompute_succeeds_without_writer_conflict() {
+        let (_tmp, db) = new_temp_db();
+        insert_cli_test_drawer(&db, "importance-success");
+        db.conn()
+            .execute(
+                "UPDATE drawers SET effective_importance = 0.0 WHERE id = ?1",
+                ["importance-success"],
+            )
+            .expect("reset effective importance");
+
+        recompute_effective_importance_command(&db)
+            .expect("effective importance recompute without writer conflict");
+
+        assert!(
+            drawer_effective_importance(&db, "importance-success") > 0.0,
+            "successful recompute should update effective_importance"
+        );
+    }
+
+    #[tokio::test]
+    async fn cli_crystallize_dry_run_does_not_require_writer_lease() {
+        let (_tmp, db) = new_temp_db();
+        let config = Config::default();
+        let _daemon_lease = hold_daemon_writer_lease(&db);
+
+        crystallize_command(
+            &db,
+            &config,
+            CrystallizeCliOptions {
+                dry_run: true,
+                project: None,
+                json: true,
+            },
+        )
+        .await
+        .expect("crystallize dry-run should not require writer lease");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2847,6 +2847,13 @@ struct HistoricalRejudgeCheckpointStart<'a> {
     judge_model: Option<String>,
     backup_dir: Option<&'a Path>,
     options_hash: String,
+    writer_lease: Option<&'a MaintenanceWriterLeaseGuard>,
+}
+
+#[derive(Clone, Copy)]
+struct HistoricalRejudgeWorkContext<'a> {
+    llm_context: Option<&'a HistoricalRejudgeLlmContext>,
+    writer_lease: Option<&'a MaintenanceWriterLeaseGuard>,
 }
 
 #[derive(Debug, Clone)]
@@ -14731,11 +14738,12 @@ async fn maintenance_rejudge_command_with_runtime(
 ) -> Result<()> {
     validate_historical_rejudge_options(options)?;
     validate_historical_rejudge_runtime_options(runtime)?;
-    let _writer_lease = if options.execute {
+    let writer_lease = if options.execute {
         Some(acquire_maintenance_writer_lease(db, "maintenance-rejudge")?)
     } else {
         None
     };
+    let writer_lease = writer_lease.as_ref();
     let current_dir = env::current_dir().ok();
     let project_id = if options.project.is_some() {
         resolve_project_id(options.project, config, current_dir.as_deref())
@@ -14753,11 +14761,20 @@ async fn maintenance_rejudge_command_with_runtime(
             runtime,
             project_id,
             progress.as_mut(),
+            writer_lease,
         )
         .await;
     }
 
-    maintenance_rejudge_limited_command(db, config, options, project_id, progress.as_mut()).await
+    maintenance_rejudge_limited_command(
+        db,
+        config,
+        options,
+        project_id,
+        progress.as_mut(),
+        writer_lease,
+    )
+    .await
 }
 
 fn validate_historical_rejudge_options(options: HistoricalRejudgeOptions<'_>) -> Result<()> {
@@ -14823,6 +14840,7 @@ async fn maintenance_rejudge_limited_command(
     options: HistoricalRejudgeOptions<'_>,
     project_id: Option<String>,
     mut progress: Option<&mut HistoricalRejudgeProgressWriter>,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<()> {
     let started = std::time::Instant::now();
     let rows = db
@@ -14956,41 +14974,48 @@ async fn maintenance_rejudge_limited_command(
     }
 
     let mutated_count = if options.execute {
-        with_historical_rejudge_transaction(db, || {
-            let mutated_count = if candidate_ids.is_empty() {
-                0
-            } else {
-                delete_rejudge_backup_items_by_version_inner(
-                    db,
-                    &candidate_backup_items,
-                    options.hard_delete,
-                )
-                .context("failed to delete historical rejudge candidates")?
-            };
-            let mutation = if options.hard_delete {
-                "hard_delete"
-            } else {
-                "soft_delete"
-            };
-            for (row, decision) in &decisions {
-                record_historical_rejudge_decision_audit(
-                    db,
-                    row,
-                    decision,
-                    judge_model.as_deref(),
-                    &config_version,
-                    mutation,
-                )?;
-            }
-            Ok(mutated_count)
-        })?
+        with_historical_rejudge_transaction_with_writer_lease(
+            db,
+            writer_lease,
+            "apply limited historical rejudge mutations",
+            || {
+                let mutated_count = if candidate_ids.is_empty() {
+                    0
+                } else {
+                    delete_rejudge_backup_items_by_version_inner(
+                        db,
+                        &candidate_backup_items,
+                        options.hard_delete,
+                    )
+                    .context("failed to delete historical rejudge candidates")?
+                };
+                let mutation = if options.hard_delete {
+                    "hard_delete"
+                } else {
+                    "soft_delete"
+                };
+                for (row, decision) in &decisions {
+                    record_historical_rejudge_decision_audit(
+                        db,
+                        row,
+                        decision,
+                        judge_model.as_deref(),
+                        &config_version,
+                        mutation,
+                    )?;
+                }
+                Ok(mutated_count)
+            },
+        )?
     } else {
         0
     };
 
     if options.execute {
-        append_audit_entry(
+        append_audit_entry_with_writer_lease(
             db,
+            writer_lease,
+            "append limited historical rejudge audit",
             "maintenance-rejudge",
             &serde_json::json!({
                 "hard_delete": options.hard_delete,
@@ -15091,6 +15116,17 @@ fn record_historical_rejudge_decision_audit(
     .context("failed to record historical rejudge audit")
 }
 
+fn append_audit_entry_with_writer_lease(
+    db: &Database,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
+    operation: &'static str,
+    command: &str,
+    details: &serde_json::Value,
+) -> Result<()> {
+    ensure_maintenance_writer_lease_active(writer_lease, operation)?;
+    append_audit_entry(db, command, details)
+}
+
 fn historical_rejudge_effective_backup_dir(
     options: HistoricalRejudgeOptions<'_>,
     backup_required: bool,
@@ -15120,6 +15156,7 @@ async fn maintenance_rejudge_all_command(
     runtime: HistoricalRejudgeRuntimeOptions,
     project_id: Option<String>,
     mut progress: Option<&mut HistoricalRejudgeProgressWriter>,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<()> {
     let started = std::time::Instant::now();
     let config_version = historical_rejudge_config_version(config);
@@ -15154,6 +15191,7 @@ async fn maintenance_rejudge_all_command(
         return print_historical_rejudge_report(&report, options.format);
     }
 
+    ensure_maintenance_writer_lease_active(writer_lease, "prepare historical rejudge checkpoint")?;
     let mut checkpoint = prepare_historical_rejudge_checkpoint(
         db,
         options,
@@ -15165,6 +15203,7 @@ async fn maintenance_rejudge_all_command(
             .may_mutate()
             .then_some(backup_dir.as_deref())
             .flatten(),
+        writer_lease,
     )
     .context("failed to prepare historical rejudge checkpoint")?;
 
@@ -15173,6 +15212,7 @@ async fn maintenance_rejudge_all_command(
         options,
         &mut checkpoint,
         backup_dir.as_deref(),
+        writer_lease,
     )?;
 
     if let Some(writer) = progress.as_mut() {
@@ -15241,7 +15281,12 @@ async fn maintenance_rejudge_all_command(
 
     checkpoint.status = "running".to_string();
     checkpoint.updated_at = iso_timestamp();
-    save_historical_rejudge_checkpoint(db, &checkpoint)?;
+    save_historical_rejudge_checkpoint_with_writer_lease(
+        db,
+        &checkpoint,
+        writer_lease,
+        "mark historical rejudge checkpoint running",
+    )?;
 
     loop {
         let page = next_historical_rejudge_work_items_for_stage(
@@ -15254,6 +15299,10 @@ async fn maintenance_rejudge_all_command(
             break;
         }
 
+        let work_context = HistoricalRejudgeWorkContext {
+            llm_context: llm_context.as_ref(),
+            writer_lease,
+        };
         let page_result = if runtime.llm_concurrency == DEFAULT_HISTORICAL_REJUDGE_LLM_CONCURRENCY {
             process_historical_rejudge_work_page(
                 db,
@@ -15261,7 +15310,7 @@ async fn maintenance_rejudge_all_command(
                 options,
                 &mut checkpoint,
                 &page,
-                llm_context.as_ref(),
+                work_context,
             )
             .await
         } else {
@@ -15271,7 +15320,7 @@ async fn maintenance_rejudge_all_command(
                 options,
                 &mut checkpoint,
                 &page,
-                llm_context.as_ref(),
+                work_context,
                 runtime.llm_concurrency,
             )
             .await
@@ -15292,11 +15341,17 @@ async fn maintenance_rejudge_all_command(
                     db,
                     &mut checkpoint,
                     "waiting_llm",
+                    writer_lease,
                 )?;
             } else {
                 checkpoint.status = "failed".to_string();
                 checkpoint.updated_at = iso_timestamp();
-                save_historical_rejudge_checkpoint(db, &checkpoint)?;
+                save_historical_rejudge_checkpoint_with_writer_lease(
+                    db,
+                    &checkpoint,
+                    writer_lease,
+                    "persist failed historical rejudge checkpoint",
+                )?;
             }
             if let Some(writer) = progress.as_mut() {
                 writer.write_event(build_historical_rejudge_progress_event(
@@ -15342,6 +15397,7 @@ async fn maintenance_rejudge_all_command(
                     db,
                     &mut checkpoint,
                     "running",
+                    writer_lease,
                 )?;
                 continue;
             }
@@ -15387,10 +15443,17 @@ async fn maintenance_rejudge_all_command(
         "proposal_pending".to_string()
     };
     checkpoint.updated_at = iso_timestamp();
-    save_historical_rejudge_checkpoint(db, &checkpoint)?;
-
-    append_audit_entry(
+    save_historical_rejudge_checkpoint_with_writer_lease(
         db,
+        &checkpoint,
+        writer_lease,
+        "persist final historical rejudge checkpoint",
+    )?;
+
+    append_audit_entry_with_writer_lease(
+        db,
+        writer_lease,
+        "append all historical rejudge audit",
         "maintenance-rejudge",
         &serde_json::json!({
             "all": true,
@@ -15657,13 +15720,18 @@ fn prepare_historical_rejudge_checkpoint(
     config_version: &str,
     judge_model: Option<String>,
     backup_dir: Option<&Path>,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<HistoricalRejudgeCheckpoint> {
+    ensure_maintenance_writer_lease_active(
+        writer_lease,
+        "prepare historical rejudge checkpoint storage",
+    )?;
     ensure_historical_rejudge_checkpoint_storage(db)?;
     let options_hash = historical_rejudge_options_hash(options, project_id, config_version)?;
 
     if options.resume {
         let Some(checkpoint) = load_historical_rejudge_checkpoint(db)? else {
-            return start_historical_rejudge_checkpoint(
+            return start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
                 db,
                 options,
                 project_id,
@@ -15671,7 +15739,8 @@ fn prepare_historical_rejudge_checkpoint(
                 judge_model,
                 backup_dir,
                 options_hash,
-            );
+                writer_lease,
+            });
         };
         if checkpoint.status == "done" {
             bail!(
@@ -15690,7 +15759,7 @@ fn prepare_historical_rejudge_checkpoint(
         return Ok(checkpoint);
     }
 
-    start_historical_rejudge_checkpoint(
+    start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
         db,
         options,
         project_id,
@@ -15698,7 +15767,8 @@ fn prepare_historical_rejudge_checkpoint(
         judge_model,
         backup_dir,
         options_hash,
-    )
+        writer_lease,
+    })
 }
 
 fn historical_rejudge_checkpoint_matches_resume(
@@ -15886,26 +15956,9 @@ fn historical_rejudge_stage_endpoint_model_parts<'a>(
 }
 
 fn start_historical_rejudge_checkpoint(
-    db: &Database,
-    options: HistoricalRejudgeOptions<'_>,
-    project_id: Option<&str>,
-    config_version: &str,
-    judge_model: Option<String>,
-    backup_dir: Option<&Path>,
-    options_hash: String,
+    input: HistoricalRejudgeCheckpointStart<'_>,
 ) -> Result<HistoricalRejudgeCheckpoint> {
-    start_historical_rejudge_checkpoint_with_observer(
-        HistoricalRejudgeCheckpointStart {
-            db,
-            options,
-            project_id,
-            config_version,
-            judge_model,
-            backup_dir,
-            options_hash,
-        },
-        |_| Ok(()),
-    )
+    start_historical_rejudge_checkpoint_with_observer(input, |_| Ok(()))
 }
 
 fn start_historical_rejudge_checkpoint_with_observer(
@@ -15920,6 +15973,7 @@ fn start_historical_rejudge_checkpoint_with_observer(
         judge_model,
         backup_dir,
         options_hash,
+        writer_lease,
     } = input;
 
     let started_at = iso_timestamp();
@@ -15936,49 +15990,54 @@ fn start_historical_rejudge_checkpoint_with_observer(
         })
         .transpose()?;
 
-    with_historical_rejudge_transaction(db, || {
-        let snapshot_max_rowid = db
-            .historical_rejudge_scope_max_rowid(options.wing, options.room, project_id)
-            .context("failed to snapshot historical rejudge max rowid")?
-            .unwrap_or(0);
-        after_snapshot_bound(snapshot_max_rowid)?;
-        reset_historical_rejudge_work_items(db, &run_id)?;
-        let snapshot_count = insert_historical_rejudge_work_items(
-            db,
-            &run_id,
-            options.wing,
-            options.room,
-            project_id,
-            snapshot_max_rowid,
-        )?;
-        let checkpoint = HistoricalRejudgeCheckpoint {
-            run_id,
-            status: "running".to_string(),
-            options_hash,
-            started_at: started_at.clone(),
-            updated_at: started_at,
-            snapshot_max_rowid,
-            snapshot_count,
-            last_processed_rowid: None,
-            scanned_count: 0,
-            candidate_count: 0,
-            kept_count: 0,
-            protected_count: 0,
-            mutated_count: 0,
-            estimated_bytes_reclaimed: 0,
-            mutation: if options.hard_delete {
-                "hard_delete".to_string()
-            } else {
-                "soft_delete".to_string()
-            },
-            page_size: options.page_size,
-            judge_model,
-            config_version: config_version.to_string(),
-            backup_path,
-        };
-        save_historical_rejudge_checkpoint(db, &checkpoint)?;
-        Ok(checkpoint)
-    })
+    with_historical_rejudge_transaction_with_writer_lease(
+        db,
+        writer_lease,
+        "start historical rejudge checkpoint",
+        || {
+            let snapshot_max_rowid = db
+                .historical_rejudge_scope_max_rowid(options.wing, options.room, project_id)
+                .context("failed to snapshot historical rejudge max rowid")?
+                .unwrap_or(0);
+            after_snapshot_bound(snapshot_max_rowid)?;
+            reset_historical_rejudge_work_items(db, &run_id)?;
+            let snapshot_count = insert_historical_rejudge_work_items(
+                db,
+                &run_id,
+                options.wing,
+                options.room,
+                project_id,
+                snapshot_max_rowid,
+            )?;
+            let checkpoint = HistoricalRejudgeCheckpoint {
+                run_id,
+                status: "running".to_string(),
+                options_hash,
+                started_at: started_at.clone(),
+                updated_at: started_at,
+                snapshot_max_rowid,
+                snapshot_count,
+                last_processed_rowid: None,
+                scanned_count: 0,
+                candidate_count: 0,
+                kept_count: 0,
+                protected_count: 0,
+                mutated_count: 0,
+                estimated_bytes_reclaimed: 0,
+                mutation: if options.hard_delete {
+                    "hard_delete".to_string()
+                } else {
+                    "soft_delete".to_string()
+                },
+                page_size: options.page_size,
+                judge_model,
+                config_version: config_version.to_string(),
+                backup_path,
+            };
+            save_historical_rejudge_checkpoint(db, &checkpoint)?;
+            Ok(checkpoint)
+        },
+    )
 }
 
 fn ensure_historical_rejudge_checkpoint_backup_for_mutation(
@@ -15986,6 +16045,7 @@ fn ensure_historical_rejudge_checkpoint_backup_for_mutation(
     options: HistoricalRejudgeOptions<'_>,
     checkpoint: &mut HistoricalRejudgeCheckpoint,
     backup_dir: Option<&Path>,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<()> {
     if !historical_rejudge_backup_required(options)
         || checkpoint.backup_path.is_some()
@@ -16007,7 +16067,12 @@ fn ensure_historical_rejudge_checkpoint_backup_for_mutation(
         .context("failed to create historical rejudge confirmation backup")?,
     );
     checkpoint.updated_at = iso_timestamp();
-    save_historical_rejudge_checkpoint(db, checkpoint)?;
+    save_historical_rejudge_checkpoint_with_writer_lease(
+        db,
+        checkpoint,
+        writer_lease,
+        "persist historical rejudge backup checkpoint",
+    )?;
     Ok(())
 }
 
@@ -16037,7 +16102,7 @@ async fn process_historical_rejudge_work_page(
     options: HistoricalRejudgeOptions<'_>,
     checkpoint: &mut HistoricalRejudgeCheckpoint,
     page: &[HistoricalRejudgeWorkItem],
-    llm_context: Option<&HistoricalRejudgeLlmContext>,
+    context: HistoricalRejudgeWorkContext<'_>,
 ) -> Result<()> {
     process_historical_rejudge_work_page_with_concurrency(
         db,
@@ -16045,7 +16110,7 @@ async fn process_historical_rejudge_work_page(
         options,
         checkpoint,
         page,
-        llm_context,
+        context,
         DEFAULT_HISTORICAL_REJUDGE_LLM_CONCURRENCY,
     )
     .await
@@ -16057,31 +16122,37 @@ async fn process_historical_rejudge_work_page_with_concurrency(
     options: HistoricalRejudgeOptions<'_>,
     checkpoint: &mut HistoricalRejudgeCheckpoint,
     page: &[HistoricalRejudgeWorkItem],
-    llm_context: Option<&HistoricalRejudgeLlmContext>,
+    context: HistoricalRejudgeWorkContext<'_>,
     llm_concurrency: usize,
 ) -> Result<()> {
     let prepared = prepare_historical_rejudge_work_page(
         db,
         config,
         page,
-        llm_context,
+        context,
         llm_concurrency,
         options.stage_mode,
     )
     .await?;
-    process_prepared_historical_rejudge_work_items(db, options, checkpoint, &prepared)
+    process_prepared_historical_rejudge_work_items(
+        db,
+        options,
+        checkpoint,
+        &prepared,
+        context.writer_lease,
+    )
 }
 
 async fn prepare_historical_rejudge_work_page(
     db: &Database,
     config: &Config,
     page: &[HistoricalRejudgeWorkItem],
-    llm_context: Option<&HistoricalRejudgeLlmContext>,
+    context: HistoricalRejudgeWorkContext<'_>,
     llm_concurrency: usize,
     stage_mode: HistoricalRejudgeStageMode,
 ) -> Result<Vec<PreparedHistoricalRejudgeWorkItem>> {
     prepare_historical_rejudge_work_page_with(page, llm_concurrency, |work_item| {
-        prepare_historical_rejudge_work_item(db, config, work_item, llm_context, stage_mode)
+        prepare_historical_rejudge_work_item(db, config, work_item, context, stage_mode)
     })
     .await
 }
@@ -16126,7 +16197,7 @@ async fn prepare_historical_rejudge_work_item(
     db: &Database,
     config: &Config,
     work_item: &HistoricalRejudgeWorkItem,
-    llm_context: Option<&HistoricalRejudgeLlmContext>,
+    context: HistoricalRejudgeWorkContext<'_>,
     stage_mode: HistoricalRejudgeStageMode,
 ) -> Result<PreparedHistoricalRejudgeWorkItem> {
     let row = db
@@ -16157,7 +16228,7 @@ async fn prepare_historical_rejudge_work_item(
     }
 
     let decision =
-        evaluate_historical_work_item(db, work_item, &row, config, llm_context, stage_mode).await?;
+        evaluate_historical_work_item(db, work_item, &row, config, context, stage_mode).await?;
     Ok(PreparedHistoricalRejudgeWorkItem {
         work_item: work_item.clone(),
         row: Some(row),
@@ -16172,12 +16243,17 @@ async fn evaluate_historical_work_item(
     work_item: &HistoricalRejudgeWorkItem,
     row: &mempal::core::db::HistoricalRejudgeCandidate,
     config: &Config,
-    llm_context: Option<&HistoricalRejudgeLlmContext>,
+    context: HistoricalRejudgeWorkContext<'_>,
     stage_mode: HistoricalRejudgeStageMode,
 ) -> Result<HistoricalRejudgeDecision> {
     if let Some(decision) = evaluate_historical_pre_llm(row, config) {
         if decision.delete_candidate && stage_mode == HistoricalRejudgeStageMode::ProposalOnly {
-            return persist_historical_rejudge_proposal_pending_decision(db, work_item, decision);
+            return persist_historical_rejudge_proposal_pending_decision(
+                db,
+                work_item,
+                decision,
+                context.writer_lease,
+            );
         }
         let drain_pending_delete = decision.delete_candidate
             && stage_mode == HistoricalRejudgeStageMode::ConfirmPendingOnly
@@ -16189,16 +16265,28 @@ async fn evaluate_historical_work_item(
         // LLM call. Drain it through the configured confirmation stage.
     }
 
-    if let Some(context) = llm_context {
-        return context
-            .evaluate_work_item(db, work_item, &row.drawer, config, stage_mode)
+    if let Some(llm_context) = context.llm_context {
+        return llm_context
+            .evaluate_work_item(
+                db,
+                work_item,
+                &row.drawer,
+                config,
+                stage_mode,
+                context.writer_lease,
+            )
             .await
             .context("historical rejudge LLM gate failed");
     }
 
     let decision = deterministic_historical_decision(&row.drawer);
     if decision.delete_candidate && stage_mode == HistoricalRejudgeStageMode::ProposalOnly {
-        return persist_historical_rejudge_proposal_pending_decision(db, work_item, decision);
+        return persist_historical_rejudge_proposal_pending_decision(
+            db,
+            work_item,
+            decision,
+            context.writer_lease,
+        );
     }
     if decision.delete_candidate
         && stage_mode == HistoricalRejudgeStageMode::ConfirmPendingOnly
@@ -16214,13 +16302,15 @@ fn persist_historical_rejudge_proposal_pending_decision(
     db: &Database,
     work_item: &HistoricalRejudgeWorkItem,
     decision: HistoricalRejudgeDecision,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<HistoricalRejudgeDecision> {
     let proposal_score = decision.score.unwrap_or(0.0);
-    match mark_historical_rejudge_work_item_llm_confirm_pending_or_keep(
+    match mark_historical_rejudge_work_item_llm_confirm_pending_or_keep_with_writer_lease(
         db,
         &work_item.run_id,
         work_item.drawer_rowid,
         proposal_score,
+        writer_lease,
     )? {
         HistoricalRejudgeConfirmPendingPersistence::Persisted => {
             Ok(historical_rejudge_proposal_pending_decision(decision))
@@ -16275,6 +16365,7 @@ fn process_prepared_historical_rejudge_work_items(
     options: HistoricalRejudgeOptions<'_>,
     checkpoint: &mut HistoricalRejudgeCheckpoint,
     prepared: &[PreparedHistoricalRejudgeWorkItem],
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<()> {
     let finalized = finalize_prepared_historical_rejudge_work_items(db, options, prepared)?;
     let backup_items = finalized
@@ -16296,58 +16387,68 @@ fn process_prepared_historical_rejudge_work_items(
     }
 
     let mut next_checkpoint = checkpoint.clone();
-    with_historical_rejudge_transaction(db, || {
-        let mutated_count = if backup_items.is_empty() {
-            0
-        } else {
-            delete_rejudge_backup_items_by_version_inner(db, &backup_items, options.hard_delete)
-                .context("failed to delete historical rejudge candidates")?
-        };
-
-        for item in &finalized {
-            if let (Some(row), Some(decision)) = (item.row.as_ref(), item.decision.as_ref()) {
-                if decision.requires_confirmation {
-                    next_checkpoint.last_processed_rowid = Some(item.work_item.drawer_rowid);
-                    continue;
-                }
-                record_historical_rejudge_decision_audit(
-                    db,
-                    row,
-                    decision,
-                    next_checkpoint.judge_model.as_deref(),
-                    &next_checkpoint.config_version,
-                    &next_checkpoint.mutation,
-                )?;
-                update_historical_rejudge_checkpoint_stats(&mut next_checkpoint, row, decision, 0);
-                mark_historical_rejudge_work_item_processed(
-                    db,
-                    &next_checkpoint.run_id,
-                    item.work_item.drawer_rowid,
-                    if decision.delete_candidate {
-                        "skip"
-                    } else {
-                        "keep"
-                    },
-                    &next_checkpoint.mutation,
-                )?;
+    with_historical_rejudge_transaction_with_writer_lease(
+        db,
+        writer_lease,
+        "apply historical rejudge page mutations",
+        || {
+            let mutated_count = if backup_items.is_empty() {
+                0
             } else {
-                next_checkpoint.scanned_count += 1;
-                let decision = item.terminal_decision.unwrap_or("missing");
-                mark_historical_rejudge_work_item_processed(
-                    db,
-                    &next_checkpoint.run_id,
-                    item.work_item.drawer_rowid,
-                    decision,
-                    "none",
-                )?;
+                delete_rejudge_backup_items_by_version_inner(db, &backup_items, options.hard_delete)
+                    .context("failed to delete historical rejudge candidates")?
+            };
+
+            for item in &finalized {
+                if let (Some(row), Some(decision)) = (item.row.as_ref(), item.decision.as_ref()) {
+                    if decision.requires_confirmation {
+                        next_checkpoint.last_processed_rowid = Some(item.work_item.drawer_rowid);
+                        continue;
+                    }
+                    record_historical_rejudge_decision_audit(
+                        db,
+                        row,
+                        decision,
+                        next_checkpoint.judge_model.as_deref(),
+                        &next_checkpoint.config_version,
+                        &next_checkpoint.mutation,
+                    )?;
+                    update_historical_rejudge_checkpoint_stats(
+                        &mut next_checkpoint,
+                        row,
+                        decision,
+                        0,
+                    );
+                    mark_historical_rejudge_work_item_processed(
+                        db,
+                        &next_checkpoint.run_id,
+                        item.work_item.drawer_rowid,
+                        if decision.delete_candidate {
+                            "skip"
+                        } else {
+                            "keep"
+                        },
+                        &next_checkpoint.mutation,
+                    )?;
+                } else {
+                    next_checkpoint.scanned_count += 1;
+                    let decision = item.terminal_decision.unwrap_or("missing");
+                    mark_historical_rejudge_work_item_processed(
+                        db,
+                        &next_checkpoint.run_id,
+                        item.work_item.drawer_rowid,
+                        decision,
+                        "none",
+                    )?;
+                }
+                next_checkpoint.last_processed_rowid = Some(item.work_item.drawer_rowid);
             }
-            next_checkpoint.last_processed_rowid = Some(item.work_item.drawer_rowid);
-        }
-        next_checkpoint.mutated_count += mutated_count;
-        next_checkpoint.updated_at = iso_timestamp();
-        save_historical_rejudge_checkpoint(db, &next_checkpoint)?;
-        Ok(())
-    })?;
+            next_checkpoint.mutated_count += mutated_count;
+            next_checkpoint.updated_at = iso_timestamp();
+            save_historical_rejudge_checkpoint(db, &next_checkpoint)?;
+            Ok(())
+        },
+    )?;
     *checkpoint = next_checkpoint;
     Ok(())
 }
@@ -16715,6 +16816,25 @@ fn mark_historical_rejudge_work_item_llm_confirm_pending_or_keep(
     historical_rejudge_confirm_pending_persistence_outcome(result, proposal_score)
 }
 
+fn mark_historical_rejudge_work_item_llm_confirm_pending_or_keep_with_writer_lease(
+    db: &Database,
+    run_id: &str,
+    drawer_rowid: i64,
+    proposal_score: f64,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
+) -> Result<HistoricalRejudgeConfirmPendingPersistence> {
+    ensure_maintenance_writer_lease_active(
+        writer_lease,
+        "persist historical rejudge proposal confirmation backlog",
+    )?;
+    mark_historical_rejudge_work_item_llm_confirm_pending_or_keep(
+        db,
+        run_id,
+        drawer_rowid,
+        proposal_score,
+    )
+}
+
 fn historical_rejudge_confirm_pending_persistence_outcome(
     result: Result<()>,
     proposal_score: f64,
@@ -16851,6 +16971,16 @@ fn save_historical_rejudge_checkpoint(
     Ok(())
 }
 
+fn save_historical_rejudge_checkpoint_with_writer_lease(
+    db: &Database,
+    checkpoint: &HistoricalRejudgeCheckpoint,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
+    operation: &'static str,
+) -> Result<()> {
+    ensure_maintenance_writer_lease_active(writer_lease, operation)?;
+    save_historical_rejudge_checkpoint(db, checkpoint)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HistoricalRejudgeCheckpointPersistence {
     Persisted,
@@ -16861,9 +16991,14 @@ fn persist_historical_rejudge_llm_retry_status_checkpoint(
     db: &Database,
     checkpoint: &mut HistoricalRejudgeCheckpoint,
     status: &'static str,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<HistoricalRejudgeCheckpointPersistence> {
     checkpoint.status = status.to_string();
     checkpoint.updated_at = iso_timestamp();
+    ensure_maintenance_writer_lease_active(
+        writer_lease,
+        "persist historical rejudge LLM retry checkpoint",
+    )?;
     historical_rejudge_checkpoint_persistence_outcome(
         save_historical_rejudge_checkpoint(db, checkpoint),
         status,
@@ -17330,6 +17465,16 @@ fn with_historical_rejudge_transaction<T>(
             Err(error)
         }
     }
+}
+
+fn with_historical_rejudge_transaction_with_writer_lease<T>(
+    db: &Database,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
+    operation_name: &'static str,
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    ensure_maintenance_writer_lease_active(writer_lease, operation_name)?;
+    with_historical_rejudge_transaction(db, operation)
 }
 
 fn append_historical_rejudge_backup_items_durable(
@@ -17959,7 +18104,7 @@ fn maintenance_rejudge_restore_command(
         conflict_count: 0,
         audit_count: 0,
     };
-    let _writer_lease = if execute {
+    let writer_lease = if execute {
         Some(acquire_maintenance_writer_lease(
             db,
             "maintenance-rejudge-restore",
@@ -17967,10 +18112,17 @@ fn maintenance_rejudge_restore_command(
     } else {
         None
     };
+    let writer_lease = writer_lease.as_ref();
 
     for item in &backup.items {
         let outcome = if execute {
-            restore_rejudge_backup_item_transaction(db, item, &backup, conflict_policy)?
+            restore_rejudge_backup_item_transaction(
+                db,
+                item,
+                &backup,
+                conflict_policy,
+                writer_lease,
+            )?
         } else {
             dry_run_rejudge_restore_item(db, item, conflict_policy)?
         };
@@ -17992,8 +18144,10 @@ fn maintenance_rejudge_restore_command(
     }
 
     if execute {
-        append_audit_entry(
+        append_audit_entry_with_writer_lease(
             db,
+            writer_lease,
+            "append historical rejudge restore audit",
             "maintenance-rejudge-restore",
             &serde_json::json!({
                 "backup": backup_path,
@@ -18203,7 +18357,9 @@ fn restore_rejudge_backup_item_transaction(
     item: &HistoricalRejudgeBackupItem,
     backup: &HistoricalRejudgeBackup,
     conflict_policy: RejudgeRestoreConflictPolicy,
+    writer_lease: Option<&MaintenanceWriterLeaseGuard>,
 ) -> Result<HistoricalRejudgeRestoreItemOutcome> {
+    ensure_maintenance_writer_lease_active(writer_lease, "restore historical rejudge backup item")?;
     db.conn()
         .execute_batch("BEGIN IMMEDIATE;")
         .context("failed to begin historical rejudge restore transaction")?;
@@ -19030,6 +19186,7 @@ impl HistoricalRejudgeLlmContext {
         drawer: &Drawer,
         config: &Config,
         stage_mode: HistoricalRejudgeStageMode,
+        writer_lease: Option<&MaintenanceWriterLeaseGuard>,
     ) -> Result<HistoricalRejudgeDecision> {
         match self {
             Self::Single { .. } => self.evaluate(drawer, config).await,
@@ -19066,11 +19223,12 @@ impl HistoricalRejudgeLlmContext {
                             requires_confirmation: false,
                         });
                     }
-                    match mark_historical_rejudge_work_item_llm_confirm_pending_or_keep(
+                    match mark_historical_rejudge_work_item_llm_confirm_pending_or_keep_with_writer_lease(
                         db,
                         &work_item.run_id,
                         work_item.drawer_rowid,
                         proposal_score,
+                        writer_lease,
                     )? {
                         HistoricalRejudgeConfirmPendingPersistence::Persisted => {}
                         HistoricalRejudgeConfirmPendingPersistence::Keep(decision) => {
@@ -21703,6 +21861,23 @@ threshold = 0.7
         tmp.path().join("rejudge-backups")
     }
 
+    fn release_writer_lease_for_test(db: &Database, lease: &MaintenanceWriterLeaseGuard) {
+        db.runtime_writer_lease_release(
+            &lease.lease().name,
+            &lease.lease().owner,
+            &lease.lease().session_id,
+        )
+        .expect("release writer lease");
+    }
+
+    fn assert_writer_lease_lost_before(error: &anyhow::Error, operation: &str) {
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains(&format!("lost before {operation}")),
+            "{rendered}"
+        );
+    }
+
     fn backup_files(dir: &Path) -> Vec<PathBuf> {
         if !dir.exists() {
             return Vec::new();
@@ -22195,6 +22370,7 @@ threshold = 0.7
             full_rejudge_options(true, None, 3),
             &mut checkpoint,
             &prepared,
+            None,
         )
         .expect("finalize prepared items");
 
@@ -22242,15 +22418,16 @@ threshold = 0.7
         ));
         let options_hash = historical_rejudge_options_hash(start_options, None, old_config_version)
             .expect("old options hash");
-        let checkpoint = start_historical_rejudge_checkpoint(
-            &db,
-            start_options,
-            None,
-            old_config_version,
-            judge_model.clone(),
-            Some(&backups),
+        let checkpoint = start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+            db: &db,
+            options: start_options,
+            project_id: None,
+            config_version: old_config_version,
+            judge_model: judge_model.clone(),
+            backup_dir: Some(&backups),
             options_hash,
-        )
+            writer_lease: None,
+        })
         .expect("start checkpoint");
 
         let resumed = prepare_historical_rejudge_checkpoint(
@@ -22263,6 +22440,7 @@ threshold = 0.7
             new_config_version,
             judge_model,
             Some(&backups),
+            None,
         )
         .expect("resume should tolerate unrelated config-version drift");
 
@@ -22280,6 +22458,7 @@ threshold = 0.7
             old_config_version,
             Some("proposal:qwen=other-model, confirm:spark=spark-model".to_string()),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed judge model even without config-version drift");
         assert!(
@@ -22308,6 +22487,7 @@ threshold = 0.7
                 historical_rejudge_endpoint_summary(&confirm_endpoint)
             )),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed endpoint identity despite same id/model");
         assert!(
@@ -22331,6 +22511,7 @@ threshold = 0.7
                 historical_rejudge_endpoint_summary(&confirm_endpoint)
             )),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed judge policy despite config-version drift");
         assert!(
@@ -22350,6 +22531,7 @@ threshold = 0.7
             new_config_version,
             Some("proposal:qwen=other-model, confirm:spark=spark-model".to_string()),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed judge model despite config-version drift");
         assert!(
@@ -22380,15 +22562,16 @@ threshold = 0.7
         let legacy_options_hash =
             historical_rejudge_options_hash(legacy_options, None, old_config_version)
                 .expect("legacy old options hash");
-        start_historical_rejudge_checkpoint(
-            &legacy_db,
-            legacy_options,
-            None,
-            old_config_version,
-            legacy_judge_model,
-            Some(&legacy_backups),
-            legacy_options_hash,
-        )
+        start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+            db: &legacy_db,
+            options: legacy_options,
+            project_id: None,
+            config_version: old_config_version,
+            judge_model: legacy_judge_model,
+            backup_dir: Some(&legacy_backups),
+            options_hash: legacy_options_hash,
+            writer_lease: None,
+        })
         .expect("start legacy checkpoint");
 
         let unsafe_required = prepare_historical_rejudge_checkpoint(
@@ -22401,6 +22584,7 @@ threshold = 0.7
             new_config_version,
             fingerprinted_judge_model.clone(),
             Some(&legacy_backups),
+            None,
         )
         .expect_err("legacy checkpoint without policy fingerprint must fail closed across config-version drift");
         assert!(
@@ -22421,6 +22605,7 @@ threshold = 0.7
             new_config_version,
             fingerprinted_judge_model,
             Some(&legacy_backups),
+            None,
         )
         .expect("explicit unsafe override should allow compatible legacy checkpoint");
         assert_eq!(unsafe_resumed.config_version, old_config_version);
@@ -22448,16 +22633,18 @@ threshold = 0.7
         );
         let options_hash = historical_rejudge_options_hash(options, None, old_config_version)
             .expect("old options hash");
-        let mut checkpoint = start_historical_rejudge_checkpoint(
-            &db,
-            options,
-            None,
-            old_config_version,
-            checkpoint_judge_model,
-            Some(&backups),
-            options_hash,
-        )
-        .expect("start checkpoint");
+        let mut checkpoint =
+            start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+                db: &db,
+                options,
+                project_id: None,
+                config_version: old_config_version,
+                judge_model: checkpoint_judge_model,
+                backup_dir: Some(&backups),
+                options_hash,
+                writer_lease: None,
+            })
+            .expect("start checkpoint");
         checkpoint.status = "waiting_llm".to_string();
         checkpoint.last_processed_rowid = Some(drawer_rowid(&db, "live-resume-drift"));
         save_historical_rejudge_checkpoint(&db, &checkpoint).expect("save live checkpoint");
@@ -22472,6 +22659,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model.clone(),
             Some(&backups),
+            None,
         )
         .expect("resume should accept live two-stage endpoint=model summary drift");
         assert_eq!(resumed.run_id, checkpoint.run_id);
@@ -22492,6 +22680,7 @@ threshold = 0.7
                     .to_string(),
             ),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed two-stage judge model");
         assert!(
@@ -22512,6 +22701,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model.clone(),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed filters");
         assert!(
@@ -22533,6 +22723,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model.clone(),
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed destructive scope");
         assert!(
@@ -22553,6 +22744,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model,
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject changed stored page size");
         assert!(
@@ -22577,15 +22769,16 @@ threshold = 0.7
         let new_policy = Some("deterministic@policy:new-policy".to_string());
         let options_hash = historical_rejudge_options_hash(options, None, old_config_version)
             .expect("old options hash");
-        start_historical_rejudge_checkpoint(
-            &db,
+        start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+            db: &db,
             options,
-            None,
-            old_config_version,
-            Some(old_policy),
-            Some(&backups),
+            project_id: None,
+            config_version: old_config_version,
+            judge_model: Some(old_policy),
+            backup_dir: Some(&backups),
             options_hash,
-        )
+            writer_lease: None,
+        })
         .expect("start deterministic checkpoint");
 
         let changed_policy = prepare_historical_rejudge_checkpoint(
@@ -22598,6 +22791,7 @@ threshold = 0.7
             new_config_version,
             new_policy,
             Some(&backups),
+            None,
         )
         .expect_err("resume must reject deterministic judge policy drift");
         assert!(
@@ -22624,15 +22818,16 @@ threshold = 0.7
         let legacy_options_hash =
             historical_rejudge_options_hash(legacy_options, None, old_config_version)
                 .expect("legacy old options hash");
-        start_historical_rejudge_checkpoint(
-            &legacy_db,
-            legacy_options,
-            None,
-            old_config_version,
-            Some("deterministic".to_string()),
-            Some(&legacy_backups),
-            legacy_options_hash,
-        )
+        start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+            db: &legacy_db,
+            options: legacy_options,
+            project_id: None,
+            config_version: old_config_version,
+            judge_model: Some("deterministic".to_string()),
+            backup_dir: Some(&legacy_backups),
+            options_hash: legacy_options_hash,
+            writer_lease: None,
+        })
         .expect("start legacy deterministic checkpoint");
 
         let legacy_bare_deterministic = prepare_historical_rejudge_checkpoint(
@@ -22645,6 +22840,7 @@ threshold = 0.7
             new_config_version,
             Some("deterministic".to_string()),
             Some(&legacy_backups),
+            None,
         )
         .expect_err("bare deterministic summary must fail closed across config-version drift");
         assert!(
@@ -22664,6 +22860,7 @@ threshold = 0.7
             new_config_version,
             Some("deterministic@policy:new-policy".to_string()),
             Some(&legacy_backups),
+            None,
         )
         .expect_err("legacy deterministic checkpoint without policy fingerprint must fail closed");
         assert!(
@@ -22684,6 +22881,7 @@ threshold = 0.7
             new_config_version,
             Some("deterministic@policy:new-policy".to_string()),
             Some(&legacy_backups),
+            None,
         )
         .expect("explicit unsafe override should allow legacy deterministic checkpoint");
         assert_eq!(legacy_unsafe_resumed.config_version, old_config_version);
@@ -22701,15 +22899,16 @@ threshold = 0.7
         let options = full_rejudge_options(true, Some(&backups), 1);
         let options_hash = historical_rejudge_options_hash(options, None, old_config_version)
             .expect("old options hash");
-        start_historical_rejudge_checkpoint(
-            &db,
+        start_historical_rejudge_checkpoint(HistoricalRejudgeCheckpointStart {
+            db: &db,
             options,
-            None,
-            old_config_version,
-            Some("legacy-model".to_string()),
-            Some(&backups),
+            project_id: None,
+            config_version: old_config_version,
+            judge_model: Some("legacy-model".to_string()),
+            backup_dir: Some(&backups),
             options_hash,
-        )
+            writer_lease: None,
+        })
         .expect("start legacy single-endpoint checkpoint");
 
         let endpoint =
@@ -22729,6 +22928,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model.clone(),
             Some(&backups),
+            None,
         )
         .expect_err("legacy single-endpoint label must fail closed without unsafe override");
         assert!(
@@ -22749,6 +22949,7 @@ threshold = 0.7
             new_config_version,
             current_judge_model,
             Some(&backups),
+            None,
         )
         .expect("unsafe override should accept legacy single-endpoint model label");
         assert_eq!(resumed.config_version, old_config_version);
@@ -22971,6 +23172,124 @@ threshold = 0.7
             fts_matches.is_empty(),
             "soft-deleted forget candidates must not remain BM25-searchable: {fts_matches:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn historical_rejudge_limited_stops_before_mutation_after_writer_lease_loss() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        insert_drawer(&db, "limited-lease-loss", "ok", "notes", None);
+        let backups = backup_dir(&tmp);
+        let writer_lease = acquire_maintenance_writer_lease(&db, "test-rejudge-limited-lease-loss")
+            .expect("writer lease");
+        release_writer_lease_for_test(&db, &writer_lease);
+
+        let error = maintenance_rejudge_limited_command(
+            &db,
+            &test_config(),
+            HistoricalRejudgeOptions {
+                execute: true,
+                hard_delete: false,
+                backup_dir: Some(&backups),
+                unsafe_no_backup: false,
+                limit: 100,
+                all: false,
+                resume: false,
+                unsafe_allow_config_version_drift: false,
+                page_size: DEFAULT_HISTORICAL_REJUDGE_PAGE_SIZE,
+                progress_file: None,
+                stage_mode: HistoricalRejudgeStageMode::Paired,
+                proposal_llm_endpoint: None,
+                confirm_llm_endpoint: None,
+                wing: None,
+                room: None,
+                project: None,
+                format: "json",
+            },
+            None,
+            None,
+            Some(&writer_lease),
+        )
+        .await
+        .expect_err("lost writer lease must stop limited rejudge before mutation");
+
+        assert_writer_lease_lost_before(&error, "apply limited historical rejudge mutations");
+        assert!(
+            db.get_drawer("limited-lease-loss")
+                .expect("load active drawer")
+                .is_some(),
+            "limited rejudge must not soft-delete after lease loss"
+        );
+        assert_eq!(db.deleted_drawer_count().expect("deleted count"), 0);
+        assert_eq!(
+            audit_count(&db),
+            0,
+            "limited rejudge must not write decision audit after lease loss"
+        );
+    }
+
+    #[tokio::test]
+    async fn historical_rejudge_all_page_stops_before_mutation_after_writer_lease_loss() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        insert_drawer(&db, "all-lease-loss", "ok", "notes", None);
+        let backups = backup_dir(&tmp);
+        let config = test_config();
+        let config_version = historical_rejudge_config_version(&config);
+        let options = full_rejudge_options(true, Some(&backups), 1);
+        let writer_lease = acquire_maintenance_writer_lease(&db, "test-rejudge-all-lease-loss")
+            .expect("writer lease");
+        let mut checkpoint = prepare_historical_rejudge_checkpoint(
+            &db,
+            options,
+            None,
+            &config_version,
+            Some("deterministic".to_string()),
+            Some(&backups),
+            Some(&writer_lease),
+        )
+        .expect("prepare checkpoint");
+        let page = next_historical_rejudge_work_items(&db, &checkpoint.run_id, 1)
+            .expect("load first work page");
+        let prepared = prepare_historical_rejudge_work_item(
+            &db,
+            &config,
+            &page[0],
+            HistoricalRejudgeWorkContext {
+                llm_context: None,
+                writer_lease: Some(&writer_lease),
+            },
+            HistoricalRejudgeStageMode::Paired,
+        )
+        .await
+        .expect("prepare deletion candidate");
+        release_writer_lease_for_test(&db, &writer_lease);
+
+        let error = process_prepared_historical_rejudge_work_items(
+            &db,
+            options,
+            &mut checkpoint,
+            &[prepared],
+            Some(&writer_lease),
+        )
+        .expect_err("lost writer lease must stop all-mode page mutation");
+
+        assert_writer_lease_lost_before(&error, "apply historical rejudge page mutations");
+        assert!(
+            db.get_drawer("all-lease-loss")
+                .expect("load active drawer")
+                .is_some(),
+            "all-mode page must not soft-delete after lease loss"
+        );
+        assert_eq!(db.deleted_drawer_count().expect("deleted count"), 0);
+        assert_eq!(audit_count(&db), 0);
+        assert_eq!(checkpoint.scanned_count, 0);
+        let persisted = load_historical_rejudge_checkpoint(&db)
+            .expect("load persisted checkpoint")
+            .expect("checkpoint");
+        assert_eq!(persisted.scanned_count, 0);
+        assert_eq!(persisted.mutated_count, 0);
+        assert_eq!(persisted.last_processed_rowid, None);
     }
 
     #[tokio::test]
@@ -23235,6 +23554,7 @@ threshold = 0.7
             &config_version,
             Some("deterministic".to_string()),
             Some(&backups),
+            None,
         )
         .expect("prepare full rejudge checkpoint");
         let page = next_historical_rejudge_work_items(&db, &checkpoint.run_id, 1)
@@ -23244,7 +23564,10 @@ threshold = 0.7
             &db,
             &config,
             &page[0],
-            None,
+            HistoricalRejudgeWorkContext {
+                llm_context: None,
+                writer_lease: None,
+            },
             HistoricalRejudgeStageMode::Paired,
         )
         .await
@@ -23259,8 +23582,14 @@ threshold = 0.7
 
         protect_rejudge_candidate_metadata(&db, "low");
 
-        process_prepared_historical_rejudge_work_items(&db, options, &mut checkpoint, &[prepared])
-            .expect("process rejudge page");
+        process_prepared_historical_rejudge_work_items(
+            &db,
+            options,
+            &mut checkpoint,
+            &[prepared],
+            None,
+        )
+        .expect("process rejudge page");
 
         assert_eq!(
             historical_rejudge_work_item_decision(&db, &checkpoint.run_id, page[0].drawer_rowid),
@@ -23978,6 +24307,73 @@ threshold = 0.7
             )
             .expect("count restore audits");
         assert_eq!(restore_audits, 0);
+    }
+
+    #[tokio::test]
+    async fn historical_rejudge_restore_item_stops_before_transaction_after_writer_lease_loss() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
+        insert_drawer(&db, "restore-lease-loss", "ok", "notes", None);
+        let backups = backup_dir(&tmp);
+
+        maintenance_rejudge_command(
+            &db,
+            &test_config(),
+            HistoricalRejudgeOptions {
+                execute: true,
+                hard_delete: false,
+                backup_dir: Some(&backups),
+                unsafe_no_backup: false,
+                limit: 100,
+                all: false,
+                resume: false,
+                unsafe_allow_config_version_drift: false,
+                page_size: DEFAULT_HISTORICAL_REJUDGE_PAGE_SIZE,
+                progress_file: None,
+                stage_mode: HistoricalRejudgeStageMode::Paired,
+                proposal_llm_endpoint: None,
+                confirm_llm_endpoint: None,
+                wing: None,
+                room: None,
+                project: None,
+                format: "json",
+            },
+        )
+        .await
+        .expect("create restore backup");
+        let backup = read_historical_rejudge_backup(&only_backup_file(&backups))
+            .expect("read rejudge backup");
+        let audit_count_before_restore = audit_count(&db);
+        let deleted_count_before_restore = db.deleted_drawer_count().expect("deleted count");
+        let writer_lease = acquire_maintenance_writer_lease(&db, "test-rejudge-restore-lease-loss")
+            .expect("writer lease");
+        release_writer_lease_for_test(&db, &writer_lease);
+
+        let error = restore_rejudge_backup_item_transaction(
+            &db,
+            &backup.items[0],
+            &backup,
+            RejudgeRestoreConflictPolicy::Skip,
+            Some(&writer_lease),
+        )
+        .expect_err("lost writer lease must stop restore item transaction");
+
+        assert_writer_lease_lost_before(&error, "restore historical rejudge backup item");
+        assert!(
+            db.get_drawer("restore-lease-loss")
+                .expect("load deleted drawer")
+                .is_none(),
+            "restore must not reactivate drawer after lease loss"
+        );
+        assert_eq!(
+            db.deleted_drawer_count().expect("deleted count"),
+            deleted_count_before_restore
+        );
+        assert_eq!(
+            audit_count(&db),
+            audit_count_before_restore,
+            "restore must not write per-drawer audit after lease loss"
+        );
     }
 
     #[tokio::test]
@@ -25288,6 +25684,7 @@ threshold = 0.7
             &config_version,
             Some("deterministic".to_string()),
             Some(&backups),
+            None,
         )
         .expect("prepare checkpoint");
         let backup_path = checkpoint.backup_path.clone().expect("backup path");
@@ -25308,7 +25705,10 @@ threshold = 0.7
             full_rejudge_options(true, Some(&backups), 1),
             &mut checkpoint,
             std::slice::from_ref(&first),
-            None,
+            HistoricalRejudgeWorkContext {
+                llm_context: None,
+                writer_lease: None,
+            },
         )
         .await
         .expect("process first item");
@@ -25384,6 +25784,7 @@ threshold = 0.7
             &config_version,
             Some("deterministic".to_string()),
             Some(&backups),
+            None,
         )
         .expect("prepare checkpoint");
         let backup_path = checkpoint.backup_path.clone().expect("backup path");
@@ -25409,7 +25810,10 @@ threshold = 0.7
             full_rejudge_options(true, Some(&backups), 1),
             &mut checkpoint,
             std::slice::from_ref(&work_item),
-            None,
+            HistoricalRejudgeWorkContext {
+                llm_context: None,
+                writer_lease: None,
+            },
         )
         .await
         .expect_err("injected work item failure must roll back");
@@ -25500,6 +25904,7 @@ threshold = 0.7
             &config_version,
             Some("deterministic".to_string()),
             Some(&backups),
+            None,
         )
         .expect("prepare checkpoint");
         let backup_path = checkpoint.backup_path.clone().expect("backup path");
@@ -25518,7 +25923,10 @@ threshold = 0.7
             full_rejudge_options(true, Some(&backups), 1),
             &mut checkpoint,
             std::slice::from_ref(&work_item),
-            None,
+            HistoricalRejudgeWorkContext {
+                llm_context: None,
+                writer_lease: None,
+            },
         )
         .await
         .expect_err("backup write failure must block deletion");
@@ -25574,6 +25982,7 @@ threshold = 0.7
             &config_version,
             Some("deterministic".to_string()),
             Some(&backups),
+            None,
         )
         .expect("prepare checkpoint");
 
@@ -25720,6 +26129,7 @@ threshold = 0.7
             &db,
             &mut checkpoint,
             "waiting_llm",
+            None,
         )
         .expect("waiting checkpoint lock must be deferred");
         assert_eq!(
@@ -25740,9 +26150,13 @@ threshold = 0.7
         blocker
             .execute_batch("COMMIT;")
             .expect("release write lock");
-        let outcome =
-            persist_historical_rejudge_llm_retry_status_checkpoint(&db, &mut checkpoint, "running")
-                .expect("running checkpoint save after lock release");
+        let outcome = persist_historical_rejudge_llm_retry_status_checkpoint(
+            &db,
+            &mut checkpoint,
+            "running",
+            None,
+        )
+        .expect("running checkpoint save after lock release");
         assert_eq!(outcome, HistoricalRejudgeCheckpointPersistence::Persisted);
         let persisted = load_historical_rejudge_checkpoint(&db)
             .expect("load running checkpoint")
@@ -26004,6 +26418,7 @@ threshold = 0.7
                 judge_model: Some("deterministic".to_string()),
                 backup_dir: Some(&backups),
                 options_hash,
+                writer_lease: None,
             },
             |snapshot_max_rowid| {
                 assert_eq!(snapshot_max_rowid, old_max_rowid);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4272,6 +4272,13 @@ fn acquire_cli_ingest_writer_lease(
     acquire_runtime_writer_lease(db, command, "ingest", "mempal-ingest")
 }
 
+fn acquire_cli_content_writer_lease(
+    db: &Database,
+    command: &str,
+) -> Result<MaintenanceWriterLeaseGuard> {
+    acquire_runtime_writer_lease(db, command, "cli-content-write", "mempal-cli")
+}
+
 fn acquire_runtime_writer_lease(
     db: &Database,
     command: &str,
@@ -6993,6 +7000,7 @@ fn set_pending_auto_card_status(
     let old_status = card.status.clone();
     card.status = status.clone();
     card.updated_at = current_timestamp();
+    let _writer_lease = acquire_cli_content_writer_lease(db, "cards-review")?;
     db.update_knowledge_card(&card)
         .context("failed to update knowledge card")?;
     db.append_knowledge_event(&KnowledgeCardEvent {
@@ -7992,6 +8000,7 @@ async fn knowledge_command(
                         .into_iter()
                         .next()
                         .context("embedder returned no vector")?;
+                    let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-distill")?;
                     commit_distill(db, *prepared, &vector)?
                 }
             };
@@ -8011,6 +8020,7 @@ async fn knowledge_command(
             reason,
             reviewer,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-promote")?;
             let outcome = promote_knowledge(
                 db,
                 PromoteRequest {
@@ -8035,6 +8045,7 @@ async fn knowledge_command(
             reason,
             reason_type,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-demote")?;
             let outcome = demote_knowledge(
                 db,
                 DemoteRequest {
@@ -8094,6 +8105,7 @@ async fn knowledge_command(
             reason,
             reviewer,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-publish-anchor")?;
             let outcome = publish_anchor(
                 db,
                 PublishAnchorRequest {
@@ -8181,6 +8193,7 @@ async fn knowledge_card_command(
                 created_at: now.clone(),
                 updated_at: now,
             };
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-card-create")?;
             db.insert_knowledge_card(&card)
                 .context("failed to insert knowledge card")?;
             match format.as_str() {
@@ -8281,6 +8294,7 @@ async fn knowledge_card_command(
                 note,
                 created_at: current_timestamp(),
             };
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-card-link")?;
             db.insert_knowledge_evidence_link(&link)
                 .context("failed to insert knowledge evidence link")?;
             println!("link_id={id} created=true");
@@ -8332,6 +8346,7 @@ async fn knowledge_card_command(
                 metadata,
                 created_at,
             };
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-card-event")?;
             db.append_knowledge_event(&event)
                 .context("failed to append knowledge card event")?;
             println!("event_id={id} created=true");
@@ -8369,6 +8384,7 @@ async fn knowledge_card_command(
             enforce_gate,
             format,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-card-promote")?;
             let outcome = promote_card(
                 db,
                 PromoteCardRequest {
@@ -8392,6 +8408,7 @@ async fn knowledge_card_command(
             reason_type,
             format,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "knowledge-card-demote")?;
             let outcome = demote_card(
                 db,
                 DemoteCardRequest {
@@ -8445,6 +8462,14 @@ async fn knowledge_card_command(
                 anchor_kind: anchor_kind.as_deref().map(parse_anchor_kind).transpose()?,
                 anchor_id,
                 ..KnowledgeCardFilter::default()
+            };
+            let _writer_lease = if execute {
+                Some(acquire_cli_content_writer_lease(
+                    db,
+                    "knowledge-card-backfill-apply",
+                )?)
+            } else {
+                None
             };
             let result = apply_backfill(db, &filter, KnowledgeCardBackfillApplyOptions { execute })
                 .context("failed to apply knowledge card backfill")?;
@@ -8955,6 +8980,8 @@ async fn research_ingest_plan_command(
                 .await
                 .context("failed to embed research evidence drawers")?;
 
+            let _writer_lease =
+                acquire_cli_content_writer_lease(db, "phase3-research-ingest-plan")?;
             for ((index, drawer_id, content), vector) in pending.into_iter().zip(vectors) {
                 let source_file = report.evidence_drawers[index].source_file.clone();
                 let drawer = research_evidence_drawer(
@@ -9079,6 +9106,14 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
                 let signal = parse_runtime_adoption_signal(&record_input.signal)?;
                 let should_write =
                     should_write_checked_record(&report.record_quality, allow_warnings);
+                let _writer_lease = if should_write {
+                    Some(acquire_cli_content_writer_lease(
+                        db,
+                        "phase3-adoption-capture",
+                    )?)
+                } else {
+                    None
+                };
                 let event = if should_write {
                     let event = runtime_adoption_event_from_input(record_input, track, signal);
                     db.insert_runtime_adoption_event(&event)
@@ -9171,6 +9206,14 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
             };
             let quality = check_runtime_adoption_record(&input);
             let should_write = should_write_checked_record(&quality, allow_warnings);
+            let _writer_lease = if should_write {
+                Some(acquire_cli_content_writer_lease(
+                    db,
+                    "phase3-adoption-record-checked",
+                )?)
+            } else {
+                None
+            };
             let event = if should_write {
                 let event = runtime_adoption_event_from_input(input, track, signal);
                 db.insert_runtime_adoption_event(&event)
@@ -9267,6 +9310,7 @@ fn phase3_adoption_command(db: &Database, command: Phase3AdoptionCommands) -> Re
                 signal,
             );
             let id = event.id.clone();
+            let _writer_lease = acquire_cli_content_writer_lease(db, "phase3-adoption-record")?;
             db.insert_runtime_adoption_event(&event)
                 .context("failed to insert runtime adoption event")?;
             match format.as_str() {
@@ -10283,6 +10327,7 @@ fn print_promotion_policy(policy: &[PromotionPolicyEntry]) {
 }
 
 fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
+    let _writer_lease = acquire_cli_content_writer_lease(db, "delete")?;
     let drawer = db
         .get_drawer(drawer_id)
         .context("failed to look up drawer")?;
@@ -10308,6 +10353,7 @@ fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
 }
 
 fn pin_command(db: &Database, drawer_id: &str) -> Result<()> {
+    let _writer_lease = acquire_cli_content_writer_lease(db, "pin")?;
     if !db
         .pin_drawer(drawer_id, None)
         .context("failed to pin drawer")?
@@ -10321,6 +10367,7 @@ fn pin_command(db: &Database, drawer_id: &str) -> Result<()> {
 }
 
 fn unpin_command(db: &Database, drawer_id: &str) -> Result<()> {
+    let _writer_lease = acquire_cli_content_writer_lease(db, "unpin")?;
     if !db
         .unpin_drawer(drawer_id)
         .context("failed to unpin drawer")?
@@ -10341,6 +10388,7 @@ fn pinned_command(
     json: bool,
 ) -> Result<()> {
     if !reorder.is_empty() {
+        let _writer_lease = acquire_cli_content_writer_lease(db, "pinned-reorder")?;
         for drawer_id in reorder {
             if db
                 .get_drawer(drawer_id)
@@ -10436,6 +10484,7 @@ fn rollback_command(
             dry_run: true,
         }
     } else {
+        let _writer_lease = acquire_cli_content_writer_lease(db, "rollback")?;
         let drawer_ids = db
             .soft_delete_drawers_since(&since, options.wing, options.room, project_id.as_deref())
             .context("failed to rollback drawers")?;
@@ -10469,6 +10518,7 @@ fn rollback_command(
 }
 
 fn purge_command(db: &Database, before: Option<&str>) -> Result<()> {
+    let _writer_lease = acquire_cli_content_writer_lease(db, "purge")?;
     let deleted_count = db
         .deleted_drawer_count()
         .context("failed to count deleted drawers")?;
@@ -10515,6 +10565,7 @@ fn kg_command(db: &Database, command: KgCommands) -> Result<()> {
             object,
             source_drawer,
         } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "kg-add")?;
             let id = build_triple_id(&subject, &predicate, &object);
             let triple = Triple {
                 id: id.clone(),
@@ -10563,6 +10614,7 @@ fn kg_command(db: &Database, command: KgCommands) -> Result<()> {
             }
         }
         KgCommands::Invalidate { triple_id } => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "kg-invalidate")?;
             if !db
                 .triple_exists(&triple_id)
                 .context("failed to check triple existence")?
@@ -10632,6 +10684,7 @@ fn tunnels_command(db: &Database, command: Option<TunnelCommands>) -> Result<()>
     match command {
         None => tunnels_discover_command(db),
         Some(TunnelCommands::Add { left, right, label }) => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "tunnels-add")?;
             let tunnel = db
                 .create_tunnel(
                     &parse_tunnel_endpoint(&left)?,
@@ -10653,6 +10706,7 @@ fn tunnels_command(db: &Database, command: Option<TunnelCommands>) -> Result<()>
             tunnels_list_command(db, wing.as_deref(), &kind)
         }
         Some(TunnelCommands::Delete { tunnel_id }) => {
+            let _writer_lease = acquire_cli_content_writer_lease(db, "tunnels-delete")?;
             if tunnel_id.starts_with("passive_") {
                 bail!("cannot delete passive tunnel");
             }
@@ -10790,6 +10844,7 @@ fn taxonomy_list_command(db: &Database) -> Result<()> {
     Ok(())
 }
 fn taxonomy_edit_command(db: &Database, wing: &str, room: &str, keywords: &str) -> Result<()> {
+    let _writer_lease = acquire_cli_content_writer_lease(db, "taxonomy-edit")?;
     let entry = TaxonomyEntry {
         wing: wing.to_string(),
         room: room.to_string(),
@@ -19968,6 +20023,14 @@ fn phase3_adoption_wrap_command(db: &Database, opts: WrapCommandOpts) -> Result<
         let track = parse_runtime_adoption_track(&record_input.track)?;
         let signal = parse_runtime_adoption_signal(&record_input.signal)?;
         let should_write = should_write_checked_record(&capture.record_quality, allow_warnings);
+        let _writer_lease = if should_write {
+            Some(acquire_cli_content_writer_lease(
+                db,
+                "phase3-adoption-wrap",
+            )?)
+        } else {
+            None
+        };
         let event = if should_write {
             let ev = runtime_adoption_event_from_input(record_input, track, signal);
             db.insert_runtime_adoption_event(&ev)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -197,6 +197,15 @@ pub struct MempalMcpServer {
     content_writer_lease_renew_interval: Duration,
     #[cfg(any(test, feature = "db-test-seam"))]
     stale_penalty_delay: Option<Duration>,
+    #[cfg(test)]
+    mcp_ingest_side_effect_hook: Option<Arc<dyn Fn(McpIngestSideEffectStage) + Send + Sync>>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum McpIngestSideEffectStage {
+    Repair,
+    Pattern,
 }
 
 struct McpIngestWriterLeaseGuard {
@@ -424,6 +433,8 @@ impl MempalMcpServer {
             content_writer_lease_renew_interval: MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL,
             #[cfg(any(test, feature = "db-test-seam"))]
             stale_penalty_delay: None,
+            #[cfg(test)]
+            mcp_ingest_side_effect_hook: None,
         })
     }
 
@@ -478,6 +489,15 @@ impl MempalMcpServer {
         self
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_mcp_ingest_side_effect_hook_for_test(
+        mut self,
+        hook: Arc<dyn Fn(McpIngestSideEffectStage) + Send + Sync>,
+    ) -> Self {
+        self.mcp_ingest_side_effect_hook = Some(hook);
+        self
+    }
+
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_mcp_deadline_for_test(mut self, deadline: Duration) -> Self {
         self.search_route_deadline = deadline;
@@ -486,6 +506,13 @@ impl MempalMcpServer {
         self.ingest_admission_deadline = deadline;
         self.operation_status_deadline = deadline;
         self
+    }
+
+    #[cfg(test)]
+    fn run_mcp_ingest_side_effect_hook_for_test(&self, stage: McpIngestSideEffectStage) {
+        if let Some(hook) = &self.mcp_ingest_side_effect_hook {
+            hook(stage);
+        }
     }
 
     pub async fn serve_stdio(
@@ -5814,6 +5841,13 @@ impl MempalMcpServer {
 
         // Failure detection (P14) — fire-and-forget for each inserted drawer.
         if config.repair.enabled && !inserted_drawer_ids.is_empty() {
+            #[cfg(test)]
+            self.run_mcp_ingest_side_effect_hook_for_test(McpIngestSideEffectStage::Repair);
+            ensure_mcp_runtime_writer_lease_active(
+                &db,
+                runtime_writer_lease,
+                "record MCP ingest repair signal",
+            )?;
             for (drawer_id_r, chunk_r) in inserted_drawer_ids.iter().zip(chunks.iter()) {
                 crate::repair::spawn_failure_detection(
                     db.path().to_path_buf(),
@@ -5829,6 +5863,13 @@ impl MempalMcpServer {
 
         // Pattern detection (P13) — fire-and-forget for each inserted drawer.
         if config.patterns.enabled && !inserted_drawer_ids.is_empty() {
+            #[cfg(test)]
+            self.run_mcp_ingest_side_effect_hook_for_test(McpIngestSideEffectStage::Pattern);
+            ensure_mcp_runtime_writer_lease_active(
+                &db,
+                runtime_writer_lease,
+                "record MCP ingest pattern signal",
+            )?;
             let session_id = request
                 .source
                 .as_deref()
@@ -9437,7 +9478,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::time::Duration;
 
     use async_trait::async_trait;
@@ -9985,6 +10026,127 @@ quality_policy = "llm_required_for_keep"
             message.contains("SQLite writer lease `sqlite-writer` is already held"),
             "{message}"
         );
+    }
+
+    fn assert_writer_lease_lost(error: &ErrorData, operation: &str) {
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!("was lost before {operation}")),
+            "{message}"
+        );
+    }
+
+    fn mcp_ingest_side_effect_config(
+        db_path: &Path,
+        repair_enabled: bool,
+        patterns_enabled: bool,
+    ) -> String {
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "model2vec"
+
+[privacy]
+enabled = false
+
+[config_hot_reload]
+enabled = false
+
+[ingest_gating]
+enabled = false
+
+[repair]
+enabled = {}
+failure_keywords = []
+window_days = 7
+min_failures = 3
+alert_threshold = 3
+
+[patterns]
+enabled = {}
+similarity_threshold = 0.0
+min_sessions = 1
+min_exemplars = 1
+promote_threshold = 3
+retire_after_days = 90
+surfacing_threshold = 0.75
+pattern_boost = 0.2
+"#,
+            db_path.display(),
+            repair_enabled,
+            patterns_enabled
+        )
+    }
+
+    fn acquire_test_ingest_writer_lease(db_path: &Path, owner: &str) -> RuntimeWriterLease {
+        let db = Database::open(db_path).expect("open db");
+        db.runtime_writer_lease_acquire(
+            SQLITE_WRITER_LEASE_NAME,
+            owner,
+            "mcp-ingest-worker-test",
+            300,
+            None,
+        )
+        .expect("acquire test ingest writer lease")
+        .expect("test ingest writer lease")
+    }
+
+    fn release_test_ingest_writer_lease(db_path: &Path, lease: &RuntimeWriterLease) {
+        let db = Database::open(db_path).expect("open db");
+        assert!(
+            db.runtime_writer_lease_release(&lease.name, &lease.owner, &lease.session_id)
+                .expect("release test ingest writer lease"),
+            "test ingest writer lease should be active before release"
+        );
+    }
+
+    fn failure_event_count(db_path: &Path) -> i64 {
+        Database::open(db_path)
+            .expect("open db")
+            .conn()
+            .query_row("SELECT COUNT(*) FROM failure_events", [], |row| row.get(0))
+            .expect("count failure events")
+    }
+
+    fn pattern_count(db_path: &Path) -> i64 {
+        Database::open(db_path)
+            .expect("open db")
+            .conn()
+            .query_row("SELECT COUNT(*) FROM patterns", [], |row| row.get(0))
+            .expect("count patterns")
+    }
+
+    async fn wait_for_failure_event_count(db_path: &Path, expected: i64) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if failure_event_count(db_path) >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("failure detection should write event");
+    }
+
+    fn mcp_side_effect_ingest_request(content: &str, source: &str) -> IngestRequest {
+        IngestRequest {
+            content: content.to_string(),
+            wing: "mcp".to_string(),
+            room: Some("lease".to_string()),
+            source: Some(source.to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        }
+    }
+
+    fn side_effect_controls() -> IngestControls {
+        IngestControls {
+            no_gate: true,
+            bypass_novelty: true,
+        }
     }
 
     fn spawn_runtime_ticker() -> (Arc<AtomicU64>, tokio::task::JoinHandle<()>) {
@@ -13713,6 +13875,173 @@ quality_policy = "llm_required_for_keep"
 
         assert!(response.timed_out, "{response:?}");
         assert_eq!(db.drawer_count().expect("drawer count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_repair_signal_rechecks_writer_lease() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let _config_guard =
+            ConfigOverrideGuard::install(&mcp_ingest_side_effect_config(&db_path, true, false))
+                .await;
+        let lease = acquire_test_ingest_writer_lease(&db_path, "repair-side-effect-test");
+        let released = Arc::new(AtomicBool::new(false));
+        let hook = {
+            let db_path = db_path.clone();
+            let lease = lease.clone();
+            let released = Arc::clone(&released);
+            Arc::new(move |stage| {
+                if stage == McpIngestSideEffectStage::Repair
+                    && !released.swap(true, Ordering::SeqCst)
+                {
+                    release_test_ingest_writer_lease(&db_path, &lease);
+                }
+            })
+        };
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server")
+        .with_external_ingest_writer_lease(lease.clone())
+        .with_mcp_ingest_side_effect_hook_for_test(hook);
+
+        let error = match server
+            .mempal_ingest_sync(
+                mcp_side_effect_ingest_request(
+                    "repair side effect failed with error",
+                    "repair-session.md",
+                ),
+                side_effect_controls(),
+                Some(&lease),
+            )
+            .await
+        {
+            Ok(_) => panic!("repair signal must reject after writer lease loss"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_lost(&error, "record MCP ingest repair signal");
+        assert!(released.load(Ordering::SeqCst));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(failure_event_count(&db_path), 0);
+        assert_eq!(
+            Database::open(&db_path)
+                .expect("open db")
+                .drawer_count()
+                .expect("drawer count"),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_pattern_signal_rechecks_writer_lease() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        insert_drawer(
+            &db_path,
+            "pattern-lease-seed",
+            "existing recurring pattern evidence",
+            "mcp",
+            Some("lease"),
+            "pattern-session-a.md",
+            2,
+        );
+        let _config_guard =
+            ConfigOverrideGuard::install(&mcp_ingest_side_effect_config(&db_path, true, true))
+                .await;
+        let lease = acquire_test_ingest_writer_lease(&db_path, "pattern-side-effect-test");
+        let released = Arc::new(AtomicBool::new(false));
+        let hook = {
+            let db_path = db_path.clone();
+            let lease = lease.clone();
+            let released = Arc::clone(&released);
+            Arc::new(move |stage| {
+                if stage == McpIngestSideEffectStage::Pattern
+                    && !released.swap(true, Ordering::SeqCst)
+                {
+                    release_test_ingest_writer_lease(&db_path, &lease);
+                }
+            })
+        };
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server")
+        .with_external_ingest_writer_lease(lease.clone())
+        .with_mcp_ingest_side_effect_hook_for_test(hook);
+
+        let error = match server
+            .mempal_ingest_sync(
+                mcp_side_effect_ingest_request(
+                    "new recurring pattern evidence",
+                    "pattern-session-b.md",
+                ),
+                side_effect_controls(),
+                Some(&lease),
+            )
+            .await
+        {
+            Ok(_) => panic!("pattern signal must reject after writer lease loss"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_lost(&error, "record MCP ingest pattern signal");
+        assert!(released.load(Ordering::SeqCst));
+        assert_eq!(pattern_count(&db_path), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_side_effect_signals_succeed_with_active_writer_lease() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        insert_drawer(
+            &db_path,
+            "pattern-success-seed",
+            "existing successful pattern evidence",
+            "mcp",
+            Some("lease"),
+            "pattern-success-a.md",
+            2,
+        );
+        let _config_guard =
+            ConfigOverrideGuard::install(&mcp_ingest_side_effect_config(&db_path, true, true))
+                .await;
+        let lease = acquire_test_ingest_writer_lease(&db_path, "side-effect-success-test");
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server")
+        .with_external_ingest_writer_lease(lease.clone());
+
+        let response = server
+            .mempal_ingest_sync(
+                mcp_side_effect_ingest_request(
+                    "new successful pattern failed with error",
+                    "pattern-success-b.md",
+                ),
+                side_effect_controls(),
+                Some(&lease),
+            )
+            .await
+            .expect("ingest succeeds with active writer lease")
+            .0;
+
+        assert!(!response.drawer_ids.is_empty());
+        wait_for_failure_event_count(&db_path, 1).await;
+        assert_eq!(pattern_count(&db_path), 1);
+        release_test_ingest_writer_lease(&db_path, &lease);
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6994,9 +6994,18 @@ impl MempalMcpServer {
                 let capture = if request.capture.unwrap_or(false) {
                     let execute = request.execute.unwrap_or(false);
                     let db = if execute { Some(self.open_db()?) } else { None };
+                    let writer_lease = if let Some(db) = db.as_ref() {
+                        Some(self.acquire_content_writer_lease(
+                            db,
+                            "mempal_cowork_bus session_close capture",
+                        )?)
+                    } else {
+                        None
+                    };
                     Some(
                         bus::capture_handoff_to_memory(
                             db.as_ref(),
+                            writer_lease.as_ref().map(|lease| &lease.lease),
                             &mempal_home,
                             &cwd,
                             bus::CoworkCaptureRequest {
@@ -7062,8 +7071,14 @@ impl MempalMcpServer {
             "capture" => {
                 let execute = request.execute.unwrap_or(false);
                 let db = if execute { Some(self.open_db()?) } else { None };
+                let writer_lease = if let Some(db) = db.as_ref() {
+                    Some(self.acquire_content_writer_lease(db, "mempal_cowork_bus capture")?)
+                } else {
+                    None
+                };
                 let report = bus::capture_handoff_to_memory(
                     db.as_ref(),
+                    writer_lease.as_ref().map(|lease| &lease.lease),
                     &mempal_home,
                     &cwd,
                     bus::CoworkCaptureRequest {
@@ -7126,6 +7141,20 @@ impl MempalMcpServer {
 
         // Apply stale penalty to drawers associated with StaleFact triples (P13).
         let stale_penalty = ConfigHandle::current().importance.stale_penalty;
+        let has_stale_penalty_targets = report.issues.iter().any(|issue| {
+            matches!(
+                issue,
+                crate::factcheck::FactIssue::StaleFact {
+                    source_drawer: Some(_),
+                    ..
+                }
+            )
+        });
+        let _writer_lease = if has_stale_penalty_targets {
+            Some(self.acquire_content_writer_lease(&db, "mempal_fact_check stale penalty")?)
+        } else {
+            None
+        };
         for issue in &report.issues {
             if let crate::factcheck::FactIssue::StaleFact {
                 source_drawer: Some(drawer_id),
@@ -7240,6 +7269,8 @@ impl MempalMcpServer {
                 })?;
 
                 let skill_min_sessions = config.skills.skill_min_sessions;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_skill promote")?;
                 let skill = tokio::task::block_in_place(|| {
                     crate::core::skills::promote_pattern_to_skill(
                         db.conn(),
@@ -7278,6 +7309,7 @@ impl MempalMcpServer {
                     ErrorData::invalid_params("skill_id is required for adopt", None)
                 })?;
                 let active_threshold = config.skills.active_threshold;
+                let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_skill adopt")?;
                 let new_status = tokio::task::block_in_place(|| {
                     crate::core::skills::adopt_skill(db.conn(), skill_id, active_threshold)
                 })
@@ -7303,6 +7335,8 @@ impl MempalMcpServer {
                     ErrorData::invalid_params("skill_id is required for reject", None)
                 })?;
                 let retire_threshold = config.skills.retire_threshold;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_skill reject")?;
                 let new_status = tokio::task::block_in_place(|| {
                     crate::core::skills::reject_skill(db.conn(), skill_id, retire_threshold)
                 })
@@ -7327,6 +7361,8 @@ impl MempalMcpServer {
                 let skill_id = request.skill_id.as_deref().ok_or_else(|| {
                     ErrorData::invalid_params("skill_id is required for retire", None)
                 })?;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_skill retire")?;
                 let found = tokio::task::block_in_place(|| {
                     crate::core::skills::retire_skill(db.conn(), skill_id)
                 })
@@ -8230,9 +8266,13 @@ fn bus_error_to_mcp(error: BusError) -> ErrorData {
         | BusError::SelfSend(_)
         | BusError::MessageTooLarge(_)
         | BusError::InboxFull { .. } => ErrorData::invalid_params(error.to_string(), None),
-        BusError::LegacyInbox(_) | BusError::Io(_) | BusError::Json(_) | BusError::Db(_) => {
-            ErrorData::internal_error(error.to_string(), None)
-        }
+        BusError::MissingCaptureWriterLease
+        | BusError::CaptureWriterLeaseVerify { .. }
+        | BusError::CaptureWriterLeaseLost { .. }
+        | BusError::LegacyInbox(_)
+        | BusError::Io(_)
+        | BusError::Json(_)
+        | BusError::Db(_) => ErrorData::internal_error(error.to_string(), None),
     }
 }
 
@@ -10976,6 +11016,100 @@ quality_policy = "llm_required_for_keep"
         .expect("insert triple");
     }
 
+    fn insert_stale_triple_with_source_drawer(
+        db_path: &Path,
+        subject: &str,
+        predicate: &str,
+        object: &str,
+        source_drawer: &str,
+    ) {
+        let db = Database::open(db_path).expect("open db");
+        db.insert_triple(&Triple {
+            id: crate::core::utils::build_triple_id(subject, predicate, object),
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+            valid_from: Some("1700000000".to_string()),
+            valid_to: Some("1799999999".to_string()),
+            confidence: 1.0,
+            source_drawer: Some(source_drawer.to_string()),
+        })
+        .expect("insert stale triple");
+    }
+
+    fn read_stale_penalty(db_path: &Path, drawer_id: &str) -> f64 {
+        let db = Database::open(db_path).expect("open db");
+        db.conn()
+            .query_row(
+                "SELECT COALESCE(stale_penalty_applied, 1.0) FROM drawers WHERE id = ?1",
+                [drawer_id],
+                |row| row.get(0),
+            )
+            .expect("read stale penalty")
+    }
+
+    fn insert_active_skill_pattern(db_path: &Path, pattern_id: &str) {
+        let db = Database::open(db_path).expect("open db");
+        db.conn()
+            .execute(
+                r#"
+                INSERT INTO patterns (
+                    pattern_id, signature, exemplar_ids, exemplar_count,
+                    session_ids, session_count, topic_tags, model_id,
+                    status, first_seen_at, updated_at, project_id
+                ) VALUES (?1, ?2, ?3, 1, ?4, 6, ?5, 'test-model', 'active', 1713000000, 1713000000, NULL)
+                "#,
+                params![
+                    pattern_id,
+                    vec![0_u8; 32],
+                    r#"["drawer-a"]"#,
+                    r#"["session-a","session-b","session-c","session-d","session-e","session-f"]"#,
+                    r#"["lease-test"]"#,
+                ],
+            )
+            .expect("insert active skill pattern");
+    }
+
+    fn skill_row_count(db_path: &Path) -> i64 {
+        let db = Database::open(db_path).expect("open db");
+        db.conn()
+            .query_row("SELECT COUNT(*) FROM skills", [], |row| row.get(0))
+            .expect("count skills")
+    }
+
+    fn cowork_bus_request(action: &str, cwd: &Path) -> CoworkBusRequest {
+        CoworkBusRequest {
+            action: action.to_string(),
+            cwd: cwd.to_string_lossy().into_owned(),
+            agent_id: None,
+            tool: None,
+            transport: None,
+            tmux_target: None,
+            from: None,
+            to: Vec::new(),
+            agents: Vec::new(),
+            message: None,
+            thread_id: None,
+            channel: None,
+            message_id: None,
+            limit: None,
+            now: None,
+            seen_at: None,
+            lines: None,
+            probe_tmux: None,
+            session_id: None,
+            title: None,
+            goal: None,
+            status: None,
+            summary_source: None,
+            wing: None,
+            room: None,
+            note: None,
+            capture: None,
+            execute: None,
+        }
+    }
+
     async fn run_search(
         server: &MempalMcpServer,
         query: &str,
@@ -13101,6 +13235,232 @@ quality_policy = "llm_required_for_keep"
             db.list_explicit_tunnels(None).expect("list tunnels").len(),
             1
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mcp_fact_check_stale_penalty_rejects_existing_content_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "fact-check-stale-lease-target",
+            "Alice works at Acme.",
+            "mcp",
+            Some("lease"),
+            "/tmp/fact-check-stale.md",
+            3,
+        );
+        insert_stale_triple_with_source_drawer(
+            &db_path,
+            "Alice",
+            "works_at",
+            "Acme",
+            "fact-check-stale-lease-target",
+        );
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let error = match server
+            .mempal_fact_check(Parameters(FactCheckRequest {
+                text: "Alice works at Acme.".to_string(),
+                wing: None,
+                room: None,
+                now: Some("2028-01-15T08:00:00Z".to_string()),
+            }))
+            .await
+        {
+            Ok(_) => panic!("stale penalty write must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_conflict(&error);
+        assert_eq!(
+            read_stale_penalty(&db_path, "fact-check-stale-lease-target"),
+            1.0
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mcp_fact_check_stale_penalty_succeeds_without_content_writer_conflict() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "fact-check-stale-success-target",
+            "Alice works at Acme.",
+            "mcp",
+            Some("lease"),
+            "/tmp/fact-check-stale-success.md",
+            3,
+        );
+        insert_stale_triple_with_source_drawer(
+            &db_path,
+            "Alice",
+            "works_at",
+            "Acme",
+            "fact-check-stale-success-target",
+        );
+
+        let response = server
+            .mempal_fact_check(Parameters(FactCheckRequest {
+                text: "Alice works at Acme.".to_string(),
+                wing: None,
+                room: None,
+                now: Some("2028-01-15T08:00:00Z".to_string()),
+            }))
+            .await
+            .expect("fact check succeeds")
+            .0;
+
+        assert!(
+            response
+                .issues
+                .iter()
+                .any(|issue| matches!(issue, crate::factcheck::FactIssue::StaleFact { .. })),
+            "expected stale fact issue: {:?}",
+            response.issues
+        );
+        assert!(
+            read_stale_penalty(&db_path, "fact-check-stale-success-target") < 1.0,
+            "stale penalty should be applied"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mcp_skill_promote_rejects_existing_content_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_active_skill_pattern(&db_path, "pat-lease-conflict");
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let error = match server
+            .mempal_skill(Parameters(SkillRequest {
+                action: "promote".to_string(),
+                skill_id: None,
+                pattern_id: Some("pat-lease-conflict".to_string()),
+                name: Some("Lease guarded skill".to_string()),
+                trigger_description: Some("Use when validating writer leases".to_string()),
+                status: None,
+                project_id: None,
+            }))
+            .await
+        {
+            Ok(_) => panic!("skill promote must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_conflict(&error);
+        assert_eq!(skill_row_count(&db_path), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mcp_skill_promote_succeeds_without_content_writer_conflict() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_active_skill_pattern(&db_path, "pat-lease-success");
+
+        let response = server
+            .mempal_skill(Parameters(SkillRequest {
+                action: "promote".to_string(),
+                skill_id: None,
+                pattern_id: Some("pat-lease-success".to_string()),
+                name: Some("Lease guarded skill".to_string()),
+                trigger_description: Some("Use when validating writer leases".to_string()),
+                status: None,
+                project_id: None,
+            }))
+            .await
+            .expect("skill promote succeeds")
+            .0;
+
+        assert_eq!(response.status.as_deref(), Some("probationary"));
+        assert_eq!(skill_row_count(&db_path), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_capture_rejects_existing_content_writer_lease() {
+        let (tempdir, db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        let mut register = cowork_bus_request("register", &repo);
+        register.agent_id = Some("claude-main".to_string());
+        register.tool = Some("claude".to_string());
+        server
+            .mempal_cowork_bus(Parameters(register))
+            .await
+            .expect("register agent");
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let mut capture = cowork_bus_request("capture", &repo);
+        capture.execute = Some(true);
+        capture.summary_source = Some("handoff".to_string());
+        let error = match server.mempal_cowork_bus(Parameters(capture)).await {
+            Ok(_) => panic!("cowork capture must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_conflict(&error);
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(db.drawer_count().expect("drawer count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_session_close_capture_rejects_existing_content_writer_lease() {
+        let (tempdir, db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        let mut register = cowork_bus_request("register", &repo);
+        register.agent_id = Some("claude-main".to_string());
+        register.tool = Some("claude".to_string());
+        server
+            .mempal_cowork_bus(Parameters(register))
+            .await
+            .expect("register agent");
+        let mut create = cowork_bus_request("session_create", &repo);
+        create.session_id = Some("lease-session".to_string());
+        create.title = Some("Lease session".to_string());
+        create.agents = vec!["claude-main".to_string()];
+        server
+            .mempal_cowork_bus(Parameters(create))
+            .await
+            .expect("create session");
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let mut close = cowork_bus_request("session_close", &repo);
+        close.session_id = Some("lease-session".to_string());
+        close.capture = Some(true);
+        close.execute = Some(true);
+        close.summary_source = Some("handoff".to_string());
+        let error = match server.mempal_cowork_bus(Parameters(close)).await {
+            Ok(_) => panic!("cowork session_close capture must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_conflict(&error);
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(db.drawer_count().expect("drawer count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_cowork_capture_succeeds_without_content_writer_conflict() {
+        let (tempdir, db_path, server) = setup_server();
+        let (_mempal_home, repo, _guard) = setup_cowork_home(&tempdir).await;
+        let mut register = cowork_bus_request("register", &repo);
+        register.agent_id = Some("claude-main".to_string());
+        register.tool = Some("claude".to_string());
+        server
+            .mempal_cowork_bus(Parameters(register))
+            .await
+            .expect("register agent");
+
+        let mut capture = cowork_bus_request("capture", &repo);
+        capture.execute = Some(true);
+        capture.summary_source = Some("handoff".to_string());
+        let response = server
+            .mempal_cowork_bus(Parameters(capture))
+            .await
+            .expect("cowork capture succeeds")
+            .0;
+
+        let drawer_id = response
+            .capture
+            .and_then(|capture| capture.drawer_id)
+            .expect("capture drawer id");
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&drawer_id).expect("get drawer").is_some());
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,7 +26,7 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
-    queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore},
+    queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueError},
     reindex::ReindexProgressStore,
     remote_calls::{
         RemoteCallService, endpoint_policy_diagnostic_label, endpoint_policy_global_runtime_error,
@@ -186,7 +186,7 @@ pub struct MempalMcpServer {
     search_stale_index_deadline: Duration,
     ingest_admission_deadline: Duration,
     operation_status_deadline: Duration,
-    ingest_writer_lease_owned_externally: bool,
+    external_ingest_writer_lease: Option<RuntimeWriterLease>,
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_processing_delay: Option<Duration>,
 }
@@ -195,7 +195,8 @@ struct McpIngestWriterLeaseGuard {
     db_path: PathBuf,
     lease: RuntimeWriterLease,
     stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
-    heartbeat: tokio::task::JoinHandle<()>,
+    heartbeat: Option<tokio::task::JoinHandle<()>>,
+    released: bool,
 }
 
 impl McpIngestWriterLeaseGuard {
@@ -210,15 +211,22 @@ impl McpIngestWriterLeaseGuard {
             db_path,
             lease,
             stop_tx: Some(stop_tx),
-            heartbeat,
+            heartbeat: Some(heartbeat),
+            released: false,
         }
+    }
+
+    fn lease(&self) -> &RuntimeWriterLease {
+        &self.lease
     }
 
     async fn release(mut self) -> anyhow::Result<()> {
         if let Some(stop_tx) = self.stop_tx.take() {
             let _ = stop_tx.send(());
         }
-        let _ = self.heartbeat.await;
+        if let Some(heartbeat) = self.heartbeat.take() {
+            let _ = heartbeat.await;
+        }
         let db_path = self.db_path.clone();
         let lease = self.lease.clone();
         tokio::task::spawn_blocking(move || {
@@ -230,10 +238,56 @@ impl McpIngestWriterLeaseGuard {
             })?;
             db.runtime_writer_lease_release(&lease.name, &lease.owner, &lease.session_id)
                 .context("failed to release MCP ingest writer lease")?;
-            Ok(())
+            Ok::<(), anyhow::Error>(())
         })
         .await
-        .context("MCP ingest writer lease release task failed")?
+        .context("MCP ingest writer lease release task failed")??;
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for McpIngestWriterLeaseGuard {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(heartbeat) = self.heartbeat.take() {
+            heartbeat.abort();
+        }
+        if !self.released
+            && let Ok(db) = Database::open(&self.db_path)
+        {
+            let _ = db.runtime_writer_lease_release(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            );
+        }
+    }
+}
+
+fn ensure_mcp_runtime_writer_lease_active(
+    db: &Database,
+    lease: Option<&RuntimeWriterLease>,
+    operation: &'static str,
+) -> std::result::Result<(), ErrorData> {
+    let Some(lease) = lease else {
+        return Ok(());
+    };
+    let active = db
+        .runtime_writer_lease_is_active(&lease.name, &lease.owner, &lease.session_id)
+        .map_err(|error| database_write_refused_error(db.path(), operation, &error))?;
+    if active {
+        Ok(())
+    } else {
+        Err(ErrorData::internal_error(
+            format!(
+                "SQLite writer lease `{}` for {} was lost before {operation}",
+                lease.name, lease.owner
+            ),
+            None,
+        ))
     }
 }
 
@@ -282,14 +336,14 @@ impl MempalMcpServer {
             search_stale_index_deadline: MCP_SEARCH_STALE_INDEX_DEADLINE,
             ingest_admission_deadline: MCP_INGEST_ADMISSION_DEADLINE,
             operation_status_deadline: MCP_OPERATION_STATUS_DEADLINE,
-            ingest_writer_lease_owned_externally: false,
+            external_ingest_writer_lease: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
         })
     }
 
-    pub fn with_external_ingest_writer_lease(mut self) -> Self {
-        self.ingest_writer_lease_owned_externally = true;
+    pub fn with_external_ingest_writer_lease(mut self, lease: RuntimeWriterLease) -> Self {
+        self.external_ingest_writer_lease = Some(lease);
         self
     }
 
@@ -592,7 +646,8 @@ impl MempalMcpServer {
 
         let (stop_tx, heartbeat) =
             Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
-        let writer_lease = if self.ingest_writer_lease_owned_externally {
+        let external_writer_lease = self.external_ingest_writer_lease.clone();
+        let writer_lease = if external_writer_lease.is_some() {
             None
         } else {
             match self
@@ -612,8 +667,14 @@ impl MempalMcpServer {
                 }
             }
         };
+        let runtime_writer_lease = external_writer_lease
+            .or_else(|| writer_lease.as_ref().map(|lease| lease.lease().clone()));
         let outcome = match self
-            .run_prepared_ingest_off_runtime(prepared.request.clone(), prepared.controls)
+            .run_prepared_ingest_off_runtime(
+                prepared.request.clone(),
+                prepared.controls,
+                runtime_writer_lease,
+            )
             .await
         {
             Ok(Ok(response)) => Ok(response),
@@ -651,8 +712,33 @@ impl MempalMcpServer {
 
         let (stop_tx, heartbeat) =
             Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
+        let external_writer_lease = self.external_ingest_writer_lease.as_ref();
+        let writer_lease = if external_writer_lease.is_some() {
+            None
+        } else {
+            match self
+                .acquire_ingest_writer_lease(worker_id)
+                .await
+                .context("failed to acquire scoped MCP ingest writer lease")?
+            {
+                Some(lease) => Some(lease),
+                None => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    queue.release_claim(claim).await.context(
+                        "failed to release scoped ingest claim after writer lease conflict",
+                    )?;
+                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                    return Ok(());
+                }
+            }
+        };
         let outcome = match self
-            .mempal_ingest_sync(prepared.request.clone(), prepared.controls)
+            .mempal_ingest_sync(
+                prepared.request.clone(),
+                prepared.controls,
+                external_writer_lease
+                    .or_else(|| writer_lease.as_ref().map(McpIngestWriterLeaseGuard::lease)),
+            )
             .await
         {
             Ok(response) => Ok(response.0),
@@ -660,8 +746,15 @@ impl MempalMcpServer {
         };
 
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-        self.complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
-            .await
+        let completed = self
+            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .await;
+        let released = match writer_lease {
+            Some(writer_lease) => writer_lease.release().await,
+            None => Ok(()),
+        };
+        completed?;
+        released
     }
 
     async fn complete_ingest_claim_outcome(
@@ -846,6 +939,7 @@ impl MempalMcpServer {
         &self,
         request: IngestRequest,
         controls: IngestControls,
+        runtime_writer_lease: Option<RuntimeWriterLease>,
     ) -> anyhow::Result<std::result::Result<IngestResponse, ErrorData>> {
         let worker = self.clone();
         #[cfg(any(test, feature = "db-test-seam"))]
@@ -862,7 +956,11 @@ impl MempalMcpServer {
                     .build()
                     .context("failed to build blocking ingest runtime")?;
                 Ok(runtime
-                    .block_on(worker.mempal_ingest_sync(request, controls))
+                    .block_on(worker.mempal_ingest_sync(
+                        request,
+                        controls,
+                        runtime_writer_lease.as_ref(),
+                    ))
                     .map(|response| response.0))
             })
         })
@@ -1110,12 +1208,7 @@ impl MempalMcpServer {
                 Ok(Some(claim)) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
-                        queue.release_claim(claim).await.map_err(|error| {
-                            ErrorData::internal_error(
-                                format!("failed to release timed-out scoped ingest claim: {error}"),
-                                None,
-                            )
-                        })?;
+                        Self::release_scoped_claim_after_timeout(&queue, claim).await?;
                         return Ok(None);
                     }
 
@@ -1132,12 +1225,7 @@ impl MempalMcpServer {
                             })?;
                         }
                         _ = tokio::time::sleep(remaining) => {
-                            queue.release_claim(claim).await.map_err(|error| {
-                                ErrorData::internal_error(
-                                    format!("failed to release timed-out scoped ingest claim: {error}"),
-                                    None,
-                                )
-                            })?;
+                            Self::release_scoped_claim_after_timeout(&queue, claim).await?;
                             return Ok(None);
                         }
                     }
@@ -1156,6 +1244,19 @@ impl MempalMcpServer {
                     ));
                 }
             }
+        }
+    }
+
+    async fn release_scoped_claim_after_timeout(
+        queue: &AsyncPendingMessageStore,
+        claim: ClaimedMessage,
+    ) -> std::result::Result<(), ErrorData> {
+        match queue.release_claim(claim).await {
+            Ok(()) | Err(QueueError::ClaimLost(_)) => Ok(()),
+            Err(error) => Err(ErrorData::internal_error(
+                format!("failed to release timed-out scoped ingest claim: {error}"),
+                None,
+            )),
         }
     }
 
@@ -1466,8 +1567,14 @@ impl MempalMcpServer {
         confidence: f64,
         inserted_drawer_ids: &mut Vec<String>,
         newly_created_drawer_ids: &mut Vec<String>,
+        runtime_writer_lease: Option<&RuntimeWriterLease>,
     ) -> std::result::Result<(), ErrorData> {
         let metadata = validate_ingest_request(request, &source_type)?;
+        ensure_mcp_runtime_writer_lease_active(
+            db,
+            runtime_writer_lease,
+            "record MCP ingest fallback novelty audit",
+        )?;
         db.record_novelty_audit(
             primary_drawer_id,
             NoveltyAction::Insert,
@@ -1504,6 +1611,11 @@ impl MempalMcpServer {
                 // Dedup-resolved: drawer pre-existed; include in response list but NOT
                 // in newly_created_drawer_ids so LLM reject cannot soft-delete it.
                 if metadata.is_pinned {
+                    ensure_mcp_runtime_writer_lease_active(
+                        db,
+                        runtime_writer_lease,
+                        "pin MCP ingest fallback duplicate drawer",
+                    )?;
                     db.pin_drawer(chunk_did, None).map_err(db_error)?;
                 }
                 inserted_drawer_ids.push(chunk_did.clone());
@@ -1521,6 +1633,11 @@ impl MempalMcpServer {
                 },
                 importance,
             );
+            ensure_mcp_runtime_writer_lease_active(
+                db,
+                runtime_writer_lease,
+                "insert MCP ingest fallback drawer",
+            )?;
             db.insert_drawer_with_project_validity(
                 &drawer,
                 project_id,
@@ -1529,6 +1646,11 @@ impl MempalMcpServer {
                 request.valid_until.as_deref(),
             )
             .map_err(db_error)?;
+            ensure_mcp_runtime_writer_lease_active(
+                db,
+                runtime_writer_lease,
+                "insert MCP ingest fallback vector",
+            )?;
             db.insert_vector_with_project(chunk_did, vector, project_id)
                 .map_err(db_error)?;
             inserted_drawer_ids.push(chunk_did.clone());
@@ -4378,7 +4500,7 @@ impl MempalMcpServer {
         if dry_run {
             let response = match tokio::time::timeout(
                 self.ingest_admission_deadline,
-                self.run_prepared_ingest_off_runtime(request, controls),
+                self.run_prepared_ingest_off_runtime(request, controls, None),
             )
             .await
             {
@@ -4649,6 +4771,7 @@ impl MempalMcpServer {
         &self,
         request: IngestRequest,
         controls: IngestControls,
+        runtime_writer_lease: Option<&RuntimeWriterLease>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let dry_run = request.dry_run.unwrap_or(false);
         if !dry_run && global_embed_status().should_block_writes() {
@@ -4793,11 +4916,21 @@ impl MempalMcpServer {
                 .map(|(_, id, _)| id.clone())
                 .collect::<Vec<_>>();
             if metadata.is_pinned {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    runtime_writer_lease,
+                    "pin duplicate MCP ingest drawer",
+                )?;
                 for id in &all_ids {
                     db.pin_drawer(id, None).map_err(db_error)?;
                 }
             }
             if let Some(old_id) = superseded_drawer_id.as_deref() {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    runtime_writer_lease,
+                    "supersede duplicate MCP ingest drawer",
+                )?;
                 let replacement_id = all_ids.first().map(String::as_str).unwrap_or("existing");
                 supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
                 superseded_response_id = Some(old_id.to_string());
@@ -4836,6 +4969,11 @@ impl MempalMcpServer {
             if let Some(decision) = gating_decision.as_ref()
                 && decision.is_rejected()
             {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    runtime_writer_lease,
+                    "record MCP ingest gating audit",
+                )?;
                 db.record_gating_audit(
                     &drawer_id,
                     decision,
@@ -4890,6 +5028,11 @@ impl MempalMcpServer {
                     {
                         let llm_decision =
                             GatingDecision::accepted(0, Some("llm_pending".to_string()), None);
+                        ensure_mcp_runtime_writer_lease_active(
+                            &db,
+                            runtime_writer_lease,
+                            "record MCP ingest LLM gating audit",
+                        )?;
                         db.record_gating_audit(
                             &drawer_id,
                             &llm_decision,
@@ -4901,6 +5044,11 @@ impl MempalMcpServer {
                         gating_decision = Some(llm_decision);
                         should_enqueue_llm_task = true;
                     } else {
+                        ensure_mcp_runtime_writer_lease_active(
+                            &db,
+                            runtime_writer_lease,
+                            "record MCP ingest tier2 audit",
+                        )?;
                         db.record_gating_audit(
                             &drawer_id,
                             &tier2.decision,
@@ -4940,6 +5088,11 @@ impl MempalMcpServer {
                 }));
             }
             if !gating_audit_recorded && let Some(decision) = gating_decision.as_ref() {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    runtime_writer_lease,
+                    "record MCP ingest gating audit",
+                )?;
                 db.record_gating_audit(
                     &drawer_id,
                     decision,
@@ -4969,7 +5122,14 @@ impl MempalMcpServer {
         if !no_gate
             && !raw_turn
             && let Some(outcome) = evaluate_fact_check_gate(
-                &drawer_id,
+                {
+                    ensure_mcp_runtime_writer_lease_active(
+                        &db,
+                        runtime_writer_lease,
+                        "record MCP ingest fact-check audit",
+                    )?;
+                    &drawer_id
+                },
                 &candidate.content,
                 &db,
                 project_id.as_deref(),
@@ -5083,6 +5243,11 @@ impl MempalMcpServer {
         match novelty.action {
             NoveltyAction::Insert => {
                 if novelty.should_audit {
+                    ensure_mcp_runtime_writer_lease_active(
+                        &db,
+                        runtime_writer_lease,
+                        "record MCP ingest novelty audit",
+                    )?;
                     db.record_novelty_audit(
                         &drawer_id,
                         NoveltyAction::Insert,
@@ -5104,6 +5269,11 @@ impl MempalMcpServer {
                         // Dedup-resolved pre-lock: include in response but NOT in
                         // newly_created_drawer_ids so LLM reject cannot delete it.
                         if metadata.is_pinned {
+                            ensure_mcp_runtime_writer_lease_active(
+                                &db,
+                                runtime_writer_lease,
+                                "pin MCP ingest duplicate drawer",
+                            )?;
                             db.pin_drawer(chunk_did, None).map_err(db_error)?;
                         }
                         inserted_drawer_ids.push(chunk_did.clone());
@@ -5131,6 +5301,11 @@ impl MempalMcpServer {
                         // Dedup-resolved post-lock: include in response but NOT in
                         // newly_created_drawer_ids so LLM reject cannot delete it.
                         if metadata.is_pinned {
+                            ensure_mcp_runtime_writer_lease_active(
+                                &db,
+                                runtime_writer_lease,
+                                "pin MCP ingest duplicate drawer",
+                            )?;
                             db.pin_drawer(chunk_did, None).map_err(db_error)?;
                         }
                         inserted_drawer_ids.push(chunk_did.clone());
@@ -5151,6 +5326,11 @@ impl MempalMcpServer {
                     if let Some(old_id) = superseded_drawer_id.as_deref() {
                         link_superseded_drawer(&mut drawer, old_id);
                     }
+                    ensure_mcp_runtime_writer_lease_active(
+                        &db,
+                        runtime_writer_lease,
+                        "insert MCP ingest drawer",
+                    )?;
                     db.insert_drawer_with_project_validity(
                         &drawer,
                         project_id.as_deref(),
@@ -5159,6 +5339,11 @@ impl MempalMcpServer {
                         request.valid_until.as_deref(),
                     )
                     .map_err(db_error)?;
+                    ensure_mcp_runtime_writer_lease_active(
+                        &db,
+                        runtime_writer_lease,
+                        "insert MCP ingest vector",
+                    )?;
                     db.insert_vector_with_project(chunk_did, vector, project_id.as_deref())
                         .map_err(db_error)?;
                     inserted_drawer_ids.push(chunk_did.clone());
@@ -5167,6 +5352,11 @@ impl MempalMcpServer {
             }
             NoveltyAction::Drop => {
                 if novelty.should_audit {
+                    ensure_mcp_runtime_writer_lease_active(
+                        &db,
+                        runtime_writer_lease,
+                        "record MCP ingest novelty drop audit",
+                    )?;
                     db.record_novelty_audit(
                         &drawer_id,
                         NoveltyAction::Drop,
@@ -5231,6 +5421,7 @@ impl MempalMcpServer {
                         confidence,
                         &mut inserted_drawer_ids,
                         &mut newly_created_drawer_ids,
+                        runtime_writer_lease,
                     )?;
                     novelty_action = Some(NoveltyAction::Insert);
                     near_drawer_id = Some(target_id);
@@ -5239,6 +5430,11 @@ impl MempalMcpServer {
                         Ok(merged_vectors) => match merged_vectors.into_iter().next() {
                             Some(merged_vector) => {
                                 ensure_vector_dim_matches(&db, merged_vector.len())?;
+                                ensure_mcp_runtime_writer_lease_active(
+                                    &db,
+                                    runtime_writer_lease,
+                                    "merge MCP ingest drawer",
+                                )?;
                                 db.update_drawer_after_merge_and_record_novelty_audit(
                                     &target_id,
                                     &merged_content,
@@ -5284,6 +5480,7 @@ impl MempalMcpServer {
                                     confidence,
                                     &mut inserted_drawer_ids,
                                     &mut newly_created_drawer_ids,
+                                    runtime_writer_lease,
                                 )?;
                                 novelty_action = Some(NoveltyAction::Insert);
                                 near_drawer_id = Some(target_id);
@@ -5312,6 +5509,7 @@ impl MempalMcpServer {
                                 confidence,
                                 &mut inserted_drawer_ids,
                                 &mut newly_created_drawer_ids,
+                                runtime_writer_lease,
                             )?;
                             novelty_action = Some(NoveltyAction::Insert);
                             near_drawer_id = Some(target_id);
@@ -5329,6 +5527,11 @@ impl MempalMcpServer {
         if let Some(old_id) = superseded_drawer_id.as_deref()
             && let Some(replacement_id) = inserted_drawer_ids.first()
         {
+            ensure_mcp_runtime_writer_lease_active(
+                &db,
+                runtime_writer_lease,
+                "supersede MCP ingest replacement target",
+            )?;
             supersede_drawer_for_ingest(&db, old_id, replacement_id)?;
             superseded_response_id = Some(old_id.to_string());
         }
@@ -5347,6 +5550,11 @@ impl MempalMcpServer {
                 })
                 .unwrap_or_default();
             if !hit_ids.is_empty() {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    runtime_writer_lease,
+                    "apply MCP ingest boost",
+                )?;
                 use std::time::{SystemTime, UNIX_EPOCH};
                 let now_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -5377,6 +5585,11 @@ impl MempalMcpServer {
         // found by hash) are excluded from newly_created_drawer_ids so a subsequent LLM reject
         // cannot soft-delete a drawer that predated this ingest request.
         if should_enqueue_llm_task && !newly_created_drawer_ids.is_empty() {
+            ensure_mcp_runtime_writer_lease_active(
+                &db,
+                runtime_writer_lease,
+                "enqueue MCP ingest LLM task",
+            )?;
             let system_prompt = config
                 .ingest_gating
                 .llm_judge
@@ -12559,6 +12772,44 @@ quality_policy = "llm_required_for_keep"
         assert_eq!(second.drawer_ids, vec![first.drawer_id.clone()]);
         let db = Database::open(&db_path).expect("open db");
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_scoped_ingest_worker_respects_existing_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        let db = Database::open(&db_path).expect("open db");
+        let _daemon_lease = db
+            .runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                "daemon-owner",
+                "daemon",
+                300,
+                None,
+            )
+            .expect("acquire daemon lease")
+            .expect("daemon lease");
+
+        let response = server
+            .mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped worker must not bypass writer lease".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("lease".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(1),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("scoped worker response")
+            .0;
+
+        assert!(response.timed_out, "{response:?}");
+        assert_eq!(db.drawer_count().expect("drawer count"), 0);
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -37,7 +37,7 @@ use crate::core::{
         AnchorKind, BootstrapIdentityParts, Drawer, DrawerSummary, ExplicitTunnel,
         KnowledgeCardFilter, KnowledgeStatus, KnowledgeTier, MemoryDomain, MemoryKind, Provenance,
         RuntimeAdoptionEvent, RuntimeAdoptionFilter, RuntimeAdoptionSignal, RuntimeAdoptionTrack,
-        SearchResult, SourceType, TriggerHints, Triple, default_confidence,
+        RuntimeWriterLease, SearchResult, SourceType, TriggerHints, Triple, default_confidence,
     },
     utils::{
         build_bootstrap_drawer_id_from_parts, build_triple_id, current_timestamp, expand_home,
@@ -143,6 +143,9 @@ const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
 const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
 const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
+const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
+const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
+const MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
     let now_ns = match SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -183,8 +186,55 @@ pub struct MempalMcpServer {
     search_stale_index_deadline: Duration,
     ingest_admission_deadline: Duration,
     operation_status_deadline: Duration,
+    ingest_writer_lease_owned_externally: bool,
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_processing_delay: Option<Duration>,
+}
+
+struct McpIngestWriterLeaseGuard {
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+    stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    heartbeat: tokio::task::JoinHandle<()>,
+}
+
+impl McpIngestWriterLeaseGuard {
+    fn new(db_path: PathBuf, lease: RuntimeWriterLease) -> Self {
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let heartbeat = MempalMcpServer::spawn_ingest_writer_lease_heartbeat(
+            db_path.clone(),
+            lease.clone(),
+            stop_rx,
+        );
+        Self {
+            db_path,
+            lease,
+            stop_tx: Some(stop_tx),
+            heartbeat,
+        }
+    }
+
+    async fn release(mut self) -> anyhow::Result<()> {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        let _ = self.heartbeat.await;
+        let db_path = self.db_path.clone();
+        let lease = self.lease.clone();
+        tokio::task::spawn_blocking(move || {
+            let db = Database::open(&db_path).with_context(|| {
+                format!(
+                    "failed to open database to release MCP ingest writer lease: {}",
+                    db_path.display()
+                )
+            })?;
+            db.runtime_writer_lease_release(&lease.name, &lease.owner, &lease.session_id)
+                .context("failed to release MCP ingest writer lease")?;
+            Ok(())
+        })
+        .await
+        .context("MCP ingest writer lease release task failed")?
+    }
 }
 
 impl MempalMcpServer {
@@ -232,9 +282,15 @@ impl MempalMcpServer {
             search_stale_index_deadline: MCP_SEARCH_STALE_INDEX_DEADLINE,
             ingest_admission_deadline: MCP_INGEST_ADMISSION_DEADLINE,
             operation_status_deadline: MCP_OPERATION_STATUS_DEADLINE,
+            ingest_writer_lease_owned_externally: false,
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
         })
+    }
+
+    pub fn with_external_ingest_writer_lease(mut self) -> Self {
+        self.ingest_writer_lease_owned_externally = true;
+        self
     }
 
     fn status_config_snapshot(&self) -> Arc<Config> {
@@ -536,6 +592,26 @@ impl MempalMcpServer {
 
         let (stop_tx, heartbeat) =
             Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
+        let writer_lease = if self.ingest_writer_lease_owned_externally {
+            None
+        } else {
+            match self
+                .acquire_ingest_writer_lease(worker_id)
+                .await
+                .context("failed to acquire MCP ingest writer lease")?
+            {
+                Some(lease) => Some(lease),
+                None => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    queue
+                        .release_claim(claim)
+                        .await
+                        .context("failed to release ingest claim after writer lease conflict")?;
+                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                    return Ok(());
+                }
+            }
+        };
         let outcome = match self
             .run_prepared_ingest_off_runtime(prepared.request.clone(), prepared.controls)
             .await
@@ -546,8 +622,15 @@ impl MempalMcpServer {
         };
 
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-        self.complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
-            .await
+        let completed = self
+            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .await;
+        let released = match writer_lease {
+            Some(writer_lease) => writer_lease.release().await,
+            None => Ok(()),
+        };
+        completed?;
+        released
     }
 
     async fn process_ingest_claim_inline(
@@ -678,6 +761,85 @@ impl MempalMcpServer {
     ) {
         let _ = stop_tx.send(());
         let _ = heartbeat.await;
+    }
+
+    async fn acquire_ingest_writer_lease(
+        &self,
+        worker_id: &str,
+    ) -> anyhow::Result<Option<McpIngestWriterLeaseGuard>> {
+        let db_path = self.db_path.clone();
+        let owner = worker_id.to_string();
+        let metadata_json = serde_json::json!({
+            "component": "mcp-ingest-worker",
+            "db_path": db_path.display().to_string(),
+        })
+        .to_string();
+        let lease = tokio::task::spawn_blocking(move || {
+            let db = Database::open(&db_path).with_context(|| {
+                format!(
+                    "failed to open database for MCP ingest writer lease: {}",
+                    db_path.display()
+                )
+            })?;
+            db.runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                &owner,
+                "mcp-ingest-worker",
+                MCP_INGEST_WRITER_LEASE_TTL_SECS,
+                Some(&metadata_json),
+            )
+            .context("failed to acquire MCP ingest writer lease")
+        })
+        .await
+        .context("MCP ingest writer lease task failed")??;
+        Ok(lease.map(|lease| McpIngestWriterLeaseGuard::new(self.db_path.clone(), lease)))
+    }
+
+    fn spawn_ingest_writer_lease_heartbeat(
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+        mut stop_rx: tokio::sync::oneshot::Receiver<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let db_path = db_path.clone();
+                        let lease_for_renew = lease.clone();
+                        let renew_result = tokio::task::spawn_blocking(move || {
+                            let db = Database::open(&db_path)?;
+                            db.runtime_writer_lease_renew(
+                                &lease_for_renew.name,
+                                &lease_for_renew.owner,
+                                &lease_for_renew.session_id,
+                                MCP_INGEST_WRITER_LEASE_TTL_SECS,
+                            )
+                        })
+                        .await;
+                        match renew_result {
+                            Ok(Ok(true)) => {}
+                            Ok(Ok(false)) => {
+                                tracing::error!(
+                                    lease_name = %lease.name,
+                                    owner = %lease.owner,
+                                    "MCP ingest writer lease lost; stopping lease heartbeat"
+                                );
+                                break;
+                            }
+                            Ok(Err(error)) => {
+                                tracing::warn!(error = %error, "failed to renew MCP ingest writer lease");
+                            }
+                            Err(error) => {
+                                tracing::warn!(error = %error, "MCP ingest writer lease heartbeat task failed");
+                            }
+                        }
+                    }
+                    _ = &mut stop_rx => break,
+                }
+            }
+        })
     }
 
     async fn run_prepared_ingest_off_runtime(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -147,6 +147,7 @@ const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
+const MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
     let now_ns = match SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -190,6 +191,12 @@ pub struct MempalMcpServer {
     external_ingest_writer_lease: Option<RuntimeWriterLease>,
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_processing_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    content_writer_lease_ttl_secs: u64,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    content_writer_lease_renew_interval: Duration,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    stale_penalty_delay: Option<Duration>,
 }
 
 struct McpIngestWriterLeaseGuard {
@@ -271,10 +278,43 @@ impl Drop for McpIngestWriterLeaseGuard {
 struct McpContentWriterLeaseGuard {
     db_path: PathBuf,
     lease: RuntimeWriterLease,
+    stop_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    heartbeat: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl McpContentWriterLeaseGuard {
+    fn new(
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+        ttl_secs: u64,
+        renew_interval: Duration,
+    ) -> Self {
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let heartbeat = MempalMcpServer::spawn_mcp_writer_lease_heartbeat(
+            db_path.clone(),
+            lease.clone(),
+            ttl_secs,
+            renew_interval,
+            "content",
+            stop_rx,
+        );
+        Self {
+            db_path,
+            lease,
+            stop_tx: Some(stop_tx),
+            heartbeat: Some(heartbeat),
+        }
+    }
 }
 
 impl Drop for McpContentWriterLeaseGuard {
     fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(heartbeat) = self.heartbeat.take() {
+            heartbeat.abort();
+        }
         if let Ok(db) = Database::open(&self.db_path) {
             let _ = db.runtime_writer_lease_release(
                 &self.lease.name,
@@ -378,6 +418,12 @@ impl MempalMcpServer {
             external_ingest_writer_lease: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            content_writer_lease_ttl_secs: MCP_CONTENT_WRITER_LEASE_TTL_SECS,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            content_writer_lease_renew_interval: MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            stale_penalty_delay: None,
         })
     }
 
@@ -412,6 +458,23 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_ingest_processing_delay_for_test(mut self, delay: Duration) -> Self {
         self.ingest_processing_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_content_writer_lease_timing_for_test(
+        mut self,
+        ttl_secs: u64,
+        renew_interval: Duration,
+    ) -> Self {
+        self.content_writer_lease_ttl_secs = ttl_secs;
+        self.content_writer_lease_renew_interval = renew_interval;
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_stale_penalty_delay_for_test(mut self, delay: Duration) -> Self {
+        self.stale_penalty_delay = Some(delay);
         self
     }
 
@@ -964,19 +1027,47 @@ impl MempalMcpServer {
                 ));
             }
         };
-        Ok(McpContentWriterLeaseGuard {
-            db_path: db.path().to_path_buf(),
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let ttl_secs = self.content_writer_lease_ttl_secs;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let ttl_secs = MCP_CONTENT_WRITER_LEASE_TTL_SECS;
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let renew_interval = self.content_writer_lease_renew_interval;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let renew_interval = MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL;
+        Ok(McpContentWriterLeaseGuard::new(
+            db.path().to_path_buf(),
             lease,
-        })
+            ttl_secs,
+            renew_interval,
+        ))
     }
 
     fn spawn_ingest_writer_lease_heartbeat(
         db_path: PathBuf,
         lease: RuntimeWriterLease,
+        stop_rx: tokio::sync::oneshot::Receiver<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        Self::spawn_mcp_writer_lease_heartbeat(
+            db_path,
+            lease,
+            MCP_INGEST_WRITER_LEASE_TTL_SECS,
+            MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL,
+            "ingest",
+            stop_rx,
+        )
+    }
+
+    fn spawn_mcp_writer_lease_heartbeat(
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+        ttl_secs: u64,
+        renew_interval: Duration,
+        lease_kind: &'static str,
         mut stop_rx: tokio::sync::oneshot::Receiver<()>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL);
+            let mut interval = tokio::time::interval(renew_interval);
             interval.tick().await;
             loop {
                 tokio::select! {
@@ -989,7 +1080,7 @@ impl MempalMcpServer {
                                 &lease_for_renew.name,
                                 &lease_for_renew.owner,
                                 &lease_for_renew.session_id,
-                                MCP_INGEST_WRITER_LEASE_TTL_SECS,
+                                ttl_secs,
                             )
                         })
                         .await;
@@ -999,15 +1090,16 @@ impl MempalMcpServer {
                                 tracing::error!(
                                     lease_name = %lease.name,
                                     owner = %lease.owner,
-                                    "MCP ingest writer lease lost; stopping lease heartbeat"
+                                    lease_kind,
+                                    "MCP writer lease lost; stopping lease heartbeat"
                                 );
                                 break;
                             }
                             Ok(Err(error)) => {
-                                tracing::warn!(error = %error, "failed to renew MCP ingest writer lease");
+                                tracing::warn!(error = %error, lease_kind, "failed to renew MCP writer lease");
                             }
                             Err(error) => {
-                                tracing::warn!(error = %error, "MCP ingest writer lease heartbeat task failed");
+                                tracing::warn!(error = %error, lease_kind, "MCP writer lease heartbeat task failed");
                             }
                         }
                     }
@@ -7150,7 +7242,7 @@ impl MempalMcpServer {
                 }
             )
         });
-        let _writer_lease = if has_stale_penalty_targets {
+        let writer_lease = if has_stale_penalty_targets {
             Some(self.acquire_content_writer_lease(&db, "mempal_fact_check stale penalty")?)
         } else {
             None
@@ -7161,8 +7253,17 @@ impl MempalMcpServer {
                 ..
             } = issue
             {
+                ensure_mcp_runtime_writer_lease_active(
+                    &db,
+                    writer_lease.as_ref().map(|lease| &lease.lease),
+                    "apply fact-check stale penalty",
+                )?;
                 if let Err(err) = db.apply_stale_penalty_to_drawer(drawer_id, stale_penalty) {
                     tracing::warn!(drawer_id, error = %err, "stale penalty application failed");
+                }
+                #[cfg(any(test, feature = "db-test-seam"))]
+                if let Some(delay) = self.stale_penalty_delay {
+                    tokio::time::sleep(delay).await;
                 }
             }
         }
@@ -13320,6 +13421,119 @@ quality_policy = "llm_required_for_keep"
         assert!(
             read_stale_penalty(&db_path, "fact-check-stale-success-target") < 1.0,
             "stale penalty should be applied"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_mcp_fact_check_stale_penalty_keeps_content_writer_lease_renewed_during_batch() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server
+            .with_content_writer_lease_timing_for_test(1, Duration::from_millis(100))
+            .with_stale_penalty_delay_for_test(Duration::from_millis(700));
+        let facts = [
+            (
+                "fact-check-stale-batch-alice",
+                "Alice works at Acme.",
+                "Alice",
+                "works_at",
+                "Acme",
+            ),
+            (
+                "fact-check-stale-batch-bob",
+                "Bob works at Beta.",
+                "Bob",
+                "works_at",
+                "Beta",
+            ),
+            (
+                "fact-check-stale-batch-carol",
+                "Carol is founder of Delta.",
+                "Carol",
+                "founder_of",
+                "Delta",
+            ),
+        ];
+        for (drawer_id, content, subject, predicate, object) in facts {
+            insert_drawer(
+                &db_path,
+                drawer_id,
+                content,
+                "mcp",
+                Some("lease"),
+                "/tmp/fact-check-stale-batch.md",
+                3,
+            );
+            insert_stale_triple_with_source_drawer(&db_path, subject, predicate, object, drawer_id);
+        }
+
+        let fact_check = {
+            let server = server.clone();
+            tokio::spawn(async move {
+                server
+                    .mempal_fact_check(Parameters(FactCheckRequest {
+                        text: "Alice works at Acme. Bob works at Beta. Carol is founder of Delta."
+                            .to_string(),
+                        wing: None,
+                        room: None,
+                        now: Some("2028-01-15T08:00:00Z".to_string()),
+                    }))
+                    .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(1300)).await;
+        let competing_lease = {
+            let db = Database::open(&db_path).expect("open db");
+            db.runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                "competing-content-writer",
+                "daemon",
+                300,
+                None,
+            )
+            .expect("attempt competing writer lease")
+        };
+        assert!(
+            competing_lease.is_none(),
+            "content writer lease must remain active after the original 1s TTL while stale penalties are still being applied"
+        );
+
+        let response = fact_check
+            .await
+            .expect("fact check task joins")
+            .expect("fact check succeeds")
+            .0;
+        let stale_count = response
+            .issues
+            .iter()
+            .filter(|issue| matches!(issue, crate::factcheck::FactIssue::StaleFact { .. }))
+            .count();
+        assert_eq!(stale_count, facts.len(), "expected stale facts in response");
+        for (drawer_id, ..) in facts {
+            assert!(
+                read_stale_penalty(&db_path, drawer_id) < 1.0,
+                "stale penalty should be applied to {drawer_id}"
+            );
+        }
+
+        let db = Database::open(&db_path).expect("open db");
+        let post_release_lease = db
+            .runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                "post-release-content-writer",
+                "daemon",
+                300,
+                None,
+            )
+            .expect("acquire writer lease after fact check")
+            .expect("content writer lease should be released after fact check");
+        assert!(
+            db.runtime_writer_lease_release(
+                &post_release_lease.name,
+                &post_release_lease.owner,
+                &post_release_lease.session_id
+            )
+            .expect("release post fact-check writer lease")
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -145,6 +145,7 @@ const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
+const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
@@ -267,6 +268,23 @@ impl Drop for McpIngestWriterLeaseGuard {
     }
 }
 
+struct McpContentWriterLeaseGuard {
+    db_path: PathBuf,
+    lease: RuntimeWriterLease,
+}
+
+impl Drop for McpContentWriterLeaseGuard {
+    fn drop(&mut self) {
+        if let Ok(db) = Database::open(&self.db_path) {
+            let _ = db.runtime_writer_lease_release(
+                &self.lease.name,
+                &self.lease.owner,
+                &self.lease.session_id,
+            );
+        }
+    }
+}
+
 fn ensure_mcp_runtime_writer_lease_active(
     db: &Database,
     lease: Option<&RuntimeWriterLease>,
@@ -289,6 +307,27 @@ fn ensure_mcp_runtime_writer_lease_active(
             None,
         ))
     }
+}
+
+fn format_runtime_writer_leases(leases: &[RuntimeWriterLease]) -> String {
+    if leases.is_empty() {
+        return "none visible".to_string();
+    }
+    leases
+        .iter()
+        .map(|lease| {
+            format!(
+                "name={} owner={} pid={} mode={} expires_at={} heartbeat_at={}",
+                lease.name,
+                lease.owner,
+                lease.pid,
+                lease.mode,
+                lease.expires_at,
+                lease.heartbeat_at
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 impl MempalMcpServer {
@@ -886,6 +925,49 @@ impl MempalMcpServer {
         .await
         .context("MCP ingest writer lease task failed")??;
         Ok(lease.map(|lease| McpIngestWriterLeaseGuard::new(self.db_path.clone(), lease)))
+    }
+
+    fn acquire_content_writer_lease(
+        &self,
+        db: &Database,
+        operation: &'static str,
+    ) -> std::result::Result<McpContentWriterLeaseGuard, ErrorData> {
+        let owner = format!("mempal-mcp-{operation}-{}", std::process::id());
+        let metadata_json = serde_json::json!({
+            "component": "mcp-content-writer",
+            "operation": operation,
+            "db_path": db.path().display().to_string(),
+        })
+        .to_string();
+        let lease = db
+            .runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                &owner,
+                "mcp-content-write",
+                MCP_CONTENT_WRITER_LEASE_TTL_SECS,
+                Some(&metadata_json),
+            )
+            .map_err(|error| database_write_refused_error(db.path(), operation, &error))?;
+        let lease = match lease {
+            Some(lease) => lease,
+            None => {
+                let active = db
+                    .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
+                    .unwrap_or_default();
+                return Err(ErrorData::internal_error(
+                    format!(
+                        "SQLite writer lease `{}` is already held; refusing to run {operation}: {}",
+                        SQLITE_WRITER_LEASE_NAME,
+                        format_runtime_writer_leases(&active)
+                    ),
+                    None,
+                ));
+            }
+        };
+        Ok(McpContentWriterLeaseGuard {
+            db_path: db.path().to_path_buf(),
+            lease,
+        })
     }
 
     fn spawn_ingest_writer_lease_heartbeat(
@@ -4060,6 +4142,7 @@ impl MempalMcpServer {
             .next()
             .ok_or_else(|| ErrorData::internal_error("embedder returned no vector", None))?;
         let db = self.open_db()?;
+        let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_knowledge_distill")?;
         let outcome = commit_distill(&db, *prepared, &vector).map_err(knowledge_distill_error)?;
         Ok(Json(KnowledgeDistillResponse::from(outcome)))
     }
@@ -4268,6 +4351,8 @@ impl MempalMcpServer {
             }
             "promote" => {
                 let db = self.open_db()?;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_knowledge_cards promote")?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let status = required_string(request.status.as_deref(), "status")?.to_string();
                 let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
@@ -4296,6 +4381,8 @@ impl MempalMcpServer {
             }
             "demote" => {
                 let db = self.open_db()?;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_knowledge_cards demote")?;
                 let card_id = required_string(request.card_id.as_deref(), "card_id")?;
                 let status = required_string(request.status.as_deref(), "status")?.to_string();
                 let reason = required_string(request.reason.as_deref(), "reason")?.to_string();
@@ -4340,6 +4427,7 @@ impl MempalMcpServer {
         Parameters(request): Parameters<KnowledgePromoteRequest>,
     ) -> std::result::Result<Json<KnowledgePromoteResponse>, ErrorData> {
         let db = self.open_db()?;
+        let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_knowledge_promote")?;
         let outcome = promote_knowledge(
             &db,
             CorePromoteRequest {
@@ -4366,6 +4454,7 @@ impl MempalMcpServer {
         Parameters(request): Parameters<KnowledgeDemoteRequest>,
     ) -> std::result::Result<Json<KnowledgeDemoteResponse>, ErrorData> {
         let db = self.open_db()?;
+        let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_knowledge_demote")?;
         let outcome = demote_knowledge(
             &db,
             CoreDemoteRequest {
@@ -4390,6 +4479,8 @@ impl MempalMcpServer {
         Parameters(request): Parameters<KnowledgePublishAnchorRequest>,
     ) -> std::result::Result<Json<KnowledgePublishAnchorResponse>, ErrorData> {
         let db = self.open_db()?;
+        let _writer_lease =
+            self.acquire_content_writer_lease(&db, "mempal_knowledge_publish_anchor")?;
         let outcome = publish_anchor(
             &db,
             CorePublishAnchorRequest {
@@ -5746,6 +5837,7 @@ impl MempalMcpServer {
         Parameters(request): Parameters<DeleteRequest>,
     ) -> std::result::Result<Json<DeleteResponse>, ErrorData> {
         let db = self.open_db()?;
+        let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_delete")?;
         let deleted = db
             .soft_delete_drawer(&request.drawer_id)
             .map_err(db_error)?;
@@ -5798,6 +5890,7 @@ impl MempalMcpServer {
                 .map_err(db_error)?;
             (count.max(0) as usize, Vec::new())
         } else {
+            let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_rollback")?;
             let drawer_ids = db
                 .soft_delete_drawers_since(
                     &since,
@@ -5958,6 +6051,8 @@ impl MempalMcpServer {
                 }))
             }
             "edit" => {
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_taxonomy edit")?;
                 let wing = request
                     .wing
                     .ok_or_else(|| ErrorData::invalid_params("missing wing", None))?;
@@ -6017,6 +6112,7 @@ impl MempalMcpServer {
                 if block_writes {
                     return Err(degraded_write_error());
                 }
+                let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_kg add")?;
                 let subject = request
                     .subject
                     .ok_or_else(|| ErrorData::invalid_params("missing subject", None))?;
@@ -6066,6 +6162,8 @@ impl MempalMcpServer {
                 if block_writes {
                     return Err(degraded_write_error());
                 }
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_kg invalidate")?;
                 let triple_id = request
                     .triple_id
                     .ok_or_else(|| ErrorData::invalid_params("missing triple_id", None))?;
@@ -6157,6 +6255,7 @@ impl MempalMcpServer {
                 }))
             }
             "add" => {
+                let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_tunnels add")?;
                 let left = request
                     .left
                     .ok_or_else(|| ErrorData::invalid_params("missing left endpoint", None))?;
@@ -6179,6 +6278,8 @@ impl MempalMcpServer {
                 }))
             }
             "delete" => {
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_tunnels delete")?;
                 let tunnel_id = trim_to_option(request.tunnel_id.as_deref())
                     .ok_or_else(|| ErrorData::invalid_params("missing tunnel_id", None))?;
                 if tunnel_id.starts_with("passive_") {
@@ -7382,6 +7483,11 @@ impl MempalMcpServer {
                         &capture.record_quality,
                         request.allow_warnings.unwrap_or(false),
                     );
+                    let _writer_lease = if should_write {
+                        Some(self.acquire_content_writer_lease(&db, "mempal_phase3 capture")?)
+                    } else {
+                        None
+                    };
                     let event = if should_write {
                         let event = RuntimeAdoptionEvent {
                             id: record_input.id.unwrap_or_else(|| {
@@ -7655,6 +7761,11 @@ impl MempalMcpServer {
                 let quality = check_runtime_adoption_record(&input);
                 let should_write =
                     should_write_checked_record(&quality, request.allow_warnings.unwrap_or(false));
+                let _writer_lease = if should_write {
+                    Some(self.acquire_content_writer_lease(&db, "mempal_phase3 record_checked")?)
+                } else {
+                    None
+                };
                 let event = if should_write {
                     let event = RuntimeAdoptionEvent {
                         id: input
@@ -7819,6 +7930,8 @@ impl MempalMcpServer {
             }
             "record" => {
                 let db = self.open_db()?;
+                let _writer_lease =
+                    self.acquire_content_writer_lease(&db, "mempal_phase3 record")?;
                 let track = parse_runtime_adoption_track(required_string(
                     request.track.as_deref(),
                     "track",
@@ -9710,6 +9823,27 @@ quality_policy = "llm_required_for_keep"
         .expect("insert drawer");
         db.insert_vector(id, &[0.1, 0.2, 0.3])
             .expect("insert vector");
+    }
+
+    fn hold_daemon_writer_lease(db_path: &Path) -> RuntimeWriterLease {
+        let db = Database::open(db_path).expect("open db");
+        db.runtime_writer_lease_acquire(
+            SQLITE_WRITER_LEASE_NAME,
+            "daemon-owner",
+            "daemon",
+            300,
+            None,
+        )
+        .expect("acquire daemon writer lease")
+        .expect("daemon writer lease")
+    }
+
+    fn assert_writer_lease_conflict(error: &ErrorData) {
+        let message = error.to_string();
+        assert!(
+            message.contains("SQLite writer lease `sqlite-writer` is already held"),
+            "{message}"
+        );
     }
 
     fn spawn_runtime_ticker() -> (Arc<AtomicU64>, tokio::task::JoinHandle<()>) {
@@ -12772,6 +12906,201 @@ quality_policy = "llm_required_for_keep"
         assert_eq!(second.drawer_ids, vec![first.drawer_id.clone()]);
         let db = Database::open(&db_path).expect("open db");
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_delete_rejects_existing_content_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "mcp-delete-lease-target",
+            "delete target must survive lease conflict",
+            "mcp",
+            Some("lease"),
+            "/tmp/mcp-delete.md",
+            2,
+        );
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let error = match server
+            .mempal_delete(Parameters(DeleteRequest {
+                drawer_id: "mcp-delete-lease-target".to_string(),
+            }))
+            .await
+        {
+            Ok(_) => panic!("delete must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+
+        assert_writer_lease_conflict(&error);
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            db.drawer_exists("mcp-delete-lease-target")
+                .expect("drawer exists")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_kg_taxonomy_and_tunnel_reject_existing_content_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        let db = Database::open(&db_path).expect("open db");
+        let baseline_triples = db.triple_count().expect("triple count");
+        let baseline_taxonomy = db.taxonomy_count().expect("taxonomy count");
+        let baseline_tunnels = db.list_explicit_tunnels(None).expect("list tunnels").len();
+        drop(db);
+        let _daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let kg_error = match server
+            .mempal_kg(Parameters(KgRequest {
+                action: "add".to_string(),
+                subject: Some("subject".to_string()),
+                predicate: Some("relates_to".to_string()),
+                object: Some("object".to_string()),
+                triple_id: None,
+                active_only: None,
+                source_drawer: None,
+            }))
+            .await
+        {
+            Ok(_) => panic!("kg add must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+        assert_writer_lease_conflict(&kg_error);
+
+        let taxonomy_error = match server
+            .mempal_taxonomy(Parameters(TaxonomyRequest {
+                action: "edit".to_string(),
+                wing: Some("mcp".to_string()),
+                room: Some("lease-taxonomy".to_string()),
+                keywords: Some(vec!["lease".to_string()]),
+            }))
+            .await
+        {
+            Ok(_) => panic!("taxonomy edit must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+        assert_writer_lease_conflict(&taxonomy_error);
+
+        let tunnel_error = match server
+            .mempal_tunnels(Parameters(TunnelsRequest {
+                action: Some("add".to_string()),
+                left: Some(TunnelEndpointDto {
+                    wing: "left".to_string(),
+                    room: Some("room".to_string()),
+                }),
+                right: Some(TunnelEndpointDto {
+                    wing: "right".to_string(),
+                    room: Some("room".to_string()),
+                }),
+                from: None,
+                label: Some("related".to_string()),
+                tunnel_id: None,
+                wing: None,
+                kind: None,
+                max_hops: None,
+            }))
+            .await
+        {
+            Ok(_) => panic!("tunnel add must reject under daemon writer lease"),
+            Err(error) => error,
+        };
+        assert_writer_lease_conflict(&tunnel_error);
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(db.triple_count().expect("triple count"), baseline_triples);
+        assert_eq!(
+            db.taxonomy_count().expect("taxonomy count"),
+            baseline_taxonomy
+        );
+        assert_eq!(
+            db.list_explicit_tunnels(None).expect("list tunnels").len(),
+            baseline_tunnels
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_non_ingest_writes_succeed_without_content_writer_conflict() {
+        let (_tempdir, db_path, server) = setup_server();
+        insert_drawer(
+            &db_path,
+            "mcp-delete-success-target",
+            "delete target can be soft deleted without lease conflict",
+            "mcp",
+            Some("lease"),
+            "/tmp/mcp-delete-success.md",
+            2,
+        );
+        let db = Database::open(&db_path).expect("open db");
+        let baseline_taxonomy = db.taxonomy_count().expect("taxonomy count");
+        drop(db);
+
+        let delete = server
+            .mempal_delete(Parameters(DeleteRequest {
+                drawer_id: "mcp-delete-success-target".to_string(),
+            }))
+            .await
+            .expect("delete succeeds")
+            .0;
+        assert!(delete.deleted);
+
+        server
+            .mempal_kg(Parameters(KgRequest {
+                action: "add".to_string(),
+                subject: Some("subject".to_string()),
+                predicate: Some("relates_to".to_string()),
+                object: Some("object".to_string()),
+                triple_id: None,
+                active_only: None,
+                source_drawer: None,
+            }))
+            .await
+            .expect("kg add succeeds");
+
+        server
+            .mempal_taxonomy(Parameters(TaxonomyRequest {
+                action: "edit".to_string(),
+                wing: Some("mcp".to_string()),
+                room: Some("lease-taxonomy".to_string()),
+                keywords: Some(vec!["lease".to_string()]),
+            }))
+            .await
+            .expect("taxonomy edit succeeds");
+
+        server
+            .mempal_tunnels(Parameters(TunnelsRequest {
+                action: Some("add".to_string()),
+                left: Some(TunnelEndpointDto {
+                    wing: "left".to_string(),
+                    room: Some("room".to_string()),
+                }),
+                right: Some(TunnelEndpointDto {
+                    wing: "right".to_string(),
+                    room: Some("room".to_string()),
+                }),
+                from: None,
+                label: Some("related".to_string()),
+                tunnel_id: None,
+                wing: None,
+                kind: None,
+                max_hops: None,
+            }))
+            .await
+            .expect("tunnel add succeeds");
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(
+            !db.drawer_exists("mcp-delete-success-target")
+                .expect("drawer exists")
+        );
+        assert_eq!(db.triple_count().expect("triple count"), 1);
+        assert_eq!(
+            db.taxonomy_count().expect("taxonomy count"),
+            baseline_taxonomy + 1
+        );
+        assert_eq!(
+            db.list_explicit_tunnels(None).expect("list tunnels").len(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -234,6 +234,7 @@ fn cmd_promote(
         project_id: project_id.as_deref(),
         skill_min_sessions: config.skills.skill_min_sessions,
     };
+    let _writer_lease = super::acquire_cli_content_writer_lease(db, "skills-promote")?;
     match promote_pattern_to_skill(db.conn(), &args) {
         Ok(skill) => {
             println!(
@@ -282,6 +283,14 @@ fn cmd_propose_from_cases(
     let current_dir = std::env::current_dir().ok();
     let project_id = resolve_project_id(args.project.as_deref(), config, current_dir.as_deref())
         .context("failed to resolve skill proposal project id")?;
+    let _writer_lease = if args.dry_run {
+        None
+    } else {
+        Some(super::acquire_cli_content_writer_lease(
+            db,
+            "skills-propose",
+        )?)
+    };
     let outcome = propose_skills_from_cases(
         db,
         SkillProposalOptions {
@@ -328,6 +337,7 @@ fn cmd_propose_from_cases(
 }
 
 fn cmd_adopt(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
+    let _writer_lease = super::acquire_cli_content_writer_lease(db, "skills-adopt")?;
     let new_status = adopt_skill(db.conn(), skill_id, config.skills.active_threshold)
         .with_context(|| format!("failed to adopt skill {skill_id}"))?;
     match new_status {
@@ -341,6 +351,7 @@ fn cmd_adopt(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
 }
 
 fn cmd_reject(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
+    let _writer_lease = super::acquire_cli_content_writer_lease(db, "skills-reject")?;
     let new_status = reject_skill(db.conn(), skill_id, config.skills.retire_threshold)
         .with_context(|| format!("failed to reject skill {skill_id}"))?;
     match new_status {
@@ -354,6 +365,7 @@ fn cmd_reject(db: &Database, config: &Config, skill_id: &str) -> Result<()> {
 }
 
 fn cmd_retire(db: &Database, skill_id: &str) -> Result<()> {
+    let _writer_lease = super::acquire_cli_content_writer_lease(db, "skills-retire")?;
     let found = retire_skill(db.conn(), skill_id)
         .with_context(|| format!("failed to retire skill {skill_id}"))?;
     if found {

--- a/tests/cowork_bus.rs
+++ b/tests/cowork_bus.rs
@@ -155,6 +155,14 @@ fn palace_db_path(home: &TempDir) -> PathBuf {
     home.path().join(".mempal/palace.db")
 }
 
+fn hold_daemon_writer_lease(home: &TempDir) -> mempal::core::types::RuntimeWriterLease {
+    fs::create_dir_all(home.path().join(".mempal")).expect("create .mempal");
+    let db = mempal::core::db::Database::open(&palace_db_path(home)).expect("open db");
+    db.runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
+        .expect("acquire daemon writer lease")
+        .expect("daemon writer lease")
+}
+
 fn event_lines(home: &TempDir, repo: &Path) -> Vec<String> {
     fs::read_to_string(bus_events_path(home, repo))
         .expect("events file")
@@ -2013,6 +2021,41 @@ fn test_cli_cowork_capture_execute_writes_evidence() {
         .expect("drawer exists");
     assert_eq!(drawer.wing, "cowork-capture");
     assert!(drawer.content.contains("Cowork Handoff Capture"));
+}
+
+#[test]
+
+fn test_cli_cowork_capture_execute_respects_existing_writer_lease() {
+    let home = TempDir::new().expect("home");
+    let repo = setup_repo(&home, "capture-lease-conflict");
+    register(&home, &repo, "claude-main", "claude");
+    let _lease = hold_daemon_writer_lease(&home);
+
+    let capture = run_mempal(
+        &home,
+        &[
+            "cowork-capture",
+            "--cwd",
+            repo.to_str().unwrap(),
+            "--summary-source",
+            "handoff",
+            "--execute",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert!(
+        !capture.status.success(),
+        "cowork-capture must fail under writer lease"
+    );
+    let err = stderr(&capture);
+    assert!(
+        err.contains("SQLite writer lease `sqlite-writer` is already held"),
+        "{err}"
+    );
+    let db = mempal::core::db::Database::open(&palace_db_path(&home)).expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 0);
 }
 
 #[test]

--- a/tests/daemon_heartbeat_wired.rs
+++ b/tests/daemon_heartbeat_wired.rs
@@ -120,6 +120,7 @@ async fn test_daemon_heartbeat_fires_during_embed_retry() {
             llm_gate: None,
             config: &config,
             mempal_home: &mempal_home,
+            runtime_writer_lease: None,
         },
     )
     .await
@@ -230,6 +231,7 @@ enabled = true
             llm_gate: None,
             config: &config,
             mempal_home: &mempal_home,
+            runtime_writer_lease: None,
         },
     )
     .await

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -2,7 +2,7 @@ mod common;
 
 use anyhow::{Context, Result};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -49,6 +49,56 @@ log_path = "{}"
     )
     .expect("write config");
     (tmp, db_path, config_path)
+}
+
+fn daemon_runtime_dir(home: &Path) -> PathBuf {
+    home.join(".mempal").join("runtime")
+}
+
+trait DaemonCommandExt {
+    fn daemon_home(&mut self, home: &Path) -> &mut Self;
+}
+
+impl DaemonCommandExt for Command {
+    fn daemon_home(&mut self, home: &Path) -> &mut Self {
+        self.env("HOME", home).env(
+            mempal::daemon_singleton::MEMPAL_RUNTIME_DIR_ENV,
+            daemon_runtime_dir(home),
+        )
+    }
+}
+
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: daemon lifecycle tests serialize process-wide environment
+        // mutation with ENV_LOCK and restore the previous value on drop.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: daemon lifecycle tests serialize process-wide environment
+        // mutation with ENV_LOCK and this restores the captured previous value.
+        unsafe {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 }
 
 fn prepared_ingest_payload(content: &str) -> String {
@@ -231,7 +281,7 @@ fn spawn_db_backed_orphan_daemon(home: &std::path::Path, db_path: &std::path::Pa
     let pid_path = mempal_home.join("daemon.pid");
     let mut child = Command::new(mempal_bin())
         .args(["daemon", "--foreground"])
-        .env("HOME", home)
+        .daemon_home(home)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -258,6 +308,11 @@ fn spawn_db_backed_orphan_daemon(home: &std::path::Path, db_path: &std::path::Pa
 #[test]
 fn test_daemon_context_bootstrap_ordering() {
     let (_tmp, _db_path, config_path) = setup_daemon_home();
+    let _env_lock = ENV_LOCK.lock().expect("env lock");
+    let _runtime_guard = EnvVarGuard::set_path(
+        mempal::daemon_singleton::MEMPAL_RUNTIME_DIR_ENV,
+        &daemon_runtime_dir(_tmp.path()),
+    );
     let runtime = tokio::runtime::Runtime::new().expect("bootstrap runtime");
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
@@ -357,7 +412,7 @@ fn test_daemon_restart_reaps_orphan_without_pidfile() {
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "restart"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .expect("run daemon restart");
@@ -398,7 +453,7 @@ fn test_daemon_start_repairs_orphan_pidfile_before_reporting_running() {
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "start"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .expect("run daemon start");
@@ -435,7 +490,7 @@ fn test_daemon_stop_terminates_pidfile_only_process() -> Result<()> {
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "stop"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .context("run daemon stop")?;
@@ -469,7 +524,7 @@ fn test_daemon_restart_terminates_pidfile_only_process_and_restarts() -> Result<
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "restart"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .context("run daemon restart")?;
@@ -516,7 +571,7 @@ fn test_daemon_reap_repairs_single_orphan_pidfile() {
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "reap"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .expect("run daemon reap");
@@ -551,7 +606,7 @@ fn test_status_full_treats_single_orphan_as_running() {
 
     let output = Command::new(mempal_bin())
         .args(["status", "--full"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .expect("run status --full");
@@ -587,7 +642,7 @@ fn test_daemon_reap_keeps_single_pidfile_process() -> Result<()> {
 
     let output = Command::new(mempal_bin())
         .args(["daemon", "reap"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .output()
         .context("run daemon reap")?;
@@ -622,7 +677,7 @@ fn test_daemon_processes_ingest_async_queue_rows() {
 
     let mut child = Command::new(mempal_bin())
         .args(["daemon", "--foreground"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -686,7 +741,7 @@ async fn test_daemon_sigterm_drains_running_ingest_async_before_reclaim() {
 
     let mut child = Command::new(mempal_bin())
         .args(["daemon", "--foreground"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -736,7 +791,7 @@ async fn test_daemon_sigterm_drains_running_ingest_async_before_reclaim() {
 
     let mut restarted = Command::new(mempal_bin())
         .args(["daemon", "--foreground"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -818,7 +873,7 @@ log_path = "{}"
 
     let mut child = Command::new(mempal_bin())
         .args(["daemon", "--foreground"])
-        .env("HOME", tmp.path())
+        .daemon_home(tmp.path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/tests/daemon_lifecycle.rs
+++ b/tests/daemon_lifecycle.rs
@@ -294,6 +294,47 @@ fn test_daemon_context_bootstrap_ordering() {
     assert!(!pid_path.exists(), "pid file must be removed on drop");
 }
 
+#[test]
+fn test_duplicate_daemon_bootstrap_is_rejected_before_work_begins() {
+    let (tmp, db_path, _config_path) = setup_daemon_home();
+    let runtime_dir = tmp.path().join("runtime");
+    let _guard = match mempal::daemon_singleton::try_acquire_for_test(&db_path, &runtime_dir)
+        .expect("first acquire")
+    {
+        mempal::daemon_singleton::DaemonLockAcquisition::Acquired(guard) => guard,
+        mempal::daemon_singleton::DaemonLockAcquisition::AlreadyHeld { .. } => {
+            panic!("test lock should be free")
+        }
+    };
+
+    let output = Command::new(mempal_bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", tmp.path())
+        .env(
+            mempal::daemon_singleton::MEMPAL_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        )
+        .stdin(Stdio::null())
+        .output()
+        .expect("run duplicate daemon");
+
+    assert!(
+        !output.status.success(),
+        "duplicate daemon must fail, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon already running"),
+        "duplicate error should include owner metadata, stderr={stderr}"
+    );
+    assert!(
+        !tmp.path().join(".mempal/daemon.pid").exists(),
+        "duplicate daemon must fail before writing pidfile"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn test_daemon_restart_reaps_orphan_without_pidfile() {

--- a/tests/hermes_auto_ingest.rs
+++ b/tests/hermes_auto_ingest.rs
@@ -148,6 +148,7 @@ preview_chars = 48
                 llm_gate: None,
                 config: &self.config,
                 mempal_home: &self.mempal_home,
+                runtime_writer_lease: None,
             },
         )
         .await

--- a/tests/hook_project_promotion.rs
+++ b/tests/hook_project_promotion.rs
@@ -153,6 +153,7 @@ enabled = false
                 llm_gate: None,
                 config: &self.config,
                 mempal_home: &self.mempal_home,
+                runtime_writer_lease: None,
             },
         )
         .await
@@ -375,6 +376,7 @@ enabled = false
                 llm_gate: None,
                 config: &self.config,
                 mempal_home: &self.mempal_home,
+                runtime_writer_lease: None,
             },
         )
         .await

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -32,6 +32,14 @@ fn run_ingest(home: &Path, target: &str, wing: &str) -> Output {
         .expect("run mempal ingest")
 }
 
+fn run_delete(home: &Path, drawer_id: &str) -> Output {
+    Command::new(mempal_bin())
+        .args(["delete", drawer_id])
+        .env("HOME", home)
+        .output()
+        .expect("run mempal delete")
+}
+
 fn run_ingest_dry(home: &Path, target: &str, wing: &str) -> Output {
     Command::new(mempal_bin())
         .args(["ingest", target, "--wing", wing, "--dry-run"])
@@ -81,6 +89,25 @@ fn hold_daemon_writer_lease(home: &Path) -> mempal::core::types::RuntimeWriterLe
     db.runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
         .expect("acquire daemon writer lease")
         .expect("daemon writer lease")
+}
+
+fn insert_drawer(home: &Path, drawer_id: &str) {
+    let db =
+        mempal::core::db::Database::open(&home.join(".mempal").join("palace.db")).expect("open db");
+    let drawer = mempal::core::types::Drawer::new_bootstrap_evidence(
+        mempal::core::types::BootstrapEvidenceArgs {
+            id: drawer_id.to_string(),
+            content: "cli delete lease fixture".to_string(),
+            wing: "lease-wing".to_string(),
+            room: Some("lease-room".to_string()),
+            source_file: Some("/tmp/cli-delete.md".to_string()),
+            source_type: mempal::core::types::SourceType::AgentInference,
+            added_at: "1713000000".to_string(),
+            chunk_index: Some(0),
+            importance: 2,
+        },
+    );
+    db.insert_drawer(&drawer).expect("insert drawer");
 }
 
 fn write_embed_config(home: &Path, base_url: &str) {
@@ -773,6 +800,51 @@ fn test_stdin_non_wait_ingest_respects_existing_writer_lease() {
     let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
         .expect("open db");
     assert_eq!(db.drawer_count().expect("drawer count"), 0);
+}
+
+#[test]
+fn test_cli_delete_respects_existing_writer_lease() {
+    let tmp = setup_home();
+    insert_drawer(tmp.path(), "cli-delete-lease-target");
+    let _lease = hold_daemon_writer_lease(tmp.path());
+
+    let output = run_delete(tmp.path(), "cli-delete-lease-target");
+
+    assert!(
+        !output.status.success(),
+        "delete must fail under writer lease"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SQLite writer lease `sqlite-writer` is already held"),
+        "{stderr}"
+    );
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    assert!(
+        db.drawer_exists("cli-delete-lease-target")
+            .expect("drawer exists")
+    );
+}
+
+#[test]
+fn test_cli_delete_succeeds_without_writer_lease_conflict() {
+    let tmp = setup_home();
+    insert_drawer(tmp.path(), "cli-delete-success-target");
+
+    let output = run_delete(tmp.path(), "cli-delete-success-target");
+
+    assert!(
+        output.status.success(),
+        "delete should succeed without writer lease conflict: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    assert!(
+        !db.drawer_exists("cli-delete-success-target")
+            .expect("drawer exists")
+    );
 }
 
 #[test]

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -75,6 +75,14 @@ fn run_ingest_stdin_bytes(home: &Path, payload: &[u8], args: &[&str]) -> Output 
         .expect("wait mempal ingest --stdin")
 }
 
+fn hold_daemon_writer_lease(home: &Path) -> mempal::core::types::RuntimeWriterLease {
+    let db =
+        mempal::core::db::Database::open(&home.join(".mempal").join("palace.db")).expect("open db");
+    db.runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
+        .expect("acquire daemon writer lease")
+        .expect("daemon writer lease")
+}
+
 fn write_embed_config(home: &Path, base_url: &str) {
     write_embed_config_with_privacy(home, base_url, false);
 }
@@ -707,6 +715,64 @@ fn test_ingest_stdin_rejects_format() {
     );
 
     assert_stdin_error(output, "--format is only supported for directory ingest");
+}
+
+#[test]
+fn test_directory_ingest_respects_existing_writer_lease() {
+    let tmp = setup_home();
+    let _lease = hold_daemon_writer_lease(tmp.path());
+    let input_dir = tmp.path().join("input");
+    fs::create_dir_all(&input_dir).expect("create input dir");
+    fs::write(
+        input_dir.join("memory.md"),
+        "directory lease conflict memory",
+    )
+    .expect("write input");
+
+    let output = run_ingest(
+        tmp.path(),
+        input_dir.to_str().expect("input path utf8"),
+        "lease-wing",
+    );
+
+    assert!(
+        !output.status.success(),
+        "directory ingest must fail under writer lease"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SQLite writer lease `sqlite-writer` is already held"),
+        "{stderr}"
+    );
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 0);
+}
+
+#[test]
+fn test_stdin_non_wait_ingest_respects_existing_writer_lease() {
+    let tmp = setup_home();
+    let _lease = hold_daemon_writer_lease(tmp.path());
+    let payload = r#"{
+        "content": "stdin direct lease conflict memory",
+        "wing": "lease-wing",
+        "room": "lease-room"
+    }"#;
+
+    let output = run_ingest_stdin_json(tmp.path(), payload, &["--no-gate", "--json"]);
+
+    assert!(
+        !output.status.success(),
+        "stdin ingest must fail under writer lease"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("SQLite writer lease `sqlite-writer` is already held"),
+        "{stderr}"
+    );
+    let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
+        .expect("open db");
+    assert_eq!(db.drawer_count().expect("drawer count"), 0);
 }
 
 #[test]

--- a/tests/lease_coordination.rs
+++ b/tests/lease_coordination.rs
@@ -114,3 +114,108 @@ fn lease_cleanup_expired() {
     assert_eq!(leases.len(), 1);
     assert_eq!(leases[0].resource_path, "c");
 }
+
+#[test]
+fn runtime_writer_lease_acquire_renew_release() {
+    let db = open_test_db();
+
+    let lease = db
+        .runtime_writer_lease_acquire(
+            "sqlite-writer",
+            "daemon-owner",
+            "daemon",
+            300,
+            Some(r#"{"command":"daemon"}"#),
+        )
+        .unwrap()
+        .expect("acquire writer lease");
+
+    assert_eq!(lease.name, "sqlite-writer");
+    assert_eq!(lease.owner, "daemon-owner");
+    assert_eq!(lease.mode, "daemon");
+    assert_eq!(lease.pid, std::process::id());
+    assert!(lease.remaining_secs > 0);
+    assert_eq!(
+        lease.metadata_json.as_deref(),
+        Some(r#"{"command":"daemon"}"#)
+    );
+
+    assert!(
+        db.runtime_writer_lease_renew(&lease.name, &lease.owner, &lease.session_id, 600)
+            .unwrap()
+    );
+    let renewed = db
+        .runtime_writer_lease_status(Some("sqlite-writer"))
+        .unwrap();
+    assert_eq!(renewed.len(), 1);
+    assert!(renewed[0].remaining_secs > 0);
+
+    assert!(
+        db.runtime_writer_lease_release(&lease.name, &lease.owner, &lease.session_id)
+            .unwrap()
+    );
+    assert!(
+        db.runtime_writer_lease_status(Some("sqlite-writer"))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn runtime_writer_lease_conflicts_until_expiry() {
+    let db = open_test_db();
+
+    let daemon = db
+        .runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 1, None)
+        .unwrap()
+        .expect("daemon lease");
+
+    assert!(
+        db.runtime_writer_lease_acquire(
+            "sqlite-writer",
+            "maintenance-owner",
+            "maintenance",
+            300,
+            None,
+        )
+        .unwrap()
+        .is_none(),
+        "maintenance writer must not acquire while daemon writer lease is active"
+    );
+    assert!(
+        !db.runtime_writer_lease_release("sqlite-writer", "maintenance-owner", &daemon.session_id)
+            .unwrap(),
+        "wrong owner/session must not release another writer lease"
+    );
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    let maintenance = db
+        .runtime_writer_lease_acquire(
+            "sqlite-writer",
+            "maintenance-owner",
+            "maintenance",
+            300,
+            None,
+        )
+        .unwrap()
+        .expect("expired daemon lease should be recoverable");
+    assert_eq!(maintenance.mode, "maintenance");
+}
+
+#[test]
+fn runtime_writer_lease_different_names_do_not_collide() {
+    let db = open_test_db();
+
+    let daemon = db
+        .runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
+        .unwrap()
+        .expect("daemon lease");
+    let independent = db
+        .runtime_writer_lease_acquire("analytics-writer", "other-owner", "maintenance", 300, None)
+        .unwrap()
+        .expect("independent lease");
+
+    assert_ne!(daemon.name, independent.name);
+    assert_eq!(db.runtime_writer_lease_status(None).unwrap().len(), 2);
+}

--- a/tests/session_self_review.rs
+++ b/tests/session_self_review.rs
@@ -215,6 +215,7 @@ preview_chars = 48
                 llm_gate: None,
                 config: &self.config,
                 mempal_home: &self.mempal_home,
+                runtime_writer_lease: None,
             },
         )
         .await

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "c25cd80d42f0411eaa86efc00bee9c037de3e037"
+commit = "4d9d094d3ab8c634d3eb1a5e148c0448790f0666"
 source_kind = "git"


### PR DESCRIPTION
Fixes #496\n\n## Summary\n- enforce singleton daemon/runtime writer leases across daemon, CLI, MCP, maintenance, and ingest side-effect write paths\n- renew/validate long-lived writer leases before SQLite mutations\n- add regression coverage for lease conflicts and lease-loss-before-write paths\n\n## Verification\n- CSA/Codex exact-head review PASS: 01KVKT3GT2DQ14D1ER6753TPZ7\n- pre-push local-gates PASS\n- pre-push review-check PASS