### PR TITLE
fix(cli): expose cleanup ids for operation JSON

### DIFF
--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -216,10 +216,13 @@ Use only when write-path validation is required.
 
    ```bash
    ingest_json="$(mktemp)"
+   operation_json=""
    smoke_ids="$(mktemp)"
-   printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
+   if printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
      | mempal ingest --stdin --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json \
-     > "$ingest_json"
+     > "$ingest_json"; then
+     :
+   fi
    python3 - "$ingest_json" > "$smoke_ids" <<'PY'
 import json
 import sys
@@ -234,13 +237,53 @@ for item in dict.fromkeys(ids):
     print(item)
 PY
    if [ ! -s "$smoke_ids" ]; then
-     echo "cleanup requires manual operator action: ingest response did not expose created_drawer_ids; do not delete drawer_id, drawer_ids, or cleanup_drawer_ids" >&2
-     rm -f "$ingest_json" "$smoke_ids"
+     operation_id="$(python3 - "$ingest_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
+operation_id = obj.get("operation_id")
+state = obj.get("state")
+if isinstance(operation_id, str) and operation_id and state not in {"completed", "rejected", "failed"}:
+    print(operation_id)
+PY
+)"
+     if [ -n "$operation_id" ]; then
+       operation_json="$(mktemp)"
+       if mempal operation wait "$operation_id" --timeout-secs 300 --json > "$operation_json"; then
+         wait_status=0
+       else
+         wait_status=$?
+       fi
+       if [ "$wait_status" -ne 0 ]; then
+         mempal operation status "$operation_id" --json > "$operation_json" || true
+       fi
+       python3 - "$operation_json" > "$smoke_ids" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
+if obj.get("state") != "completed":
+    raise SystemExit(0)
+ids = []
+drawer_ids = obj.get("created_drawer_ids")
+if isinstance(drawer_ids, list):
+    ids.extend(item for item in drawer_ids if isinstance(item, str) and item)
+for item in dict.fromkeys(ids):
+    print(item)
+PY
+     fi
+   fi
+   if [ ! -s "$smoke_ids" ]; then
+     echo "cleanup requires manual operator action: terminal response did not expose created_drawer_ids; do not delete drawer_id, drawer_ids, or cleanup_drawer_ids" >&2
+     rm -f "$ingest_json" "$operation_json" "$smoke_ids"
      exit 1
    fi
    ```
 
-   Do not print the ingest response or smoke IDs unless cleanup fails. `created_drawer_ids` is the cleanup authority; `cleanup_drawer_ids` is only a human-readable alias when it mirrors the created list. `drawer_id` and `drawer_ids` are informational because they may name pre-existing, deduplicated, dropped, or merge-target drawers. If the ingest response timed out and returned only an `operation_id`, inspect it with `mempal operation wait <operation_id> --timeout-secs <seconds>` or `mempal operation status <operation_id>`, then delete only IDs from `created_drawer_ids`; if that list is empty, fail closed.
+   Do not print the ingest response, operation response, or smoke IDs unless cleanup fails. `created_drawer_ids` from the terminal ingest JSON, or from terminal `mempal operation wait/status --json`, is the cleanup authority. `cleanup_drawer_ids` is only a human-readable alias when it mirrors the created list. `drawer_id` and `drawer_ids` are informational because they may name pre-existing, deduplicated, dropped, or merge-target drawers. If `created_drawer_ids` is empty after the terminal wait/status step, fail closed.
 
 3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, never print search result bodies/snippets, and never use search result IDs for deletion:
 
@@ -277,7 +320,7 @@ PY
        exit 1
      fi
    done < "$smoke_ids"
