### PR TITLE
fix(resources): bound read-path sqlite and access writes

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -485,6 +485,7 @@ struct StatusResponse {
     embedder_cache: crate::embed::SharedEmbedderRuntimeSnapshot,
     search_mode: String,
     embedder_circuit: EmbedderCircuitStatus,
+    resource_usage: ResourceUsageStatus,
     write_queue: WriteQueueStats,
     feature_flags: FeatureFlags,
     hermes_compat_version: String,
@@ -495,6 +496,86 @@ struct StatusResponse {
     search_telemetry: SearchTelemetrySnapshot,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     status_warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResourceUsageStatus {
+    process: ProcessResourceUsageStatus,
+    sqlite: SqliteResourceUsageStatus,
+    counters: ResourceCounterStatus,
+}
+
+#[derive(Debug, Serialize)]
+struct ProcessResourceUsageStatus {
+    pid: i32,
+    rss_bytes: Option<u64>,
+    pss_bytes: Option<u64>,
+    private_dirty_bytes: Option<u64>,
+    anonymous_bytes: Option<u64>,
+    swap_bytes: Option<u64>,
+    io_read_bytes: Option<u64>,
+    io_write_bytes: Option<u64>,
+    io_cancelled_write_bytes: Option<u64>,
+}
+
+impl From<crate::process_diagnostics::ProcessMemoryReport> for ProcessResourceUsageStatus {
+    fn from(value: crate::process_diagnostics::ProcessMemoryReport) -> Self {
+        Self {
+            pid: value.pid,
+            rss_bytes: value.rss_bytes,
+            pss_bytes: value.pss_bytes,
+            private_dirty_bytes: value.private_dirty_bytes,
+            anonymous_bytes: value.anonymous_bytes,
+            swap_bytes: value.swap_bytes,
+            io_read_bytes: value.io_read_bytes,
+            io_write_bytes: value.io_write_bytes,
+            io_cancelled_write_bytes: value.io_cancelled_write_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct SqliteResourceUsageStatus {
+    async_pool_loaded: bool,
+    async_reader_connections: usize,
+    async_writer_connections: usize,
+    async_total_connections: usize,
+    per_connection_cache_kib: i64,
+    per_connection_cache_bytes: u64,
+    configured_page_cache_bytes: u64,
+    page_cache_budget_bytes: u64,
+}
+
+impl From<crate::core::async_db::AsyncDbResourceSnapshot> for SqliteResourceUsageStatus {
+    fn from(value: crate::core::async_db::AsyncDbResourceSnapshot) -> Self {
+        Self {
+            async_pool_loaded: true,
+            async_reader_connections: value.reader_connections,
+            async_writer_connections: value.writer_connections,
+            async_total_connections: value.total_connections,
+            per_connection_cache_kib: value.per_connection_cache_kib,
+            per_connection_cache_bytes: value.per_connection_cache_bytes,
+            configured_page_cache_bytes: value.configured_page_cache_bytes,
+            page_cache_budget_bytes: value.page_cache_budget_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ResourceCounterStatus {
+    access_writeback_scheduled_total: u64,
+    access_writeback_skipped_total: u64,
+    access_writeback_failed_total: u64,
+}
+
+impl From<crate::observability::ResourceCounterSnapshot> for ResourceCounterStatus {
+    fn from(value: crate::observability::ResourceCounterSnapshot) -> Self {
+        Self {
+            access_writeback_scheduled_total: value.access_writeback_scheduled_total,
+            access_writeback_skipped_total: value.access_writeback_skipped_total,
+            access_writeback_failed_total: value.access_writeback_failed_total,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1476,6 +1557,20 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
                 .to_string(),
         );
     }
+    let process_report =
+        crate::process_diagnostics::inspect_process_memory(std::process::id() as i32);
+    let sqlite_resource = state
+        .async_db_resource_snapshot()
+        .map(SqliteResourceUsageStatus::from)
+        .unwrap_or_else(|| SqliteResourceUsageStatus {
+            async_pool_loaded: false,
+            ..SqliteResourceUsageStatus::default()
+        });
+    let resource_usage = ResourceUsageStatus {
+        process: ProcessResourceUsageStatus::from(process_report),
+        sqlite: sqlite_resource,
+        counters: ResourceCounterStatus::from(crate::observability::resource_counters()),
+    };
 
     Ok(Json(StatusResponse {
         drawer_count: db_snapshot.drawer_count,
@@ -1530,6 +1625,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             .as_str()
             .to_string(),
         embedder_circuit: vector_search_circuit.into(),
+        resource_usage,
         write_queue: state.write_queue().stats(),
         feature_flags: FeatureFlags {
             typed_ingest: true,

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -4,12 +4,17 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::core::{AsyncDb, config::ConfigHandle, db::DbError};
+use crate::core::{
+    AsyncDb,
+    async_db::{AsyncDbResourceSnapshot, RESOURCE_BOUNDED_READERS},
+    config::ConfigHandle,
+    db::DbError,
+};
 use crate::embed::EmbedderFactory;
 use serde::Serialize;
 use tokio::sync::OnceCell;
 
-const API_ASYNC_DB_READERS: usize = 4;
+const API_ASYNC_DB_READERS: usize = RESOURCE_BOUNDED_READERS;
 const MAX_SLOW_SEARCHES: usize = 10;
 const SLOW_SEARCH_THRESHOLD: Duration = Duration::from_secs(1);
 
@@ -64,6 +69,10 @@ impl ApiState {
             .get_or_try_init(|| async move { AsyncDb::open(&db_path, API_ASYNC_DB_READERS) })
             .await
             .cloned()
+    }
+
+    pub(crate) fn async_db_resource_snapshot(&self) -> Option<AsyncDbResourceSnapshot> {
+        self.async_db.get().map(AsyncDb::resource_snapshot)
     }
 
     pub(crate) async fn run_read_anyhow_bounded<F, R>(

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -31,8 +31,10 @@
 //!   open `Transaction` is ever handed across calls.
 //! * A task holds at most one pooled connection at a time, so the pool can never
 //!   self-deadlock waiting on its own checkout.
-//! * `(n_read + 1) × 256 MiB` page cache stays under a 1.5 GiB cap (issue #311);
-//!   `mmap_size` stays `0`.
+//! * `(n_read + 1) × 16 MiB` page cache stays under a 256 MiB cap for
+//!   long-lived read paths (#525); high-throughput maintenance jobs opt into a
+//!   larger cache outside this pool.
+//! * `mmap_size` stays `0`.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
@@ -40,14 +42,29 @@ use std::time::Duration;
 
 use tokio::sync::Semaphore;
 
-use super::db::{Database, DbError, SQLITE_CACHE_SIZE_KIB_256_MIB};
+use super::db::{Database, DbError, SQLITE_CACHE_SIZE_KIB_DEFAULT};
 
 /// Hard cap on the aggregate SQLite page cache across all pooled connections.
 ///
-/// Each connection carries a 256 MiB cache ([`SQLITE_CACHE_SIZE_KIB_256_MIB`]);
-/// the default `n_read = 4` plus the writer is `5 × 256 MiB = 1.28 GiB`, well
-/// under this 1.5 GiB cap and far below issue #311's 4 GiB peak-memory budget.
-const PAGE_CACHE_BUDGET_MIB: i64 = 1536;
+/// Each long-lived connection carries a 16 MiB cache
+/// ([`SQLITE_CACHE_SIZE_KIB_DEFAULT`]). The default daemon/MCP/API pools use two
+/// readers plus one writer, so their configured resident page-cache ceiling is
+/// 48 MiB before SQLite and allocator overhead.
+const PAGE_CACHE_BUDGET_MIB: i64 = 256;
+
+/// Conservative production reader count for daemon/MCP/REST read pools.
+pub const RESOURCE_BOUNDED_READERS: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AsyncDbResourceSnapshot {
+    pub reader_connections: usize,
+    pub writer_connections: usize,
+    pub total_connections: usize,
+    pub per_connection_cache_kib: i64,
+    pub per_connection_cache_bytes: u64,
+    pub configured_page_cache_bytes: u64,
+    pub page_cache_budget_bytes: u64,
+}
 
 /// Bounded connection pool: a tokio [`Semaphore`] whose permit count equals the
 /// connection count, paired with the idle connections themselves. Acquiring a
@@ -58,6 +75,7 @@ struct ConnPool {
     idle: Mutex<Vec<Database>>,
     path: PathBuf,
     query_only: bool,
+    count: usize,
 }
 
 impl ConnPool {
@@ -73,6 +91,7 @@ impl ConnPool {
             idle: Mutex::new(idle),
             path: path.to_path_buf(),
             query_only,
+            count,
         })
     }
 
@@ -129,7 +148,7 @@ impl AsyncDb {
     /// least 1 so the read pool always has a connection to hand out.
     pub fn open(path: &Path, n_read: usize) -> Result<Self, DbError> {
         let n_read = n_read.max(1);
-        let per_conn_mib = (-SQLITE_CACHE_SIZE_KIB_256_MIB) / 1024;
+        let per_conn_mib = (-SQLITE_CACHE_SIZE_KIB_DEFAULT) / 1024;
         let conns = (n_read as i64) + 1;
         let requested_mib = conns * per_conn_mib;
         if requested_mib > PAGE_CACHE_BUDGET_MIB {
@@ -150,6 +169,23 @@ impl AsyncDb {
             #[cfg(any(test, feature = "db-test-seam"))]
             write_delay: None,
         })
+    }
+
+    pub fn resource_snapshot(&self) -> AsyncDbResourceSnapshot {
+        let reader_connections = self.readers.count;
+        let writer_connections = self.writer.count;
+        let total_connections = reader_connections + writer_connections;
+        let per_connection_cache_bytes = sqlite_cache_size_bytes(SQLITE_CACHE_SIZE_KIB_DEFAULT);
+        AsyncDbResourceSnapshot {
+            reader_connections,
+            writer_connections,
+            total_connections,
+            per_connection_cache_kib: SQLITE_CACHE_SIZE_KIB_DEFAULT,
+            per_connection_cache_bytes,
+            configured_page_cache_bytes: per_connection_cache_bytes
+                .saturating_mul(total_connections as u64),
+            page_cache_budget_bytes: (PAGE_CACHE_BUDGET_MIB as u64) * 1024 * 1024,
+        }
     }
 
     /// Inject a synthetic cold-read delay into every `run_read` (tests only).
@@ -232,6 +268,10 @@ impl AsyncDb {
         let delay: Option<Duration> = None;
         exec_anyhow(Arc::clone(&self.writer), delay, f).await
     }
+}
+
+fn sqlite_cache_size_bytes(cache_size_kib: i64) -> u64 {
+    cache_size_kib.unsigned_abs().saturating_mul(1024)
 }
 
 /// Execute `f` on a blocking thread over a connection borrowed from `pool`.
@@ -374,27 +414,34 @@ mod tests {
         );
     }
 
-    /// Every reader connection must enforce `query_only` and carry no `mmap`
-    /// (issue #311 RSS budget).
+    /// Every reader connection must enforce `query_only`, carry the low-RSS
+    /// cache profile, and carry no `mmap`.
     #[tokio::test]
-    async fn readers_are_query_only_without_mmap() {
+    async fn readers_are_query_only_low_cache_without_mmap() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let adb = AsyncDb::open(&tmp.path().join("palace.db"), 4).expect("open async db");
 
-        let (query_only, mmap_size): (i64, i64) = adb
+        let (query_only, cache_size, mmap_size): (i64, i64, i64) = adb
             .run_read(|db| {
                 let query_only = db
                     .conn()
                     .query_row("PRAGMA query_only", [], |row| row.get(0))?;
+                let cache_size = db
+                    .conn()
+                    .query_row("PRAGMA cache_size", [], |row| row.get(0))?;
                 let mmap_size = db
                     .conn()
                     .query_row("PRAGMA mmap_size", [], |row| row.get(0))?;
-                Ok((query_only, mmap_size))
+                Ok((query_only, cache_size, mmap_size))
             })
             .await
             .expect("read pragmas");
 
         assert_eq!(query_only, 1, "readers must be query_only");
+        assert_eq!(
+            cache_size, SQLITE_CACHE_SIZE_KIB_DEFAULT,
+            "long-lived read pools must use the low-RSS cache profile"
+        );
         assert_eq!(mmap_size, 0, "issue #311: pooled readers must not add mmap");
     }
 
@@ -417,21 +464,43 @@ mod tests {
     }
 
     /// Startup must reject a read pool whose aggregate page cache would blow the
-    /// issue #311 budget; the default-sized pool must be accepted.
+    /// long-lived process budget; the default-sized pool must be accepted.
     #[test]
     fn open_rejects_oversized_read_pool() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let path = tmp.path().join("palace.db");
 
-        // (n_read + 1) × 256 MiB: n_read = 5 ⇒ 6 conns ⇒ 1536 MiB == budget (ok).
-        AsyncDb::open(&path, 5).expect("at-budget pool opens");
+        // (n_read + 1) × 16 MiB: n_read = 15 ⇒ 16 conns ⇒ 256 MiB == budget.
+        AsyncDb::open(&path, 15).expect("at-budget pool opens");
 
-        // n_read = 6 ⇒ 7 conns ⇒ 1792 MiB > 1536 MiB budget (rejected before any
-        // connection is opened).
-        let result = AsyncDb::open(&path, 6);
+        // n_read = 16 ⇒ 17 conns ⇒ 272 MiB > 256 MiB budget.
+        let result = AsyncDb::open(&path, 16);
         assert!(
             matches!(result, Err(DbError::PoolCacheBudgetExceeded { .. })),
             "oversized pool must be rejected with PoolCacheBudgetExceeded"
+        );
+    }
+
+    #[test]
+    fn resource_snapshot_reports_configured_page_cache_budget() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let adb = AsyncDb::open(&tmp.path().join("palace.db"), RESOURCE_BOUNDED_READERS)
+            .expect("open async db");
+
+        let snapshot = adb.resource_snapshot();
+
+        assert_eq!(snapshot.reader_connections, RESOURCE_BOUNDED_READERS);
+        assert_eq!(snapshot.writer_connections, 1);
+        assert_eq!(snapshot.total_connections, RESOURCE_BOUNDED_READERS + 1);
+        assert_eq!(
+            snapshot.per_connection_cache_kib,
+            SQLITE_CACHE_SIZE_KIB_DEFAULT
+        );
+        assert_eq!(snapshot.per_connection_cache_bytes, 16 * 1024 * 1024);
+        assert_eq!(
+            snapshot.configured_page_cache_bytes,
+            48 * 1024 * 1024,
+            "daemon/MCP/API default async DB pool must stay well below old GiB-scale cache"
         );
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -37,6 +37,7 @@ const DEFAULT_SEARCH_PREVIEW_CHARS: usize = 120;
 const DEFAULT_SEARCH_TUNNEL_FANOUT_CAP: usize = 5;
 const DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP: usize = 8;
 const DEFAULT_SEARCH_TUNNEL_PENALTY: f32 = 0.7;
+const DEFAULT_SEARCH_RECORD_ACCESS: bool = false;
 const DEFAULT_SEARCH_DECAY_HALF_LIFE_DAYS: u64 = 90;
 const DEFAULT_SEARCH_DECAY_STEP_FULL_DAYS: u64 = 30;
 const DEFAULT_SEARCH_DECAY_STEP_REDUCED_WEIGHT: f64 = 0.5;
@@ -2302,6 +2303,12 @@ pub struct SearchConfig {
     pub bm25_fallback: bool,
     pub progressive_disclosure: bool,
     pub exclude_raw_turns: bool,
+    /// Persist search-hit access metadata (`last_accessed_at`/`access_count`).
+    ///
+    /// Disabled by default so read-only MCP/search/smoke probes do not produce
+    /// background SQLite writes or SSD churn (#526). Enable explicitly when
+    /// access-based salience feedback is worth the extra write IO.
+    pub record_access: bool,
     pub preview_chars: usize,
     pub tunnel_fanout_cap: usize,
     /// Maximum wing names shown per result in `tunnel_hints`. Excess entries are
@@ -2323,6 +2330,7 @@ impl Default for SearchConfig {
             bm25_fallback: DEFAULT_SEARCH_BM25_FALLBACK,
             progressive_disclosure: true,
             exclude_raw_turns: true,
+            record_access: DEFAULT_SEARCH_RECORD_ACCESS,
             preview_chars: DEFAULT_SEARCH_PREVIEW_CHARS,
             tunnel_fanout_cap: DEFAULT_SEARCH_TUNNEL_FANOUT_CAP,
             tunnel_hints_display_cap: DEFAULT_SEARCH_TUNNEL_HINTS_DISPLAY_CAP,
@@ -3171,9 +3179,23 @@ mod tests {
         assert_eq!(config.search.decay.half_life_days, 90);
         assert_eq!(config.search.decay.step_full_days, 30);
         assert_eq!(config.search.decay.step_reduced_weight, 0.5);
+        assert!(!config.search.record_access);
         assert!(!config.search.reranker.enabled);
         assert!(config.search.reranker.endpoint.is_none());
         assert!(config.search.reranker.model.is_none());
+    }
+
+    #[test]
+    fn search_record_access_is_explicit_opt_in() {
+        let config = Config::parse(
+            r#"
+            [search]
+            record_access = true
+            "#,
+        )
+        .expect("search record_access config should parse");
+
+        assert!(config.search.record_access);
     }
 
     #[test]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -43,6 +43,13 @@ use crate::ingest::novelty::NoveltyAction;
 pub const CURRENT_SCHEMA_VERSION: u32 = 20;
 pub const CURRENT_VECTOR_INDEX_VERSION: &str = "v2";
 pub const VECTOR_DISTANCE_METRIC: &str = "cosine";
+/// Default SQLite page cache budget for normal CLI/daemon/MCP connections.
+///
+/// Negative `PRAGMA cache_size` values are KiB. Keep the default small because
+/// read-only status/search probes can leave page-cache memory resident in
+/// long-lived daemon and MCP processes (#525). High-throughput maintenance
+/// paths that need a larger cache must opt in explicitly.
+pub(crate) const SQLITE_CACHE_SIZE_KIB_DEFAULT: i64 = -16_384;
 /// SQLite page cache budget for issue #311's large-DB stale reindex path.
 ///
 /// Negative `PRAGMA cache_size` values are KiB, so `-262144` is 256 MiB.
@@ -471,7 +478,7 @@ impl Database {
             OpenMode::ReadWrite => Connection::open(path)?,
         };
         conn.busy_timeout(busy_timeout)?;
-        conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_256_MIB)?;
+        conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_DEFAULT)?;
         register_math_functions(&conn)?;
         if mode.allows_write() {
             conn.pragma_update(None, "journal_mode", "WAL")?;
@@ -7311,7 +7318,7 @@ mod tests {
     }
 
     #[test]
-    fn database_connection_uses_256mib_cache_without_mmap() {
+    fn database_connection_uses_low_rss_cache_without_mmap() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
 
@@ -7324,7 +7331,7 @@ mod tests {
             .query_row("PRAGMA mmap_size", [], |row| row.get::<_, i64>(0))
             .expect("query mmap_size");
 
-        assert_eq!(cache_size, SQLITE_CACHE_SIZE_KIB_256_MIB);
+        assert_eq!(cache_size, SQLITE_CACHE_SIZE_KIB_DEFAULT);
         assert_eq!(mmap_size, 0, "issue #311 must not add multi-GiB mmap");
     }
 

--- a/src/daemon_bootstrap.rs
+++ b/src/daemon_bootstrap.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::bootstrap_events::BootstrapEvent;
 use crate::core::{
     AsyncDb,
+    async_db::RESOURCE_BOUNDED_READERS,
     config::{Config, ConfigHandle},
     db::Database,
     queue::AsyncPendingMessageStore,
@@ -301,7 +302,8 @@ fn open_daemon_storage_once(
     db_path: &Path,
 ) -> Result<(Database, AsyncDb, AsyncPendingMessageStore)> {
     let db = Database::open(db_path).context("failed to open daemon database")?;
-    let async_db = AsyncDb::open(db_path, 4).context("failed to open daemon async database")?;
+    let async_db = AsyncDb::open(db_path, RESOURCE_BOUNDED_READERS)
+        .context("failed to open daemon async database")?;
     let store = AsyncPendingMessageStore::new(db.path()).context("failed to open pending queue")?;
     Ok((db, async_db, store))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13748,6 +13748,7 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
         && let Ok(Some(status)) = block_on_result(fetch_daemon_status(&config.api.addr))
     {
         print_daemon_rest_embedder_cache(&status);
+        print_daemon_rest_resource_usage(&status);
         if let Some(telemetry) = status.get("search_telemetry") {
             print_daemon_search_telemetry(telemetry);
         }
@@ -13820,6 +13821,18 @@ fn print_daemon_process_report(pid: i32, prefix: &str) {
         "{prefix}memory.swap_bytes: {}",
         display_opt_u64(report.swap_bytes)
     );
+    println!(
+        "{prefix}io.read_bytes: {}",
+        display_opt_u64(report.io_read_bytes)
+    );
+    println!(
+        "{prefix}io.write_bytes: {}",
+        display_opt_u64(report.io_write_bytes)
+    );
+    println!(
+        "{prefix}io.cancelled_write_bytes: {}",
+        display_opt_u64(report.io_cancelled_write_bytes)
+    );
     if report.exe_deleted {
         println!(
             "{prefix}warning: daemon binary has been deleted or replaced; run `mempal daemon restart` after upgrade"
@@ -13888,6 +13901,55 @@ fn print_daemon_rest_embedder_cache(status: &Value) {
     );
 }
 
+#[cfg(feature = "rest")]
+fn print_daemon_rest_resource_usage(status: &Value) {
+    let Some(resource) = status.get("resource_usage") else {
+        return;
+    };
+    let process = resource.get("process").unwrap_or(&Value::Null);
+    println!(
+        "rest.resource.process.io_read_bytes: {}",
+        json_opt_u64(process, "io_read_bytes")
+    );
+    println!(
+        "rest.resource.process.io_write_bytes: {}",
+        json_opt_u64(process, "io_write_bytes")
+    );
+    let sqlite = resource.get("sqlite").unwrap_or(&Value::Null);
+    println!(
+        "rest.resource.sqlite.async_pool_loaded: {}",
+        sqlite
+            .get("async_pool_loaded")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    );
+    println!(
+        "rest.resource.sqlite.async_total_connections: {}",
+        json_u64(sqlite, "async_total_connections")
+    );
+    println!(
+        "rest.resource.sqlite.configured_page_cache_bytes: {}",
+        json_u64(sqlite, "configured_page_cache_bytes")
+    );
+    println!(
+        "rest.resource.sqlite.page_cache_budget_bytes: {}",
+        json_u64(sqlite, "page_cache_budget_bytes")
+    );
+    let counters = resource.get("counters").unwrap_or(&Value::Null);
+    println!(
+        "rest.resource.access_writeback_scheduled_total: {}",
+        json_u64(counters, "access_writeback_scheduled_total")
+    );
+    println!(
+        "rest.resource.access_writeback_skipped_total: {}",
+        json_u64(counters, "access_writeback_skipped_total")
+    );
+    println!(
+        "rest.resource.access_writeback_failed_total: {}",
+        json_u64(counters, "access_writeback_failed_total")
+    );
+}
+
 fn display_opt_u64(value: Option<u64>) -> String {
     value
         .map(|value| value.to_string())
@@ -13896,6 +13958,15 @@ fn display_opt_u64(value: Option<u64>) -> String {
 
 fn display_opt_usize(value: Option<usize>) -> String {
     value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+#[cfg(feature = "rest")]
+fn json_opt_u64(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
         .map(|value| value.to_string())
         .unwrap_or_else(|| "none".to_string())
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,6 +10,7 @@ use crate::context::assemble_context_with_vector;
 use crate::core::{
     AsyncDb,
     anchor::{self, DerivedAnchor},
+    async_db::RESOURCE_BOUNDED_READERS,
     config::{Config, ConfigHandle},
     db::{
         CURRENT_VECTOR_INDEX_VERSION, Database, NoveltyAuditInsert, VECTOR_DISTANCE_METRIC,
@@ -117,14 +118,15 @@ use super::tools::{
     LlmEndpointStatusDto, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
     OperationStatusRequest, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto,
     Phase3Request, Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
-    PinnedFactsResponse, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse, ReadDrawersRequest,
-    ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto, RetrievalScopeRequest,
+    PinnedFactsResponse, ProcessResourceUsageDto, QueueStatsDto, ReadDrawerRequest,
+    ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse, ResearchAdapterPlanDto,
+    ResearchIngestPlanDto, ResourceCounterDto, ResourceUsageDto, RetrievalScopeRequest,
     RetrievedKnowledgeCardDto, RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto,
     RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse,
     SearchResultDto, SkillDto, SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount,
-    StatusDetail, StatusRequest, StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto,
-    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
-    TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    SqliteResourceUsageDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
+    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
+    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
 fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool {
@@ -1200,7 +1202,7 @@ impl MempalMcpServer {
             .get_or_try_init(|| async move {
                 let display_path = db_path.display().to_string();
                 tokio::task::spawn_blocking(move || {
-                    AsyncDb::open(&db_path, 4).with_context(|| {
+                    AsyncDb::open(&db_path, RESOURCE_BOUNDED_READERS).with_context(|| {
                         format!("failed to open MCP async database pool for {display_path}")
                     })
                 })
@@ -3372,6 +3374,21 @@ impl MempalMcpServer {
         let llm_endpoint_label = |base_url: &str| {
             endpoint_policy_diagnostic_label(remote_call_policy, RemoteCallService::Llm, base_url)
         };
+        let process_report =
+            crate::process_diagnostics::inspect_process_memory(std::process::id() as i32);
+        let sqlite_resource = self
+            .async_db
+            .get()
+            .map(|db| SqliteResourceUsageDto::from(db.resource_snapshot()))
+            .unwrap_or_else(|| SqliteResourceUsageDto {
+                async_pool_loaded: false,
+                ..SqliteResourceUsageDto::default()
+            });
+        let resource_usage = ResourceUsageDto {
+            process: ProcessResourceUsageDto::from(process_report),
+            sqlite: sqlite_resource,
+            counters: ResourceCounterDto::from(crate::observability::resource_counters()),
+        };
 
         Ok(Json(StatusResponse {
             schema_version: db_snapshot.schema_version,
@@ -3509,6 +3526,7 @@ impl MempalMcpServer {
                 eta_secs: queue_stats.eta_secs,
             },
             db_holders,
+            resource_usage,
             scrub_stats: ScrubStatsDto::from(ConfigHandle::scrub_stats()),
             chunker_stats: ChunkerStatsDto::from(
                 crate::ingest::chunk::global_chunker_stats().snapshot(),
@@ -11109,6 +11127,17 @@ pattern_boost = 0.2
         assert_eq!(status.embed_status.failed_count, 1);
         assert!(json.get("endpoint_health").is_some());
         assert!(json.get("intelligence_status").is_some());
+        assert!(json.get("resource_usage").is_some());
+        assert!(status.resource_usage.sqlite.async_pool_loaded);
+        assert_eq!(
+            status.resource_usage.sqlite.per_connection_cache_bytes,
+            16 * 1024 * 1024
+        );
+        assert!(
+            status.resource_usage.sqlite.configured_page_cache_bytes
+                <= status.resource_usage.sqlite.page_cache_budget_bytes,
+            "compact status path must keep daemon/MCP SQLite cache within its configured budget"
+        );
         assert!(
             status
                 .system_warnings

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1970,6 +1970,10 @@ pub struct StatusResponse {
     /// `palace.db-shm` open, classified as current daemon/MCP server versus
     /// stale or extra holders.
     pub db_holders: DbHolderReport,
+    /// Aggregate, content-safe resource usage. Contains only process-level
+    /// counters and configured SQLite cache ceilings; never drawer content,
+    /// prompts, tokens, argv, or secret-bearing URLs.
+    pub resource_usage: ResourceUsageDto,
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,
@@ -1982,6 +1986,94 @@ pub struct StatusResponse {
     pub database_diagnostic: Option<DatabaseDiagnosticDto>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system_warnings: Vec<SystemWarning>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ResourceUsageDto {
+    pub process: ProcessResourceUsageDto,
+    pub sqlite: SqliteResourceUsageDto,
+    pub counters: ResourceCounterDto,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ProcessResourceUsageDto {
+    pub pid: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rss_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pss_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_dirty_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anonymous_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub swap_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_read_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_write_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_cancelled_write_bytes: Option<u64>,
+}
+
+impl From<crate::process_diagnostics::ProcessMemoryReport> for ProcessResourceUsageDto {
+    fn from(value: crate::process_diagnostics::ProcessMemoryReport) -> Self {
+        Self {
+            pid: value.pid,
+            rss_bytes: value.rss_bytes,
+            pss_bytes: value.pss_bytes,
+            private_dirty_bytes: value.private_dirty_bytes,
+            anonymous_bytes: value.anonymous_bytes,
+            swap_bytes: value.swap_bytes,
+            io_read_bytes: value.io_read_bytes,
+            io_write_bytes: value.io_write_bytes,
+            io_cancelled_write_bytes: value.io_cancelled_write_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct SqliteResourceUsageDto {
+    pub async_pool_loaded: bool,
+    pub async_reader_connections: usize,
+    pub async_writer_connections: usize,
+    pub async_total_connections: usize,
+    pub per_connection_cache_kib: i64,
+    pub per_connection_cache_bytes: u64,
+    pub configured_page_cache_bytes: u64,
+    pub page_cache_budget_bytes: u64,
+}
+
+impl From<crate::core::async_db::AsyncDbResourceSnapshot> for SqliteResourceUsageDto {
+    fn from(value: crate::core::async_db::AsyncDbResourceSnapshot) -> Self {
+        Self {
+            async_pool_loaded: true,
+            async_reader_connections: value.reader_connections,
+            async_writer_connections: value.writer_connections,
+            async_total_connections: value.total_connections,
+            per_connection_cache_kib: value.per_connection_cache_kib,
+            per_connection_cache_bytes: value.per_connection_cache_bytes,
+            configured_page_cache_bytes: value.configured_page_cache_bytes,
+            page_cache_budget_bytes: value.page_cache_budget_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ResourceCounterDto {
+    pub access_writeback_scheduled_total: u64,
+    pub access_writeback_skipped_total: u64,
+    pub access_writeback_failed_total: u64,
+}
+
+impl From<crate::observability::ResourceCounterSnapshot> for ResourceCounterDto {
+    fn from(value: crate::observability::ResourceCounterSnapshot) -> Self {
+        Self {
+            access_writeback_scheduled_total: value.access_writeback_scheduled_total,
+            access_writeback_skipped_total: value.access_writeback_skipped_total,
+            access_writeback_failed_total: value.access_writeback_failed_total,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::core::config::{Config, ConfigHandle};
@@ -20,6 +21,44 @@ const FOLLOW_DEBOUNCE_MS: u64 = 250;
 const FOLLOW_SILENCE_TIMEOUT_MS: u64 = 3_000;
 const PREVIEW_CHARS: usize = 120;
 const GATING_STATUS_RECENT_WINDOW_SECS: u64 = 86_400;
+
+static ACCESS_WRITEBACK_SCHEDULED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static ACCESS_WRITEBACK_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
+static ACCESS_WRITEBACK_FAILED_TOTAL: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct ResourceCounterSnapshot {
+    pub access_writeback_scheduled_total: u64,
+    pub access_writeback_skipped_total: u64,
+    pub access_writeback_failed_total: u64,
+}
+
+pub fn record_access_writeback_scheduled() {
+    ACCESS_WRITEBACK_SCHEDULED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_access_writeback_skipped() {
+    ACCESS_WRITEBACK_SKIPPED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn record_access_writeback_failed() {
+    ACCESS_WRITEBACK_FAILED_TOTAL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn resource_counters() -> ResourceCounterSnapshot {
+    ResourceCounterSnapshot {
+        access_writeback_scheduled_total: ACCESS_WRITEBACK_SCHEDULED_TOTAL.load(Ordering::Relaxed),
+        access_writeback_skipped_total: ACCESS_WRITEBACK_SKIPPED_TOTAL.load(Ordering::Relaxed),
+        access_writeback_failed_total: ACCESS_WRITEBACK_FAILED_TOTAL.load(Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+pub fn reset_resource_counters_for_tests() {
+    ACCESS_WRITEBACK_SCHEDULED_TOTAL.store(0, Ordering::Relaxed);
+    ACCESS_WRITEBACK_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
+    ACCESS_WRITEBACK_FAILED_TOTAL.store(0, Ordering::Relaxed);
+}
 
 pub struct TailOptions<'a> {
     pub limit: usize,

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -294,6 +294,12 @@ pub struct ProcessMemoryReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub swap_bytes: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_read_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_write_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub io_cancelled_write_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exe_path: Option<String>,
     pub exe_deleted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -594,6 +600,11 @@ fn inspect_process_memory_in_proc(pid: i32, proc_root: &Path) -> ProcessMemoryRe
         report.anonymous_bytes = parse_proc_kb_metric(&smaps, "Anonymous:");
         report.swap_bytes = parse_proc_kb_metric(&smaps, "Swap:");
     }
+    if let Ok(io) = fs::read_to_string(pid_dir.join("io")) {
+        report.io_read_bytes = parse_proc_byte_metric(&io, "read_bytes:");
+        report.io_write_bytes = parse_proc_byte_metric(&io, "write_bytes:");
+        report.io_cancelled_write_bytes = parse_proc_byte_metric(&io, "cancelled_write_bytes:");
+    }
     report
 }
 
@@ -603,6 +614,14 @@ fn parse_proc_kb_metric(contents: &str, label: &str) -> Option<u64> {
         let value = line.strip_prefix(label)?.trim();
         let kb = value.split_ascii_whitespace().next()?.parse::<u64>().ok()?;
         kb.checked_mul(1024)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_byte_metric(contents: &str, label: &str) -> Option<u64> {
+    contents.lines().find_map(|line| {
+        let value = line.strip_prefix(label)?.trim();
+        value.split_ascii_whitespace().next()?.parse::<u64>().ok()
     })
 }
 
@@ -1335,6 +1354,11 @@ mod tests {
                 "Rss: 2048 kB\nPss: 1536 kB\nPrivate_Dirty: 1024 kB\nAnonymous: 768 kB\nSwap: 256 kB\n",
             )
             .expect("write smaps");
+            fs::write(
+                pid_dir.join("io"),
+                "rchar: 100\nwchar: 200\nread_bytes: 4096\nwrite_bytes: 8192\ncancelled_write_bytes: 1024\n",
+            )
+            .expect("write io");
             symlink("/usr/local/bin/mempal (deleted)", pid_dir.join("exe")).expect("symlink exe");
 
             let report = inspect_process_memory_in_proc(321, proc_root);
@@ -1345,6 +1369,9 @@ mod tests {
             assert_eq!(report.private_dirty_bytes, Some(1_048_576));
             assert_eq!(report.anonymous_bytes, Some(786_432));
             assert_eq!(report.swap_bytes, Some(262_144));
+            assert_eq!(report.io_read_bytes, Some(4_096));
+            assert_eq!(report.io_write_bytes, Some(8_192));
+            assert_eq!(report.io_cancelled_write_bytes, Some(1_024));
             assert!(report.exe_deleted);
             assert_eq!(
                 report.exe_path.as_deref(),

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -854,24 +854,31 @@ pub fn dispatch_access_update(db_path: std::path::PathBuf, drawer_ids: Vec<Strin
     if drawer_ids.is_empty() {
         return;
     }
+    let config = crate::core::config::ConfigHandle::current();
+    if !config.search.record_access {
+        crate::observability::record_access_writeback_skipped();
+        return;
+    }
     use std::time::{SystemTime, UNIX_EPOCH};
     let now_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
-    let config = crate::core::config::ConfigHandle::current();
     let decay_rate = config.importance.decay_rate;
     let floor = config.importance.floor;
     let boost_cap = config.importance.boost_cap;
+    crate::observability::record_access_writeback_scheduled();
     tokio::task::spawn_blocking(move || match crate::core::db::Database::open(&db_path) {
         Ok(db) => {
             if let Err(err) =
                 db.update_access_fields_batch(&drawer_ids, now_ms, decay_rate, floor, boost_cap)
             {
+                crate::observability::record_access_writeback_failed();
                 tracing::warn!(error = %err, "access field update failed");
             }
         }
         Err(err) => {
+            crate::observability::record_access_writeback_failed();
             tracing::warn!(error = %err, "failed to open db for access update");
         }
     });
@@ -1943,6 +1950,7 @@ fn build_fts_match_query(query: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::config::{Config, ConfigHandle, SearchConfig};
     use crate::core::project::{ProjectSearchScope, SearchResultSource};
     use crate::core::types::{Drawer, RouteDecision, SearchResult, SourceType};
     use tempfile::TempDir;
@@ -2020,6 +2028,87 @@ mod tests {
 
     fn scoped_to_proj_a() -> ProjectSearchScope {
         ProjectSearchScope::from_request(Some("proj-a".to_string()), false, false, false)
+    }
+
+    fn access_count(db_path: &std::path::Path, drawer_id: &str) -> i64 {
+        let db = Database::open(db_path).expect("open db");
+        db.conn()
+            .query_row(
+                "SELECT COALESCE(access_count, 0) FROM drawers WHERE id = ?1",
+                [drawer_id],
+                |row| row.get(0),
+            )
+            .expect("read access count")
+    }
+
+    async fn configure_record_access(
+        dir: &std::path::Path,
+        db_path: &std::path::Path,
+        enabled: bool,
+    ) {
+        let config_path = dir.join("config.toml");
+        let config = Config {
+            db_path: db_path.to_string_lossy().into_owned(),
+            search: SearchConfig {
+                record_access: enabled,
+                ..SearchConfig::default()
+            },
+            ..Config::default()
+        };
+        config.save_to(&config_path).expect("save config");
+        ConfigHandle::bootstrap(&config_path).expect("bootstrap config");
+        ConfigHandle::harness_reload_from_path(&config_path);
+        crate::observability::reset_resource_counters_for_tests();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_access_update_skips_db_write_by_default() {
+        let lock = crate::core::config::global_config_test_lock();
+        let _guard = lock.lock().await;
+        let tmp = TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).expect("db");
+        let drawer = make_drawer("access-default", "alpha", "decision");
+        db.insert_drawer(&drawer).expect("insert drawer");
+        configure_record_access(tmp.path(), &db_path, false).await;
+
+        dispatch_access_update(db_path.clone(), vec![drawer.id.clone()]);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert_eq!(access_count(&db_path, &drawer.id), 0);
+        let counters = crate::observability::resource_counters();
+        assert_eq!(counters.access_writeback_skipped_total, 1);
+        assert_eq!(counters.access_writeback_scheduled_total, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_access_update_writes_only_when_opted_in() {
+        let lock = crate::core::config::global_config_test_lock();
+        let _guard = lock.lock().await;
+        let tmp = TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).expect("db");
+        let drawer = make_drawer("access-opt-in", "alpha", "decision");
+        db.insert_drawer(&drawer).expect("insert drawer");
+        configure_record_access(tmp.path(), &db_path, true).await;
+
+        dispatch_access_update(db_path.clone(), vec![drawer.id.clone()]);
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if access_count(&db_path, &drawer.id) == 1 {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "access writeback did not complete"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let counters = crate::observability::resource_counters();
+        assert_eq!(counters.access_writeback_scheduled_total, 1);
+        assert_eq!(counters.access_writeback_skipped_total, 0);
+        assert_eq!(counters.access_writeback_failed_total, 0);
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "a88f1f7dee1a0a8803a0b02704fda4b7ca190796"
+commit = "941316dcd04f524d57cd3cb01f03d113377fbc32"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Bound SQLite/cache behavior on read-oriented daemon, MCP, REST, and CLI paths to reduce daemon RSS and disk IO churn.
- Add content-safe process/resource diagnostics so operators can inspect aggregate cache/process metrics without printing memory content.
- Make search access writeback explicit opt-in instead of happening during ordinary read-only queries.

Fixes #526
Fixes #525

## Verification

- CSA Codex writer committed `89093e5fe149302e6b80f5dc538010d858a061fc` with worktree clean.
- Tier-4 CSA Codex exact-head review: `01KVQDWBYZBKTN8ZAA30KWY8NM` PASS/CLEAN.
- `csa review --check-verdict --session 01KVQDWBYZBKTN8ZAA30KWY8NM --range main...HEAD` passed.
- Hook-enabled pre-push local gates passed:
  - `local-gates 1382.89s`
  - `review-check 0.29s`
