### PR TITLE
docs(skills): harden mempal smoke test skill

### DIFF
--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -1,91 +1,203 @@
-# Smoke Test: mempal Read-Only Regression Check
+---
+name: smoke-test
+description: "Project-local mempal manual smoke test skill. Use after installing, restarting, merging, or changing mempal to verify daemon health, CLI/REST/MCP/read-only surfaces, optional reversible write/delete paths, memory growth, and database-holder safety without starting duplicate daemons or leaking drawer content."
+---
 
-Non-destructive smoke test covering every side-effect-free CLI feature.
-Run after a new binary install or MCP reconnect to catch regressions.
+# mempal Manual Smoke Test
 
-## Prerequisites
+Use this project-local skill when a main agent must manually verify that the installed `mempal` binary and live daemon still work after a merge, install, restart, MCP reconnect, or production-like debugging session.
 
-1. **Restart the daemon** so the new binary is loaded:
-   ```
-   mempal daemon restart
-   ```
-2. **Ask the user to run `/mcp`** (or reconnect MCP manually) so the MCP
-   server picks up the new binary. **Wait for user confirmation before
-   proceeding** — MCP reconnect is a user-side action.
+Default to direct installed-CLI probes. Do not start extra daemons or long-lived REST/MCP servers unless the test explicitly requires them and the owner process is tracked for cleanup.
 
-## Test Matrix
+## Safety rules
 
-Run every command below. A test **passes** if it exits 0 and produces
-non-empty, structurally valid output (not just an error message).
-Collect results into a markdown table at the end.
+1. Keep diagnostics aggregate-only. Do not print raw drawer content, prompts, model responses, Authorization headers, bearer tokens, API keys, passwords, `drawer_content`, or secret-bearing URLs.
+2. Use the installed binary (`command -v mempal`, `mempal --version`) and the live user daemon. Do not run `cargo run` for smoke unless debugging source changes.
+3. Maintain singleton ownership:
+   - Prefer `systemctl --user restart mempal-daemon.service` for restart.
+   - Verify exactly one `/usr/local/bin/mempal daemon --foreground` after restart.
+   - Do not run `mempal serve` as a long-lived REST server for smoke unless a route test requires it; if started, track and kill it.
+   - Do not spawn extra `mempal serve --mcp` processes from the shell. MCP reconnect is a client action.
+4. Before declaring a lock failure, inspect DB holders with `mempal daemon status` and summarize only roles/counts/PIDs/commands.
+5. Prefer read-only CLI smoke first. Use reversible write/delete only when the requested task requires proving write paths or when read-only probes expose a write-path risk.
+6. If using a synthetic write, use a unique marker, a `smoke/manual` wing-room, `--no-gate`, `--wait`, then immediately find the created drawer ID(s), pin/unpin if needed, and `mempal delete` them. Report IDs only if needed; do not print content.
+7. If there is already context that should become durable memory, it is acceptable to ingest a concise real note instead of synthetic content, but only when the note is genuinely useful and non-secret.
 
-### Group 1 — System Health
+## Preflight
 
-| # | Command | Pass criteria |
-|---|---------|---------------|
-| 1 | `mempal status` | Shows `schema_version`, `drawer_count > 0`, `daemon running: true` |
-| 2 | `mempal daemon status` | Shows `status: running`, valid PID, `uptime_secs > 0` |
-| 3 | `mempal stats` | Shows `drawers total > 0`, at least one scope entry |
+Run from the repository root:
 
