### PR TITLE
fix(cli): use read-only db for CLI probes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3456,18 +3456,35 @@ fn run() -> Result<()> {
     if let Commands::Serve { mcp } = &cli.command {
         return block_on_result(serve_command(config.as_ref(), *mcp));
     }
+    if let Commands::FieldTaxonomy { format } = &cli.command {
+        return field_taxonomy_command(format);
+    }
+    if matches!(
+        &cli.command,
+        Commands::Bench {
+            command: BenchCommands::Matrix { .. }
+        }
+    ) {
+        let Commands::Bench { command } = cli.command else {
+            unreachable!("bench command preflight matched")
+        };
+        return block_on_result(bench_command(config.as_ref(), command));
+    }
 
     let db_path = expand_home(&config.db_path);
-    let dashboard_mode = is_dashboard_command(&cli.command);
-    if dashboard_mode && !db_path.exists() {
+    let read_only_database = command_uses_read_only_database(&cli.command);
+    if read_only_database {
+        validate_read_only_command_args(&cli.command)?;
+    }
+    if read_only_database && !db_path.exists() {
         bail!(
             "no palace.db found at {}; run `mempal init` first",
             display_path_for_user(&db_path)
         );
     }
 
-    let db = match if dashboard_mode {
-        open_dashboard_database(&db_path).context("failed to open dashboard database")
+    let db = match if read_only_database {
+        open_read_only_database(&db_path).context("failed to open read-only database")
     } else if command_retries_stdin_ingest_startup_open(&cli.command) {
         open_stdin_ingest_database_with_retry(&db_path)
     } else if command_retries_historical_rejudge_startup_open(&cli.command) {
@@ -4130,13 +4147,13 @@ fn run() -> Result<()> {
         Commands::Checkpoint { command } => {
             block_on_result(checkpoint_command(&db, config.as_ref(), command))
         }
-        Commands::Patterns { command } => patterns::run_command(config.as_ref(), command),
+        Commands::Patterns { command } => patterns::run_command(&db, command),
         Commands::Case { command } => case_skill::run_command(config.as_ref(), command),
         Commands::Foresight { command } => {
             foresight_cli::run_command(&db, config.as_ref(), command)
         }
-        Commands::Skills { command } => skills::run_command(config.as_ref(), command),
-        Commands::Repair { command } => repair_cli::run_command(config.as_ref(), command),
+        Commands::Skills { command } => skills::run_command(&db, config.as_ref(), command),
+        Commands::Repair { command } => repair_cli::run_command(&db, config.as_ref(), command),
         Commands::Xurl { command } => {
             block_on_result(xurl_ingest_command(&db, config.as_ref(), command))
         }
@@ -4251,16 +4268,79 @@ fn open_historical_rejudge_startup_database_with_retry(
     unreachable!("historical rejudge startup database retry loop returns on terminal attempt")
 }
 
-fn is_dashboard_command(command: &Commands) -> bool {
+fn command_uses_read_only_database(command: &Commands) -> bool {
     match command {
         Commands::Status { .. }
+        | Commands::Search { .. }
+        | Commands::Context { .. }
+        | Commands::WakeUp { .. }
         | Commands::Tail { .. }
         | Commands::Timeline { .. }
         | Commands::Stats { .. }
         | Commands::View { .. }
         | Commands::Reflect { .. }
         | Commands::Export { .. }
-        | Commands::Wiki { .. } => true,
+        | Commands::Wiki { .. }
+        | Commands::FactCheck { .. } => true,
+        Commands::Pinned { reorder, .. } => reorder.is_empty(),
+        Commands::Kg { command } => matches!(
+            command,
+            KgCommands::Query { .. }
+                | KgCommands::Timeline { .. }
+                | KgCommands::Stats
+                | KgCommands::List
+        ),
+        Commands::Knowledge { command } => {
+            matches!(
+                command,
+                KnowledgeCommands::Gate { .. } | KnowledgeCommands::Policy { .. }
+            )
+        }
+        Commands::KnowledgeCard { command } => matches!(
+            command,
+            KnowledgeCardCommands::Get { .. }
+                | KnowledgeCardCommands::List { .. }
+                | KnowledgeCardCommands::Retrieve { .. }
+                | KnowledgeCardCommands::Events { .. }
+                | KnowledgeCardCommands::Gate { .. }
+                | KnowledgeCardCommands::BackfillPlan { .. }
+                | KnowledgeCardCommands::BackfillApply { execute: false, .. }
+        ),
+        Commands::Cards {
+            pending,
+            approve,
+            reject,
+            ..
+        } => *pending && approve.is_none() && reject.is_none(),
+        Commands::Tunnels { command } => matches!(
+            command,
+            None | Some(TunnelCommands::List { .. }) | Some(TunnelCommands::Follow { .. })
+        ),
+        Commands::Taxonomy { command } => matches!(command, TaxonomyCommands::List),
+        Commands::Gating { command } => matches!(command, GatingCommands::Stats { .. }),
+        Commands::Checkpoint { command } => matches!(
+            command,
+            CheckpointCommands::Latest { .. }
+                | CheckpointCommands::Extract { .. }
+                | CheckpointCommands::Status
+                | CheckpointCommands::Cleanup { dry_run: true, .. }
+        ),
+        Commands::Patterns { command } => matches!(
+            command,
+            patterns::PatternsCommands::List { .. } | patterns::PatternsCommands::Show { .. }
+        ),
+        Commands::Skills { command } => matches!(
+            command,
+            skills::SkillsCommands::List { .. } | skills::SkillsCommands::Show { .. }
+        ),
+        Commands::Repair { .. } => true,
+        Commands::Xurl { command } => matches!(
+            command,
+            XurlCommands::Search { .. }
+                | XurlCommands::Timeline { .. }
+                | XurlCommands::Stats { .. }
+                | XurlCommands::Reindex { dry_run: true, .. }
+        ),
         Commands::Audit { command, .. } => {
             !matches!(command, Some(AuditCommands::Cleanup { dry_run: false, .. }))
         }
@@ -4268,11 +4348,28 @@ fn is_dashboard_command(command: &Commands) -> bool {
     }
 }
 
-fn open_dashboard_database(path: &Path) -> Result<Database> {
+fn validate_read_only_command_args(command: &Commands) -> Result<()> {
+    if let Commands::Xurl { command } = command {
+        match command {
+            XurlCommands::Search { since, .. }
+            | XurlCommands::Timeline { since, .. }
+            | XurlCommands::Stats { since, .. } => {
+                if let Some(since) = since {
+                    parse_since_to_epoch(since)?;
+                }
+            }
+            XurlCommands::Reindex { .. } => {}
+            XurlCommands::Ingest { .. } | XurlCommands::Backfill { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn open_read_only_database(path: &Path) -> Result<Database> {
     let db = Database::open_read_only(path)?;
     db.conn()
         .execute_batch("PRAGMA query_only = ON;")
-        .context("failed to enable query_only for dashboard connection")?;
+        .context("failed to enable query_only for read-only connection")?;
     Ok(db)
 }
 
@@ -4565,7 +4662,7 @@ fn prime_command(config_path: &Path, args: PrimeArgs) -> Result<()> {
         eprintln!("mempal: palace.db not found; skipping priming");
         return Ok(());
     }
-    let db = open_dashboard_database(&db_path).context("failed to open priming database")?;
+    let db = open_read_only_database(&db_path).context("failed to open priming database")?;
     let current_dir = env::current_dir().ok();
     let project_id =
         resolve_project_id(args.project_id.as_deref(), &config, current_dir.as_deref())

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -4,7 +4,6 @@ use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 
 use mempal::core::{
-    config::Config,
     db::Database,
     patterns::{
         get_pattern, list_patterns, patterns_table_exists, promote_pattern, retire_pattern,
@@ -45,11 +44,7 @@ pub enum PatternsCommands {
     },
 }
 
-pub fn run_command(config: &Config, command: PatternsCommands) -> Result<()> {
-    let db_path = mempal::core::utils::expand_home(&config.db_path);
-    let db = Database::open(std::path::Path::new(&db_path))
-        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
-
+pub fn run_command(db: &Database, command: PatternsCommands) -> Result<()> {
     if !patterns_table_exists(db.conn()) {
         bail!("patterns table not yet created — run `mempal init` to apply migrations");
     }
@@ -59,10 +54,10 @@ pub fn run_command(config: &Config, command: PatternsCommands) -> Result<()> {
             status,
             project,
             json,
-        } => cmd_list(&db, status.as_deref(), project.as_deref(), json),
-        PatternsCommands::Show { pattern_id, json } => cmd_show(&db, &pattern_id, json),
-        PatternsCommands::Retire { pattern_id } => cmd_retire(&db, &pattern_id),
-        PatternsCommands::Promote { pattern_id } => cmd_promote(&db, &pattern_id),
+        } => cmd_list(db, status.as_deref(), project.as_deref(), json),
+        PatternsCommands::Show { pattern_id, json } => cmd_show(db, &pattern_id, json),
+        PatternsCommands::Retire { pattern_id } => cmd_retire(db, &pattern_id),
+        PatternsCommands::Promote { pattern_id } => cmd_promote(db, &pattern_id),
     }
 }
 

--- a/src/repair_cli.rs
+++ b/src/repair_cli.rs
@@ -30,11 +30,7 @@ pub enum RepairCommands {
     },
 }
 
-pub fn run_command(config: &Config, command: RepairCommands) -> Result<()> {
-    let db_path = mempal::core::utils::expand_home(&config.db_path);
-    let db = Database::open(std::path::Path::new(&db_path))
-        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
-
+pub fn run_command(db: &Database, config: &Config, command: RepairCommands) -> Result<()> {
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
@@ -42,9 +38,9 @@ pub fn run_command(config: &Config, command: RepairCommands) -> Result<()> {
 
     match command {
         RepairCommands::List { wing, since, json } => {
-            cmd_list(&db, config, wing.as_deref(), since, json, now_ms)
+            cmd_list(db, config, wing.as_deref(), since, json, now_ms)
         }
-        RepairCommands::Show { topic_sig, json } => cmd_show(&db, config, &topic_sig, json, now_ms),
+        RepairCommands::Show { topic_sig, json } => cmd_show(db, config, &topic_sig, json, now_ms),
     }
 }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -91,11 +91,7 @@ pub enum SkillsCommands {
     },
 }
 
-pub fn run_command(config: &Config, command: SkillsCommands) -> Result<()> {
-    let db_path = mempal::core::utils::expand_home(&config.db_path);
-    let db = Database::open(std::path::Path::new(&db_path))
-        .with_context(|| format!("failed to open database at {}", db_path.display()))?;
-
+pub fn run_command(db: &Database, config: &Config, command: SkillsCommands) -> Result<()> {
     if !skills_table_exists(db.conn()) {
         bail!("skills table not yet created — run `mempal init` to apply migrations");
     }
@@ -105,21 +101,14 @@ pub fn run_command(config: &Config, command: SkillsCommands) -> Result<()> {
             status,
             project,
             json,
-        } => cmd_list(&db, status.as_deref(), project.as_deref(), json),
-        SkillsCommands::Show { skill_id, json } => cmd_show(&db, &skill_id, json),
+        } => cmd_list(db, status.as_deref(), project.as_deref(), json),
+        SkillsCommands::Show { skill_id, json } => cmd_show(db, &skill_id, json),
         SkillsCommands::Promote {
             pattern_id,
             name,
             trigger,
             project,
-        } => cmd_promote(
-            &db,
-            config,
-            &pattern_id,
-            &name,
-            &trigger,
-            project.as_deref(),
-        ),
+        } => cmd_promote(db, config, &pattern_id, &name, &trigger, project.as_deref()),
         SkillsCommands::Propose {
             from_cases,
             min_support,
@@ -129,7 +118,7 @@ pub fn run_command(config: &Config, command: SkillsCommands) -> Result<()> {
             json,
             dry_run,
         } => cmd_propose_from_cases(
-            &db,
+            db,
             config,
             ProposeFromCasesCliArgs {
                 from_cases,
@@ -141,9 +130,9 @@ pub fn run_command(config: &Config, command: SkillsCommands) -> Result<()> {
                 dry_run,
             },
         ),
-        SkillsCommands::Adopt { skill_id } => cmd_adopt(&db, config, &skill_id),
-        SkillsCommands::Reject { skill_id } => cmd_reject(&db, config, &skill_id),
-        SkillsCommands::Retire { skill_id } => cmd_retire(&db, &skill_id),
+        SkillsCommands::Adopt { skill_id } => cmd_adopt(db, config, &skill_id),
+        SkillsCommands::Reject { skill_id } => cmd_reject(db, config, &skill_id),
+        SkillsCommands::Retire { skill_id } => cmd_retire(db, &skill_id),
     }
 }
 

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -525,6 +525,65 @@ fn test_observability_subcommands_readonly() {
 }
 
 #[test]
+fn test_readonly_cli_probes_tolerate_active_db_holder() {
+    let env = DashboardEnv::new();
+    let holder = rusqlite::Connection::open(&env.db_path).expect("open holder");
+    holder
+        .busy_timeout(Duration::ZERO)
+        .expect("holder fail-fast timeout");
+    holder
+        .execute_batch("BEGIN EXCLUSIVE;")
+        .expect("hold controlled write transaction");
+
+    let old_style_open = Database::open_with_busy_timeout(&env.db_path, Duration::ZERO);
+    assert!(
+        old_style_open.is_err(),
+        "controlled holder must block write-mode startup so the regression is meaningful"
+    );
+
+    let probes: [(&str, &[&str]); 12] = [
+        ("status", &["status"]),
+        ("pinned", &["pinned", "--json"]),
+        ("kg_stats", &["kg", "stats"]),
+        (
+            "knowledge_card_list",
+            &["knowledge-card", "list", "--format", "json"],
+        ),
+        ("cards_pending", &["cards", "--pending", "--format", "json"]),
+        ("wake_up", &["wake-up", "--format", "protocol"]),
+        ("field_taxonomy", &["field-taxonomy", "--format", "json"]),
+        ("checkpoint_status", &["checkpoint", "status"]),
+        ("repair_list", &["repair", "list", "--json"]),
+        ("xurl_stats", &["xurl", "stats", "--json"]),
+        ("bench_matrix", &["bench", "matrix", "--format", "json"]),
+        (
+            "search",
+            &["search", "lock probe", "--top-k", "3", "--json"],
+        ),
+    ];
+
+    for (label, args) in probes {
+        let output = run_mempal(&env.home, env.cwd(), args);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let lock_error =
+            stderr.contains("database is locked") || stderr.contains("database file is locked");
+        assert!(
+            output.status.success(),
+            "read-only probe {label} failed under active DB holder; lock_error={lock_error}; status={}",
+            output.status
+        );
+        assert!(
+            !lock_error,
+            "read-only probe {label} reported a SQLite lock under active DB holder"
+        );
+    }
+
+    holder
+        .execute_batch("ROLLBACK;")
+        .expect("release controlled write transaction");
+}
+
+#[test]
 fn test_stats_shows_all_sections() {
     let env = DashboardEnv::new();
     insert_drawer(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "941316dcd04f524d57cd3cb01f03d113377fbc32"
+commit = "0d2031c49119bb2576fd1a8a044217edd73b016b"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Route read-only CLI probes through read-only SQLite connections with `query_only` enabled.
- Let DB-free probes avoid opening `palace.db` during startup.
- Reuse the startup-selected `Database` for patterns, skills, and repair CLI handlers so they cannot bypass read-only mode.
- Add regression coverage for an active DB holder across status/search and issue-listed probes.

Fixes #524

## Verification

- CSA Codex writer committed `2c062adf89095526333139a13a827d351f4aca83` with worktree clean.
- Tier-4 CSA Codex exact-head review: `01KVQHYD43BQ2C592EXBCHTZTG` PASS/CLEAN.
- `csa review --check-verdict --session 01KVQHYD43BQ2C592EXBCHTZTG --range main...HEAD` passed.
- Hook-enabled pre-push local gates passed:
  - `local-gates 1214.91s`
  - `review-check 0.15s`
