### PR TITLE
refactor(algo): separate stateless memory ranking operators

### DIFF
--- a/docs/design/stateless-memory-operators.md
+++ b/docs/design/stateless-memory-operators.md
@@ -1,0 +1,48 @@
+# Stateless Memory Operators
+
+Issue #477 separates memory algorithms from store/runtime concerns without
+splitting the single `mempal` crate prematurely.
+
+## Current Boundary Map
+
+| Candidate boundary | Current modules | Responsibility | Should depend on |
+| --- | --- | --- | --- |
+| `core` | `src/core/types.rs`, `src/core/config.rs`, `src/core/project.rs`, `src/core/protocol.rs` | Shared data contracts, config snapshots, project-scope value types, protocol text | std, serde, small pure helpers |
+| `store` | `src/core/db.rs`, `src/core/async_db.rs`, `src/core/queue.rs`, `src/core/reindex.rs` | SQLite schema, migrations, FTS/vector SQL, queue persistence, row hydration | `core`, `algo` outputs when persistence needs ranking/filter decisions |
+| `algo` | `src/algo/*`, existing pure candidates in `src/search/route.rs`, `src/search/preview.rs`, `src/importance.rs`, parts of `src/factcheck/*` | Stateless parsing, routing, ranking, scoring, filtering, citation/recall operators | `core` value types when needed; never SQLite, CLI, MCP, daemon, globals, network |
+| `embed` | `src/embed/*` | Embedding backend traits, routing, retry policy, transport clients | `core` config/status types; not store/runtime orchestration except explicit adapters |
+| `runtime` | `src/daemon*.rs`, `src/hook*.rs`, `src/llm/*`, `src/endpoint_pool.rs`, `src/intelligence.rs` | Long-running workers, retries, daemon lifecycle, hook capture, LLM workers | `core`, `store`, `embed`, `algo`; owns side effects |
+| `mcp` | `src/mcp/*` | MCP request/response DTOs and tool orchestration | `core`, `store`, `embed`, `runtime`, `algo`; no algorithm ownership |
+| `cli` | `src/main.rs`, `src/cli/*`, command-specific top-level modules | User-facing commands and output formatting | all lower layers; no reusable algorithm ownership |
+| `wiki` | `src/wiki.rs`, `src/markdown_export.rs`, `books/*`, `docs/*` | Documentation generation/export surfaces | `core`/`store` read models; no search/runtime policy |
+
+These are module boundaries inside the existing crate. They are not a crate
+split plan. The published ergonomics remain one `mempal` binary and one
+library crate until there is a concrete compile-time or release reason to split.
+
+## Concrete Operator Boundary
+
+`src/algo/ranking.rs` introduces a stateless ranking boundary:
+
+- `ReciprocalRankFusion` fuses ranked memory IDs and returns `FusedRank` values.
+- `RankedMemoryItem` is a small trait for caller-owned memory items.
+- `sort_by_similarity_desc_then_id` and `rerank_by_effective_importance` are
+  pure ordering operators.
+
+The search store path now adapts DB-backed `SearchResult` values into those
+operators. SQLite remains responsible for FTS/vector recall, drawer hydration,
+tunnel fanout, and neighbor loading. The operator remains responsible only for
+score fusion and deterministic ordering.
+
+## Rules For Future Moves
+
+1. Move logic to `algo` only when it can run from owned inputs without opening a
+   database, reading hot config, spawning work, or calling network/embedding
+   clients.
+2. Keep adapters in `store`, `runtime`, `mcp`, or `cli` when the code performs
+   IO, hydration, retries, telemetry, or output formatting.
+3. Do not create pass-through modules. A module boundary must own a stable
+   concept such as ranking, route matching, leakage filtering, citation
+   assembly, or fact contradiction detection.
+4. Preserve single-binary behavior. Internal module moves are allowed; CLI/MCP
+   contracts should change only when the issue explicitly asks for it.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::all)]
+
+//! Stateless memory operators.
+//!
+//! This module is the home for deterministic algorithms that operate on plain
+//! memory-shaped inputs. Operators here must not open databases, call embedders,
+//! read global config, spawn tasks, or depend on CLI/MCP/runtime handles. Store
+//! and runtime layers adapt their data into these APIs and then persist or
+//! render the outputs.
+
+pub mod ranking;