-### Group 2 — Search & Retrieval
-
-| # | Command | Pass criteria |
-|---|---------|---------------|
-| 4 | `mempal search '<chinese-query>' --top-k 3` | Returns >= 1 result with score |
-| 5 | `mempal search '<english-query>' --top-k 3` | Returns >= 1 result with score |
-| 6 | `mempal context '<query>'` | Exits 0 (may return "no context" — that is OK) |
-| 7 | `mempal context '<query>' --include-cards` | Exits 0 |
-
-For search queries, pick terms known to exist in the palace (e.g. a recent
-commit message, a wing name, or a domain concept from the project).
-
-### Group 3 — Timeline & History
-
-| # | Command | Pass criteria |
-|---|---------|---------------|
-| 8  | `mempal timeline` | Returns dated entries |
-| 9  | `mempal tail --limit 5` | Returns 5 drawer previews |
-| 10 | `mempal prime` | Returns timeline overview with star ratings |
-
-### Group 4 — Knowledge & Topology
-
-| # | Command | Pass criteria |
-|---|---------|---------------|
-| 11 | `mempal knowledge-card list --format json` | Exits 0, returns `[]` or valid JSON array |
-| 12 | `mempal tunnels list` | Returns tunnel entries or "0 tunnel(s)" |
-
-### Group 5 — MCP Tools (post-reconnect only)
-
-After MCP reconnect, test each read-only MCP tool if available:
-
-| # | Tool | Pass criteria |
-|---|------|---------------|
-| 13 | `mempal_status()` | Returns status object |
-| 14 | `mempal_search(query="test")` | Returns results array |
-| 15 | `mempal_context(query="test")` | Returns context or empty |
-| 16 | `mempal_timeline()` | Returns timeline entries |
-
-## Execution
-
-1. Run `mempal daemon restart` and verify `mempal daemon status` shows running.
-2. Tell the user: "Please run `/mcp` to reconnect the MCP server, then confirm."
-3. Wait for user confirmation.
-4. Execute Groups 1-4 via CLI (all in parallel where independent).
-5. Execute Group 5 via MCP tool calls.
-6. Collect all results into a summary table:
-
-```
-| # | Test | Result | Notes |
-|---|------|--------|-------|
-| 1 | status | PASS/FAIL | ... |
+```bash
+git status --short --branch --untracked-files=all
+command -v mempal
+mempal --version
+systemctl --user is-active mempal-daemon.service || true
+systemctl --user show mempal-daemon.service -p MainPID -p ActiveState -p SubState --value || true
+ps -eo pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args --sort=-rss | awk '/[m]empal/ {print}'
+mempal daemon status | sed -E 's/(authorization|bearer|token|password|secret|api[_-]?key|drawer_content)[^[:space:]]*/\1=[REDACTED]/Ig' | sed -n '1,180p'
 ```
 
-7. If any test FAILs, report the failing command, exit code, and stderr.
+Record:
 
-## Done When
+- installed version;
+- daemon PID;
+- `exe_deleted`;
+- `live_daemons`;
+- `extra_holders` / `stale_mcp_servers` / `orphan_daemons`;
+- RSS/PSS/private dirty/anonymous memory;
+- queue counts;
+- `search.active`;
+- REST health summary.
 
-- All 12+ CLI tests executed
-- MCP tools tested (if available after reconnect)
-- Summary table printed
-- Zero FAIL = "No regression detected"
-- Any FAIL = list affected features for investigation
+## Restart procedure
+
+When restart is allowed or needed:
+
+```bash
+systemctl --user restart mempal-daemon.service
+sleep 3
+main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
+systemctl --user is-active mempal-daemon.service
+ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args
+readlink "/proc/$main_pid/exe"
+pgrep -af '^/usr/local/bin/mempal (daemon --foreground|serve --mcp)$' || true
+```
+
+Pass criteria:
+
+- service is `active`;
+- exactly one daemon process exists;
+- daemon exe resolves to `/usr/local/bin/mempal` and is not deleted;
+- no untracked extra `mempal serve --mcp` processes were created by the smoke;
+- RSS is reasonable immediately after restart (normally hundreds of MB, not multi-GB).
+
+## Read-only CLI smoke matrix
+
+Run these commands directly. Capture exit code, latency, stdout byte count, stderr byte count, and JSON shape/field names where applicable. Do not print raw drawer bodies.
+
+| Group | Command | Pass criteria |
+|---|---|---|
+| Identity | `mempal --version` | exits 0, expected version string |
+| Daemon | `mempal daemon status` | exits 0, running, singleton/current binary |
+| Doctor | `mempal doctor` | exits 0; warnings summarized |
+| REST doctor | `mempal doctor rest --format json` | exits 0, JSON parses, routes reported; degraded is allowed only with warning recorded |
+| Dashboard | `mempal status` | exits 0 |
+| Stats | `mempal stats` | exits 0 |
+| Config | `mempal config intelligence` | exits 0 |
+| Cost | `mempal cost status` | exits 0 |
+| Gating | `mempal gating stats` | exits 0 |
+| Timeline | `mempal timeline --since 1h --format json` | exits 0, empty output or valid JSON accepted |
+| Tail | `mempal tail --limit 3` | exits 0 |
+| Pinned | `mempal pinned --json` | exits 0, JSON parses |
+| KG | `mempal kg stats` | exits 0 |
+| Cards | `mempal knowledge-card list --format json` and `mempal cards --pending --format json` | exits 0, JSON parses |
+| Reflection | `mempal reflect --json --limit 3` | exits 0, JSON parses |
+| Prime | `mempal prime --format json --token-budget 512 --no-stats` | exits 0, JSON parses |
+| Wake-up | `mempal wake-up --format protocol` | exits 0 |
+| Taxonomy | `mempal field-taxonomy --format json` | exits 0, JSON parses |
+| Integrations | `mempal integrations status` | exits 0 |
+| Checkpoint | `mempal checkpoint status` | exits 0 |
+| Patterns/skills/repair | `mempal patterns list`, `mempal skills list`, `mempal repair list` | exits 0 |
+| Cowork | `mempal cowork-status --cwd "$PWD"` | exits 0 |
+| Maintenance | `mempal maintenance guided-run --format json` | exits 0, JSON parses |
+| Release | `mempal release-readiness --format json` | exits 0, JSON parses |
+| xurl | `mempal xurl stats` | exits 0 |
+| Benchmark | `mempal bench matrix --mode no-llm --top-k 3 --format json` | exits 0, JSON parses |
+| Recall help | `mempal recall hermes --help` | exits 0 |
+
+For expensive semantic queries, run them only when needed and bound time explicitly:
+
+```bash
+timeout 180s mempal search '<known safe query>' --top-k 3 --json
+timeout 120s mempal context '<known safe query>' --format json --max-items 3 --no-distill-suggestions
+```
+
+If these are slow, report latency and memory growth; do not treat slowness as pass unless the task only asked for availability.
+
+## Optional reversible write smoke
+
+Use only when write-path validation is required.
+
+1. Generate a unique marker:
+
+   ```bash
+   marker="mempal-smoke-$(date +%s)-$RANDOM"
+   ```
+
+2. Ingest via stdin with a smoke scope:
+
+   ```bash
+   printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
+     | mempal ingest --stdin --format json --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json
+   ```
+
+3. Search only for the marker and parse IDs from JSON without printing content:
+
+   ```bash
+   mempal search "$marker" --top-k 5 --json > /tmp/mempal-smoke-search.json
+   python3 - <<'PY'
+import json
+from pathlib import Path
+obj=json.loads(Path('/tmp/mempal-smoke-search.json').read_text() or '[]')
+ids=[]
+def walk(x):
+    if isinstance(x, dict):
+        for k,v in x.items():
+            if k in ('id','drawer_id','drawerId') and isinstance(v,(str,int)):
+                ids.append(str(v))
+            else:
+                walk(v)
+    elif isinstance(x, list):
+        for y in x:
+            walk(y)
+walk(obj)
+print('\n'.join(dict.fromkeys(ids)))
+PY
+   ```
+
+4. For each smoke ID, optionally test pin/unpin, then delete:
+
+   ```bash
+   mempal pin "$id" || true
+   mempal unpin "$id" || true
+   mempal delete "$id"
+   ```
+
+5. Re-run marker search and confirm no active smoke drawer remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
+
+## REST checks
+
+Prefer `mempal doctor rest --format json` for route availability. If an actual REST route smoke is required:
+
+1. First check whether an endpoint is already running (`doctor rest`).
+2. If not running, start `mempal serve` as a tracked background process and ensure it listens before probing.
+3. Probe only aggregate/status endpoints or synthetic content.
+4. Kill the temporary server and verify no extra `mempal serve` process remains.
+
+Do not confuse daemon service health with REST server availability; they are separate surfaces.
+
+## MCP checks
+
+Do not spawn MCP servers manually for smoke. If MCP tool validation is required, ask the interactive client to reconnect MCP (for example `/mcp`) and then call available read-only MCP tools. Pass criteria are shape/status only; do not print raw memory content.
+
+## Memory growth guard
+
+Capture daemon memory before and after smoke:
+
+```bash
+main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
+ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args
+mempal daemon status | awk '/^(memory\.|live_daemons:|extra_holders:|search\.active:|rest\.embedder_cache\.|embedder\.)/ {print}'
+```
+
+If read-only commands push RSS into multi-GB territory, file or update an issue with aggregate evidence. Restarting is only mitigation; the product fix should bound/lazily load/evict caches.
+
+## Done when
+
+- Preflight state recorded without leaking content.
+- Daemon restart, if performed, leaves one current-binary daemon.
+- Read-only matrix exits 0 or failures are classified by command/stderr class.
+- Optional write smoke cleans up its own drawers.
+- REST/MCP checks do not leave extra processes.
+- Memory before/after is recorded.
+- Worktree remains clean except intentional skill/code changes.

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -76,43 +76,128 @@ Pass criteria:
 
 ## Read-only CLI smoke matrix
 
-Run these commands directly. Capture exit code, latency, stdout byte count, stderr byte count, and JSON shape/field names where applicable. Do not print raw drawer bodies.
+Do not paste raw stdout or stderr from `mempal` commands into chat, issues, or logs unless the command is explicitly listed as safe-direct below. For every other command, capture stdout/stderr to temporary files and report only:
 
-| Group | Command | Pass criteria |
-|---|---|---|
-| Identity | `mempal --version` | exits 0, expected version string |
-| Daemon | `mempal daemon status` | exits 0, running, singleton/current binary |
-| Doctor | `mempal doctor` | exits 0; warnings summarized |
-| REST doctor | `mempal doctor rest --format json` | exits 0, JSON parses, routes reported; degraded is allowed only with warning recorded |
-| Dashboard | `mempal status` | exits 0 |
-| Stats | `mempal stats` | exits 0 |
-| Config | `mempal config intelligence` | exits 0 |
-| Cost | `mempal cost status` | exits 0 |
-| Gating | `mempal gating stats` | exits 0 |
-| Timeline | `mempal timeline --since 1h --format json` | exits 0, empty output or valid JSON accepted |
-| Tail | `mempal tail --limit 3` | exits 0 |
-| Pinned | `mempal pinned --json` | exits 0, JSON parses |
-| KG | `mempal kg stats` | exits 0 |
-| Cards | `mempal knowledge-card list --format json` and `mempal cards --pending --format json` | exits 0, JSON parses |
-| Reflection | `mempal reflect --json --limit 3` | exits 0, JSON parses |
-| Prime | `mempal prime --format json --token-budget 512 --no-stats` | exits 0, JSON parses |
-| Wake-up | `mempal wake-up --format protocol` | exits 0 |
-| Taxonomy | `mempal field-taxonomy --format json` | exits 0, JSON parses |
-| Integrations | `mempal integrations status` | exits 0 |
-| Checkpoint | `mempal checkpoint status` | exits 0 |
-| Patterns/skills/repair | `mempal patterns list`, `mempal skills list`, `mempal repair list` | exits 0 |
-| Cowork | `mempal cowork-status --cwd "$PWD"` | exits 0 |
-| Maintenance | `mempal maintenance guided-run --format json` | exits 0, JSON parses |
-| Release | `mempal release-readiness --format json` | exits 0, JSON parses |
-| xurl | `mempal xurl stats` | exits 0 |
-| Benchmark | `mempal bench matrix --mode no-llm --top-k 3 --format json` | exits 0, JSON parses |
-| Recall help | `mempal recall hermes --help` | exits 0 |
+- exit code;
+- latency;
+- stdout/stderr byte counts;
+- JSON/NDJSON parse success/failure;
+- top-level JSON type, field names, line counts, and item counts;
+- health/status/warning strings only after redaction and only when they do not include drawer/card/prompt content.
+
+Treat these commands as content-bearing by default and never print their raw stdout in chat: `mempal status`, `mempal status --full`, `mempal timeline`, `mempal tail`, `mempal pinned`, `mempal knowledge-card list`, `mempal cards --pending`, `mempal reflect`, `mempal prime`, `mempal wake-up`, `mempal context`, `mempal search`, `mempal recall hermes search`, and any command that returns drawers, cards, recall snippets, evidence, timeline entries, prompts, model responses, or previews.
+
+Simple non-content identity commands may be displayed directly only when their output is known not to include memory content, for example `mempal --version`. For `doctor`, `doctor rest`, `daemon status`, stats, cost, and gating commands, still prefer summarized fields and redacted warning categories over raw output.
+
+Use a capture harness for all content-bearing or uncertain commands:
+
+```bash
+run_mempal_probe() {
+  name="$1"
+  expect_json="$2"
+  shift 2
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/mempal-smoke.XXXXXX")"
+  stdout_file="$tmpdir/stdout"
+  stderr_file="$tmpdir/stderr"
+  start_ms="$(date +%s%3N)"
+  "$@" >"$stdout_file" 2>"$stderr_file"
+  status=$?
+  end_ms="$(date +%s%3N)"
+  python3 - "$name" "$expect_json" "$status" "$start_ms" "$end_ms" "$stdout_file" "$stderr_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+name, expect_json, status, start_ms, end_ms, stdout_path, stderr_path = sys.argv[1:]
+stdout = Path(stdout_path).read_bytes()
+stderr = Path(stderr_path).read_bytes()
+summary = {
+    "name": name,
+    "exit_code": int(status),
+    "latency_ms": max(0, int(end_ms) - int(start_ms)),
+    "stdout_bytes": len(stdout),
+    "stderr_bytes": len(stderr),
+}
+
+if expect_json == "json":
+    try:
+        parsed = json.loads(stdout.decode("utf-8") or "null")
+    except Exception as exc:
+        lines = [line for line in stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
+        try:
+            parsed_lines = [json.loads(line) for line in lines]
+        except Exception:
+            summary["json"] = {"ok": False, "error_type": type(exc).__name__}
+        else:
+            field_names = sorted({
+                key
+                for item in parsed_lines
+                if isinstance(item, dict)
+                for key in item.keys()
+            })
+            summary["json"] = {
+                "ok": True,
+                "type": "ndjson",
+                "line_count": len(parsed_lines),
+                "fields": field_names,
+            }
+    else:
+        if isinstance(parsed, dict):
+            summary["json"] = {
+                "ok": True,
+                "type": "object",
+                "fields": sorted(parsed.keys()),
+                "field_count": len(parsed),
+            }
+        elif isinstance(parsed, list):
+            summary["json"] = {"ok": True, "type": "array", "count": len(parsed)}
+        else:
+            summary["json"] = {"ok": True, "type": type(parsed).__name__}
+
+print(json.dumps(summary, sort_keys=True))
+PY
+  rm -rf "$tmpdir"
+  return "$status"
+}
+```
+
+The harness prints structure only. It must not print command stdout/stderr, JSON values, drawer IDs from content-bearing output, search snippets, previews, prompts, or model responses.
+
+| Group | Command | Output handling | Pass criteria |
+|---|---|---|---|
+| Identity | `mempal --version` | safe-direct | exits 0, expected version string |
+| Daemon | `mempal daemon status` | summarize/redact | exits 0, running, singleton/current binary |
+| Doctor | `mempal doctor` | summarize/redact | exits 0; warning categories summarized |
+| REST doctor | `mempal doctor rest --format json` | harness JSON/NDJSON | exits 0, JSON parses, routes reported; degraded is allowed only with warning recorded |
+| Dashboard | `mempal status` | content-bearing harness | exits 0 |
+| Stats | `mempal stats` | summarize/redact | exits 0 |
+| Config | `mempal config intelligence` | summarize/redact | exits 0 |
+| Cost | `mempal cost status` | summarize/redact | exits 0 |
+| Gating | `mempal gating stats` | summarize/redact | exits 0 |
+| Timeline | `mempal timeline --since 1h --format json` | content-bearing harness JSON/NDJSON | exits 0, empty output or valid JSON/NDJSON accepted |
+| Tail | `mempal tail --limit 3` | content-bearing harness | exits 0 |
+| Pinned | `mempal pinned --json` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
+| KG | `mempal kg stats` | summarize/redact | exits 0 |
+| Cards | `mempal knowledge-card list --format json` and `mempal cards --pending --format json` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
+| Reflection | `mempal reflect --json --limit 3` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
+| Prime | `mempal prime --format json --token-budget 512 --no-stats` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
+| Wake-up | `mempal wake-up --format protocol` | content-bearing harness | exits 0 |
+| Taxonomy | `mempal field-taxonomy --format json` | harness JSON/NDJSON | exits 0, JSON parses |
+| Integrations | `mempal integrations status` | summarize/redact | exits 0 |
+| Checkpoint | `mempal checkpoint status` | summarize/redact | exits 0 |
+| Patterns/skills/repair | `mempal patterns list`, `mempal skills list`, `mempal repair list` | summarize/redact | exits 0 |
+| Cowork | `mempal cowork-status --cwd "$PWD"` | summarize/redact | exits 0 |
+| Maintenance | `mempal maintenance guided-run --format json` | harness JSON/NDJSON | exits 0, JSON parses |
+| Release | `mempal release-readiness --format json` | harness JSON/NDJSON | exits 0, JSON parses |
+| xurl | `mempal xurl stats` | summarize/redact | exits 0 |
+| Benchmark | `mempal bench matrix --mode no-llm --top-k 3 --format json` | harness JSON/NDJSON | exits 0, JSON parses |
+| Recall help | `mempal recall hermes --help` | safe-direct | exits 0 |
 
 For expensive semantic queries, run them only when needed and bound time explicitly:
 
 ```bash
-timeout 180s mempal search '<known safe query>' --top-k 3 --json
-timeout 120s mempal context '<known safe query>' --format json --max-items 3 --no-distill-suggestions
+run_mempal_probe search json timeout 180s mempal search '<known safe query>' --top-k 3 --json
+run_mempal_probe context json timeout 120s mempal context '<known safe query>' --format json --max-items 3 --no-distill-suggestions
 ```
 
 If these are slow, report latency and memory growth; do not treat slowness as pass unless the task only asked for availability.
@@ -160,7 +245,7 @@ PY
 
    Do not print the ingest response or smoke IDs unless cleanup fails.
 
-3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, and never use search result IDs for deletion:
+3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, never print search result bodies/snippets, and never use search result IDs for deletion:
 
    ```bash
    verify_json="$(mktemp)"
@@ -232,6 +317,7 @@ If read-only commands push RSS into multi-GB territory, file or update an issue 
 - Preflight state recorded without leaking content.
 - Daemon restart, if performed, leaves one current-binary daemon.
 - Read-only matrix exits 0 or failures are classified by command/stderr class.
+- Raw stdout/stderr from content-bearing `mempal` commands was captured, structurally summarized, and not pasted into chat or log summaries.
 - Optional write smoke cleans up its own drawers.
 - REST/MCP checks do not leave extra processes.
 - Memory before/after is recorded.

--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -11,7 +11,7 @@ Default to direct installed-CLI probes. Do not start extra daemons or long-lived
 
 ## Safety rules
 
-1. Keep diagnostics aggregate-only. Do not print raw drawer content, prompts, model responses, Authorization headers, bearer tokens, API keys, passwords, `drawer_content`, or secret-bearing URLs.
+1. Keep diagnostics aggregate-only. Do not print raw drawer content, prompts, model responses, raw process command lines, environment variables, connection strings, URLs, Authorization headers, bearer tokens, API keys, passwords, `drawer_content`, or prompt-like arguments.
 2. Use the installed binary (`command -v mempal`, `mempal --version`) and the live user daemon. Do not run `cargo run` for smoke unless debugging source changes.
 3. Maintain singleton ownership:
    - Prefer `systemctl --user restart mempal-daemon.service` for restart.
@@ -20,7 +20,7 @@ Default to direct installed-CLI probes. Do not start extra daemons or long-lived
    - Do not spawn extra `mempal serve --mcp` processes from the shell. MCP reconnect is a client action.
 4. Before declaring a lock failure, inspect DB holders with `mempal daemon status` and summarize only roles/counts/PIDs/commands.
 5. Prefer read-only CLI smoke first. Use reversible write/delete only when the requested task requires proving write paths or when read-only probes expose a write-path risk.
-6. If using a synthetic write, use a unique marker, a `smoke/manual` wing-room, `--no-gate`, `--wait`, then immediately find the created drawer ID(s), pin/unpin if needed, and `mempal delete` them. Report IDs only if needed; do not print content.
+6. If using a synthetic write, use a unique marker, a `smoke/manual` wing-room, `--no-gate`, and `--wait`, then clean up only the exact drawer ID(s) returned by the ingest response. Never delete IDs discovered from generic search results. Report IDs only when cleanup fails; do not print content.
 7. If there is already context that should become durable memory, it is acceptable to ingest a concise real note instead of synthetic content, but only when the note is genuinely useful and non-secret.
 
 ## Preflight
@@ -33,8 +33,8 @@ command -v mempal
 mempal --version
 systemctl --user is-active mempal-daemon.service || true
 systemctl --user show mempal-daemon.service -p MainPID -p ActiveState -p SubState --value || true
-ps -eo pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args --sort=-rss | awk '/[m]empal/ {print}'
-mempal daemon status | sed -E 's/(authorization|bearer|token|password|secret|api[_-]?key|drawer_content)[^[:space:]]*/\1=[REDACTED]/Ig' | sed -n '1,180p'
+ps -C mempal -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm --sort=-rss || true
+mempal daemon status | awk '/^(status:|pid:|uptime_secs:|memory\.|live_daemons:|extra_holders:|stale_mcp_servers:|orphan_daemons:|search\.active:|rest\.health:|rest\.embedder_cache\.|embedder\.)/ {print}'
 ```
 
 Record:
@@ -49,6 +49,8 @@ Record:
 - `search.active`;
 - REST health summary.
 
+Do not record raw command lines, process arguments, environment variables, URLs, connection strings, bearer tokens, prompt-like arguments, or daemon status sections that contain drawer bodies.
+
 ## Restart procedure
 
 When restart is allowed or needed:
@@ -58,9 +60,10 @@ systemctl --user restart mempal-daemon.service
 sleep 3
 main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
 systemctl --user is-active mempal-daemon.service
-ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args
+ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm
 readlink "/proc/$main_pid/exe"
-pgrep -af '^/usr/local/bin/mempal (daemon --foreground|serve --mcp)$' || true
+printf 'daemon_processes=%s\n' "$(pgrep -fc '^/usr/local/bin/mempal daemon --foreground$' || true)"
+printf 'mcp_server_processes=%s\n' "$(pgrep -fc '^/usr/local/bin/mempal serve --mcp$' || true)"
 ```
 
 Pass criteria:
@@ -124,46 +127,78 @@ Use only when write-path validation is required.
    marker="mempal-smoke-$(date +%s)-$RANDOM"
    ```
 
-2. Ingest via stdin with a smoke scope:
+2. Ingest via stdin with a smoke scope, capture the response, and extract only top-level ID fields returned by ingest:
 
    ```bash
+   ingest_json="$(mktemp)"
+   smoke_ids="$(mktemp)"
    printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
-     | mempal ingest --stdin --format json --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json
-   ```
-
-3. Search only for the marker and parse IDs from JSON without printing content:
-
-   ```bash
-   mempal search "$marker" --top-k 5 --json > /tmp/mempal-smoke-search.json
-   python3 - <<'PY'
+     | mempal ingest --stdin --format json --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json \
+     > "$ingest_json"
+   python3 - "$ingest_json" > "$smoke_ids" <<'PY'
 import json
+import sys
 from pathlib import Path
-obj=json.loads(Path('/tmp/mempal-smoke-search.json').read_text() or '[]')
-ids=[]
-def walk(x):
-    if isinstance(x, dict):
-        for k,v in x.items():
-            if k in ('id','drawer_id','drawerId') and isinstance(v,(str,int)):
-                ids.append(str(v))
-            else:
-                walk(v)
-    elif isinstance(x, list):
-        for y in x:
-            walk(y)
-walk(obj)
-print('\n'.join(dict.fromkeys(ids)))
+
+obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
+ids = []
+drawer_id = obj.get("drawer_id")
+if isinstance(drawer_id, str) and drawer_id:
+    ids.append(drawer_id)
+drawer_ids = obj.get("drawer_ids")
+if isinstance(drawer_ids, list):
+    ids.extend(item for item in drawer_ids if isinstance(item, str) and item)
+for item in dict.fromkeys(ids):
+    print(item)
 PY
+   if [ ! -s "$smoke_ids" ]; then
+     echo "cleanup requires manual operator action: ingest response did not expose exact drawer ID(s)" >&2
+     rm -f "$ingest_json" "$smoke_ids"
+     exit 1
+   fi
    ```
 
-4. For each smoke ID, optionally test pin/unpin, then delete:
+   Do not print the ingest response or smoke IDs unless cleanup fails.
+
+3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, and never use search result IDs for deletion:
 
    ```bash
-   mempal pin "$id" || true
-   mempal unpin "$id" || true
-   mempal delete "$id"
+   verify_json="$(mktemp)"
+   mempal search "$marker" --top-k 5 --json > "$verify_json"
+   python3 - "$verify_json" "$marker" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+results = json.loads(Path(sys.argv[1]).read_text() or "[]")
+marker = sys.argv[2]
+matches = [
+    item for item in results
+    if isinstance(item, dict)
+    and item.get("wing") == "smoke"
+    and item.get("room") == "manual"
+    and marker in str(item.get("content", ""))
+]
+print(f"active_smoke_marker_matches={len(matches)}")
+PY
+   rm -f "$verify_json"
    ```
 
-5. Re-run marker search and confirm no active smoke drawer remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
+4. For each exact smoke ID from the ingest response, optionally test pin/unpin, then delete. Suppress command output so `mempal delete` cannot print drawer summaries:
+
+   ```bash
+   while IFS= read -r smoke_id; do
+     mempal pin "$smoke_id" >/dev/null || true
+     mempal unpin "$smoke_id" >/dev/null || true
+     if ! mempal delete "$smoke_id" >/dev/null; then
+       echo "cleanup failed for smoke drawer id: $smoke_id" >&2
+       exit 1
+     fi
+   done < "$smoke_ids"
+   rm -f "$ingest_json" "$smoke_ids"
+   ```
+
+5. Re-run the aggregate marker verification from step 3 and confirm no active `smoke/manual` marker match remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
 
 ## REST checks
 
@@ -186,7 +221,7 @@ Capture daemon memory before and after smoke:
 
 ```bash
 main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
-ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,args
+ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm
 mempal daemon status | awk '/^(memory\.|live_daemons:|extra_holders:|search\.active:|rest\.embedder_cache\.|embedder\.)/ {print}'
 ```
 


### PR DESCRIPTION
## Summary

- Expand the project-local mempal smoke-test skill into a full post-merge/manual validation playbook.
- Harden the smoke flow against duplicate daemon/DB holders, raw memory-content output, and unsafe cleanup of non-smoke drawers.
- Add structure-only capture guidance plus optional reversible write-smoke rules.

## Verification

- `git diff --check`
- precise staged secret scan for concrete secret values
- tier-4 CSA Codex exact-head review: `01KVQ9TANNQ1TPMXSE9BNEKAWE` PASS/CLEAN
- hook-enabled pre-push local gates: PASS (`local-gates 1340.93s`, `review-check 0.25s`)
