### PR TITLE
perf(embed): decouple model2vec from daemon defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ name = "mempal"
 path = "src/main.rs"
 
 [features]
-default = ["model2vec"]
+default = []
 integration = []
 model2vec = ["dep:model2vec-rs"]
 onnx = ["dep:ort", "dep:tokenizers"]
-rest = ["dep:axum", "dep:tower", "dep:tower-http", "model2vec"]
+rest = ["dep:axum", "dep:tower", "dep:tower-http"]
 # Test-only seam: exposes `AsyncDb::with_read_delay` so the runtime-liveness /
 # read-concurrency regression tests (#345) can inject cold-read latency without
 # a multi-GB database. The default build does NOT carry this overhead.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mempal
 
-Project memory for coding agents. Single binary, `cargo install mempal`, find past decisions with citations in seconds. Local-first by default: SQLite + model2vec, with no cloud LLM, embedding, or rerank calls unless you opt in.
+Project memory for coding agents. Single binary, `cargo install mempal`, find past decisions with citations in seconds. Local-first storage by default: SQLite with no hidden model2vec download and no cloud LLM, embedding, or rerank calls unless you configure them.
 
 ## What It Does
 
@@ -13,7 +13,7 @@ Next session (any agent) → mempal search → finds the decision with source ci
 - **Knowledge graph**: subject-predicate-object triples with temporal validity (valid_from/valid_to)
 - **Cross-project tunnels**: automatic discovery when the same room appears in multiple wings
 - **Self-describing protocol**: MEMORY_PROTOCOL embedded in MCP ServerInfo teaches any agent how to use mempal — no system prompt configuration required
-- **Multilingual**: model2vec-rs (BGE-M3 distilled) as default embedder, zero native dependencies
+- **Configurable embeddings**: prefer an explicit OpenAI-compatible local/LAN provider for production; model2vec is an opt-in feature/backend
 - **Single file**: everything lives in `~/.mempal/palace.db` (SQLite + sqlite-vec)
 - **No cloud by default**: remote embeddings, LLM gating, and rerankers are disabled until configured explicitly
 
@@ -55,26 +55,25 @@ cargo install --path . --locked --features rest
 
 ## Configuration
 
-Config at `~/.mempal/config.toml` (optional, defaults work without it):
+Config at `~/.mempal/config.toml`:
 
-With no config file, mempal uses the local SQLite database at `~/.mempal/palace.db`, the local model2vec embedder, and no reranker or LLM calls. OpenAI-compatible embedding, LLM gating, and reranking examples below are opt-in.
+With no config file, mempal uses the local SQLite database at `~/.mempal/palace.db` and does not silently download or load model2vec. Configure an embedding endpoint for ingest/search, or explicitly enable `backend = "model2vec"` with the `model2vec` Cargo feature for local static models.
 
 ```toml
 db_path = "~/.mempal/palace.db"
 
 [embed]
-backend = "model2vec"                          # default, zero native deps
-# model = "minishlab/potion-multilingual-128M" # default multilingual model (1024d)
+backend = "openai_compat"                      # default provider family
 
-# Optional: keep long-lived daemon RSS lower than the in-process default model.
+# Optional: keep long-lived daemon RSS lower than in-process local models.
 # Requires [embed.openai_compat] or [[embed.endpoints]] below.
 [daemon]
 embedder_mode = "remote"                       # configured | remote | small_local
 
 [embed.openai_compat]
-# base_url = "http://127.0.0.1:18002/v1"       # local/LAN embedding endpoint
-# model = "Qwen/Qwen3-Embedding-8B"
-# dim = 4096
+base_url = "http://127.0.0.1:18002/v1"         # local/LAN embedding endpoint
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
 
 [search.reranker]
 enabled = false                                # default: no reranker call
@@ -176,7 +175,7 @@ Daemon low-memory mode:
 
 - `[daemon].embedder_mode = "configured"` uses the normal `[embed]` backend.
 - `"remote"` forces daemon workers and daemon REST embedding to use the configured OpenAI-compatible/API endpoint and disables daemon fallback to local model2vec.
-- `"small_local"` forces the daemon to use `minishlab/potion-base-8M` instead of the larger default in-process model.
+- `"small_local"` forces the daemon to use `minishlab/potion-base-8M` instead of a larger explicitly configured in-process model.
 - After changing backend/model/dimensions, run `mempal reindex`, then `mempal daemon restart`.
 - `mempal daemon status` and `mempal doctor` report daemon RSS/PSS, whether the daemon executable is deleted/replaced, and whether the daemon embedder cache is loaded.
 
@@ -387,7 +386,7 @@ mempal currently builds as one Cargo package named `mempal`, with the binary at 
 | Path | Responsibility |
 |------|---------------|
 | `src/core/` | Types, SQLite schema, taxonomy, triples, config, queue |
-| `src/embed/` | Embedder implementations (model2vec default, ONNX and OpenAI-compatible optional paths) |
+| `src/embed/` | Embedder implementations (OpenAI-compatible routing, explicit model2vec and ONNX paths) |
 | `src/ingest/` | Format detection, normalization, chunking, gating, novelty |
 | `src/search/` | Hybrid search (BM25 + vector + RRF), routing, tunnels |
 | `src/aaak/` | AAAK encode/decode with BNF grammar + roundtrip tests |
@@ -396,7 +395,7 @@ mempal currently builds as one Cargo package named `mempal`, with the binary at 
 | `src/main.rs`, `src/cli/` | CLI entrypoint and command helpers |
 
 Key design choices:
-- **model2vec-rs** default embedder — zero native deps, multilingual (BGE-M3 distilled)
+- **OpenAI-compatible embeddings** as the default provider family; model2vec stays explicit opt-in
 - **ort (ONNX)** available behind `onnx` feature flag for max quality
 - **FTS5** for BM25 keyword search — synced via SQLite triggers
 - **Soft-delete** with audit trail — `mempal delete` + `mempal purge`

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Daemon low-memory mode:
 
 - `[daemon].embedder_mode = "configured"` uses the normal `[embed]` backend.
 - `"remote"` forces daemon workers and daemon REST embedding to use the configured OpenAI-compatible/API endpoint and disables daemon fallback to local model2vec.
-- `"small_local"` forces the daemon to use `minishlab/potion-base-8M` instead of a larger explicitly configured in-process model.
+- `"small_local"` forces the daemon to use `minishlab/potion-base-8M` instead of a larger explicitly configured in-process model; it requires installing with `--features model2vec`.
 - After changing backend/model/dimensions, run `mempal reindex`, then `mempal daemon restart`.
 - `mempal daemon status` and `mempal doctor` report daemon RSS/PSS, whether the daemon executable is deleted/replaced, and whether the daemon embedder cache is loaded.
 

--- a/docs/site/en/index.html
+++ b/docs/site/en/index.html
@@ -97,7 +97,7 @@ footer { text-align: center; padding: 40px 24px; color: var(--dim); font-size: 1
     <div class="card">
       <div class="icon">🌍</div>
       <h3>Multilingual Embedding</h3>
-      <p>model2vec-rs (BGE-M3 distilled) as default embedder. Zero native dependencies, supports Chinese, Japanese, Korean, English.</p>
+      <p>OpenAI-compatible local/LAN embedding is the default provider family. model2vec-rs remains an explicit opt-in backend.</p>
     </div>
     <div class="card">
       <div class="icon">📦</div>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ Before using the CLI, keep four nouns straight:
 - original text lives in the `drawers` table
 - vectors live in `drawer_vectors`
 - AAAK is output-only and does not replace stored raw text
-- default operation is local-first: SQLite + model2vec, with no cloud LLM, embedding, or rerank calls unless configured explicitly
+- default storage is local-first: SQLite only, with no hidden model2vec load and no cloud LLM, embedding, or rerank calls unless configured explicitly
 
 ## Install
 
@@ -68,18 +68,22 @@ Config file path:
 ~/.mempal/config.toml
 ```
 
