### PR TITLE
fix(gates): bound local cargo test hangs

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ clippy:
 # are behind the `integration` feature.
 # CARGO_BUILD_JOBS=2 limits parallel LLVM codegen to avoid OOM on this host.
 test:
-    CARGO_BUILD_JOBS=2 {{cargo}} test
+    CARGO_BUILD_JOBS=2 bash scripts/gates/cargo-test-with-timeout.sh {{cargo}} test
 
 # REST feature test tier, batched to control disk and memory pressure.
 test-rest:

--- a/scripts/gates/cargo-test-with-timeout.sh
+++ b/scripts/gates/cargo-test-with-timeout.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIMEOUT_SECS="${MEMPAL_CARGO_TEST_TIMEOUT_SECS:-1800}"
+KILL_GRACE_SECS="${MEMPAL_CARGO_TEST_KILL_GRACE_SECS:-30}"
+
+if (($# == 0)); then
+    echo "usage: $0 <cargo-test-command> [args...]" >&2
+    exit 2
+fi
+
+if ! [[ "${TIMEOUT_SECS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "MEMPAL_CARGO_TEST_TIMEOUT_SECS must be a positive integer" >&2
+    exit 2
+fi
+
+if ! [[ "${KILL_GRACE_SECS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "MEMPAL_CARGO_TEST_KILL_GRACE_SECS must be a positive integer" >&2
+    exit 2
+fi
+
+print_command() {
+    printf ' %q' "$@"
+}
+
+print_process_context() {
+    local pgid="$1"
+
+    echo "process tree:" >&2
+    if command -v ps >/dev/null 2>&1; then
+        ps -o pid,ppid,pgid,stat,etime,pcpu,pmem,comm,args --forest -g "${pgid}" >&2 \
+            || ps -o pid,ppid,pgid,stat,etime,pcpu,pmem,comm,args -g "${pgid}" >&2 \
+            || true
+    else
+        echo "ps unavailable; cannot print process tree" >&2
+    fi
+}
+
+terminate_group() {
+    local pgid="$1"
+    local pid="$2"
+
+    kill -TERM "-${pgid}" 2>/dev/null || kill -TERM "${pid}" 2>/dev/null || true
+    sleep "${KILL_GRACE_SECS}"
+    if kill -0 "${pid}" 2>/dev/null; then
+        kill -KILL "-${pgid}" 2>/dev/null || kill -KILL "${pid}" 2>/dev/null || true
+    fi
+}
+
+timeout_marker="$(mktemp "${TMPDIR:-/tmp}/mempal-cargo-test-timeout.XXXXXX")"
+rm -f "${timeout_marker}"
+
+if command -v setsid >/dev/null 2>&1; then
+    setsid "$@" &
+else
+    "$@" &
+fi
+cmd_pid="$!"
+cmd_pgid="$cmd_pid"
+
+cleanup() {
+    local exit_code="$1"
+    if [[ -n "${watchdog_pid:-}" ]]; then
+        kill "${watchdog_pid}" 2>/dev/null || true
+        wait "${watchdog_pid}" 2>/dev/null || true
+    fi
+    if kill -0 "${cmd_pid}" 2>/dev/null; then
+        terminate_group "${cmd_pgid}" "${cmd_pid}"
+    fi
+    rm -f "${timeout_marker}"
+    exit "${exit_code}"
+}
+
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+
+(
+    sleep_pid=""
+    cleanup_watchdog() {
+        if [[ -n "${sleep_pid}" ]]; then
+            kill "${sleep_pid}" 2>/dev/null || true
+            wait "${sleep_pid}" 2>/dev/null || true
+        fi
+        exit 0
+    }
+    trap cleanup_watchdog INT TERM HUP
+
+    sleep "${TIMEOUT_SECS}" &
+    sleep_pid="$!"
+    wait "${sleep_pid}" || exit 0
+    sleep_pid=""
+
+    if kill -0 "${cmd_pid}" 2>/dev/null; then
+        {
+            echo "cargo test command timed out after ${TIMEOUT_SECS}s"
+            printf 'active command:'
+            print_command "$@"
+            printf '\n'
+            print_process_context "${cmd_pgid}"
+        } >&2
+        : >"${timeout_marker}"
+        terminate_group "${cmd_pgid}" "${cmd_pid}"
+    fi
+) &
+watchdog_pid="$!"
+
+set +e
+wait "${cmd_pid}"
+status="$?"
+set -e
+
+kill "${watchdog_pid}" 2>/dev/null || true
+wait "${watchdog_pid}" 2>/dev/null || true
+
+if [[ -f "${timeout_marker}" ]]; then
+    rm -f "${timeout_marker}"
+    exit 124
+fi
+
+rm -f "${timeout_marker}"
+exit "${status}"

--- a/scripts/gates/rest-tests.sh
+++ b/scripts/gates/rest-tests.sh
@@ -10,6 +10,8 @@ else
     cargo_cmd=(cargo)
 fi
 
+test_timeout_wrapper="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)/scripts/gates/cargo-test-with-timeout.sh"
+
 if ! [[ "${REST_TEST_TARGETS_PER_BATCH}" =~ ^[1-9][0-9]*$ ]]; then
     echo "REST_TEST_TARGETS_PER_BATCH must be a positive integer" >&2
     exit 2
@@ -29,6 +31,10 @@ clean_mempal_artifacts() {
     run_cmd "${cargo_cmd[@]}" clean -p mempal
 }
 
+run_cargo_test() {
+    run_cmd bash "${test_timeout_wrapper}" "${cargo_cmd[@]}" test "$@"
+}
+
 run_integration_batch() {
     local batch_index="$1"
     shift
@@ -40,14 +46,14 @@ run_integration_batch() {
     done
 
     printf 'rest integration batch %s: %s target(s)\n' "${batch_index}" "$#"
-    run_cmd "${cargo_cmd[@]}" test --workspace --features rest "${target_args[@]}"
+    run_cargo_test --workspace --features rest "${target_args[@]}"
     clean_mempal_artifacts
 }
 
 echo "rest target batch size: ${REST_TEST_TARGETS_PER_BATCH}"
 
-run_cmd "${cargo_cmd[@]}" test --workspace --features rest --lib --bins
-run_cmd "${cargo_cmd[@]}" test --workspace --features rest --doc
+run_cargo_test --workspace --features rest --lib --bins
+run_cargo_test --workspace --features rest --doc
 clean_mempal_artifacts
 
 mapfile -t integration_tests < <(

--- a/tests/local_gate_scripts.rs
+++ b/tests/local_gate_scripts.rs
@@ -1,0 +1,155 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn wait_with_timeout(mut child: Child, timeout: Duration) -> io::Result<Output> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if child.try_wait()?.is_some() {
+            return child.wait_with_output();
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let output = child.wait_with_output()?;
+            panic!(
+                "child did not exit within {timeout:?}; stdout={}, stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn run_bash_script(
+    script: &Path,
+    args: &[&str],
+    envs: &[(&str, &str)],
+    timeout: Duration,
+) -> Output {
+    let mut command = Command::new("bash");
+    command
+        .arg(script)
+        .args(args)
+        .current_dir(repo_root())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    let child = command.spawn().expect("spawn bash script");
+    wait_with_timeout(child, timeout).expect("wait for bash script")
+}
+
+fn sleeper_pids(timeout_secs: &str) -> Vec<String> {
+    let ps = Command::new("ps")
+        .args(["-eo", "pid=,args="])
+        .output()
+        .expect("run ps");
+    let stdout = String::from_utf8_lossy(&ps.stdout);
+    let expected = format!("sleep {timeout_secs}");
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let (pid, args) = trimmed.split_once(' ')?;
+            (args.trim() == expected).then(|| pid.to_string())
+        })
+        .collect()
+}
+
+fn kill_pids(pids: &[String]) {
+    for pid in pids {
+        let _ = Command::new("kill").arg(pid).status();
+    }
+}
+
+#[test]
+fn cargo_test_wrapper_times_out_and_reports_process_context() {
+    let script = repo_root().join("scripts/gates/cargo-test-with-timeout.sh");
+
+    let output = run_bash_script(
+        &script,
+        &["bash", "-c", "sleep 5"],
+        &[
+            ("MEMPAL_CARGO_TEST_TIMEOUT_SECS", "1"),
+            ("MEMPAL_CARGO_TEST_KILL_GRACE_SECS", "1"),
+        ],
+        Duration::from_secs(6),
+    );
+
+    assert_eq!(output.status.code(), Some(124));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cargo test command timed out"),
+        "stderr={stderr}"
+    );
+    assert!(stderr.contains("active command:"), "stderr={stderr}");
+    assert!(stderr.contains("process tree:"), "stderr={stderr}");
+}
+
+#[test]
+fn cargo_test_wrapper_success_does_not_leave_timeout_sleeper() {
+    let script = repo_root().join("scripts/gates/cargo-test-with-timeout.sh");
+    kill_pids(&sleeper_pids("313"));
+
+    let status = Command::new("timeout")
+        .arg("3s")
+        .arg("bash")
+        .arg(&script)
+        .args(["bash", "-c", "true"])
+        .current_dir(repo_root())
+        .env("MEMPAL_CARGO_TEST_TIMEOUT_SECS", "313")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run wrapper through timeout");
+
+    assert!(status.success());
+    let leaked = sleeper_pids("313");
+    kill_pids(&leaked);
+    assert!(
+        leaked.is_empty(),
+        "timeout sleeper leaked after successful wrapper run: {leaked:?}"
+    );
+}
+
+#[test]
+fn rest_gate_dry_run_wraps_cargo_test_phases() {
+    let script = repo_root().join("scripts/gates/rest-tests.sh");
+    let output = run_bash_script(
+        &script,
+        &[],
+        &[
+            ("REST_GATE_DRY_RUN", "1"),
+            ("REST_TEST_TARGETS_PER_BATCH", "999"),
+        ],
+        Duration::from_secs(10),
+    );
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("scripts/gates/cargo-test-with-timeout.sh"),
+        "stdout={stdout}"
+    );
+    assert!(stdout.contains("--features rest --lib --bins"));
+    assert!(stdout.contains("--features rest --doc"));
+}
+
+#[test]
+fn just_test_recipe_uses_cargo_test_timeout_wrapper() {
+    let justfile = fs::read_to_string(repo_root().join("justfile")).expect("read justfile");
+
+    assert!(
+        justfile.contains("bash scripts/gates/cargo-test-with-timeout.sh {{cargo}} test"),
+        "just test must run cargo test through the bounded local-gate wrapper"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a bounded timeout wrapper for local gate Cargo test phases so a stuck libtest child cannot block pre-push indefinitely.
- Emit the active test command and process tree diagnostics before terminating timed-out test process groups.
- Route the normal and REST local-gate test phases through the wrapper while preserving branch-protection, local-gates, and review-check behavior.

## Verification

- CSA Codex exact-head review PASS/CLEAN: `01KVPPX55XRJ8GN3CH88M1HFYD`
- `csa review --check-verdict --sa-mode true --range main...HEAD`
- Hook-enabled push without `RUST_TEST_THREADS=1`
- Local gates passed during pre-push:
  - branch-protection
  - local-gates
  - review-check

Fixes #514
