### PR TITLE
fix(cli): allow cleanup id writes under daemon lease

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1773,14 +1773,37 @@ impl Database {
     }
 
     pub fn pin_drawer(&self, drawer_id: &str, pin_order: Option<i64>) -> Result<bool, DbError> {
-        let resolved_order = match pin_order {
-            Some(order) => Some(order),
-            None => self.conn.query_row(
+        if let Some(order) = pin_order {
+            return self.pin_drawer_with_order(drawer_id, Some(order));
+        }
+
+        self.conn.execute_batch("BEGIN IMMEDIATE;")?;
+        let result = (|| -> Result<bool, DbError> {
+            let resolved_order = self.conn.query_row(
                 "SELECT COALESCE(MAX(pin_order), -1) + 1 FROM drawers WHERE is_pinned = 1",
                 [],
                 |row| row.get::<_, Option<i64>>(0),
-            )?,
-        };
+            )?;
+            self.pin_drawer_with_order(drawer_id, resolved_order)
+        })();
+
+        match result {
+            Ok(affected) => {
+                self.conn.execute_batch("COMMIT;")?;
+                Ok(affected)
+            }
+            Err(error) => {
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                Err(error)
+            }
+        }
+    }
+
+    fn pin_drawer_with_order(
+        &self,
+        drawer_id: &str,
+        resolved_order: Option<i64>,
+    ) -> Result<bool, DbError> {
         let affected = self.conn.execute(
             "UPDATE drawers SET is_pinned = 1, pin_order = COALESCE(?2, pin_order) WHERE id = ?1 AND deleted_at IS NULL",
             params![drawer_id, resolved_order],
@@ -7291,6 +7314,71 @@ mod tests {
     fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
         db.insert_drawer_with_project(&test_drawer(id, content), project_id)
             .expect("insert drawer");
+    }
+
+    #[test]
+    fn concurrent_default_pin_order_allocation_is_atomic_across_connections() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("test.db");
+        let db = Database::open(&db_path).expect("open db");
+        insert_test_drawer(&db, "already-pinned", "already pinned", None);
+        insert_test_drawer(&db, "pin-a", "pin a", None);
+        insert_test_drawer(&db, "pin-b", "pin b", None);
+        assert!(
+            db.pin_drawer("already-pinned", None)
+                .expect("pin initial drawer")
+        );
+        let _daemon_lease = db
+            .runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
+            .expect("acquire daemon writer lease")
+            .expect("daemon writer lease");
+
+        let worker_a = Database::open(&db_path).expect("open worker a");
+        let worker_b = Database::open(&db_path).expect("open worker b");
+        let lock_holder = Connection::open(&db_path).expect("open lock holder");
+        lock_holder
+            .busy_timeout(Duration::from_secs(5))
+            .expect("set lock holder busy timeout");
+        lock_holder
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold write lock");
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let barrier_a = std::sync::Arc::clone(&barrier);
+        let handle_a = std::thread::spawn(move || {
+            barrier_a.wait();
+            worker_a.pin_drawer("pin-a", None).expect("pin a")
+        });
+        let barrier_b = std::sync::Arc::clone(&barrier);
+        let handle_b = std::thread::spawn(move || {
+            barrier_b.wait();
+            worker_b.pin_drawer("pin-b", None).expect("pin b")
+        });
+
+        barrier.wait();
+        std::thread::sleep(Duration::from_millis(150));
+        lock_holder
+            .execute_batch("COMMIT;")
+            .expect("release write lock");
+
+        assert!(handle_a.join().expect("join pin a"));
+        assert!(handle_b.join().expect("join pin b"));
+
+        let order_a = db
+            .get_drawer("pin-a")
+            .expect("load pin a")
+            .expect("pin a exists")
+            .pin_order
+            .expect("pin a order");
+        let order_b = db
+            .get_drawer("pin-b")
+            .expect("load pin b")
+            .expect("pin b exists")
+            .pin_order
+            .expect("pin b order");
+        let mut orders = vec![order_a, order_b];
+        orders.sort_unstable();
+        assert_eq!(orders, vec![1, 2]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3493,6 +3493,8 @@ fn run() -> Result<()> {
         open_read_only_database(&db_path).context("failed to open read-only database")
     } else if command_retries_stdin_ingest_startup_open(&cli.command) {
         open_stdin_ingest_database_with_retry(&db_path)
+    } else if let Some(operation) = cli_content_write_operation(&cli.command) {
+        open_cli_content_write_database_with_retry(&db_path, operation)
     } else if command_retries_historical_rejudge_startup_open(&cli.command) {
         open_historical_rejudge_startup_database_with_retry(|| {
             Database::open(&db_path).context("failed to open database")
@@ -4214,6 +4216,15 @@ fn command_retries_stdin_ingest_startup_open(command: &Commands) -> bool {
     matches!(command, Commands::Ingest { stdin: true, .. })
 }
 
+fn cli_content_write_operation(command: &Commands) -> Option<&'static str> {
+    match command {
+        Commands::Delete { .. } => Some("delete"),
+        Commands::Pin { .. } => Some("pin"),
+        Commands::Unpin { .. } => Some("unpin"),
+        _ => None,
+    }
+}
+
 const STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES: usize = 40;
 const STDIN_INGEST_STARTUP_BUSY_TIMEOUT: std::time::Duration =
     std::time::Duration::from_millis(100);
@@ -4245,6 +4256,40 @@ fn open_stdin_ingest_database_with_retry(path: &Path) -> Result<Database> {
     unreachable!("stdin ingest startup database retry loop returns on terminal attempt")
 }
 
+fn open_cli_content_write_database_with_retry(
+    path: &Path,
+    operation: &'static str,
+) -> Result<Database> {
+    for attempt in 0..=STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES {
+        match Database::open_with_busy_timeout(path, STDIN_INGEST_STARTUP_BUSY_TIMEOUT)
+            .context("failed to open database")
+        {
+            Ok(db) => {
+                db.conn()
+                    .busy_timeout(STDIN_INGEST_SQLITE_BUSY_TIMEOUT)
+                    .with_context(|| {
+                        format!("failed to set SQLite busy timeout for {operation}")
+                    })?;
+                return Ok(db);
+            }
+            Err(error)
+                if is_transient_sqlite_lock_error(&error)
+                    && attempt < STDIN_INGEST_SQLITE_LOCK_MAX_RETRIES =>
+            {
+                std::thread::sleep(historical_rejudge_sqlite_lock_retry_delay(attempt));
+            }
+            Err(error) if is_transient_sqlite_lock_error(&error) => {
+                bail!(
+                    "{}",
+                    cli_content_write_sqlite_lock_diagnostic(path, operation)
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("CLI content write startup database retry loop returns on terminal attempt")
+}
+
 fn stdin_ingest_sqlite_lock_diagnostic(path: &Path, error: &anyhow::Error) -> String {
     let holders = mempal::process_diagnostics::inspect_db_holders(path);
     format!(
@@ -4254,6 +4299,34 @@ fn stdin_ingest_sqlite_lock_diagnostic(path: &Path, error: &anyhow::Error) -> St
         mempal::process_diagnostics::format_db_holder_role_summary(&holders),
         mempal::process_diagnostics::sqlite_lock_safe_next_step(&holders)
     )
+}
+
+fn cli_content_write_sqlite_lock_diagnostic(path: &Path, operation: &str) -> String {
+    let holders = mempal::process_diagnostics::inspect_db_holders(path);
+    format!(
+        "write_blocked=true reason=sqlite_locked operation={operation}\n\
+         holder_summary={}\n\
+         safe_next_step={}",
+        mempal::process_diagnostics::format_db_holder_role_summary(&holders),
+        mempal::process_diagnostics::sqlite_lock_safe_next_step(&holders)
+    )
+}
+
+fn classify_cli_content_write_result<T>(
+    db: &Database,
+    operation: &'static str,
+    result: Result<T>,
+) -> Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if is_transient_sqlite_lock_error(&error) => {
+            bail!(
+                "{}",
+                cli_content_write_sqlite_lock_diagnostic(db.path(), operation)
+            )
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn open_historical_rejudge_startup_database_with_retry(
@@ -10669,14 +10742,20 @@ fn print_promotion_policy(policy: &[PromotionPolicyEntry]) {
 }
 
 fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
-    let _writer_lease = acquire_cli_content_writer_lease(db, "delete")?;
     let drawer = db
         .get_drawer(drawer_id)
         .context("failed to look up drawer")?;
     match drawer {
         Some(drawer) => {
-            db.soft_delete_drawer(drawer_id)
-                .context("failed to soft-delete drawer")?;
+            let deleted = classify_cli_content_write_result(
+                db,
+                "delete",
+                db.soft_delete_drawer(drawer_id)
+                    .context("failed to soft-delete drawer"),
+            )?;
+            if !deleted {
+                bail!("drawer not found: {drawer_id}");
+            }
             append_audit_entry(db, "delete", &serde_json::json!({ "drawer_id": drawer_id }))
                 .context("failed to append audit log")?;
             println!("soft-deleted {}", drawer_id);
@@ -10686,7 +10765,6 @@ fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
                 drawer.room.as_deref().unwrap_or("default"),
                 drawer.source_file.as_deref().unwrap_or("(none)")
             );
-            println!("  content: {}", truncate_for_summary(&drawer.content, 100));
             println!("  (use `mempal purge` to permanently remove)");
         }
         None => bail!("drawer not found: {drawer_id}"),
@@ -10695,11 +10773,12 @@ fn delete_command(db: &Database, drawer_id: &str) -> Result<()> {
 }
 
 fn pin_command(db: &Database, drawer_id: &str) -> Result<()> {
-    let _writer_lease = acquire_cli_content_writer_lease(db, "pin")?;
-    if !db
-        .pin_drawer(drawer_id, None)
-        .context("failed to pin drawer")?
-    {
+    if !classify_cli_content_write_result(
+        db,
+        "pin",
+        db.pin_drawer(drawer_id, None)
+            .context("failed to pin drawer"),
+    )? {
         bail!("drawer not found: {drawer_id}");
     }
     append_audit_entry(db, "pin", &serde_json::json!({ "drawer_id": drawer_id }))
@@ -10709,11 +10788,11 @@ fn pin_command(db: &Database, drawer_id: &str) -> Result<()> {
 }
 
 fn unpin_command(db: &Database, drawer_id: &str) -> Result<()> {
-    let _writer_lease = acquire_cli_content_writer_lease(db, "unpin")?;
-    if !db
-        .unpin_drawer(drawer_id)
-        .context("failed to unpin drawer")?
-    {
+    if !classify_cli_content_write_result(
+        db,
+        "unpin",
+        db.unpin_drawer(drawer_id).context("failed to unpin drawer"),
+    )? {
         bail!("drawer not found: {drawer_id}");
     }
     append_audit_entry(db, "unpin", &serde_json::json!({ "drawer_id": drawer_id }))
@@ -21832,6 +21911,22 @@ mod ingest_wait_timeout_error_tests {
         assert!(diagnostic.contains("holder summary:"));
         assert!(diagnostic.contains("safe next step:"));
         assert!(!diagnostic.contains("stdin transient sqlite lock fixture"));
+    }
+
+    #[test]
+    fn cli_content_write_lock_diagnostic_is_structured_without_payload() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let _db = Database::open(&db_path).expect("open db");
+
+        let diagnostic = cli_content_write_sqlite_lock_diagnostic(&db_path, "delete");
+
+        assert!(diagnostic.contains("write_blocked=true"));
+        assert!(diagnostic.contains("reason=sqlite_locked"));
+        assert!(diagnostic.contains("operation=delete"));
+        assert!(diagnostic.contains("holder_summary="));
+        assert!(diagnostic.contains("safe_next_step="));
+        assert!(!diagnostic.contains("cleanup authority smoke safe to delete unique body"));
     }
 }
 

--- a/tests/ingest_cli_errors.rs
+++ b/tests/ingest_cli_errors.rs
@@ -803,7 +803,7 @@ fn test_stdin_non_wait_ingest_respects_existing_writer_lease() {
 }
 
 #[test]
-fn test_cli_delete_respects_existing_writer_lease() {
+fn test_cli_delete_succeeds_under_existing_writer_lease() {
     let tmp = setup_home();
     insert_drawer(tmp.path(), "cli-delete-lease-target");
     let _lease = hold_daemon_writer_lease(tmp.path());
@@ -811,18 +811,19 @@ fn test_cli_delete_respects_existing_writer_lease() {
     let output = run_delete(tmp.path(), "cli-delete-lease-target");
 
     assert!(
-        !output.status.success(),
-        "delete must fail under writer lease"
+        output.status.success(),
+        "delete should succeed under daemon writer lease: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("SQLite writer lease `sqlite-writer` is already held"),
-        "{stderr}"
+        !stdout.contains("cli delete lease fixture"),
+        "delete stdout must not expose raw drawer content"
     );
     let db = mempal::core::db::Database::open(&tmp.path().join(".mempal").join("palace.db"))
         .expect("open db");
     assert!(
-        db.drawer_exists("cli-delete-lease-target")
+        !db.drawer_exists("cli-delete-lease-target")
             .expect("drawer exists")
     );
 }

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -291,6 +291,13 @@ fn delete_cleanup_ids(home: &Path, drawer_ids: &[String]) {
     }
 }
 
+fn hold_daemon_writer_lease(home: &Path) -> mempal::core::types::RuntimeWriterLease {
+    let db = Database::open(&home.join(".mempal/palace.db")).expect("open db");
+    db.runtime_writer_lease_acquire("sqlite-writer", "daemon-owner", "daemon", 300, None)
+        .expect("acquire daemon writer lease")
+        .expect("daemon writer lease")
+}
+
 fn insert_existing_drawer(home: &Path, drawer_id: &str) {
     let db = Database::open(&home.join(".mempal/palace.db")).expect("open db");
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
@@ -706,6 +713,74 @@ async fn test_ingest_wait_json_cleanup_ids_delete_exact_drawers() {
             "reported cleanup id must be deletable by mempal delete"
         );
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ingest_wait_json_cleanup_id_writes_under_daemon_lease() {
+    let home = setup_home();
+    let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
+    let _config = write_config(home.path(), &format!("http://{addr}/v1"));
+    let wait_timeout = u64::MAX.to_string();
+    let payload = br#"{"content":"cleanup authority smoke safe to delete unique body"}"#;
+
+    let output = run_cli_with_stdin(
+        home.path(),
+        &[
+            "ingest",
+            "--stdin",
+            "--wing",
+            "smoke",
+            "--room",
+            "manual",
+            "--source-type",
+            "user_explicit",
+            "--no-gate",
+            "--wait",
+            "--wait-timeout-secs",
+            wait_timeout.as_str(),
+            "--json",
+        ],
+        payload,
+    );
+    handle.shutdown().await;
+
+    assert!(output.status.success(), "stdin wait ingest must succeed");
+    let stdout: Value = serde_json::from_slice(&output.stdout).expect("parse wait JSON");
+    let cleanup_ids = cleanup_ids_from_ingest_json(&stdout);
+    assert_eq!(
+        cleanup_ids.len(),
+        1,
+        "stdin wait JSON must expose exactly one cleanup-safe drawer id"
+    );
+    assert_eq!(
+        stdout["cleanup_drawer_ids"], stdout["created_drawer_ids"],
+        "cleanup authority must come from created_drawer_ids"
+    );
+
+    let cleanup_id = cleanup_ids.first().expect("cleanup id");
+    let _daemon_lease = hold_daemon_writer_lease(home.path());
+
+    let pin = run_cli(home.path(), &["pin", cleanup_id]);
+    assert!(pin.status.success(), "pin by cleanup id must succeed");
+
+    let unpin = run_cli(home.path(), &["unpin", cleanup_id]);
+    assert!(unpin.status.success(), "unpin by cleanup id must succeed");
+
+    let delete = run_cli(home.path(), &["delete", cleanup_id]);
+    assert!(delete.status.success(), "delete by cleanup id must succeed");
+    let delete_stdout = String::from_utf8_lossy(&delete.stdout);
+    assert!(
+        !delete_stdout.contains("cleanup authority smoke safe to delete unique body"),
+        "delete stdout must not expose raw drawer content"
+    );
+
+    let db = Database::open(&home.path().join(".mempal/palace.db")).expect("open db");
+    assert!(
+        db.get_drawer(cleanup_id)
+            .expect("get deleted cleanup drawer")
+            .is_none(),
+        "created cleanup id must be soft-deleted"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "d8ed4a169f0f5de45fe0d8c91dfc13d44e7ed0c3"
+commit = "f2d550964ac9d64de6b46be902b588c8256a33fe"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- allow cleanup-safe exact-ID delete/pin/unpin writes while a daemon writer lease is active
- make implicit pin order allocation atomic with SQLite transaction serialization
- keep delete output content-safe and expose bounded write-block diagnostics
- add regression coverage for daemon-lease cleanup writes and concurrent pin order allocation

## Verification
- `cargo test test_ingest_wait_json_cleanup_id_writes_under_daemon_lease -- --exact`
- `cargo test test_cli_delete_succeeds_under_existing_writer_lease -- --exact`
- `cargo test pin_order`
- `csa review --check-verdict --sa-mode true --range main...HEAD`
- hook-enabled `git push --force-with-lease origin HEAD:fix/535-created-ids-cleanup-delete` (local-gates + review-check)

Fixes #535