-Default config:
+Recommended explicit embedder config:
 
 ```toml
 db_path = "~/.mempal/palace.db"
 
 [embed]
-backend = "model2vec"
-# model = "minishlab/potion-multilingual-128M" # default multilingual model
+backend = "openai_compat"
+
+[embed.openai_compat]
+base_url = "http://127.0.0.1:18002/v1"
+model = "Qwen/Qwen3-Embedding-8B"
+dim = 4096
 
 [daemon]
 # configured: use [embed] as-is
-# remote: daemon uses [embed.openai_compat] / [[embed.endpoints]] and does not load local model2vec fallback
+# remote: daemon uses [embed.openai_compat] / [[embed.endpoints]]
 # small_local: daemon uses minishlab/potion-base-8M
 embedder_mode = "configured"
 
@@ -97,11 +101,11 @@ allow_llm = false
 allow_rerank = false
 ```
 
-With no config file, `mempal` uses the local SQLite database at `~/.mempal/palace.db`, the local model2vec embedder, and no reranker or LLM calls. OpenAI-compatible embeddings, LLM gating, and reranking are opt-in.
+With no config file, `mempal` uses the local SQLite database at `~/.mempal/palace.db` and does not silently download or load model2vec. Configure an embedding endpoint for ingest/search, or explicitly enable `backend = "model2vec"` with the `model2vec` Cargo feature for local static models.
 
 Use `mempal cost status` to print redacted remote-call status for embedding, LLM, and rerank paths. Set `[privacy.remote_calls] fail_closed = true` to block external endpoints unless the matching `allow_*` toggle is also true.
 