-   rm -f "$ingest_json" "$smoke_ids"
+   rm -f "$ingest_json" "$operation_json" "$smoke_ids"
    ```
 
 5. Re-run the aggregate marker verification from step 3 and confirm no active `smoke/manual` marker match remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1176,12 +1176,18 @@ enum Commands {
 #[derive(Subcommand)]
 enum OperationCommands {
     /// Print the current status of a receipt-backed ingest operation.
-    Status { operation_id: String },
+    Status {
+        operation_id: String,
+        #[arg(long)]
+        json: bool,
+    },
     /// Block until a receipt-backed ingest operation reaches a terminal state.
     Wait {
         operation_id: String,
         #[arg(long = "timeout-secs", default_value_t = 30)]
         timeout_secs: u64,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -5713,6 +5719,18 @@ fn print_operation_response(response: &IngestResponse) -> Result<()> {
     Ok(())
 }
 
+fn print_operation_response_format(json: bool, response: &IngestResponse) -> Result<()> {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(response)
+                .context("failed to serialize operation response JSON")?
+        );
+        return Ok(());
+    }
+    print_operation_response(response)
+}
+
 fn ingest_stdin_wait_stats_from_response(response: &IngestResponse) -> IngestStats {
     let mut stats = IngestStats {
         files: 1,
@@ -5730,8 +5748,12 @@ fn ingest_stdin_wait_stats_from_response(response: &IngestResponse) -> IngestSta
     stats
 }
 
-fn finish_operation_wait_response(response: IngestResponse, operation_id: &str) -> Result<()> {
-    print_operation_response(&response)?;
+fn finish_operation_wait_response(
+    response: IngestResponse,
+    operation_id: &str,
+    json: bool,
+) -> Result<()> {
+    print_operation_response_format(json, &response)?;
     match response.state {
         Some(IngestOperationState::Completed) => Ok(()),
         Some(IngestOperationState::Rejected) => bail!("operation {operation_id} was rejected"),
@@ -5747,7 +5769,7 @@ async fn operation_command(
 ) -> Result<()> {
     let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone())?;
     match command {
-        OperationCommands::Status { operation_id } => {
+        OperationCommands::Status { operation_id, json } => {
             let response = server
                 .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
                     OperationStatusRequest { operation_id },
@@ -5755,12 +5777,13 @@ async fn operation_command(
                 .await
                 .context("failed to load operation status")?
                 .0;
-            print_operation_response(&response)?;
+            print_operation_response_format(json, &response)?;
             Ok(())
         }
         OperationCommands::Wait {
             operation_id,
             timeout_secs,
+            json,
         } => {
             eprintln!(
                 "waiting for operation_id={} timeout_secs={timeout_secs}",
@@ -5788,7 +5811,7 @@ async fn operation_command(
                 .map(IngestOperationState::is_terminal)
                 .unwrap_or(false)
             {
-                return finish_operation_wait_response(initial_status, &operation_id);
+                return finish_operation_wait_response(initial_status, &operation_id, json);
             }
             let wait_result = server
                 .wait_for_operation_status_with_scoped_worker(
@@ -5799,7 +5822,7 @@ async fn operation_command(
                 .await
                 .map_err(|error| anyhow::anyhow!(error.to_string()))?;
             match wait_result {
-                Some(response) => finish_operation_wait_response(response, &operation_id),
+                Some(response) => finish_operation_wait_response(response, &operation_id, json),
                 None => {
                     let mut response = server
                         .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
@@ -5815,10 +5838,10 @@ async fn operation_command(
                         .map(IngestOperationState::is_terminal)
                         .unwrap_or(false)
                     {
-                        return finish_operation_wait_response(response, &operation_id);
+                        return finish_operation_wait_response(response, &operation_id, json);
                     }
                     response.timed_out = true;
-                    print_operation_response(&response)?;
+                    print_operation_response_format(json, &response)?;
                     bail!("timed out waiting for operation {operation_id}")
                 }
             }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6054,7 +6054,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_operation_status",
-        description = "Return the current status of an asynchronous ingest operation, including the queue state, stored drawer_id, rejection reason, failure detail, and persisted per-stage timings. Use this to confirm a receipt-based write landed."
+        description = "Return the current status of an asynchronous ingest operation, including the queue state, informational drawer_id/drawer_ids, cleanup-safe created_drawer_ids, rejection reason, failure detail, and persisted per-stage timings. Use created_drawer_ids, not drawer_id/drawer_ids, as delete authority for receipt-backed cleanup."
     )]
     pub async fn mempal_operation_status(
         &self,
@@ -12322,7 +12322,7 @@ pattern_boost = 0.2
                 .description
                 .as_deref()
                 .unwrap_or_default()
-                .contains("receipt-based write landed")
+                .contains("cleanup-safe created_drawer_ids")
         );
 
         let ingest_tool = tools
@@ -13770,6 +13770,57 @@ pattern_boost = 0.2
     }
 
     #[tokio::test]
+    async fn test_mcp_queued_duplicate_completion_does_not_create_cleanup_ids() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let first = ingest_manual(&server, "queued duplicate cleanup fact", None, None, None).await;
+        let duplicate = server
+            .mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "queued duplicate cleanup fact".to_string(),
+                    wing: "mempal".to_string(),
+                    room: Some("replace".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(30),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("queued duplicate ingest")
+            .0;
+
+        assert_eq!(duplicate.state, Some(IngestOperationState::Completed));
+        assert_eq!(duplicate.drawer_id, first.drawer_id);
+        assert_eq!(duplicate.drawer_ids, vec![first.drawer_id.clone()]);
+        assert!(
+            duplicate.created_drawer_ids.is_empty(),
+            "queued duplicate completion must not grant cleanup authority for an existing drawer"
+        );
+
+        let operation_id = duplicate
+            .operation_id
+            .as_deref()
+            .expect("queued duplicate operation id");
+        let status = server
+            .operation_status_json_for_test(operation_id)
+            .await
+            .expect("queued duplicate status");
+        assert_eq!(status.state, Some(IngestOperationState::Completed));
+        assert_eq!(status.drawer_ids, vec![first.drawer_id]);
+        assert!(
+            status.created_drawer_ids.is_empty(),
+            "persisted duplicate status must not grant cleanup authority"
+        );
+
+        let db = Database::open(&db_path).expect("open db");
+        assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
     async fn test_mcp_delete_rejects_existing_content_writer_lease() {
         let (_tempdir, db_path, server) = setup_server();
         insert_drawer(
@@ -15202,6 +15253,11 @@ enabled = true
             .expect("completed status");
         assert_eq!(completed.state, Some(IngestOperationState::Completed));
         assert!(!completed.drawer_id.is_empty());
+        assert_eq!(
+            completed.created_drawer_ids,
+            vec![completed.drawer_id.clone()]
+        );
+        assert_eq!(completed.drawer_ids, completed.created_drawer_ids);
 
         let completed_record =
             crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
@@ -15220,6 +15276,10 @@ enabled = true
             .expect("final status");
         assert_eq!(final_status.state, Some(IngestOperationState::Completed));
         assert_eq!(final_status.drawer_id, completed.drawer_id);
+        assert_eq!(
+            final_status.created_drawer_ids,
+            completed.created_drawer_ids
+        );
     }
 
     #[tokio::test]

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -802,9 +802,15 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
     handle.resume();
     let recovery = run_cli(
         home.path(),
-        &["operation", "wait", &operation_id, "--timeout-secs", "10"],
+        &[
+            "operation",
+            "wait",
+            &operation_id,
+            "--timeout-secs",
+            "10",
+            "--json",
+        ],
     );
-    handle.shutdown().await;
 
     assert!(
         recovery.status.success(),
@@ -813,28 +819,58 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
         String::from_utf8_lossy(&recovery.stderr)
     );
     let (recovery_stdout, recovery_stderr) = print_lines(&recovery);
+    let recovery_json: Value =
+        serde_json::from_str(&recovery_stdout).expect("parse operation wait recovery JSON");
+    assert_eq!(recovery_json["operation_id"], operation_id);
+    assert_eq!(recovery_json["state"], "completed");
+    assert!(!recovery_json["timed_out"].as_bool().unwrap_or(false));
     assert!(
-        recovery_stdout.contains("state=completed"),
-        "{recovery_stdout}"
-    );
-    assert!(
-        recovery_stdout.contains("timed_out=false"),
-        "{recovery_stdout}"
+        !recovery_stdout.contains("cli wait json timeout content"),
+        "operation wait JSON must not expose raw content: {recovery_stdout}"
     );
     assert!(
         recovery_stderr.contains("waiting for operation_id="),
         "{recovery_stderr}"
     );
-    let recovery_ids = cleanup_ids_from_operation_stdout(&recovery_stdout);
-    assert!(
-        !recovery_ids.is_empty(),
+    let recovery_ids = cleanup_ids_from_ingest_json(&recovery_json);
+    assert_eq!(
+        recovery_ids.len(),
+        1,
         "operation wait recovery must expose exact cleanup ids: {recovery_stdout}"
+    );
+    assert_eq!(
+        recovery_json["created_drawer_ids"], recovery_json["drawer_ids"],
+        "new operation completion should report the same affected and cleanup-safe IDs"
     );
     let completed = PendingMessageStore::new_without_reclaim(&db_path)
         .operation_status(&operation_id)
         .expect("load completed status")
         .expect("operation record exists");
     assert_eq!(completed.op_state, "completed");
+    let status = run_cli(
+        home.path(),
+        &["operation", "status", &operation_id, "--json"],
+    );
+    handle.shutdown().await;
+
+    assert!(
+        status.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: Value =
+        serde_json::from_slice(&status.stdout).expect("parse operation status JSON");
+    assert_eq!(status_json["state"], "completed");
+    assert_eq!(
+        cleanup_ids_from_ingest_json(&status_json),
+        recovery_ids,
+        "operation status JSON must preserve cleanup-safe IDs after wait"
+    );
+    assert!(
+        !String::from_utf8_lossy(&status.stdout).contains("cli wait json timeout content"),
+        "operation status JSON must not expose raw content"
+    );
     let db = Database::open(&db_path).expect("open db");
     assert_eq!(db.drawer_count().expect("drawer count"), 1);
     drop(db);


### PR DESCRIPTION
## Summary

- Expose cleanup-safe created IDs in operation JSON after queued stdin ingest completion.
- Keep `drawer_id` / `drawer_ids` informational and separate from cleanup authority.
- Update smoke guidance and regression coverage for follow-up operation wait/status cleanup.

Fixes #532

## Verification

- CSA Codex exact-head review PASS/CLEAN: `01KVQXWT0VWBH340K4D5V798RV`
- `csa review --check-verdict --sa-mode true --session 01KVQXWT0VWBH340K4D5V798RV --range main...HEAD`
- Hook-enabled pre-push local gates:
  - `just release-gate`
  - release build
  - release build with `rest`
  - `cargo package --locked`
  - review-check

## Safety

- Cleanup automation must only use explicit cleanup-safe created IDs.
- `drawer_id` and `drawer_ids` remain non-deletion authority.
- Smoke path fails closed if cleanup-safe IDs are unavailable.
