### PR TITLE
fix(mcp): align ingest source type schema

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -108,25 +108,26 @@ use super::tools::{
     DesignInsightStatusDto, DoctorMcpDto, DoctorRequest, DoctorResponse, DoctorToolDto,
     DuplicateWarning, EmbedEndpointStatusDto, EmbedStatusDto, EmbedderCircuitDto,
     EndpointHealthDto, FactCheckRequest, FactCheckResponse, FieldTaxonomyEntryDto,
-    FieldTaxonomyResponse, GatingRuntimeStatusDto, IngestControls, IngestOperationState,
-    IngestRequest, IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto,
-    KnowledgeCardDto, KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse,
-    KnowledgeDemoteRequest, KnowledgeDemoteResponse, KnowledgeDistillRequest,
-    KnowledgeDistillResponse, KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse,
-    KnowledgePromoteRequest, KnowledgePromoteResponse, KnowledgePublishAnchorRequest,
-    KnowledgePublishAnchorResponse, LeaseInfoDto, LeaseRequest, LeaseResponse,
-    LlmEndpointStatusDto, LlmStatusDto, MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS,
-    OperationStatusRequest, PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto,
-    Phase3Request, Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest,
-    PinnedFactsResponse, ProcessResourceUsageDto, QueueStatsDto, ReadDrawerRequest,
-    ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse, ResearchAdapterPlanDto,
-    ResearchIngestPlanDto, ResourceCounterDto, ResourceUsageDto, RetrievalScopeRequest,
-    RetrievedKnowledgeCardDto, RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto,
-    RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse,
-    SearchResultDto, SkillDto, SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount,
-    SqliteResourceUsageDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
-    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
-    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    FieldTaxonomyResponse, GatingRuntimeStatusDto, INGEST_SOURCE_TYPE_VALUES,
+    INGEST_SOURCE_TYPE_VALUES_DESCRIPTION, IngestControls, IngestOperationState, IngestRequest,
+    IngestResponse, IntelligenceStatusDto, KgRequest, KgResponse, KgStatsDto, KnowledgeCardDto,
+    KnowledgeCardEventDto, KnowledgeCardsRequest, KnowledgeCardsResponse, KnowledgeDemoteRequest,
+    KnowledgeDemoteResponse, KnowledgeDistillRequest, KnowledgeDistillResponse,
+    KnowledgeGateRequest, KnowledgeGateResponse, KnowledgePolicyResponse, KnowledgePromoteRequest,
+    KnowledgePromoteResponse, KnowledgePublishAnchorRequest, KnowledgePublishAnchorResponse,
+    LeaseInfoDto, LeaseRequest, LeaseResponse, LlmEndpointStatusDto, LlmStatusDto,
+    MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
+    PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
+    Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
+    ProcessResourceUsageDto, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse,
+    ReadDrawersRequest, ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto,
+    ResourceCounterDto, ResourceUsageDto, RetrievalScopeRequest, RetrievedKnowledgeCardDto,
+    RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto,
+    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto,
+    SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, SqliteResourceUsageDto,
+    StatusDetail, StatusRequest, StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto,
+    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
+    TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
 fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool {
@@ -2395,14 +2396,22 @@ fn validate_temporal_param(name: &str, value: Option<&str>) -> std::result::Resu
 
 fn parse_source_type_param(value: Option<&str>) -> std::result::Result<SourceType, ErrorData> {
     match value {
-        Some(raw) => raw.parse::<SourceType>().map_err(|_| {
+        Some(raw) => parse_ingest_source_type(raw).ok_or_else(|| {
             ErrorData::invalid_params(
-                "source_type must be one of: user_explicit, agent_observation, agent_inference, system_generated",
+                format!("source_type must be one of: {INGEST_SOURCE_TYPE_VALUES_DESCRIPTION}"),
                 None,
             )
         }),
         None => Ok(SourceType::AgentInference),
     }
+}
+
+fn parse_ingest_source_type(raw: &str) -> Option<SourceType> {
+    if !INGEST_SOURCE_TYPE_VALUES.contains(&raw) {
+        return None;
+    }
+
+    raw.parse::<SourceType>().ok()
 }
 
 fn should_apply_async_llm_gating(source_type: SourceType) -> bool {
@@ -9711,6 +9720,7 @@ mod tests {
     use crate::core::types::BootstrapEvidenceArgs;
     use crate::core::types::{KnowledgeCard, KnowledgeEvidenceLink, KnowledgeEvidenceRole};
     use crate::embed::Embedder;
+    use crate::mcp::tools::INGEST_SOURCE_TYPE_SCHEMA_DESCRIPTION;
 
     #[derive(Clone)]
     struct StubEmbedderFactory {
@@ -10054,6 +10064,37 @@ api_key = "sk-secret-should-not-print"
             !message.contains(raw),
             "invalid source_type errors must not echo caller-supplied raw values"
         );
+    }
+
+    #[test]
+    fn test_mcp_source_type_parser_accepts_only_advertised_values() {
+        assert_eq!(
+            parse_source_type_param(None).expect("default source_type"),
+            SourceType::AgentInference
+        );
+
+        for value in INGEST_SOURCE_TYPE_VALUES {
+            assert_eq!(
+                parse_source_type_param(Some(value)).expect("advertised source_type should parse"),
+                value
+                    .parse::<SourceType>()
+                    .expect("advertised source_type should map to core enum")
+            );
+        }
+
+        for value in [
+            "runtime",
+            "research",
+            "human",
+            "manual",
+            "project",
+            "conversation",
+        ] {
+            assert!(
+                parse_source_type_param(Some(value)).is_err(),
+                "MCP ingest should reject unadvertised source_type {value}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -12339,6 +12380,42 @@ pattern_boost = 0.2
             assert!(
                 props.get(field).is_some(),
                 "mempal_ingest must expose {field} in tools/list"
+            );
+        }
+        let source_type_schema = props
+            .get("source_type")
+            .expect("mempal_ingest must expose source_type in tools/list");
+        let advertised_source_types = source_type_schema
+            .get("enum")
+            .and_then(|value| value.as_array())
+            .expect("source_type schema must expose enum values")
+            .iter()
+            .filter_map(|value| value.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            advertised_source_types, INGEST_SOURCE_TYPE_VALUES,
+            "source_type schema enum must match MCP validation"
+        );
+        let source_type_description = source_type_schema
+            .get("description")
+            .and_then(|value| value.as_str())
+            .expect("source_type schema must describe accepted values");
+        assert_eq!(
+            source_type_description, INGEST_SOURCE_TYPE_SCHEMA_DESCRIPTION,
+            "source_type schema description must use the shared MCP description"
+        );
+        assert!(
+            source_type_description.contains(INGEST_SOURCE_TYPE_VALUES_DESCRIPTION),
+            "source_type description must name the accepted enum: {source_type_description}"
+        );
+        for unaccepted in ["runtime", "research", "human"] {
+            assert!(
+                !advertised_source_types.contains(&unaccepted),
+                "source_type schema must not advertise unsupported value {unaccepted}"
+            );
+            assert!(
+                !source_type_description.contains(unaccepted),
+                "source_type description must not advertise unsupported value {unaccepted}"
             );
         }
         for field in ["no_gate", "bypass_novelty"] {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -32,6 +32,7 @@ use crate::knowledge_lifecycle::{DemoteOutcome, PromoteOutcome};
 use crate::process_diagnostics::DbHolderReport;
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// schemars 1.x emits boolean `true` for `serde_json::Value`, which MCP clients
 /// (e.g. Claude Code) reject when validating `tools/list`. Use this helper via
@@ -40,7 +41,33 @@ use serde::{Deserialize, Serialize};
 fn json_object_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
     schemars::json_schema!({ "type": "object" })
 }
-use std::collections::BTreeMap;
+
+pub const INGEST_SOURCE_TYPE_VALUES: [&str; 4] = [
+    "user_explicit",
+    "agent_observation",
+    "agent_inference",
+    "system_generated",
+];
+pub const INGEST_SOURCE_TYPE_VALUES_DESCRIPTION: &str =
+    "user_explicit, agent_observation, agent_inference, system_generated";
+pub const INGEST_SOURCE_TYPE_SCHEMA_DESCRIPTION: &str = concat!(
+    "Optional source_type provenance: user_explicit, agent_observation, ",
+    "agent_inference, system_generated."
+);
+
+fn ingest_source_type_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": ["string", "null"],
+        "enum": [
+            "user_explicit",
+            "agent_observation",
+            "agent_inference",
+            "system_generated",
+            null
+        ],
+        "description": INGEST_SOURCE_TYPE_SCHEMA_DESCRIPTION
+    })
+}
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct StatusRequest {
@@ -1622,6 +1649,8 @@ pub struct IngestRequest {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_file: Option<String>,
+    /// Optional source_type provenance: user_explicit, agent_observation, agent_inference, system_generated.
+    #[schemars(schema_with = "ingest_source_type_schema")]
     pub source_type: Option<String>,
     pub confidence: Option<f64>,
     pub project_id: Option<String>,

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f2d550964ac9d64de6b46be902b588c8256a33fe"
+commit = "fafa4c9a8318b2fe7dc249b1adbb7cf630e95078"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- align the `mempal_ingest` MCP `source_type` schema with the actual write-time validation contract
- reject formerly advertised unsupported values (`runtime`, `research`, `human`) at the MCP input boundary
- keep legacy core `SourceType` parsing available for old stored rows
- include focused tests preventing future schema/parser drift

## Verification
- CSA review `01KVR9CNA1D3K8JT8NYFPANABJ`: PASS/CLEAN for `main...HEAD`
- pre-push local gates: PASS (`branch-protection`, `local-gates`, `review-check`)
- review-check validated HEAD `2a632555676`

Fixes #536