-Use local ONNX instead of the default model2vec backend:
+Use local ONNX instead of the default OpenAI-compatible provider family:
 
 ```toml
 db_path = "~/.mempal/palace.db"
@@ -139,14 +143,14 @@ dim = 4096
 
 `remote` mode is daemon-only: normal one-shot CLI commands still use `[embed]`
 as configured, while daemon workers and daemon REST embedding avoid loading the
-in-process model2vec cache. If you need an all-local low-memory daemon, set
+in-process local embedder cache. If you need an all-local low-memory daemon, set
 `embedder_mode = "small_local"` to use `minishlab/potion-base-8M`. After
 changing backend/model/dimensions, run `mempal reindex` and restart the daemon.
 
 Notes:
 
-- `model2vec` is the default backend.
-- The default local model is `minishlab/potion-multilingual-128M`.
+- `openai_compat` is the default backend family, but real embedding work needs a configured endpoint.
+- `model2vec` is explicit opt-in through both Cargo feature and `backend = "model2vec"`.
 - First use of `model2vec` or `onnx` may download model assets.
 - If `config.toml` is missing, `mempal` still works with defaults.
 - The benchmark and search commands use whatever embedder backend is configured here.
@@ -1152,7 +1156,7 @@ Working style: small reversible edits, verify before asserting.
 
 ### Search returns irrelevant results for Chinese (or other non-English) queries
 
-The default embedder is now a multilingual `model2vec` model, but English queries still retrieve more reliably than Chinese (and other non-English) queries in practice.
+The configured embedder can affect multilingual retrieval quality; English query normalization still tends to retrieve more reliably for Chinese and other non-English prompts in practice.
 
 **For AI agents**: MEMORY_PROTOCOL rule 3a tells agents to translate queries to English before calling `mempal_search`. This is handled automatically by agents that read the protocol.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,8 +143,8 @@ dim = 4096
 
 `remote` mode is daemon-only: normal one-shot CLI commands still use `[embed]`
 as configured, while daemon workers and daemon REST embedding avoid loading the
-in-process local embedder cache. If you need an all-local low-memory daemon, set
-`embedder_mode = "small_local"` to use `minishlab/potion-base-8M`. After
+in-process local embedder cache. If you need an all-local low-memory daemon, install
+with `--features model2vec` and set `embedder_mode = "small_local"` to use `minishlab/potion-base-8M`. After
 changing backend/model/dimensions, run `mempal reindex` and restart the daemon.
 
 Notes:

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -304,6 +304,7 @@ impl Config {
             ));
         }
         self.embed.validate_endpoint_pool()?;
+        self.validate_daemon_embedder_mode()?;
         self.llm.validate_endpoint_pool()?;
         self.validate_llm_judge_guardrails()?;
         if self.llm.enabled && self.llm.effective_endpoints()?.is_empty() {
@@ -530,6 +531,20 @@ impl Config {
             }
         }
         config
+    }
+
+    /// Validates that the configured daemon embedder mode is available in this build.
+    pub fn validate_daemon_embedder_mode(&self) -> Result<(), ConfigError> {
+        #[cfg(not(feature = "model2vec"))]
+        if matches!(self.daemon.embedder_mode, DaemonEmbedderMode::SmallLocal) {
+            return Err(ConfigError::InvalidConfig(
+                "daemon.embedder_mode = \"small_local\" requires building mempal with the \
+                 `model2vec` Cargo feature; use \"remote\"/\"configured\" or reinstall with \
+                 `--features model2vec`"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     pub fn compile_privacy(&self) -> Result<CompiledPrivacyConfig, ConfigError> {
@@ -3097,10 +3112,9 @@ impl Default for SleepConfig {
 mod tests {
     use std::sync::{Mutex, OnceLock};
 
-    use super::{
-        Config, DAEMON_SMALL_LOCAL_EMBED_MODEL, DaemonEmbedderMode, DecayMode,
-        endpoint_url_display_label,
-    };
+    #[cfg(feature = "model2vec")]
+    use super::DAEMON_SMALL_LOCAL_EMBED_MODEL;
+    use super::{Config, DaemonEmbedderMode, DecayMode, endpoint_url_display_label};
 
     // Serialize env-mutating tests to prevent flaky parallel interference.
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -3427,6 +3441,25 @@ embedder_mode = "remote"
     }
 
     #[test]
+    #[cfg(not(feature = "model2vec"))]
+    fn daemon_embedder_small_local_requires_model2vec_feature() {
+        let error = Config::parse(
+            r#"
+[daemon]
+embedder_mode = "small_local"
+"#,
+        )
+        .expect_err("small_local must fail fast when model2vec is not compiled");
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("requires building mempal with the `model2vec` Cargo feature"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "model2vec")]
     fn daemon_embedder_small_local_mode_uses_small_model_without_fallback() {
         let _guard = env_lock();
         let saved_env = save_embed_env();

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -173,7 +173,6 @@ impl Config {
             Ok(contents) => Self::parse(&contents),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let mut config = Self::default();
-                config.embed.backend = "model2vec".to_string();
                 config.apply_env_overrides();
                 config.validate()?;
                 Ok(config)
@@ -189,9 +188,6 @@ impl Config {
         let root: toml::Value = toml::from_str(contents)?;
         validate_llm_endpoint_pool_toml(&root)?;
         let mut config: Self = toml::from_str(contents)?;
-        if root.get("embed").is_none() && root.get("embedder").is_none() {
-            config.embed.backend = "model2vec".to_string();
-        }
         config.apply_env_overrides();
         config.validate()?;
         Ok(config)
@@ -3367,8 +3363,9 @@ mod tests {
                 std::env::set_var("MEMPAL_EMBED_DIM", v);
             }
         }
-        // Empty config.toml with no env overrides → model2vec fallback; dim keeps struct default
-        assert_eq!(config.embed.backend, "model2vec");
+        // Empty config.toml with no env overrides keeps the configured-provider default;
+        // it must not silently select or load the upstream model2vec model.
+        assert_eq!(config.embed.backend, "openai_compat");
         assert!(config.embed.openai_compat.base_url.is_none());
         assert!(config.embed.openai_compat.model.is_none());
         assert_eq!(
@@ -3378,7 +3375,7 @@ mod tests {
     }
 
     #[test]
-    fn load_from_missing_config_uses_model2vec_default() {
+    fn load_from_missing_config_uses_configured_provider_default() {
         let _guard = env_lock();
         let saved_env = save_embed_env();
         clear_embed_env();
@@ -3388,7 +3385,7 @@ mod tests {
         let config = Config::load_from(&config_path).expect("missing config should load defaults");
 
         restore_embed_env(saved_env);
-        assert_eq!(config.embed.backend, "model2vec");
+        assert_eq!(config.embed.backend, "openai_compat");
         assert!(config.embed.openai_compat.base_url.is_none());
         assert!(config.embed.openai_compat.model.is_none());
     }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -82,13 +82,13 @@ You have persistent project memory via mempal. Follow these rules in every sessi
    field strings remain valid when the recommended fields are too coarse.
 
 3a. TRANSLATE QUERIES TO ENGLISH
-   The default embedding model is a multilingual distillation (model2vec) but
-   still performs best with English queries. Non-English queries may miss
-   relevant results. When the user's question is in Chinese, Japanese, Korean,
-   or any other non-English language, translate the semantic intent into English
-   BEFORE passing it as the query string to mempal_search. Do NOT transliterate
-   — capture the meaning. Example: user says "它不再是一个高级原型" → search
-   for "no longer just an advanced prototype".
+   The default embedding path follows the configured provider; model2vec is an
+   explicit opt-in fallback for local static models. Retrieval can still perform
+   better when queries are normalized to English. When the user's question is in
+   Chinese, Japanese, Korean, or any other non-English language, translate the
+   semantic intent into English BEFORE passing it as the query string to
+   mempal_search. Do NOT transliterate - capture the meaning. Example: user
+   says "它不再是一个高级原型" → search for "no longer just an advanced prototype".
 
 3b. USE TIMELINE FOR PROJECT OVERVIEW
    When you want project state overview without a specific question in mind,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1506,15 +1506,10 @@ async fn auto_ingest_hermes_session_end<E: Embedder + ?Sized>(
         })
         .await?;
     let turn_ids = insert_stats.turn_ids.clone();
-    let vector_fingerprint = context
-        .config
-        .embed
-        .current_vector_embedder_fingerprint(embedder.dimensions());
     let vectors_created = embed_and_write_hermes_turn_vectors(
         db,
         embedder,
         &turn_ids,
-        &vector_fingerprint,
         context.config,
         context.runtime_writer_lease,
         Some(&embed_heartbeat),
@@ -1535,7 +1530,6 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
     db: &AsyncDb,
     embedder: &E,
     turn_ids: &[String],
-    fingerprint: &str,
     config: &crate::core::config::Config,
     runtime_writer_lease: Option<&RuntimeWriterLease>,
     heartbeat: Option<&HeartbeatCallback>,
@@ -1574,7 +1568,7 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
             continue;
         }
 
-        let mut vector_rows = Vec::<(String, i64, Vec<u8>)>::new();
+        let mut vector_rows = Vec::<(String, i64, Vec<u8>, String, i64)>::new();
         for (turn_id, content) in candidates {
             let chunks = crate::ingest::chunk::chunk_text_token_aware(
                 &content,
@@ -1584,10 +1578,16 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
             );
             for (chunk_index, chunk) in chunks.iter().enumerate() {
                 let vector = embed_text_with_heartbeat(embedder, chunk, heartbeat).await?;
+                let dim = i64::try_from(vector.len()).unwrap_or(i64::MAX);
+                let fingerprint = config
+                    .embed
+                    .current_vector_embedder_fingerprint(vector.len());
                 vector_rows.push((
                     turn_id.clone(),
                     chunk_index as i64,
                     serialize_f32_vector(&vector),
+                    fingerprint,
+                    dim,
                 ));
             }
         }
@@ -1595,8 +1595,6 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
             continue;
         }
 
-        let fingerprint = fingerprint.to_string();
-        let dim = i64::try_from(embedder.dimensions()).unwrap_or(i64::MAX);
         let runtime_writer_lease = runtime_writer_lease.cloned();
         let rows_written = db
             .run_write_anyhow(move |db| {
@@ -1609,7 +1607,7 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
                 conn.execute_batch("BEGIN IMMEDIATE")?;
                 let write = (|| -> rusqlite::Result<usize> {
                     let mut rows_written = 0usize;
-                    for (turn_id, chunk_index, blob) in &vector_rows {
+                    for (turn_id, chunk_index, blob, fingerprint, dim) in &vector_rows {
                         rows_written += conn.execute(
                             "INSERT INTO conversation_turn_vectors \
                              (turn_id, chunk_index, vector, embedder_fingerprint, dim, index_version) \
@@ -1619,7 +1617,7 @@ async fn embed_and_write_hermes_turn_vectors<E: Embedder + ?Sized>(
                                 turn_id,
                                 chunk_index,
                                 blob,
-                                &fingerprint,
+                                fingerprint,
                                 dim,
                                 crate::core::db::CURRENT_VECTOR_INDEX_VERSION,
                             ],
@@ -3031,7 +3029,9 @@ pub(crate) fn llm_worker_claim_enabled(config: &crate::core::config::Config) -> 
 
 struct DaemonEmbedder {
     name: String,
-    runtime: Mutex<DaemonEmbedderRuntime>,
+    config: crate::core::config::Config,
+    runtime_init_lock: tokio::sync::Mutex<()>,
+    runtime: Mutex<Option<DaemonEmbedderRuntime>>,
     status_path: Option<PathBuf>,
 }
 
@@ -3267,16 +3267,20 @@ impl DaemonEmbedder {
         config: &crate::core::config::Config,
         mempal_home: &Path,
     ) -> crate::embed::Result<Self> {
-        let generation = crate::core::config::ConfigHandle::current_embed_generation();
-        let runtime = DaemonEmbedderRuntime::from_config(config, generation).await?;
-        let name = runtime.primary.name().to_string();
+        let daemon_config = config.daemon_embedder_config();
+        let name = daemon_config
+            .embed
+            .effective_model_summary()
+            .unwrap_or_else(|| daemon_config.embed.backend.clone());
         let status_path = Some(crate::daemon_status::embedder_status_path(mempal_home));
         let embedder = Self {
             name,
-            runtime: Mutex::new(runtime),
+            config: config.clone(),
+            runtime_init_lock: tokio::sync::Mutex::new(()),
+            runtime: Mutex::new(None),
             status_path,
         };
-        embedder.write_loaded_status(config, "daemon-hook-worker");
+        embedder.write_unloaded_status(config, "daemon-hook-worker");
         Ok(embedder)
     }
 
@@ -3286,19 +3290,30 @@ impl DaemonEmbedder {
             return Ok(snapshot);
         }
 
-        let config = crate::core::config::ConfigHandle::current();
+        let _init_guard = self.runtime_init_lock.lock().await;
+        if let Some(snapshot) = self.snapshot_if_generation(generation) {
+            return Ok(snapshot);
+        }
+
+        let config = self.active_config();
         let replacement = DaemonEmbedderRuntime::from_config(config.as_ref(), generation).await?;
         let mut guard = self
             .runtime
             .lock()
             .expect("daemon embedder runtime mutex poisoned");
-        let status = if guard.generation != generation {
-            *guard = replacement;
+        let status = if guard
+            .as_ref()
+            .is_none_or(|runtime| runtime.generation != generation)
+        {
+            *guard = Some(replacement);
+            let runtime = guard
+                .as_ref()
+                .expect("daemon embedder runtime was just loaded");
             Some(
                 crate::daemon_status::DaemonEmbedderRuntimeStatus::loaded_from_config(
                     config.as_ref(),
-                    guard.primary.dimensions(),
-                    guard
+                    runtime.primary.dimensions(),
+                    runtime
                         .fallback
                         .as_ref()
                         .map(|fallback| fallback.name().to_string()),
@@ -3308,7 +3323,10 @@ impl DaemonEmbedder {
         } else {
             None
         };
-        let snapshot = guard.snapshot();
+        let snapshot = guard
+            .as_ref()
+            .expect("daemon embedder runtime must be loaded")
+            .snapshot();
         drop(guard);
         if let (Some(status_path), Some(status)) = (&self.status_path, status) {
             write_daemon_embedder_status_path(status_path, &status);
@@ -3321,7 +3339,10 @@ impl DaemonEmbedder {
             .runtime
             .lock()
             .expect("daemon embedder runtime mutex poisoned");
-        (guard.generation == generation).then(|| guard.snapshot())
+        guard
+            .as_ref()
+            .filter(|runtime| runtime.generation == generation)
+            .map(DaemonEmbedderRuntime::snapshot)
     }
 
     #[cfg(test)]
@@ -3334,28 +3355,30 @@ impl DaemonEmbedder {
         };
         Self {
             name,
-            runtime: Mutex::new(runtime),
+            config: crate::core::config::Config::default(),
+            runtime_init_lock: tokio::sync::Mutex::new(()),
+            runtime: Mutex::new(Some(runtime)),
             status_path: None,
         }
     }
 
-    fn write_loaded_status(&self, config: &crate::core::config::Config, source: &str) {
+    fn active_config(&self) -> std::sync::Arc<crate::core::config::Config> {
+        let current = crate::core::config::ConfigHandle::current();
+        if current.db_path == self.config.db_path
+            && !daemon_config_is_default_snapshot(current.as_ref())
+        {
+            current
+        } else {
+            std::sync::Arc::new(self.config.clone())
+        }
+    }
+
+    fn write_unloaded_status(&self, config: &crate::core::config::Config, source: &str) {
         let Some(status_path) = &self.status_path else {
             return;
         };
-        let guard = self
-            .runtime
-            .lock()
-            .expect("daemon embedder runtime mutex poisoned");
-        let status = crate::daemon_status::DaemonEmbedderRuntimeStatus::loaded_from_config(
-            config,
-            guard.primary.dimensions(),
-            guard
-                .fallback
-                .as_ref()
-                .map(|fallback| fallback.name().to_string()),
-            source,
-        );
+        let status =
+            crate::daemon_status::DaemonEmbedderRuntimeStatus::unloaded_from_config(config, source);
         write_daemon_embedder_status_path(status_path, &status);
     }
 }
@@ -3389,11 +3412,18 @@ impl Embedder for DaemonEmbedder {
     }
 
     fn dimensions(&self) -> usize {
-        self.runtime
+        if let Some(runtime) = self
+            .runtime
             .lock()
             .expect("daemon embedder runtime mutex poisoned")
-            .primary
-            .dimensions()
+            .as_ref()
+        {
+            return runtime.primary.dimensions();
+        }
+        self.active_config()
+            .daemon_embedder_config()
+            .embed
+            .resolved_openai_dim()
     }
 
     fn name(&self) -> &str {
@@ -3426,6 +3456,16 @@ impl DaemonEmbedderRuntime {
             primary: Arc::clone(&self.primary),
             fallback: self.fallback.as_ref().map(Arc::clone),
         }
+    }
+}
+
+fn daemon_config_is_default_snapshot(config: &crate::core::config::Config) -> bool {
+    match (
+        config.effective_hash(),
+        crate::core::config::Config::default().effective_hash(),
+    ) {
+        (Ok(current), Ok(default)) => current == default,
+        _ => false,
     }
 }
 
@@ -3482,6 +3522,64 @@ mod tests {
         request_shutdown, reset_shutdown_request, run_hook_worker, wait_for_hook_worker_or_tick,
         wing_from_cwd,
     };
+
+    #[tokio::test]
+    async fn daemon_embedder_from_config_defers_explicit_model2vec_construction() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let mut config = Config {
+            db_path: tmp.path().join("palace.db").display().to_string(),
+            ..Config::default()
+        };
+        config.embed.backend = "model2vec".to_string();
+        config.embed.model = Some("explicit-model2vec-not-loaded-at-startup".to_string());
+
+        let _embedder = DaemonEmbedder::from_config(&config, tmp.path())
+            .await
+            .expect("daemon startup must not construct explicit model2vec");
+
+        let status = crate::daemon_status::read_embedder_status(tmp.path())
+            .expect("read daemon embedder status")
+            .expect("daemon embedder status should be written");
+        assert_eq!(status.backend, "model2vec");
+        assert!(
+            !status.cache_loaded,
+            "daemon startup/status path must not load the configured embedder"
+        );
+        assert_eq!(status.dimensions, None);
+    }
+
+    #[tokio::test]
+    async fn daemon_embedder_marks_cache_loaded_only_after_first_embed() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let mut config = Config {
+            db_path: tmp.path().join("palace.db").display().to_string(),
+            ..Config::default()
+        };
+        config.embed.backend = "stub".to_string();
+        config.embed.openai_compat.dim = Some(7);
+
+        let embedder = DaemonEmbedder::from_config(&config, tmp.path())
+            .await
+            .expect("daemon startup should defer stub construction too");
+        let initial_status = crate::daemon_status::read_embedder_status(tmp.path())
+            .expect("read initial daemon embedder status")
+            .expect("initial daemon embedder status should be written");
+        assert!(!initial_status.cache_loaded);
+
+        let vectors = embedder
+            .embed(&["lazy daemon embedder"])
+            .await
+            .expect("embed");
+        assert_eq!(vectors.len(), 1);
+        assert_eq!(vectors[0].len(), 7);
+
+        let loaded_status = crate::daemon_status::read_embedder_status(tmp.path())
+            .expect("read loaded daemon embedder status")
+            .expect("loaded daemon embedder status should be written");
+        assert!(loaded_status.cache_loaded);
+        assert_eq!(loaded_status.backend, "stub");
+        assert_eq!(loaded_status.dimensions, Some(7));
+    }
 
     struct ShutdownResetGuard;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3267,6 +3267,9 @@ impl DaemonEmbedder {
         config: &crate::core::config::Config,
         mempal_home: &Path,
     ) -> crate::embed::Result<Self> {
+        config
+            .validate_daemon_embedder_mode()
+            .map_err(|error| crate::embed::EmbedError::InvalidConfiguration(error.to_string()))?;
         let daemon_config = config.daemon_embedder_config();
         let name = daemon_config
             .embed
@@ -3514,6 +3517,9 @@ mod tests {
     use std::pin::Pin;
     use tokio::sync::Notify;
 
+    #[cfg(not(feature = "model2vec"))]
+    use crate::core::config::DaemonEmbedderMode;
+
     use super::{
         ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext,
         EndpointRecoveryConfigProvider, EndpointRecoveryRequeuePlan, EndpointRecoveryRequeueState,
@@ -3546,6 +3552,30 @@ mod tests {
             "daemon startup/status path must not load the configured embedder"
         );
         assert_eq!(status.dimensions, None);
+    }
+
+    #[tokio::test]
+    #[cfg(not(feature = "model2vec"))]
+    async fn daemon_embedder_from_config_rejects_small_local_without_model2vec_feature() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let mut config = Config {
+            db_path: tmp.path().join("palace.db").display().to_string(),
+            ..Config::default()
+        };
+        config.daemon.embedder_mode = DaemonEmbedderMode::SmallLocal;
+
+        let error = match DaemonEmbedder::from_config(&config, tmp.path()).await {
+            Ok(_) => {
+                panic!("small_local must fail before daemon embedder startup without model2vec")
+            }
+            Err(error) => error,
+        };
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("requires building mempal with the `model2vec` Cargo feature"),
+            "{rendered}"
+        );
     }
 
     #[tokio::test]

--- a/src/embed/factory.rs
+++ b/src/embed/factory.rs
@@ -5,7 +5,7 @@ use crate::core::config::{Config, ConfigHandle};
 use async_trait::async_trait;
 use serde::Serialize;
 
-use super::{Embedder, Result};
+use super::{EmbedError, Embedder, Result};
 
 #[async_trait]
 pub trait EmbedderFactory: Send + Sync {
@@ -33,7 +33,7 @@ impl ConfiguredEmbedderFactory {
         }
     }
 
-    fn active_config(&self) -> Config {
+    fn active_config(&self) -> Result<Config> {
         let current = ConfigHandle::current();
         let config = if current.db_path == self.config.db_path
             && !config_is_default_snapshot(current.as_ref())
@@ -43,9 +43,12 @@ impl ConfiguredEmbedderFactory {
             self.config.clone()
         };
         if self.daemon_mode {
-            config.daemon_embedder_config()
-        } else {
             config
+                .validate_daemon_embedder_mode()
+                .map_err(|error| EmbedError::InvalidConfiguration(error.to_string()))?;
+            Ok(config.daemon_embedder_config())
+        } else {
+            Ok(config)
         }
     }
 }
@@ -53,7 +56,7 @@ impl ConfiguredEmbedderFactory {
 #[async_trait]
 impl EmbedderFactory for ConfiguredEmbedderFactory {
     async fn build(&self) -> Result<Box<dyn Embedder>> {
-        let config = self.active_config();
+        let config = self.active_config()?;
         let signature = embedder_runtime_signature(&config);
         let cache = shared_embedder_cache();
         let mut guard = cache.lock().await;

--- a/src/embed/model2vec.rs
+++ b/src/embed/model2vec.rs
@@ -1,8 +1,9 @@
-//! Model2Vec embedding backend — static distilled models, zero native deps.
+//! Model2Vec embedding backend — explicit opt-in static distilled models.
 //!
-//! Default model: `minishlab/potion-multilingual-128M` (BGE-M3 distilled, 1024-dim).
-//! Falls back to `minishlab/potion-base-8M` (256-dim) if the multilingual model
-//! is not available.
+//! When the `model2vec` feature and `backend = "model2vec"` are both selected,
+//! omitting `embed.model` uses `minishlab/potion-multilingual-128M`
+//! (BGE-M3 distilled, 1024-dim). Default REST and correctness gates do not enable
+//! this backend.
 
 use super::{EmbedError, Embedder, Result};
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10088,7 +10088,7 @@ quality_policy = "llm_required_for_keep"
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [privacy]
 enabled = false

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -125,7 +125,7 @@ fn write_dashboard_config(
 db_path = "{}"
 {}
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [search]
 strict_project_isolation = {}
@@ -855,12 +855,8 @@ fn test_view_prints_full_drawer() {
     let db = Database::open(&env.db_path).expect("open db");
     db.insert_vector("view-full", &[0.1, 0.2, 0.3, 0.4])
         .expect("insert view vector");
-    db.record_vector_metadata(
-        "view-full",
-        CURRENT_VECTOR_INDEX_VERSION,
-        "model2vec:model2vec/potion-multilingual-128M::4",
-    )
-    .expect("record view vector metadata");
+    db.record_vector_metadata("view-full", CURRENT_VECTOR_INDEX_VERSION, "stub:::4")
+        .expect("record view vector metadata");
 
     let output = run_mempal(&env.home, env.cwd(), &["view", "view-full"]);
     assert!(
@@ -879,11 +875,8 @@ fn test_view_prints_full_drawer() {
         stdout.contains("vector_distance_metric: cosine"),
         "{stdout}"
     );
-    assert!(stdout.contains("vector_embedder: model2vec"), "{stdout}");
-    assert!(
-        stdout.contains("vector_model: model2vec/potion-multilingual-128M"),
-        "{stdout}"
-    );
+    assert!(stdout.contains("vector_embedder: stub"), "{stdout}");
+    assert!(stdout.contains("vector_model: unknown"), "{stdout}");
     assert!(stdout.contains("vector_index_version: v2"), "{stdout}");
     assert!(stdout.contains("vector_stale: false"), "{stdout}");
     assert!(stdout.contains("content_truncated: false"), "{stdout}");
@@ -953,7 +946,7 @@ fn test_view_project_allows_cross_project_vector_diagnostics() {
     db.record_vector_metadata(
         "view-cross-project",
         CURRENT_VECTOR_INDEX_VERSION,
-        "model2vec:model2vec/potion-multilingual-128M::4",
+        "stub:::4",
     )
     .expect("record view vector metadata");
 

--- a/tests/common/harness/mcp_stdio.rs
+++ b/tests/common/harness/mcp_stdio.rs
@@ -52,7 +52,7 @@ request_timeout_secs = 2
         } else {
             r#"
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#
             .to_string()
         };

--- a/tests/cost_status.rs
+++ b/tests/cost_status.rs
@@ -29,7 +29,7 @@ fn stderr(output: &Output) -> String {
 }
 
 #[test]
-fn cost_status_missing_config_reports_default_local() {
+fn cost_status_missing_config_reports_missing_embedding_endpoint() {
     let home = TempDir::new().expect("temp home");
 
     let output = run_mempal(&home, &["cost", "status"]);
@@ -42,7 +42,8 @@ fn cost_status_missing_config_reports_default_local() {
     );
     let stdout = stdout(&output);
     assert!(stdout.contains("embedding:"));
-    assert!(stdout.contains("status: default_local"));
+    assert!(stdout.contains("status: misconfigured"));
+    assert!(stdout.contains("openai_compat endpoint is missing"));
     assert!(stdout.contains("llm:"));
     assert!(stdout.contains("rerank:"));
     assert!(stdout.contains("status: disabled"));

--- a/tests/embedder_fallback.rs
+++ b/tests/embedder_fallback.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "integration")]
+#![cfg(all(feature = "integration", feature = "model2vec"))]
 
 use std::fs;
 use std::sync::{Arc, OnceLock};

--- a/tests/embedder_reindex_scenarios.rs
+++ b/tests/embedder_reindex_scenarios.rs
@@ -1208,6 +1208,7 @@ async fn test_reindex_dim_change_invalidates_existing() {
     handle6.shutdown().await;
 }
 
+#[cfg(feature = "model2vec")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_default_model2vec_reindex_records_non_stale_fingerprint() {
     let _guard = test_guard().await;
@@ -1257,7 +1258,7 @@ async fn test_embed_degraded_blocks_writes_when_configured() {
 db_path = "__DB_PATH__"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [embed.degradation]
 degrade_after_n_failures = 2

--- a/tests/embedder_router.rs
+++ b/tests/embedder_router.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
+#[cfg(not(feature = "model2vec"))]
+use mempal::core::config::DaemonEmbedderMode;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::embed::{
     ConfiguredEmbedderFactory, EmbedError, EmbedderFactory, router::EmbeddingRouter,
@@ -475,4 +477,28 @@ embedder_mode = "remote"
     assert_eq!(snapshot.backend.as_deref(), Some("openai_compat"));
     assert_eq!(snapshot.model.as_deref(), Some("Qwen/Qwen3-Embedding-8B"));
     assert_eq!(snapshot.dimensions, Some(3));
+}
+
+#[tokio::test]
+#[cfg(not(feature = "model2vec"))]
+async fn test_daemon_embedder_factory_rejects_small_local_without_model2vec_feature() {
+    let _guard = shared_embedder_cache_test_lock().lock().await;
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut config = Config {
+        db_path: tmp.path().join("palace.db").display().to_string(),
+        ..Config::default()
+    };
+    config.daemon.embedder_mode = DaemonEmbedderMode::SmallLocal;
+
+    let factory = ConfiguredEmbedderFactory::new_for_daemon(config);
+    let error = match factory.build().await {
+        Ok(_) => panic!("small_local must fail before building an embedder without model2vec"),
+        Err(error) => error,
+    };
+
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("requires building mempal with the `model2vec` Cargo feature"),
+        "{rendered}"
+    );
 }

--- a/tests/embedder_router.rs
+++ b/tests/embedder_router.rs
@@ -437,7 +437,7 @@ dim = 3
 }
 
 #[tokio::test]
-async fn test_daemon_embedder_factory_remote_mode_avoids_local_model2vec() {
+async fn test_daemon_embedder_factory_remote_mode_uses_configured_remote_provider() {
     let _cache_guard = shared_embedder_cache_test_lock().lock().await;
     let (base_url, request_count, server) =
         spawn_counting_embedding_server(Duration::from_millis(1)).await;
@@ -448,7 +448,7 @@ async fn test_daemon_embedder_factory_remote_mode_avoids_local_model2vec() {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [embed.openai_compat]
 base_url = "{base_url}"

--- a/tests/embedder_transport_scenarios.rs
+++ b/tests/embedder_transport_scenarios.rs
@@ -462,7 +462,7 @@ async fn test_server_info_injects_rule_11_when_degraded() {
 db_path = "/tmp/mempal-server-info.db"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [embed.degradation]
 degrade_after_n_failures = 1
@@ -483,7 +483,7 @@ block_writes_when_degraded = true
 db_path = "/tmp/mempal-server-info.db"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [embed.degradation]
 degrade_after_n_failures = 1
@@ -623,7 +623,7 @@ fn test_base_url_rejects_userinfo_and_query_secret() {
 }
 
 #[test]
-fn test_legacy_config_missing_embed_keeps_model2vec() {
+fn test_legacy_config_missing_embed_keeps_configured_provider_default() {
     let config = Config::parse(
         r#"
 db_path = "/tmp/mempal-legacy.db"
@@ -633,7 +633,7 @@ strict_project_isolation = false
 "#,
     )
     .expect("parse legacy config");
-    assert_eq!(config.embed.backend, "model2vec");
+    assert_eq!(config.embed.backend, "openai_compat");
 }
 
 #[derive(Clone)]

--- a/tests/hermes_integration.rs
+++ b/tests/hermes_integration.rs
@@ -187,7 +187,7 @@ db_path = "{}"
 enabled = false
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [llm]
 enabled = false

--- a/tests/hook_passive_capture.rs
+++ b/tests/hook_passive_capture.rs
@@ -66,7 +66,7 @@ request_timeout_secs = 2
         ),
         None => r#"
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#
         .to_string(),
     };

--- a/tests/importance_decay.rs
+++ b/tests/importance_decay.rs
@@ -28,7 +28,7 @@ fn setup_home(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#,
             db_path.display()
         ),

--- a/tests/importance_scorer.rs
+++ b/tests/importance_scorer.rs
@@ -26,7 +26,7 @@ fn setup_home(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#,
             db_path.display()
         ),

--- a/tests/mcp_timeline.rs
+++ b/tests/mcp_timeline.rs
@@ -90,7 +90,7 @@ fn timeline_config(
 db_path = "{}"
 {}
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [embed.degradation]
 degrade_after_n_failures = {}

--- a/tests/memory_compaction_cli.rs
+++ b/tests/memory_compaction_cli.rs
@@ -31,7 +31,7 @@ impl CompactionEnv {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [project]
 id = "project-a"

--- a/tests/model2vec_decoupling.rs
+++ b/tests/model2vec_decoupling.rs
@@ -1,0 +1,45 @@
+use toml::Value;
+
+fn cargo_manifest() -> Value {
+    include_str!("../Cargo.toml")
+        .parse::<Value>()
+        .expect("Cargo.toml must parse")
+}
+
+fn feature_entries(name: &str) -> Vec<String> {
+    cargo_manifest()
+        .get("features")
+        .and_then(|features| features.get(name))
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("feature {name} must be defined"))
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .unwrap_or_else(|| panic!("feature {name} contains non-string entry"))
+                .to_string()
+        })
+        .collect()
+}
+
+fn assert_feature_does_not_enable_model2vec(name: &str) {
+    let entries = feature_entries(name);
+    assert!(
+        !entries.iter().any(|entry| entry == "model2vec"),
+        "{name} feature must not enable model2vec implicitly: {entries:?}"
+    );
+    assert!(
+        !entries.iter().any(|entry| entry == "dep:model2vec-rs"),
+        "{name} feature must not enable model2vec-rs directly: {entries:?}"
+    );
+}
+
+#[test]
+fn default_feature_set_does_not_enable_model2vec() {
+    assert_feature_does_not_enable_model2vec("default");
+}
+
+#[test]
+fn rest_feature_does_not_enable_model2vec() {
+    assert_feature_does_not_enable_model2vec("rest");
+}

--- a/tests/normalize_added_at.rs
+++ b/tests/normalize_added_at.rs
@@ -27,7 +27,7 @@ fn setup() -> (TempDir, std::path::PathBuf) {
             r#"
 db_path = "{}"
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#,
             db_path.display()
         ),

--- a/tests/pattern_induction.rs
+++ b/tests/pattern_induction.rs
@@ -145,7 +145,7 @@ fn config_text(db_path: &Path, patterns_enabled: bool, promote_threshold: usize)
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [config_hot_reload]
 enabled = false
@@ -491,8 +491,8 @@ fn test_pattern_promotes_to_active_at_threshold() {
 // Test: active pattern boosts exemplar results in search
 // ---------------------------------------------------------------------------
 
-// model_id that apply_pattern_boost derives for config backend = "model2vec"
-const MODEL2VEC_MODEL_ID: &str = "model2vec/potion-multilingual-128M";
+// model_id that apply_pattern_boost derives for config backend = "stub".
+const STUB_MODEL_ID: &str = "";
 
 #[tokio::test]
 async fn test_active_pattern_boosts_exemplar_results() {
@@ -548,7 +548,7 @@ async fn test_active_pattern_boosts_exemplar_results() {
                     "sess-c.md".to_string(),
                 ],
                 topic_tags: vec!["recurring".to_string(), "memory".to_string()],
-                model_id: Some(MODEL2VEC_MODEL_ID.to_string()),
+                model_id: Some(STUB_MODEL_ID.to_string()),
                 project_id: None,
             },
         )

--- a/tests/phase3_runtime.rs
+++ b/tests/phase3_runtime.rs
@@ -2523,7 +2523,7 @@ fn test_cli_phase3_research_ingest_plan_execute_writes_research_evidence() {
 
     fs::write(
         home.path().join(".mempal/config.toml"),
-        "[embed]\nbackend = \"model2vec\"\n",
+        "[embed]\nbackend = \"stub\"\n",
     )
     .expect("write embed config");
 

--- a/tests/priming.rs
+++ b/tests/priming.rs
@@ -41,7 +41,7 @@ impl PrimeEnv {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [search]
 strict_project_isolation = false

--- a/tests/retrieval_scope.rs
+++ b/tests/retrieval_scope.rs
@@ -91,7 +91,7 @@ fn config(db_path: &Path, project_id: Option<&str>) -> String {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 {}
 "#,
         db_path.display(),

--- a/tests/rollback.rs
+++ b/tests/rollback.rs
@@ -31,7 +31,7 @@ impl TestEnv {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#,
                 db_path.display()
             ),

--- a/tests/skill_crystallization.rs
+++ b/tests/skill_crystallization.rs
@@ -604,7 +604,7 @@ fn test_skills_promote_cli() {
 db_path = "{}"
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 
 [config_hot_reload]
 enabled = false

--- a/tests/typed_ingest_pinned.rs
+++ b/tests/typed_ingest_pinned.rs
@@ -82,7 +82,7 @@ db_path = "{}"
 enabled = false
 
 [embed]
-backend = "model2vec"
+backend = "stub"
 "#,
                 db_path.display()
             ),

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "31f83cb068364b30245fc40734e0b45f3f0914fe"
+commit = "0844f389989e632c37f1f1f2866e128da15c2f97"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Decouple `model2vec` from default/REST daemon paths so default gates do not implicitly load the upstream local model.
- Keep `model2vec` as explicit opt-in and reject `small_local` fail-fast when the feature is unavailable.
- Preserve configured/openai_compat embedding providers as first-class daemon/runtime configuration.
- Update docs/tests for the no-model2vec default contract.

Fixes #513

## Local gates / review

- Exact-head CSA Codex review: `01KVNWGNQJE6KW490JEKSPJTJP`
- Reviewed SHA: `ab33f5bb30063d0b3f88402c142affd3345971b1`
- Range: `main...HEAD`
- Verdict: PASS/CLEAN
- `csa review --check-verdict --sa-mode true --range main...HEAD`: passed
- Hook-enabled push/local gates: passed with `RUST_TEST_THREADS=1`
- Pre-push summary: branch-protection passed, local-gates passed, review-check passed
