### PR TITLE
fix(ingest): retry transient sqlite lock admission

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -11,7 +11,7 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rusqlite::{
     Connection, OpenFlags, OptionalExtension, Row, functions::FunctionFlags, params,
@@ -432,11 +432,24 @@ impl Database {
         Self::open_with_mode(path, OpenMode::ReadWrite)
     }
 
+    /// Open a read-write database connection with a caller-selected SQLite busy timeout.
+    pub fn open_with_busy_timeout(path: &Path, busy_timeout: Duration) -> Result<Self, DbError> {
+        Self::open_with_mode_and_busy_timeout(path, OpenMode::ReadWrite, busy_timeout)
+    }
+
     pub fn open_read_only(path: &Path) -> Result<Self, DbError> {
         Self::open_with_mode(path, OpenMode::ReadOnly)
     }
 
     fn open_with_mode(path: &Path, mode: OpenMode) -> Result<Self, DbError> {
+        Self::open_with_mode_and_busy_timeout(path, mode, Duration::from_secs(5))
+    }
+
+    fn open_with_mode_and_busy_timeout(
+        path: &Path,
+        mode: OpenMode,
+        busy_timeout: Duration,
+    ) -> Result<Self, DbError> {
         if mode.allows_write() {
             if let Some(parent) = path
                 .parent()
@@ -457,7 +470,7 @@ impl Database {
             }
             OpenMode::ReadWrite => Connection::open(path)?,
         };
-        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        conn.busy_timeout(busy_timeout)?;
         conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_256_MIB)?;
         register_math_functions(&conn)?;
         if mode.allows_write() {

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -32,6 +32,23 @@ pub enum QueueError {
     UnsupportedModelTaskKind(String),
 }
 
+impl QueueError {
+    pub fn is_sqlite_lock(&self) -> bool {
+        matches!(
+            self,
+            Self::Sqlite(rusqlite::Error::SqliteFailure(sqlite, _))
+                if matches!(
+                    sqlite.code,
+                    rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+                )
+                    || matches!(
+                        sqlite.extended_code & 0xff,
+                        rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+                    )
+        )
+    }
+}
+
 pub type Result<T> = std::result::Result<T, QueueError>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3450,6 +3450,8 @@ fn run() -> Result<()> {
 
     let db = match if dashboard_mode {
         open_dashboard_database(&db_path).context("failed to open dashboard database")
+    } else if command_retries_stdin_ingest_startup_open(&cli.command) {
+        open_stdin_ingest_database_with_retry(&db_path)
     } else if command_retries_historical_rejudge_startup_open(&cli.command) {
         open_historical_rejudge_startup_database_with_retry(|| {
             Database::open(&db_path).context("failed to open database")
@@ -4164,6 +4166,52 @@ fn command_retries_historical_rejudge_startup_open(command: &Commands) -> bool {
         Commands::Maintenance {
             command: MaintenanceCommands::Rejudge(args),
         } if args.command.is_none() && args.resume
+    )
+}
+
+fn command_retries_stdin_ingest_startup_open(command: &Commands) -> bool {
+    matches!(command, Commands::Ingest { stdin: true, .. })
+}
+
+const STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES: usize = 40;
+const STDIN_INGEST_STARTUP_BUSY_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_millis(100);
+const STDIN_INGEST_SQLITE_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn open_stdin_ingest_database_with_retry(path: &Path) -> Result<Database> {
+    for attempt in 0..=STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES {
+        match Database::open_with_busy_timeout(path, STDIN_INGEST_STARTUP_BUSY_TIMEOUT)
+            .context("failed to open database")
+        {
+            Ok(db) => {
+                db.conn()
+                    .busy_timeout(STDIN_INGEST_SQLITE_BUSY_TIMEOUT)
+                    .context("failed to set stdin ingest SQLite busy timeout")?;
+                return Ok(db);
+            }
+            Err(error)
+                if is_transient_sqlite_lock_error(&error)
+                    && attempt < STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES =>
+            {
+                std::thread::sleep(historical_rejudge_sqlite_lock_retry_delay(attempt));
+            }
+            Err(error) if is_transient_sqlite_lock_error(&error) => {
+                bail!("{}", stdin_ingest_sqlite_lock_diagnostic(path, &error));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("stdin ingest startup database retry loop returns on terminal attempt")
+}
+
+fn stdin_ingest_sqlite_lock_diagnostic(path: &Path, error: &anyhow::Error) -> String {
+    let holders = mempal::process_diagnostics::inspect_db_holders(path);
+    format!(
+        "failed to open database for ingest --stdin after waiting for transient SQLite locks: {error}\n\
+         holder summary: {}\n\
+         safe next step: {}",
+        mempal::process_diagnostics::format_db_holder_role_summary(&holders),
+        mempal::process_diagnostics::sqlite_lock_safe_next_step(&holders)
     )
 }
 
@@ -21498,6 +21546,21 @@ mod ingest_wait_timeout_error_tests {
         let error = anyhow::anyhow!("other error");
 
         assert!(!is_ingest_wait_timed_out(&error));
+    }
+
+    #[test]
+    fn stdin_ingest_lock_diagnostic_is_actionable_without_payload() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let _db = Database::open(&db_path).expect("open db");
+        let error = anyhow::anyhow!("failed to open database: database is locked");
+
+        let diagnostic = stdin_ingest_sqlite_lock_diagnostic(&db_path, &error);
+
+        assert!(diagnostic.contains("failed to open database for ingest --stdin"));
+        assert!(diagnostic.contains("holder summary:"));
+        assert!(diagnostic.contains("safe next step:"));
+        assert!(!diagnostic.contains("stdin transient sqlite lock fixture"));
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -143,6 +143,8 @@ const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
 const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
 const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
+const MCP_INGEST_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(5);
+const MCP_INGEST_QUEUE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
@@ -2331,12 +2333,24 @@ fn status_database_diagnostic(
     error: &(dyn std::error::Error + 'static),
 ) -> DatabaseDiagnosticDto {
     let failure_kind = status_db_failure_kind(error);
+    let mut hint = status_db_failure_hint(failure_kind).to_string();
+    if failure_kind == "locked_or_busy" {
+        let holder_report = crate::process_diagnostics::inspect_db_holders(db_path);
+        if !holder_report.holders.is_empty() || holder_report.error.is_some() {
+            hint = format!(
+                "{} Holder summary: {}. Safe next step: {}.",
+                hint,
+                crate::process_diagnostics::format_db_holder_role_summary(&holder_report),
+                crate::process_diagnostics::sqlite_lock_safe_next_step(&holder_report)
+            );
+        }
+    }
     DatabaseDiagnosticDto {
         path: db_path.display().to_string(),
         source: source.to_string(),
         failure_kind: failure_kind.to_string(),
         summary: status_error_summary(error),
-        hint: status_db_failure_hint(failure_kind).to_string(),
+        hint,
     }
 }
 
@@ -2345,10 +2359,15 @@ fn record_status_database_diagnostic(
     database_diagnostic: &mut Option<DatabaseDiagnosticDto>,
     diagnostic: DatabaseDiagnosticDto,
 ) {
+    let headline = if diagnostic.failure_kind == "locked_or_busy" {
+        "database lock diagnostic"
+    } else {
+        "database diagnostic degraded"
+    };
     system_warnings.push(SystemWarning {
         level: "warn".to_string(),
         message: format!(
-            "database diagnostic degraded at {}: {} ({})",
+            "{headline} at {}: {} ({})",
             diagnostic.source, diagnostic.summary, diagnostic.failure_kind
         ),
         source: "database".to_string(),
@@ -4874,10 +4893,40 @@ impl MempalMcpServer {
             return Ok(operation_id);
         }
 
-        self.async_queue
-            .enqueue_idempotent_with_key(INGEST_ASYNC_KIND.to_string(), payload, idempotency_key)
+        self.enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
             .await
-            .map_err(Into::into)
+    }
+
+    async fn enqueue_ingest_operation_locally_with_retry(
+        &self,
+        payload: String,
+        idempotency_key: String,
+    ) -> anyhow::Result<String> {
+        let deadline = Instant::now() + MCP_INGEST_QUEUE_LOCK_RETRY_DEADLINE;
+        let last_lock_error = loop {
+            match self
+                .async_queue
+                .enqueue_idempotent_with_key_fail_fast(
+                    INGEST_ASYNC_KIND.to_string(),
+                    payload.clone(),
+                    idempotency_key.clone(),
+                )
+                .await
+            {
+                Ok(operation_id) => return Ok(operation_id),
+                Err(error) if error.is_sqlite_lock() => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        break error;
+                    }
+                    tokio::time::sleep(MCP_INGEST_QUEUE_LOCK_RETRY_DELAY.min(remaining)).await;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        };
+
+        Err(anyhow::Error::new(last_lock_error)
+            .context("SQLite queue admission lock retry exhausted"))
     }
 
     async fn try_enqueue_ingest_operation_via_daemon(
@@ -8993,10 +9042,15 @@ fn database_warning_snapshot(
     error: &(dyn std::error::Error + 'static),
 ) -> Vec<SystemWarning> {
     let diagnostic = status_database_diagnostic(db_path, stage, error);
+    let headline = if diagnostic.failure_kind == "locked_or_busy" {
+        "database lock diagnostic"
+    } else {
+        "database diagnostic degraded"
+    };
     warnings.push(SystemWarning {
         level: "warn".to_string(),
         message: format!(
-            "database diagnostic degraded at {}: {} ({})",
+            "{headline} at {}: {} ({})",
             diagnostic.source, diagnostic.summary, diagnostic.failure_kind
         ),
         source: "database".to_string(),
@@ -9005,24 +9059,59 @@ fn database_warning_snapshot(
 }
 
 fn database_write_refused_error_from_diagnostic(diagnostic: DatabaseDiagnosticDto) -> ErrorData {
+    let warning_headline = if diagnostic.failure_kind == "locked_or_busy" {
+        "database lock diagnostic"
+    } else {
+        "database diagnostic degraded"
+    };
     let warning = SystemWarning {
         level: "warn".to_string(),
         message: format!(
-            "database diagnostic degraded at {}: {} ({})",
+            "{warning_headline} at {}: {} ({})",
             diagnostic.source, diagnostic.summary, diagnostic.failure_kind
         ),
         source: "database".to_string(),
     };
-    let message = format!(
-        "mempal database degraded; writes are refused to preserve memory integrity. {}: {} ({}). {}",
-        diagnostic.source, diagnostic.summary, diagnostic.failure_kind, diagnostic.hint
-    );
+    let holder_report = if diagnostic.failure_kind == "locked_or_busy" {
+        Some(crate::process_diagnostics::inspect_db_holders(Path::new(
+            &diagnostic.path,
+        )))
+    } else {
+        None
+    };
+    let holder_summary = holder_report
+        .as_ref()
+        .map(crate::process_diagnostics::format_db_holder_role_summary);
+    let safe_next_step = holder_report
+        .as_ref()
+        .map(crate::process_diagnostics::sqlite_lock_safe_next_step);
+    let (reason, action, message) = if diagnostic.failure_kind == "locked_or_busy" {
+        (
+            "database_locked",
+            "retry_after_transient_lock",
+            format!(
+                "mempal database is busy; write admission was not confirmed. {}: {} ({}). {}",
+                diagnostic.source, diagnostic.summary, diagnostic.failure_kind, diagnostic.hint
+            ),
+        )
+    } else {
+        (
+            "database_degraded",
+            "write_refused",
+            format!(
+                "mempal database degraded; writes are refused to preserve memory integrity. {}: {} ({}). {}",
+                diagnostic.source, diagnostic.summary, diagnostic.failure_kind, diagnostic.hint
+            ),
+        )
+    };
     ErrorData::internal_error(
         message,
         Some(serde_json::json!({
-            "reason": "database_degraded",
-            "action": "write_refused",
+            "reason": reason,
+            "action": action,
             "database_diagnostic": diagnostic,
+            "db_holder_summary": holder_summary,
+            "safe_next_step": safe_next_step,
             "system_warnings": [warning],
         })),
     )
@@ -9521,6 +9610,8 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::thread;
     use std::time::Duration;
 
     use async_trait::async_trait;
@@ -9548,12 +9639,14 @@ mod tests {
         vector: Vec<f32>,
         call_count: Arc<AtomicUsize>,
         gate: Arc<Notify>,
+        released: Arc<AtomicBool>,
     }
 
     struct BlockingEmbedder {
         vector: Vec<f32>,
         call_count: Arc<AtomicUsize>,
         gate: Arc<Notify>,
+        released: Arc<AtomicBool>,
     }
 
     struct EmbedStatusResetGuard;
@@ -9610,6 +9703,7 @@ mod tests {
                 vector: self.vector.clone(),
                 call_count: Arc::clone(&self.call_count),
                 gate: Arc::clone(&self.gate),
+                released: Arc::clone(&self.released),
             }))
         }
     }
@@ -9618,7 +9712,12 @@ mod tests {
     impl Embedder for BlockingEmbedder {
         async fn embed(&self, texts: &[&str]) -> crate::embed::Result<Vec<Vec<f32>>> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
-            self.gate.notified().await;
+            if !self.released.load(Ordering::SeqCst) {
+                self.gate.notified().await;
+                if !self.released.swap(true, Ordering::SeqCst) {
+                    self.gate.notify_waiters();
+                }
+            }
             Ok(texts.iter().map(|_| self.vector.clone()).collect())
         }
 
@@ -9644,6 +9743,23 @@ mod tests {
         .expect("create MCP server")
         .with_async_db_for_test(async_db);
         (tempdir, db_path, server)
+    }
+
+    fn hold_sqlite_write_lock(db_path: PathBuf, hold_for: Duration) -> thread::JoinHandle<()> {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let conn = rusqlite::Connection::open(db_path).expect("open sqlite lock connection");
+            conn.execute_batch("BEGIN IMMEDIATE;")
+                .expect("hold SQLite write lock");
+            ready_tx.send(()).expect("signal SQLite lock ready");
+            thread::sleep(hold_for);
+            conn.execute_batch("ROLLBACK;")
+                .expect("release SQLite lock");
+        });
+        ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("SQLite write lock ready");
+        handle
     }
 
     fn assert_json_string_values_do_not_contain(value: &Value, needle: &str, rendered: &str) {
@@ -9895,6 +10011,44 @@ quality_policy = "llm_required_for_keep"
         assert!(
             local_record.is_none(),
             "MCP admission should not write the local queue when daemon IPC accepts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_enqueue_waits_for_transient_sqlite_lock() {
+        let (_tempdir, db_path, server) = setup_server();
+        assert!(
+            MCP_INGEST_QUEUE_LOCK_RETRY_DEADLINE >= Duration::from_secs(5),
+            "MCP ingest queue admission must preserve the previous SQLite busy-timeout budget"
+        );
+        let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_millis(2_500));
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "transient SQLite lock should not refuse MCP ingest".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest admission should retry through transient SQLite busy")
+            .0;
+
+        lock.join().expect("lock thread");
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query queued operation")
+            .expect("queued operation");
+        assert!(
+            matches!(
+                record.op_state.as_str(),
+                "queued" | "claimed" | "running" | "completed"
+            ),
+            "unexpected operation state after transient lock retry: {}",
+            record.op_state
         );
     }
 
@@ -10905,16 +11059,16 @@ pattern_boost = 0.2
 
         let error = database_write_refused_error(Path::new("/tmp/palace.db"), "async_db", &busy);
 
-        assert!(error.message.contains("writes are refused"));
+        assert!(error.message.contains("write admission was not confirmed"));
         assert!(error.message.contains("locked_or_busy"));
         let data = error.data.expect("structured error data");
         assert_eq!(
             data.get("reason").and_then(Value::as_str),
-            Some("database_degraded")
+            Some("database_locked")
         );
         assert_eq!(
             data.get("action").and_then(Value::as_str),
-            Some("write_refused")
+            Some("retry_after_transient_lock")
         );
         let diagnostic = data
             .get("database_diagnostic")
@@ -10938,11 +11092,20 @@ pattern_boost = 0.2
                 .is_some_and(|summary| summary.contains("database is locked")),
             "diagnostic summary should include the SQLite lock message: {diagnostic}"
         );
-        assert_eq!(
-            diagnostic.get("hint").and_then(Value::as_str),
-            Some(
-                "Check for stale daemon/MCP processes holding palace.db, wait for the writer to finish, then retry status."
-            )
+        assert!(
+            diagnostic
+                .get("hint")
+                .and_then(Value::as_str)
+                .is_some_and(|hint| hint.contains("wait for the writer to finish")),
+            "diagnostic hint should guide retry: {diagnostic}"
+        );
+        assert!(
+            data.get("db_holder_summary").is_some(),
+            "structured lock error should include holder summary: {data}"
+        );
+        assert!(
+            data.get("safe_next_step").is_some(),
+            "structured lock error should include safe next step: {data}"
         );
         assert!(
             data.get("system_warnings")
@@ -14440,6 +14603,7 @@ pattern_boost = 0.2
                 vector: vec![0.1, 0.2, 0.3],
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
+                released: Arc::new(AtomicBool::new(false)),
             }),
         )
         .expect("create MCP server");
@@ -14504,6 +14668,7 @@ pattern_boost = 0.2
                 vector: vec![0.1, 0.2, 0.3],
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
+                released: Arc::new(AtomicBool::new(false)),
             }),
         )
         .expect("create MCP server");
@@ -14622,6 +14787,7 @@ pattern_boost = 0.2
                 vector: vec![0.1, 0.2, 0.3],
                 call_count: Arc::new(AtomicUsize::new(0)),
                 gate: Arc::clone(&gate),
+                released: Arc::new(AtomicBool::new(false)),
             }),
         )
         .expect("create MCP server");
@@ -14987,6 +15153,7 @@ enabled = false
                 vector: vec![0.1, 0.2, 0.3],
                 call_count: Arc::clone(&call_count),
                 gate: Arc::clone(&gate),
+                released: Arc::new(AtomicBool::new(false)),
             }),
         )
         .expect("create MCP server");

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -202,6 +202,56 @@ pub fn format_db_lock_remediation_hint(
     lines.join("\n")
 }
 
+/// Summarize live SQLite holders without exposing argv or payload content.
+pub fn format_db_holder_role_summary(report: &DbHolderReport) -> String {
+    if let Some(error) = report.error.as_deref() {
+        return format!("holder inspection failed: {error}");
+    }
+    if report.holders.is_empty() {
+        return "no live DB holders visible".to_string();
+    }
+
+    report
+        .holders
+        .iter()
+        .map(|holder| {
+            format!(
+                "pid={} role={} classification={} files={}",
+                holder.pid,
+                holder.role,
+                holder.classification,
+                holder.opened_files.join(",")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Return the safe next operator step for a busy SQLite diagnostic.
+pub fn sqlite_lock_safe_next_step(report: &DbHolderReport) -> &'static str {
+    if report.stale_mcp_server_count > 0 || report.orphan_daemon_count > 0 {
+        return "run `mempal doctor` or `mempal daemon status` to inspect stale mempal-owned holders before retrying";
+    }
+    if report.extra_holder_count > 0 {
+        return "stop or wait for the extra process holding palace.db, then retry";
+    }
+    if report
+        .holders
+        .iter()
+        .any(|holder| holder.current_mcp_server || holder.classification == "current_mcp_server")
+    {
+        return "the current MCP server is the visible holder; wait for the active write to finish and retry without killing the server";
+    }
+    if report
+        .holders
+        .iter()
+        .any(|holder| holder.current_daemon || holder.classification == "current_daemon")
+    {
+        return "the current daemon is the visible holder; wait for the active queued write to finish and retry";
+    }
+    "wait for the transient SQLite writer to finish, then retry"
+}
+
 fn format_pid_list(pids: &[i32]) -> String {
     pids.iter()
         .map(i32::to_string)
@@ -839,6 +889,37 @@ mod tests {
         assert!(message.contains("pid=44 role=mempal_daemon classification=current_daemon"));
         assert!(message.contains("mempal only auto-terminates stale_mcp_server and orphan_daemon"));
         assert!(message.contains("mempal daemon status"));
+    }
+
+    #[test]
+    fn test_db_holder_role_summary_uses_sanitized_fields() {
+        let report = build_report(
+            Path::new("/tmp/palace.db"),
+            vec![holder(55, "mempal_mcp_server", "current_mcp_server")],
+            None,
+        );
+
+        let summary = format_db_holder_role_summary(&report);
+
+        assert!(summary.contains("pid=55"));
+        assert!(summary.contains("role=mempal_mcp_server"));
+        assert!(summary.contains("classification=current_mcp_server"));
+        assert!(!summary.contains("content"));
+        assert!(!summary.contains("token"));
+    }
+
+    #[test]
+    fn test_sqlite_lock_safe_next_step_distinguishes_current_mcp() {
+        let report = build_report(
+            Path::new("/tmp/palace.db"),
+            vec![holder(55, "mempal_mcp_server", "current_mcp_server")],
+            None,
+        );
+
+        let step = sqlite_lock_safe_next_step(&report);
+
+        assert!(step.contains("current MCP server"));
+        assert!(step.contains("without killing the server"));
     }
 
     #[cfg(target_os = "linux")]

--- a/tests/ingest_stdin_lock.rs
+++ b/tests/ingest_stdin_lock.rs
@@ -1,0 +1,120 @@
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use mempal::core::db::Database;
+use rusqlite::Connection;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+
+[embed]
+backend = "stub"
+
+[ingest_gating]
+enabled = false
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
+fn hold_sqlite_write_lock(db_path: PathBuf, hold_for: Duration) -> thread::JoinHandle<()> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let conn = Connection::open(db_path).expect("open sqlite lock connection");
+        conn.execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold SQLite write lock");
+        ready_tx.send(()).expect("signal SQLite lock ready");
+        thread::sleep(hold_for);
+        conn.execute_batch("ROLLBACK;")
+            .expect("release SQLite lock");
+    });
+    ready_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("SQLite write lock ready");
+    handle
+}
+
+#[test]
+fn test_stdin_ingest_waits_for_transient_sqlite_lock() {
+    let (home, db_path) = setup_home();
+    let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_millis(300));
+    let payload = br#"{"content":"stdin transient sqlite lock fixture"}"#;
+
+    let mut child = Command::new(mempal_bin())
+        .args([
+            "ingest",
+            "--stdin",
+            "--wing",
+            "mempal",
+            "--source-type",
+            "user_explicit",
+            "--confidence",
+            "0.9",
+            "--no-gate",
+            "--json",
+        ])
+        .env("HOME", home.path())
+        .env("MEMPAL_EMBED_BACKEND", "stub")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn stdin ingest");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload)
+        .expect("write stdin payload");
+    let output = child.wait_with_output().expect("wait stdin ingest");
+    lock.join().expect("lock thread");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("database is locked") && !stderr.contains("write admission"),
+        "successful stdin ingest should not print lock diagnostics: {stderr}"
+    );
+    assert!(
+        !stderr.contains("stdin transient sqlite lock fixture"),
+        "stderr must not include raw stdin content: {stderr}"
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("stdout json");
+    assert_eq!(stdout["stats"]["files"], 1);
+    assert_eq!(stdout["stats"]["chunks"], 1);
+    assert_eq!(
+        stdout["drawer_ids"].as_array().expect("drawer ids").len(),
+        1
+    );
+
+    let db = Database::open(&db_path).expect("open db after ingest");
+    assert_eq!(db.drawer_count().expect("drawer count"), 1);
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "0844f389989e632c37f1f1f2866e128da15c2f97"
+commit = "46797fc176ff5b012e8ad49a117c056717d90b32"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Add bounded retry/write-admission handling for transient SQLite lock failures in MCP ingest queue admission.
- Preserve the prior SQLite busy-timeout budget so transient writer locks are not failed faster than before.
- Return actionable, redacted lock-holder diagnostics on exhausted admission attempts.
- Extend the same lock-resilience behavior to explicit stdin ingest startup/open paths.

## Verification

- CSA Codex exact-head review PASS/CLEAN: `01KVPG8TA8F0WYXJ926QSZ45ZP`
- `csa review --check-verdict --sa-mode true --range main...HEAD`
- Hook-enabled push with `RUST_TEST_THREADS=1`
- Local gates passed during pre-push:
  - branch-protection
  - local-gates
  - review-check

Fixes #517
Fixes #516