--- a/src/algo/ranking.rs
+++ b/src/algo/ranking.rs
@@ -1,0 +1,211 @@
+#![warn(clippy::all)]
+
+//! Stateless ranking operators for memory retrieval.
+//!
+//! The APIs in this module consume ranked identifiers or caller-owned memory
+//! items. They deliberately know nothing about SQLite rows, embedders, daemon
+//! handles, or transport layers.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+/// A memory-like item that can be ranked without store access.
+pub trait RankedMemoryItem {
+    /// Stable memory identifier used for deterministic tie-breaking.
+    fn memory_id(&self) -> &str;
+
+    /// Primary retrieval score, where larger is better.
+    fn similarity_score(&self) -> f32;
+
+    /// Secondary importance score, where larger is better.
+    fn effective_importance(&self) -> f64;
+}
+
+/// One fused memory reference emitted by reciprocal rank fusion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedRank {
+    pub id: String,
+    pub score: f64,
+}
+
+/// Stateless Reciprocal Rank Fusion operator.
+///
+/// The operator accepts any number of ranked identifier lists and returns one
+/// deterministic fused list. It does not load missing records; callers decide
+/// how to hydrate the returned IDs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReciprocalRankFusion {
+    rank_constant: f64,
+}
+
+impl ReciprocalRankFusion {
+    /// Create an RRF operator with an explicit rank constant.
+    pub fn new(rank_constant: f64) -> Self {
+        Self { rank_constant }
+    }
+
+    /// Fuse ranked lists into descending RRF score order.
+    ///
+    /// Ties resolve by ascending memory id so equal-score merges are stable
+    /// across hash seeds, platforms, and process runs.
+    pub fn fuse<'a, Lists, List>(self, ranked_lists: Lists) -> Vec<FusedRank>
+    where
+        Lists: IntoIterator<Item = List>,
+        List: IntoIterator<Item = &'a str>,
+    {
+        let mut scores = HashMap::<String, f64>::new();
+        for list in ranked_lists {
+            for (rank, id) in list.into_iter().enumerate() {
+                let score = 1.0 / (self.rank_constant + rank as f64 + 1.0);
+                *scores.entry(id.to_string()).or_default() += score;
+            }
+        }
+
+        let mut fused = scores
+            .into_iter()
+            .map(|(id, score)| FusedRank { id, score })
+            .collect::<Vec<_>>();
+        fused.sort_by(|left, right| {
+            compare_score_desc_then_id(left.score, &left.id, right.score, &right.id)
+        });
+        fused
+    }
+}
+
+impl Default for ReciprocalRankFusion {
+    fn default() -> Self {
+        Self::new(60.0)
+    }
+}
+
+/// Sort by descending similarity and ascending id.
+pub fn sort_by_similarity_desc_then_id<T: RankedMemoryItem>(items: &mut [T]) {
+    items.sort_by(|left, right| {
+        compare_score_desc_then_id(
+            f64::from(left.similarity_score()),
+            left.memory_id(),
+            f64::from(right.similarity_score()),
+            right.memory_id(),
+        )
+    });
+}
+
+/// Stable secondary rerank by descending effective importance.
+///
+/// Equal or non-comparable importance values preserve the incoming order. This
+/// lets callers keep the primary retrieval order from RRF or vector search.
+pub fn rerank_by_effective_importance<T: RankedMemoryItem>(items: &mut [T]) {
+    items.sort_by(|left, right| {
+        right
+            .effective_importance()
+            .partial_cmp(&left.effective_importance())
+            .unwrap_or(Ordering::Equal)
+    });
+}
+
+fn compare_score_desc_then_id(
+    left_score: f64,
+    left_id: &str,
+    right_score: f64,
+    right_id: &str,
+) -> Ordering {
+    right_score
+        .partial_cmp(&left_score)
+        .unwrap_or(Ordering::Equal)
+        .then_with(|| left_id.cmp(right_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Item {
+        id: &'static str,
+        similarity: f32,
+        importance: f64,
+    }
+
+    impl RankedMemoryItem for Item {
+        fn memory_id(&self) -> &str {
+            self.id
+        }
+
+        fn similarity_score(&self) -> f32 {
+            self.similarity
+        }
+
+        fn effective_importance(&self) -> f64 {
+            self.importance
+        }
+    }
+
+    fn ids(items: &[Item]) -> Vec<&str> {
+        items.iter().map(|item| item.id).collect()
+    }
+
+    #[test]
+    fn rrf_fuses_ranked_lists_and_tie_breaks_by_id() {
+        let fused = ReciprocalRankFusion::default().fuse([
+            vec!["tie_b", "tie_a", "vector_only"],
+            vec!["tie_a", "tie_b", "bm25_only"],
+        ]);
+
+        let ids = fused
+            .iter()
+            .map(|rank| rank.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["tie_a", "tie_b", "bm25_only", "vector_only"]);
+        assert_eq!(fused[0].score, fused[1].score);
+    }
+
+    #[test]
+    fn similarity_sort_orders_by_score_then_id() {
+        let mut items = vec![
+            Item {
+                id: "b",
+                similarity: 0.7,
+                importance: 0.0,
+            },
+            Item {
+                id: "a",
+                similarity: 0.7,
+                importance: 0.0,
+            },
+            Item {
+                id: "c",
+                similarity: 0.9,
+                importance: 0.0,
+            },
+        ];
+
+        sort_by_similarity_desc_then_id(&mut items);
+
+        assert_eq!(ids(&items), vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn importance_rerank_is_stable_for_equal_scores() {
+        let mut items = vec![
+            Item {
+                id: "rrf-first",
+                similarity: 0.3,
+                importance: 2.0,
+            },
+            Item {
+                id: "rrf-second",
+                similarity: 0.9,
+                importance: 2.0,
+            },
+            Item {
+                id: "important",
+                similarity: 0.1,
+                importance: 5.0,
+            },
+        ];
+
+        rerank_by_effective_importance(&mut items);
+
+        assert_eq!(ids(&items), vec!["important", "rrf-first", "rrf-second"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod aaak;
 pub mod adoption_analytics;
+pub mod algo;
 #[cfg(feature = "rest")]
 pub mod api;
 pub mod bootstrap_events;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all)]
 
+use crate::algo::ranking::{RankedMemoryItem, ReciprocalRankFusion};
 use crate::core::decay::{search_decay_factor_at, validity_window_contains_at};
 use crate::core::{
     db::{Database, FtsMetadataFilters, FtsSearchScope},
@@ -27,6 +28,20 @@ pub mod tiered;
 const EXACT_VECTOR_CANDIDATE_LIMIT: i64 = 4_096;
 
 pub type Result<T> = std::result::Result<T, SearchError>;
+
+impl RankedMemoryItem for SearchResult {
+    fn memory_id(&self) -> &str {
+        &self.drawer_id
+    }
+
+    fn similarity_score(&self) -> f32 {
+        self.similarity
+    }
+
+    fn effective_importance(&self) -> f64 {
+        self.effective_importance
+    }
+}
 
 // --- Upstream knowledge-filter types ---
 
@@ -760,12 +775,7 @@ fn apply_temporal_decay(
         result.similarity *= factor as f32;
         result.effective_importance *= factor;
     }
-    results.sort_by(|a, b| {
-        b.similarity
-            .partial_cmp(&a.similarity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.drawer_id.cmp(&b.drawer_id))
-    });
+    crate::algo::ranking::sort_by_similarity_desc_then_id(results);
 }
 
 /// Apply active-pattern score boost to matching exemplar drawers.
@@ -833,11 +843,7 @@ fn apply_pattern_boost(
 /// Uses a stable sort so ties preserve the RRF score ordering.
 /// Per spec: must not modify the `similarity` field.
 fn rerank_by_effective_importance(results: &mut [SearchResult]) {
-    results.sort_by(|a, b| {
-        b.effective_importance
-            .partial_cmp(&a.effective_importance)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    crate::algo::ranking::rerank_by_effective_importance(results);
 }
 
 /// Dispatch an async task to update access tracking fields for the given drawer IDs.
@@ -1225,24 +1231,22 @@ fn rrf_merge(
 ) -> Vec<SearchResult> {
     use std::collections::HashMap;
 
-    const RRF_K: f64 = 60.0;
-
-    let mut scores: HashMap<String, f64> = HashMap::new();
+    let vector_ids = vector_results
+        .iter()
+        .map(|result| result.drawer_id.as_str())
+        .collect::<Vec<_>>();
+    let fts_ranked_ids = fts_ids
+        .iter()
+        .map(|(id, _bm25_score)| id.as_str())
+        .collect::<Vec<_>>();
+    let fused = ReciprocalRankFusion::default().fuse([vector_ids, fts_ranked_ids]);
     let mut result_map: HashMap<String, SearchResult> = HashMap::new();
 
-    // Score vector results
-    for (rank, result) in vector_results.into_iter().enumerate() {
-        let score = 1.0 / (RRF_K + rank as f64 + 1.0);
-        scores.insert(result.drawer_id.clone(), score);
+    for result in vector_results {
         result_map.insert(result.drawer_id.clone(), result);
     }
 
-    // Score FTS results and merge
-    for (rank, (id, _bm25_score)) in fts_ids.iter().enumerate() {
-        let score = 1.0 / (RRF_K + rank as f64 + 1.0);
-        *scores.entry(id.clone()).or_default() += score;
-
-        // If this ID wasn't in vector results, load the drawer
+    for (id, _bm25_score) in fts_ids {
         if !result_map.contains_key(id) {
             if let Ok(Some(drawer)) = db.get_drawer(id) {
                 let source = scope.classify_row(db.drawer_project_id(id).ok().flatten().as_deref());
@@ -1254,21 +1258,14 @@ fn rrf_merge(
         }
     }
 
-    // Sort by RRF score descending, fill in similarity field
-    let mut merged: Vec<SearchResult> = scores
+    let mut merged: Vec<SearchResult> = fused
         .into_iter()
-        .filter_map(|(id, rrf_score)| {
-            let mut result = result_map.remove(&id)?;
-            result.similarity = rrf_score as f32;
+        .filter_map(|rank| {
+            let mut result = result_map.remove(&rank.id)?;
+            result.similarity = rank.score as f32;
             Some(result)
         })
         .collect();
-    merged.sort_by(|a, b| {
-        b.similarity
-            .partial_cmp(&a.similarity)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.drawer_id.cmp(&b.drawer_id))
-    });
     merged.truncate(top_k);
     merged
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "4d9d094d3ab8c634d3eb1a5e148c0448790f0666"
+commit = "73309c0db14ed4431984c20ebeabc9b84a683e8c"
 source_kind = "git"


### PR DESCRIPTION
Fixes #477\n\n## Summary\n- introduce a SQLite-free stateless ranking operator boundary\n- adapt search hydration into the new operator API while preserving CLI/MCP behavior\n- document current core/store/algo/embed/runtime/mcp/cli/wiki boundary map\n\n## Verification\n- CSA/Codex exact-head review PASS: 01KVKYE9G38VPXVK0SM30VG94F\n- pre-push local-gates PASS\n- pre-push review-check PASS