### PR TITLE
fix(cli): separate cleanup-safe created ids

### DIFF
--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -212,13 +212,13 @@ Use only when write-path validation is required.
    marker="mempal-smoke-$(date +%s)-$RANDOM"
    ```
 
-2. Ingest via stdin with a smoke scope, capture the response, and extract only top-level ID fields returned by ingest:
+2. Ingest via stdin with a smoke scope, capture the response, and extract only cleanup-safe IDs explicitly returned by ingest:
 
    ```bash
    ingest_json="$(mktemp)"
    smoke_ids="$(mktemp)"
    printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
-     | mempal ingest --stdin --format json --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json \
+     | mempal ingest --stdin --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json \
      > "$ingest_json"
    python3 - "$ingest_json" > "$smoke_ids" <<'PY'
 import json
@@ -227,23 +227,20 @@ from pathlib import Path
 
 obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
 ids = []
-drawer_id = obj.get("drawer_id")
-if isinstance(drawer_id, str) and drawer_id:
-    ids.append(drawer_id)
-drawer_ids = obj.get("drawer_ids")
+drawer_ids = obj.get("created_drawer_ids")
 if isinstance(drawer_ids, list):
     ids.extend(item for item in drawer_ids if isinstance(item, str) and item)
 for item in dict.fromkeys(ids):
     print(item)
 PY
    if [ ! -s "$smoke_ids" ]; then
