### PR TITLE
fix(mcp): guard busy ingest transport errors

### DIFF
--- a/tests/common/harness/mcp_stdio.rs
+++ b/tests/common/harness/mcp_stdio.rs
@@ -172,6 +172,14 @@ log_path = "{}"
     }
 
     pub async fn call(&mut self, method: &str, params: Value) -> Result<Value> {
+        let message = self.call_raw(method, params).await?;
+        if let Some(error) = message.get("error") {
+            bail!("JSON-RPC error: {error}");
+        }
+        Ok(message["result"].clone())
+    }
+
+    pub async fn call_raw(&mut self, method: &str, params: Value) -> Result<Value> {
         let id = self.next_id;
         self.next_id += 1;
         self.send(json!({
@@ -181,7 +189,7 @@ log_path = "{}"
             "params": params,
         }))
         .await?;
-        self.read_response(id).await
+        self.read_response_message(id).await
     }
 
     pub async fn shutdown(&mut self) -> Result<()> {
@@ -215,7 +223,7 @@ log_path = "{}"
         Ok(())
     }
 
-    async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
+    async fn read_response_message(&mut self, expected_id: u64) -> Result<Value> {
         loop {
             let mut line = String::new();
             let bytes = self
@@ -259,10 +267,7 @@ log_path = "{}"
             if message["id"].as_u64() != Some(expected_id) {
                 bail!("unexpected JSON-RPC id: {message}");
             }
-            if let Some(error) = message.get("error") {
-                bail!("JSON-RPC error: {error}");
-            }
-            return Ok(message["result"].clone());
+            return Ok(message);
         }
     }
 }

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -119,6 +119,83 @@ async fn mcp_stdio_initialize_does_not_wait_for_busy_db_or_noop_llm() -> Result<
     Ok(())
 }
 
+#[tokio::test]
+async fn mcp_stdio_ingest_busy_after_status_keeps_transport_alive() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path)?;
+
+    let lock_conn = rusqlite::Connection::open(&db_path)?;
+    lock_conn.execute_batch("BEGIN EXCLUSIVE;")?;
+
+    let mut client = McpStdio::start(&db_path, HashMap::new()).await?;
+    let server_info = tokio::time::timeout(Duration::from_secs(5), client.initialize()).await??;
+    assert!(!server_info.server_info.name.trim().is_empty());
+
+    let status = tokio::time::timeout(
+        Duration::from_secs(15),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_status",
+                "arguments": {},
+            }),
+        ),
+    )
+    .await??;
+    let status_body = &status["structuredContent"];
+    assert_eq!(
+        status_body["database_diagnostic"]["failure_kind"].as_str(),
+        Some("locked_or_busy")
+    );
+
+    let ingest = tokio::time::timeout(
+        Duration::from_secs(12),
+        client.call_raw(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_ingest",
+                "arguments": {
+                    "content": "issue 534 locked transport regression payload",
+                    "wing": "mcp",
+                    "room": "busy",
+                    "source_type": "agent_inference",
+                    "wait": false
+                },
+            }),
+        ),
+    )
+    .await??;
+    let error = ingest
+        .get("error")
+        .expect("busy ingest should return a JSON-RPC error");
+    let error_text = error.to_string();
+    assert!(
+        error_text.contains("database_locked")
+            || error_text.contains("locked_or_busy")
+            || error_text.contains("retry_after_transient_lock"),
+        "busy ingest error must be structured and retryable: {error}"
+    );
+
+    lock_conn.execute_batch("ROLLBACK;")?;
+    let recovered_status = tokio::time::timeout(
+        Duration::from_secs(15),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_status",
+                "arguments": {},
+            }),
+        ),
+    )
+    .await??;
+    assert!(recovered_status["structuredContent"].is_object());
+    client.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn harness_integration_smoke() -> Result<()> {
     let tmp = TempDir::new()?;

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "fafa4c9a8318b2fe7dc249b1adbb7cf630e95078"
+commit = "f46d756aca684862210f59f987d4a8b6d048f786"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- keep MCP stdio transport alive when `mempal_ingest` hits a busy/locked DB path
- return a structured retryable JSON-RPC error instead of closing the transport
- add a regression covering status locked diagnostics followed by busy ingest and a follow-up status call
- include the existing `weave.lock` CSA version update per lockfile hygiene

## Verification
- CSA review `01KVRCF7FCZYF8HFMSRK6CA2FF`: PASS/CLEAN for `main...HEAD`
- pre-push local gates: PASS (`branch-protection`, `local-gates`, `review-check`)
- review-check validated HEAD `5d43caaf072`

Fixes #534