-     echo "cleanup requires manual operator action: ingest response did not expose exact drawer ID(s)" >&2
+     echo "cleanup requires manual operator action: ingest response did not expose created_drawer_ids; do not delete drawer_id, drawer_ids, or cleanup_drawer_ids" >&2
      rm -f "$ingest_json" "$smoke_ids"
      exit 1
    fi
    ```
 
-   Do not print the ingest response or smoke IDs unless cleanup fails.
+   Do not print the ingest response or smoke IDs unless cleanup fails. `created_drawer_ids` is the cleanup authority; `cleanup_drawer_ids` is only a human-readable alias when it mirrors the created list. `drawer_id` and `drawer_ids` are informational because they may name pre-existing, deduplicated, dropped, or merge-target drawers. If the ingest response timed out and returned only an `operation_id`, inspect it with `mempal operation wait <operation_id> --timeout-secs <seconds>` or `mempal operation status <operation_id>`, then delete only IDs from `created_drawer_ids`; if that list is empty, fail closed.
 
 3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, never print search result bodies/snippets, and never use search result IDs for deletion:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5009,6 +5009,9 @@ impl ResolvedStdinIngest {
 
 #[derive(Serialize)]
 struct StdinIngestJsonOutput<'a> {
+    drawer_id: &'a str,
+    created_drawer_ids: &'a [String],
+    cleanup_drawer_ids: &'a [String],
     drawer_ids: &'a [String],
     stats: StdinIngestStatsJson,
 }
@@ -5369,7 +5372,12 @@ async fn ingest_stdin_command(
             Some(IngestOperationState::Completed) => {
                 append_ingest_stdin_audit_log(db, &resolved.wing, false, &record, &wait_stats)
                     .context("failed to append ingest audit log")?;
-                print_stdin_ingest_output(options.json, false, &wait_stats)?;
+                print_stdin_ingest_output_with_created_ids(
+                    options.json,
+                    false,
+                    &wait_stats,
+                    &response.created_drawer_ids,
+                )?;
                 return Ok(());
             }
             Some(IngestOperationState::Rejected) => {
@@ -5564,10 +5572,16 @@ async fn ingest_stdin_command(
     }
 
     stats.chunks = 1;
+    let created_drawer_ids = vec![drawer_id.clone()];
     stats.drawer_ids.push(drawer_id);
     append_ingest_stdin_audit_log(db, &resolved.wing, options.dry_run, &record, &stats)
         .context("failed to append ingest audit log")?;
-    print_stdin_ingest_output(options.json, options.dry_run, &stats)?;
+    print_stdin_ingest_output_with_created_ids(
+        options.json,
+        options.dry_run,
+        &stats,
+        &created_drawer_ids,
+    )?;
     Ok(())
 }
 
@@ -5591,9 +5605,23 @@ fn normalize_stdin_content(content: &str, no_strip_noise: bool) -> Result<String
 }
 
 fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> Result<()> {
+    print_stdin_ingest_output_with_created_ids(json, dry_run, stats, &[])
+}
+
+fn print_stdin_ingest_output_with_created_ids(
+    json: bool,
+    dry_run: bool,
+    stats: &IngestStats,
+    created_drawer_ids: &[String],
+) -> Result<()> {
     print_fact_check_warnings(&stats.fact_check_warnings);
     if json {
+        let cleanup_drawer_ids =
+            cleanup_drawer_ids_for_stdin_output_from_created(dry_run, stats, created_drawer_ids);
         let output = StdinIngestJsonOutput {
+            drawer_id: cleanup_drawer_ids.first().map(String::as_str).unwrap_or(""),
+            created_drawer_ids: cleanup_drawer_ids,
+            cleanup_drawer_ids,
             drawer_ids: &stats.drawer_ids,
             stats: StdinIngestStatsJson {
                 dry_run,
@@ -5625,6 +5653,18 @@ fn print_stdin_ingest_output(json: bool, dry_run: bool, stats: &IngestStats) -> 
     Ok(())
 }
 
+fn cleanup_drawer_ids_for_stdin_output_from_created<'a>(
+    dry_run: bool,
+    stats: &IngestStats,
+    created_drawer_ids: &'a [String],
+) -> &'a [String] {
+    if dry_run || stats.chunks == 0 || stats.skipped > 0 || stats.dropped_by_gate > 0 {
+        &[]
+    } else {
+        created_drawer_ids
+    }
+}
+
 fn print_fact_check_warnings(warnings: &[String]) {
     for warning in warnings {
         eprintln!("{warning}");
@@ -5644,6 +5684,16 @@ fn print_operation_response(response: &IngestResponse) -> Result<()> {
     println!("drawer_id={}", response.drawer_id);
     if !response.drawer_ids.is_empty() {
         println!("drawer_ids={}", response.drawer_ids.join(","));
+    }
+    if !response.created_drawer_ids.is_empty() {
+        println!(
+            "created_drawer_ids={}",
+            response.created_drawer_ids.join(",")
+        );
+        println!(
+            "cleanup_drawer_ids={}",
+            response.created_drawer_ids.join(",")
+        );
     }
     println!("chunk_count={}", response.chunk_count);
     println!("dropped={}", response.dropped);
@@ -5674,11 +5724,7 @@ fn ingest_stdin_wait_stats_from_response(response: &IngestResponse) -> IngestSta
         dropped_by_gate: if response.dropped { 1 } else { 0 },
         ..IngestStats::default()
     };
-    stats.drawer_ids = if response.drawer_ids.is_empty() && !response.drawer_id.is_empty() {
-        vec![response.drawer_id.clone()]
-    } else {
-        response.drawer_ids.clone()
-    };
+    stats.drawer_ids = response.drawer_ids.clone();
     stats.fact_check_warnings = response.fact_check_warnings.clone();
     stats.superseded_drawer_id = response.superseded_drawer_id.clone();
     stats

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -922,6 +922,7 @@ impl MempalMcpServer {
                 if matches!(state, IngestOperationState::Rejected) {
                     response.drawer_id.clear();
                     response.drawer_ids.clear();
+                    response.created_drawer_ids.clear();
                 }
                 let mut finalized = finalize_ingest_response(
                     claim.id.clone(),
@@ -4744,6 +4745,7 @@ impl MempalMcpServer {
                 timed_out: false,
                 drawer_id: String::new(),
                 drawer_ids: Vec::new(),
+                created_drawer_ids: Vec::new(),
                 chunk_count: 0,
                 dropped: false,
                 gating_decision: None,
@@ -4836,6 +4838,7 @@ impl MempalMcpServer {
             timed_out: false,
             drawer_id: String::new(),
             drawer_ids: Vec::new(),
+            created_drawer_ids: Vec::new(),
             chunk_count: 0,
             dropped: false,
             gating_decision: None,
@@ -5142,6 +5145,7 @@ impl MempalMcpServer {
                 timed_out: false,
                 drawer_id: String::new(),
                 drawer_ids: Vec::new(),
+                created_drawer_ids: Vec::new(),
                 chunk_count: 0,
                 dropped: false,
                 gating_decision: None,
@@ -6032,6 +6036,7 @@ impl MempalMcpServer {
         Ok(Json(IngestResponse {
             drawer_id: response_drawer_id,
             drawer_ids: inserted_drawer_ids,
+            created_drawer_ids: newly_created_drawer_ids,
             chunk_count: chunks.len(),
             dropped: false,
             gating_decision,
@@ -9462,6 +9467,7 @@ fn finalize_failed_ingest_response(
             timed_out: false,
             drawer_id: String::new(),
             drawer_ids: Vec::new(),
+            created_drawer_ids: Vec::new(),
             chunk_count: 0,
             dropped: false,
             gating_decision: None,
@@ -9504,6 +9510,7 @@ fn operation_record_to_response(
         if !matches!(state, IngestOperationState::Completed) {
             response.drawer_id.clear();
             response.drawer_ids.clear();
+            response.created_drawer_ids.clear();
         }
         response.rejected_reason = record.rejected_reason.or(response.rejected_reason);
         response.failure_detail = record.failure_detail.or(response.failure_detail);
@@ -9522,6 +9529,7 @@ fn operation_record_to_response(
             String::new()
         },
         drawer_ids: Vec::new(),
+        created_drawer_ids: Vec::new(),
         chunk_count: 0,
         dropped: matches!(state, IngestOperationState::Rejected),
         gating_decision: None,
@@ -13750,8 +13758,13 @@ pattern_boost = 0.2
         let first = ingest_manual(&server, "idempotent exact fact", None, None, None).await;
         let second = ingest_manual(&server, "idempotent exact fact", None, None, None).await;
 
+        assert_eq!(first.created_drawer_ids, vec![first.drawer_id.clone()]);
         assert_eq!(second.drawer_id, first.drawer_id);
         assert_eq!(second.drawer_ids, vec![first.drawer_id.clone()]);
+        assert!(
+            second.created_drawer_ids.is_empty(),
+            "deduplicated queued completion must not expose cleanup-safe IDs for existing drawer"
+        );
         let db = Database::open(&db_path).expect("open db");
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1857,15 +1857,19 @@ pub struct IngestResponse {
     /// `mempal_operation_status`.
     #[serde(default, skip_serializing_if = "is_false")]
     pub timed_out: bool,
-    /// ID of the first (or only) drawer created once the ingest completes.
-    /// Empty while queued/running and for rejection/failure outcomes without
-    /// stored drawers.
+    /// Primary outcome drawer for status display. This can identify an existing
+    /// dedup, novelty drop, or merge target, so callers must not use it as a
+    /// deletion or cleanup authority.
     pub drawer_id: String,
-    /// All drawer IDs created by this ingest (one per chunk). When content
-    /// fits in a single chunk, this contains exactly one element matching
-    /// `drawer_id`. Empty while queued/running and when `dropped` is true.
+    /// Operation-scoped drawer IDs reported by the ingest result (one per
+    /// inserted, deduplicated, dropped, or merged target chunk). These are
+    /// informational affected/result IDs and are not deletion authority.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub drawer_ids: Vec<String>,
+    /// Drawer IDs newly created by this operation. This is the only response
+    /// list safe for cleanup/delete automation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub created_drawer_ids: Vec<String>,
     /// Number of chunks the content was split into. Always >= 1 for
     /// successful ingests; 0 while queued/running, during dry-run previews,
     /// and when `dropped` is true.

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -591,6 +591,11 @@ async fn test_high_similarity_candidate_dropped() {
 
     assert_eq!(drawer_count(&env.db_path), 2);
     assert_eq!(response.drawer_id, "existing-proj-a");
+    assert_eq!(response.drawer_ids, Vec::<String>::new());
+    assert!(
+        response.created_drawer_ids.is_empty(),
+        "novelty drop must not expose cleanup-safe IDs for existing target"
+    );
     assert_eq!(
         response.novelty_action,
         Some(mempal::ingest::novelty::NoveltyAction::Drop)
@@ -634,6 +639,10 @@ async fn test_low_similarity_candidate_inserted() {
         response.novelty_action,
         Some(mempal::ingest::novelty::NoveltyAction::Insert)
     );
+    assert_eq!(
+        response.created_drawer_ids,
+        vec![response.drawer_id.clone()]
+    );
     assert_eq!(response.near_drawer_id, None);
     let audits = novelty_rows(&env.db_path);
     assert_eq!(audits.len(), 1);
@@ -663,6 +672,11 @@ async fn test_medium_similarity_candidate_merged() {
 
     assert_eq!(drawer_count(&env.db_path), 1);
     assert_eq!(response.drawer_id, "existing");
+    assert_eq!(response.drawer_ids, Vec::<String>::new());
+    assert!(
+        response.created_drawer_ids.is_empty(),
+        "novelty merge must not expose cleanup-safe IDs for existing target"
+    );
     assert_eq!(
         response.novelty_action,
         Some(mempal::ingest::novelty::NoveltyAction::Merge)

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -11,7 +11,7 @@ use common::harness::embed_mock::start as start_embed_mock;
 use mempal::core::config::{Config, ConfigHandle};
 use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
-use mempal::core::types::Triple;
+use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType, Triple};
 use mempal::core::utils::build_triple_id;
 use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
 use rmcp::handler::server::wrapper::Parameters;
@@ -235,6 +235,100 @@ fn print_lines(output: &Output) -> (String, String) {
         String::from_utf8_lossy(&output.stdout).to_string(),
         String::from_utf8_lossy(&output.stderr).to_string(),
     )
+}
+
+fn cleanup_ids_from_ingest_json(json: &Value) -> Vec<String> {
+    let cleanup_key = if json.get("cleanup_drawer_ids").is_some() {
+        "cleanup_drawer_ids"
+    } else {
+        "created_drawer_ids"
+    };
+    let ids = json[cleanup_key]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned);
+    ids.into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn cleanup_ids_from_operation_stdout(stdout: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    for line in stdout.lines() {
+        if let Some(raw_ids) = line
+            .strip_prefix("cleanup_drawer_ids=")
+            .or_else(|| line.strip_prefix("created_drawer_ids="))
+        {
+            ids.extend(
+                raw_ids
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(ToOwned::to_owned),
+            );
+        }
+    }
+    ids.into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn delete_cleanup_ids(home: &Path, drawer_ids: &[String]) {
+    assert!(!drawer_ids.is_empty(), "cleanup ids must not be empty");
+    for drawer_id in drawer_ids {
+        let delete_output = run_cli(home, &["delete", drawer_id]);
+        assert!(
+            delete_output.status.success(),
+            "delete {drawer_id} must succeed, stdout={}, stderr={}",
+            String::from_utf8_lossy(&delete_output.stdout),
+            String::from_utf8_lossy(&delete_output.stderr)
+        );
+    }
+}
+
+fn insert_existing_drawer(home: &Path, drawer_id: &str) {
+    let db = Database::open(&home.join(".mempal/palace.db")).expect("open db");
+    let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
+        id: drawer_id.to_string(),
+        content: "existing novelty target".to_string(),
+        wing: "smoke".to_string(),
+        room: Some("manual".to_string()),
+        source_file: Some("test://existing-novelty-target".to_string()),
+        source_type: SourceType::AgentInference,
+        added_at: "1713000000".to_string(),
+        chunk_index: Some(0),
+        importance: 0,
+    });
+    db.insert_drawer(&drawer).expect("insert existing drawer");
+}
+
+#[test]
+fn test_operation_stdout_cleanup_ids_ignore_informational_drawer_id_without_created_list() {
+    let home = setup_home();
+    let existing_id = "existing-novelty-target";
+    insert_existing_drawer(home.path(), existing_id);
+    let stdout = format!(
+        "operation_id=op\nstate=completed\ntimed_out=false\ndrawer_id={existing_id}\ndrawer_ids={existing_id}\nchunk_count=1\ndropped=false\ntimings={{}}\n"
+    );
+
+    let cleanup_ids = cleanup_ids_from_operation_stdout(&stdout);
+    assert!(
+        cleanup_ids.is_empty(),
+        "lone operation drawer_id must not be treated as cleanup-safe: {stdout}"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.get_drawer(existing_id)
+            .expect("get existing novelty target")
+            .is_some(),
+        "existing novelty target must remain present when no cleanup ids are exposed"
+    );
 }
 
 fn novelty_audit_count(home: &Path) -> i64 {
@@ -523,6 +617,95 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
         drawer_ids.iter().all(|value| value.as_str().is_some()),
         "drawer_ids must contain strings"
     );
+    assert_eq!(
+        wait_json["cleanup_drawer_ids"], wait_json["created_drawer_ids"],
+        "cleanup_drawer_ids must mirror newly-created cleanup authority"
+    );
+    assert_eq!(
+        wait_json["drawer_id"], drawer_ids[0],
+        "top-level drawer_id must identify the same fresh drawer reported in created_drawer_ids"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_json_cleanup_ids_delete_exact_drawers() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _config = write_config(home.path(), &format!("http://{addr}/v1"));
+    let wait_timeout = u64::MAX.to_string();
+    let payload = br#"{"content":"cli wait cleanup-safe drawer id content"}"#;
+
+    let output = run_cli_with_stdin(
+        home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "smoke",
+            "--room",
+            "manual",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+            "--json",
+        ],
+        payload,
+    );
+    handle.shutdown().await;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("parse wait JSON");
+    assert_eq!(stdout["stats"]["chunks"], 1);
+    assert_eq!(
+        stdout["cleanup_drawer_ids"], stdout["created_drawer_ids"],
+        "cleanup_drawer_ids must match newly-created drawer ids"
+    );
+    let cleanup_ids = cleanup_ids_from_ingest_json(&stdout);
+    assert_eq!(
+        cleanup_ids.len(),
+        1,
+        "stdin wait JSON must expose exactly one cleanup-safe drawer id: {stdout}"
+    );
+    assert_eq!(
+        stdout["drawer_id"].as_str(),
+        cleanup_ids.first().map(String::as_str)
+    );
+    assert_eq!(
+        stdout["drawer_ids"][0].as_str(),
+        cleanup_ids.first().map(String::as_str)
+    );
+
+    let db_path = home.path().join(".mempal/palace.db");
+    let db = Database::open(&db_path).expect("open db");
+    for drawer_id in &cleanup_ids {
+        assert!(
+            db.get_drawer(drawer_id)
+                .expect("get cleanup drawer")
+                .is_some(),
+            "reported cleanup id must identify an active drawer"
+        );
+    }
+    drop(db);
+
+    delete_cleanup_ids(home.path(), &cleanup_ids);
+
+    let db = Database::open(&db_path).expect("reopen db");
+    for drawer_id in &cleanup_ids {
+        assert!(
+            db.get_drawer(drawer_id)
+                .expect("get deleted cleanup drawer")
+                .is_none(),
+            "reported cleanup id must be deletable by mempal delete"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -606,6 +789,10 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
             .contains_key("drawer_ids"),
         "timed-out receipt must not report drawer ids: {stdout}"
     );
+    assert!(
+        cleanup_ids_from_ingest_json(&stdout).is_empty(),
+        "timed-out receipt must not expose cleanup ids: {stdout}"
+    );
     let queued = PendingMessageStore::new_without_reclaim(&db_path)
         .operation_status(&operation_id)
         .expect("load queued status")
@@ -638,6 +825,11 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
         recovery_stderr.contains("waiting for operation_id="),
         "{recovery_stderr}"
     );
+    let recovery_ids = cleanup_ids_from_operation_stdout(&recovery_stdout);
+    assert!(
+        !recovery_ids.is_empty(),
+        "operation wait recovery must expose exact cleanup ids: {recovery_stdout}"
+    );
     let completed = PendingMessageStore::new_without_reclaim(&db_path)
         .operation_status(&operation_id)
         .expect("load completed status")
@@ -645,6 +837,18 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
     assert_eq!(completed.op_state, "completed");
     let db = Database::open(&db_path).expect("open db");
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    drop(db);
+
+    delete_cleanup_ids(home.path(), &recovery_ids);
+    let db = Database::open(&db_path).expect("reopen db");
+    for drawer_id in &recovery_ids {
+        assert!(
+            db.get_drawer(drawer_id)
+                .expect("get deleted recovery drawer")
+                .is_none(),
+            "operation wait cleanup id must be deletable"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -961,6 +1165,21 @@ async fn test_ingest_wait_exact_duplicate_matches_non_wait_plain_and_json_output
                     .len(),
                 1
             );
+            assert!(
+                direct_json["cleanup_drawer_ids"]
+                    .as_array()
+                    .expect("cleanup drawer ids")
+                    .is_empty(),
+                "exact duplicates must not expose cleanup ids for pre-existing drawers"
+            );
+            assert!(
+                direct_json["created_drawer_ids"]
+                    .as_array()
+                    .expect("created drawer ids")
+                    .is_empty(),
+                "exact duplicates must not expose created ids for pre-existing drawers"
+            );
+            assert_eq!(direct_json["drawer_id"], "");
         } else {
             assert_eq!(
                 String::from_utf8_lossy(&wait_output.stdout),

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "0d2031c49119bb2576fd1a8a044217edd73b016b"
+commit = "d8ed4a169f0f5de45fe0d8c91dfc13d44e7ed0c3"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Separate cleanup-safe `created_drawer_ids` / `cleanup_drawer_ids` from informational `drawer_id` and affected `drawer_ids`.
- Ensure stdin ingest wait/status cleanup never deletes deduplicated or pre-existing drawers.
- Update smoke-test guidance and regression coverage for cleanup-safe reversible writes.

Fixes #530

## Verification

- CSA Codex exact-head review PASS/CLEAN: `01KVQT6P9HT42HXTB6S1D7AV9C`
- `csa review --check-verdict --sa-mode true --session 01KVQT6P9HT42HXTB6S1D7AV9C --range main...HEAD`
- Hook-enabled pre-push local gates:
  - `just release-gate`
  - release build
  - release build with `rest`
  - `cargo package --locked`
  - review-check

## Safety

- `drawer_id` and `drawer_ids` remain informational/affected IDs and are not deletion authority.
- Cleanup automation must use only explicitly cleanup-safe created IDs and fail closed otherwise.
