### PR TITLE
fix(smoke): add MCP smoke CRUD path and I/O telemetry

### DIFF
--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: smoke-test
-description: "Project-local mempal manual smoke test skill. Use after installing, restarting, merging, or changing mempal to verify daemon health, CLI/REST/MCP/read-only surfaces, optional reversible write/delete paths, memory growth, and database-holder safety without starting duplicate daemons or leaking drawer content."
+description: "Project-local mempal exhaustive smoke test skill. Use after installing, restarting, merging, or changing mempal to verify daemon health, CLI/REST/MCP read surfaces, reversible CLI and MCP memory CRUD, memory growth, and database-holder safety without starting duplicate daemons or leaking drawer content."
 ---
 
 # mempal Manual Smoke Test
 
-Use this project-local skill when a main agent must manually verify that the installed `mempal` binary and live daemon still work after a merge, install, restart, MCP reconnect, or production-like debugging session.
+Use this project-local skill when a main agent must manually verify that the installed `mempal` binary, live daemon, command-line surfaces, REST availability, and MCP tools still work after a merge, install, restart, MCP reconnect, or production-like debugging session.
 
-Default to direct installed-CLI probes. Do not start extra daemons or long-lived REST/MCP servers unless the test explicitly requires them and the owner process is tracked for cleanup.
+Default to the installed CLI plus the MCP tools already exposed to the active client. Do not start extra daemons or long-lived REST/MCP servers unless the test explicitly requires them and the owner process is tracked for cleanup.
 
 ## Safety rules
 
@@ -17,11 +17,46 @@ Default to direct installed-CLI probes. Do not start extra daemons or long-lived
    - Prefer `systemctl --user restart mempal-daemon.service` for restart.
    - Verify exactly one `/usr/local/bin/mempal daemon --foreground` after restart.
    - Do not run `mempal serve` as a long-lived REST server for smoke unless a route test requires it; if started, track and kill it.
-   - Do not spawn extra `mempal serve --mcp` processes from the shell. MCP reconnect is a client action.
+   - Do not spawn unmanaged `mempal serve --mcp` processes from the shell. The checked-in `scripts/full_smoke.py` runner may start short-lived MCP stdio servers because it owns their PID lifecycle, sends shutdown/exit, and kills leftovers.
 4. Before declaring a lock failure, inspect DB holders with `mempal daemon status` and summarize only roles/counts/PIDs/commands.
-5. Prefer read-only CLI smoke first. Use reversible write/delete only when the requested task requires proving write paths or when read-only probes expose a write-path risk.
-6. If using a synthetic write, use a unique marker, a `smoke/manual` wing-room, `--no-gate`, and `--wait`, then clean up only the exact drawer ID(s) returned by the ingest response. Never delete IDs discovered from generic search results. Report IDs only when cleanup fails; do not print content.
-7. If there is already context that should become durable memory, it is acceptable to ingest a concise real note instead of synthetic content, but only when the note is genuinely useful and non-secret.
+5. Full smoke means read-only probes plus reversible memory CRUD through both CLI and MCP when the active client exposes MCP tools. If MCP tools are unavailable, record `mcp_crud=skipped_unavailable` and do not spawn an unmanaged MCP holder just to satisfy the matrix.
+6. If using a synthetic write, use a unique marker, a `smoke/cli` or `smoke/mcp` wing-room, explicit typed metadata, and bounded wait/poll behavior, then clean up only exact drawer ID(s) returned by the create/update operation's `created_drawer_ids`. Never delete IDs discovered from generic search/read results. Report IDs only when cleanup fails; do not print content.
+7. Update smoke must use replacement semantics (`--supersedes` / `supersedes`) against an exact drawer ID created earlier in the same smoke run. If the initial create did not expose a cleanup-safe created ID, skip update/delete and fail closed.
+8. If there is already context that should become durable memory, it is acceptable to ingest a concise real note instead of synthetic content, but only when the note is genuinely useful and non-secret.
+
+## Preferred automated full smoke
+
+Use the checked-in runner first when the goal is broad coverage rather than one-off diagnosis:
+
+```bash
+python3 skills/smoke-test/scripts/full_smoke.py | tee /tmp/mempal-skill-full-smoke.log
+```
+
+The runner is intentionally part of this repo-local skill (`skills/smoke-test/scripts/full_smoke.py`) rather than `/tmp` so the exact CLI/MCP protocol, safety rules, and cleanup behavior stay versioned with the skill. It prints one aggregate JSON object and avoids raw memory content.
+
+Runner behavior:
+
+- CLI CRUD: JSON stdin `mempal ingest --stdin --json`, `search`, `view`, `context`, `pin`, `unpin`, `ingest --supersedes`, exact-ID `delete`, post-delete search verification.
+- MCP read-only probes: short-lived isolated MCP stdio servers per optional probe to avoid one tool's SQLite read lock poisoning the rest of the matrix.
+- MCP CRUD: `mempal_ingest`, `mempal_operation_status`, `mempal_search`, `mempal_read_drawer`, `mempal_read_drawers`, `mempal_context`, `mempal_brief`, `mempal_ingest` with `supersedes`, `mempal_delete`, post-delete search verification.
+- Timed-out MCP ingest receipts: close the MCP server before following the returned `operation_id` with `mempal operation wait --json`; this avoids MCP self-holder SQLite lock false failures.
+- Cleanup: if a later step fails after create exposed cleanup-safe IDs, delete those exact IDs before exiting.
+- I/O telemetry: sample daemon `/proc/<pid>/io` before/after when the daemon PID stays stable, sample `/proc/<pid>/io` for CLI child commands and short-lived MCP stdio servers, and keep `resource.getrusage(RUSAGE_CHILDREN)` block counters as an aggregate fallback. The runner also appends content-free telemetry to `target/smoke-io-history.jsonl`.
+
+If the runner exits nonzero, parse only the final JSON summary:
+
+```bash
+python3 - <<'PY'
+import json, pathlib
+line = [line for line in pathlib.Path('/tmp/mempal-skill-full-smoke.log').read_text(errors='replace').splitlines() if line.strip()][-1]
+data = json.loads(line)
+print({'overall_ok': data.get('overall_ok'), 'failures': data.get('failures'), 'cleanup': data.get('cleanup'), 'created_counts': data.get('created_counts'), 'io': data.get('io')})
+for name in data.get('failures', []):
+    print(name, data.get('groups', {}).get(name))
+PY
+```
+
+Do not paste raw command output from the log into chat; the JSON summary is already redacted/aggregate-only.
 
 ## Preflight
 
@@ -73,6 +108,22 @@ Pass criteria:
 - daemon exe resolves to `/usr/local/bin/mempal` and is not deleted;
 - no untracked extra `mempal serve --mcp` processes were created by the smoke;
 - RSS is reasonable immediately after restart (normally hundreds of MB, not multi-GB).
+
+## Coverage target
+
+Run the broadest safe matrix the current environment supports. A full report should classify each group as `pass`, `fail`, or `skipped_<reason>`.
+
+| Group | Surface | Required coverage |
+|---|---|---|
+| Runtime | CLI/systemd/process | installed binary, daemon singleton, current executable, DB holders, RSS/resource summary |
+| Read-only memory | CLI | status, stats, search, context, timeline/tail shape, pinned shape, knowledge/card/repair/pattern/skill surfaces where supported |
+| Reversible CRUD | CLI | create via `mempal ingest`, read via `search` + `view`, update via `ingest --supersedes`, pin/unpin, delete via exact created IDs, post-delete verification |
+| REST | CLI doctor or tracked REST server | route/health shape and degraded warning categories |
+| Read-only MCP | MCP tools | `mempal_status`, `mempal_search`, `mempal_context`, `mempal_pinned_facts`, `mempal_timeline`, `mempal_doctor`, plus optional knowledge/brief/taxonomy/skill tools exposed by the client |
+| Reversible CRUD | MCP tools | create via `mempal_ingest`, read via `mempal_search` + `mempal_read_drawer`, update via `mempal_ingest` with `supersedes`, delete via `mempal_delete`, post-delete search verification |
+| Cleanup | CLI/process | no extra daemon/MCP/REST holders, all exact-created smoke IDs soft-deleted or explicitly reported |
+
+Never downgrade a failed CRUD path to pass because another surface worked. Report CLI CRUD and MCP CRUD separately.
 
 ## Read-only CLI smoke matrix
 
@@ -202,9 +253,9 @@ run_mempal_probe context json timeout 120s mempal context '<known safe query>' -
 
 If these are slow, report latency and memory growth; do not treat slowness as pass unless the task only asked for availability.
 
-## Optional reversible write smoke
+## Reversible CLI memory CRUD smoke
 
-Use only when write-path validation is required.
+Run this by default for full smoke unless the operator explicitly requests read-only mode. The flow must exercise create, read, update, pin/unpin, search, context, and delete through the command line.
 
 1. Generate a unique marker:
 
@@ -218,9 +269,21 @@ Use only when write-path validation is required.
    ingest_json="$(mktemp)"
    operation_json=""
    smoke_ids="$(mktemp)"
-   if printf '{"content":"%s reversible smoke drawer; safe to delete","wing":"smoke","room":"manual"}\n' "$marker" \
-     | mempal ingest --stdin --wing smoke --room manual --no-gate --wait --wait-timeout-secs 60 --json \
+   if python3 - "$marker" <<'PY' \
+     | mempal ingest --stdin --wing smoke --room cli --source-type agent_inference --memory-kind evidence --domain project --field smoke --no-gate --wait --wait-timeout-secs 90 --json \
      > "$ingest_json"; then
+import json, sys
+marker = sys.argv[1]
+print(json.dumps({
+    "content": f"{marker} reversible CLI smoke drawer; safe to delete",
+    "wing": "smoke",
+    "room": "cli",
+    "source_type": "agent_inference",
+    "memory_kind": "evidence",
+    "domain": "project",
+    "field": "smoke",
+}))
+PY
      :
    fi
    python3 - "$ingest_json" > "$smoke_ids" <<'PY'
@@ -285,7 +348,82 @@ PY
 
    Do not print the ingest response, operation response, or smoke IDs unless cleanup fails. `created_drawer_ids` from the terminal ingest JSON, or from terminal `mempal operation wait/status --json`, is the cleanup authority. `cleanup_drawer_ids` is only a human-readable alias when it mirrors the created list. `drawer_id` and `drawer_ids` are informational because they may name pre-existing, deduplicated, dropped, or merge-target drawers. If `created_drawer_ids` is empty after the terminal wait/status step, fail closed.
 
-3. Optionally search for the marker as a verification probe only. Keep output in a temporary file, print aggregate counts only, never print search result bodies/snippets, and never use search result IDs for deletion:
+3. Read and query the created memory without printing content:
+
+   ```bash
+   created_id="$(head -n 1 "$smoke_ids")"
+   view_out="$(mktemp)"
+   search_json="$(mktemp)"
+   context_json="$(mktemp)"
+   pinned_json="$(mktemp)"
+
+   mempal view "$created_id" --all-projects > "$view_out"
+   mempal search "$marker" --top-k 5 --json > "$search_json"
+   mempal context "$marker" --format json --max-items 3 --no-distill-suggestions > "$context_json"
+   mempal pinned --json > "$pinned_json"
+
+   python3 - "$view_out" "$search_json" "$context_json" "$pinned_json" <<'PY'
+import json, sys
+from pathlib import Path
+view_out, search_path, context_path, pinned_path = [Path(p) for p in sys.argv[1:]]
+results = json.loads(search_path.read_text() or "[]")
+context = json.loads(context_path.read_text() or "{}")
+pinned = json.loads(pinned_path.read_text() or "[]")
+summary = {
+    "view_stdout_bytes": view_out.stat().st_size,
+    "search_count": len(results) if isinstance(results, list) else None,
+    "context_fields": sorted(context.keys()) if isinstance(context, dict) else [],
+    "pinned_type": type(pinned).__name__,
+}
+print(json.dumps(summary, sort_keys=True))
+PY
+   rm -f "$view_out" "$search_json" "$context_json" "$pinned_json"
+   ```
+
+   The summary is aggregate-only. Do not print `view`, search result content, context sections, pinned text, snippets, or previews. Search result IDs are not cleanup authority.
+
+4. Update by replacement semantics, then verify the replacement ID:
+
+   ```bash
+   created_id="$(head -n 1 "$smoke_ids")"
+   update_json="$(mktemp)"
+   update_ids="$(mktemp)"
+   if python3 - "$marker" <<'PY' \
+     | mempal ingest --stdin --wing smoke --room cli --source-type agent_inference --memory-kind evidence --domain project --field smoke --no-gate --supersedes "$created_id" --wait --wait-timeout-secs 90 --json \
+     > "$update_json"; then
+import json, sys
+marker = sys.argv[1]
+print(json.dumps({
+    "content": f"{marker} reversible CLI smoke drawer updated; safe to delete",
+    "wing": "smoke",
+    "room": "cli",
+    "source_type": "agent_inference",
+    "memory_kind": "evidence",
+    "domain": "project",
+    "field": "smoke",
+}))
+PY
+     :
+   fi
+   python3 - "$update_json" > "$update_ids" <<'PY'
+import json, sys
+from pathlib import Path
+obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
+for item in dict.fromkeys(x for x in obj.get("created_drawer_ids", []) if isinstance(x, str) and x):
+    print(item)
+PY
+   if [ ! -s "$update_ids" ]; then
+     echo "update smoke did not expose cleanup-safe created_drawer_ids; fail closed" >&2
+     exit 1
+   fi
+   cat "$update_ids" >> "$smoke_ids"
+   updated_id="$(head -n 1 "$update_ids")"
+   updated_view="$(mktemp)"
+   mempal view "$updated_id" --all-projects > "$updated_view"
+   rm -f "$updated_view" "$update_json" "$update_ids"
+   ```
+
+5. Verify marker visibility again, then pin/unpin and delete exact smoke IDs from create/update responses. Suppress command output so `mempal delete` cannot print drawer summaries:
 
    ```bash
    verify_json="$(mktemp)"
@@ -301,17 +439,14 @@ matches = [
     item for item in results
     if isinstance(item, dict)
     and item.get("wing") == "smoke"
-    and item.get("room") == "manual"
+    and item.get("room") == "cli"
     and marker in str(item.get("content", ""))
 ]
-print(f"active_smoke_marker_matches={len(matches)}")
+print(f"active_cli_smoke_marker_matches={len(matches)}")
 PY
    rm -f "$verify_json"
-   ```
 
-4. For each exact smoke ID from the ingest response, optionally test pin/unpin, then delete. Suppress command output so `mempal delete` cannot print drawer summaries:
-
-   ```bash
+   sort -u "$smoke_ids" -o "$smoke_ids"
    while IFS= read -r smoke_id; do
      mempal pin "$smoke_id" >/dev/null || true
      mempal unpin "$smoke_id" >/dev/null || true
@@ -323,7 +458,54 @@ PY
    rm -f "$ingest_json" "$operation_json" "$smoke_ids"
    ```
 
-5. Re-run the aggregate marker verification from step 3 and confirm no active `smoke/manual` marker match remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
+6. Re-run aggregate marker verification and confirm no active `smoke/cli` marker match remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
+
+## Reversible MCP memory CRUD smoke
+
+Run this by default for full smoke. Prefer MCP tools already exposed to the active client. If the active client has no mempal MCP tools, it is acceptable to start a short-lived tracked stdio child with `mempal serve --mcp`, call the tools, then shut it down and verify no extra holder remains.
+
+Required MCP tool coverage when available:
+
+| Step | MCP method/tool | Required assertion |
+|---|---|---|
+| initialize | JSON-RPC `initialize` then `notifications/initialized` | server name present |
+| discover | `tools/list` | includes `mempal_ingest`, `mempal_operation_status`, `mempal_search`, `mempal_read_drawer`, `mempal_delete` |
+| status | `mempal_status` | structured object, db holder fields summarized only |
+| create | `mempal_ingest` with `wing="smoke"`, `room="mcp"`, `smoke=true`, `wait=true`, typed metadata | completed or terminal success; `created_drawer_ids` non-empty |
+| read/search | `mempal_search`, `mempal_read_drawer`, optionally `mempal_read_drawers` | structured responses parse; do not print content |
+| context/read-only | `mempal_context`, `mempal_pinned_facts`, `mempal_timeline`, `mempal_doctor`, optionally `mempal_taxonomy`, `mempal_field_taxonomy`, `mempal_kg`, `mempal_skill`, `mempal_brief` | shape-only success or classified skip/failure |
+| update | `mempal_ingest` with `supersedes=<created_id>`, same smoke scope, `smoke=true`, `wait=true` | replacement `created_drawer_ids` non-empty |
+| delete | `mempal_delete` for every exact create/update ID | `deleted=true` or explicit already-deleted for duplicate cleanup attempt |
+| post-delete | `mempal_search` marker query | no active `smoke/mcp` marker matches, or soft-delete visibility classified |
+| shutdown | `shutdown` then `notifications/exit`; kill only if needed | child exits; no extra MCP/DB holder remains |
+
+MCP stdio uses newline-delimited JSON-RPC messages in this project. A minimal client pattern is:
+
+```python
+send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mempal-smoke","version":"0"}}})
+send({"jsonrpc":"2.0","method":"notifications/initialized"})
+send({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}})
+send({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"mempal_ingest","arguments":{"content":"<marker> reversible MCP smoke drawer; safe to delete","wing":"smoke","room":"mcp","source_type":"agent_inference","memory_kind":"evidence","domain":"project","field":"smoke","smoke":True,"wait":True,"wait_timeout_secs":90}}})
+```
+
+Capture MCP responses to temp files and report only: method/tool name, JSON-RPC error class if any, latency, structuredContent top-level fields, result counts, and cleanup-created ID counts. Never print `content`, snippets, previews, prompts, drawer text, or raw response bodies.
+
+Cleanup authority is the same as CLI: only `created_drawer_ids` from `mempal_ingest` or `mempal_operation_status` may be deleted automatically. Do not delete `drawer_id`, search hits, read results, or marker matches.
+
+Public MCP `mempal_ingest` exposes a constrained smoke path through `smoke=true`. The server accepts it only for small writes under `wing="smoke"` and `room="mcp"`, rejects diary rollup, and internally bypasses gating/novelty so automated smoke can receive cleanup-authoritative `created_drawer_ids`. If a terminal MCP smoke write still has no `created_drawer_ids`, classify it as `inconclusive_no_cleanup_id`, do not attempt update/delete, and do not use search result IDs for cleanup.
+
+## Dangerous or non-default surfaces
+
+Default smoke must skip these unless the task explicitly asks for them and an exact cleanup plan exists:
+
+- `mempal_rollback`: dry-run only; never execute real rollback in smoke.
+- Purge/delete-all style commands: forbidden for smoke.
+- `mempal_peek_partner`: may read live session text; skip.
+- `mempal_cowork_push` and `mempal_cowork_bus send/broadcast/drain/capture`: skip because they mutate or expose cowork traffic.
+- Taxonomy/tunnel/knowledge graph mutations such as taxonomy edit, tunnel add/delete, and `mempal_kg add/invalidate`: skip unless exact synthetic IDs and cleanup are proven.
+- Knowledge/profile promotion workflows (`promote`, `adopt`, `reject`, `retire`, `publish`, card promote/demote): read/list/gate summaries only by default.
+
+For content-bearing read-only tools (`mempal_context`, `mempal_brief`, `mempal_pinned_facts`, `mempal_timeline`, search/read tools), summarize counts/fields/bytes only and redact or omit values named `content`, `text`, `preview`, `statement`, `narrative`, `messages`, `facts.content`, snippets, prompts, and model output.
 
 ## REST checks
 
@@ -335,10 +517,6 @@ Prefer `mempal doctor rest --format json` for route availability. If an actual R
 4. Kill the temporary server and verify no extra `mempal serve` process remains.
 
 Do not confuse daemon service health with REST server availability; they are separate surfaces.
-
-## MCP checks
-
-Do not spawn MCP servers manually for smoke. If MCP tool validation is required, ask the interactive client to reconnect MCP (for example `/mcp`) and then call available read-only MCP tools. Pass criteria are shape/status only; do not print raw memory content.
 
 ## Memory growth guard
 
@@ -358,7 +536,8 @@ If read-only commands push RSS into multi-GB territory, file or update an issue 
 - Daemon restart, if performed, leaves one current-binary daemon.
 - Read-only matrix exits 0 or failures are classified by command/stderr class.
 - Raw stdout/stderr from content-bearing `mempal` commands was captured, structurally summarized, and not pasted into chat or log summaries.
-- Optional write smoke cleans up its own drawers.
-- REST/MCP checks do not leave extra processes.
+- CLI CRUD smoke creates, reads/searches/contexts, updates, pin/unpins, deletes, and verifies cleanup using only exact `created_drawer_ids`.
+- MCP CRUD smoke creates, reads/searches/contexts, updates, deletes, and verifies cleanup through MCP tools using the constrained `smoke=true` write path. If a terminal MCP smoke write lacks cleanup-safe `created_drawer_ids`, classify it as `inconclusive_no_cleanup_id` and keep the MCP CRUD group non-pass. Use `skipped_unavailable` only when no MCP client/tooling is available.
+- REST/MCP checks do not leave extra processes or DB holders.
 - Memory before/after is recorded.
 - Worktree remains clean except intentional skill/code changes.

--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -1,0 +1,832 @@
+#!/usr/bin/env python3
+"""Aggregate-only mempal smoke runner for repo-local skills/smoke-test.
+
+Exercises CLI and MCP CRUD without printing drawer content or raw command output.
+"""
+from __future__ import annotations
+
+import json
+import os
+import select
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import resource
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[3]
+MARKER = f"mempal-skill-smoke-{int(time.time())}-{os.getpid()}"
+NONCE = os.urandom(16).hex()
+SUMMARY: dict[str, Any] = {
+    'marker_hash': None,
+    'groups': {},
+    'cleanup': {'cli_deleted_count': 0, 'mcp_deleted_count': 0, 'failures': 0},
+    'created_counts': {'cli': 0, 'mcp': 0},
+    'failures': [],
+    'io': {
+        'schema': 'mempal_smoke_io_v2',
+        'included_sources': [
+            'daemon_proc_io_delta_when_pid_stable',
+            'cli_child_proc_io_delta',
+            'mcp_stdio_child_proc_io_delta',
+            'children_resource_block_io_delta',
+        ],
+    },
+}
+
+PROC_IO_KEYS = ('read_bytes', 'write_bytes', 'cancelled_write_bytes', 'rchar', 'wchar')
+
+
+def note(name: str, ok: bool, **fields: Any) -> None:
+    safe = {'ok': ok}
+    safe.update(fields)
+    SUMMARY['groups'][name] = safe
+    if not ok:
+        SUMMARY['failures'].append(name)
+
+
+def without_ok(info: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in info.items() if key != 'ok'}
+
+
+def daemon_main_pid() -> int | None:
+    try:
+        proc = run_child_process(
+            ['systemctl', '--user', 'show', 'mempal-daemon.service', '-p', 'MainPID'],
+            timeout=10,
+            io_category='cli_child_processes',
+        )
+        stdout = proc['stdout'].decode('utf-8', errors='replace')
+        for line in stdout.splitlines():
+            if line.startswith('MainPID='):
+                value = int(line.split('=', 1)[1])
+                return value or None
+    except Exception:
+        return None
+    return None
+
+
+def read_proc_io(pid: int | None) -> dict[str, int] | None:
+    if pid is None:
+        return None
+    try:
+        data = Path(f'/proc/{pid}/io').read_text()
+    except Exception:
+        return None
+    keys = {'read_bytes', 'write_bytes', 'cancelled_write_bytes', 'rchar', 'wchar'}
+    parsed: dict[str, int] = {}
+    for line in data.splitlines():
+        if ':' not in line:
+            continue
+        key, value = line.split(':', 1)
+        if key in keys:
+            try:
+                parsed[key] = int(value.strip())
+            except ValueError:
+                pass
+    return parsed
+
+
+def io_delta(before: dict[str, int] | None, after: dict[str, int] | None) -> dict[str, int] | None:
+    if before is None or after is None:
+        return None
+    return {key: after.get(key, 0) - before.get(key, 0) for key in sorted(set(before) | set(after))}
+
+
+def proc_io_aggregate() -> dict[str, Any]:
+    return {
+        'process_count': 0,
+        'sampled_process_count': 0,
+        'missing_process_count': 0,
+        **{key: 0 for key in PROC_IO_KEYS},
+    }
+
+
+def record_proc_io_delta(category: str, before: dict[str, int] | None, after: dict[str, int] | None) -> None:
+    aggregate = SUMMARY['io'].setdefault(category, proc_io_aggregate())
+    aggregate['process_count'] += 1
+    delta = io_delta(before, after)
+    if delta is None:
+        aggregate['missing_process_count'] += 1
+        return
+    aggregate['sampled_process_count'] += 1
+    for key in PROC_IO_KEYS:
+        aggregate[key] += max(0, int(delta.get(key, 0)))
+
+
+def wait_exited_without_reap(pid: int, timeout: float) -> bool | None:
+    if not hasattr(os, 'waitid') or not hasattr(os, 'P_PID'):
+        return None
+    deadline = time.monotonic() + timeout
+    flags = os.WEXITED | os.WNOHANG | getattr(os, 'WNOWAIT', 0)
+    while True:
+        try:
+            info = os.waitid(os.P_PID, pid, flags)
+        except ChildProcessError:
+            return None
+        if info is not None:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.02)
+
+
+def read_tempfile_bytes(handle: Any) -> bytes:
+    handle.flush()
+    handle.seek(0)
+    return handle.read()
+
+
+def run_child_process(
+    args: list[str],
+    *,
+    input_text: str | None = None,
+    timeout: int = 120,
+    io_category: str,
+) -> dict[str, Any]:
+    stdout_file = tempfile.TemporaryFile()
+    stderr_file = tempfile.TemporaryFile()
+    start = time.monotonic()
+    timed_out = False
+    killed = False
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        proc = subprocess.Popen(
+            args,
+            cwd=REPO,
+            stdin=subprocess.PIPE if input_text is not None else subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+        )
+        before = read_proc_io(proc.pid)
+        if input_text is not None and proc.stdin is not None:
+            try:
+                proc.stdin.write(input_text.encode())
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+
+        exited = wait_exited_without_reap(proc.pid, timeout)
+        if exited is False:
+            timed_out = True
+            killed = True
+            proc.kill()
+            wait_exited_without_reap(proc.pid, 5)
+        elif exited is None:
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                killed = True
+                proc.kill()
+                proc.wait(timeout=5)
+
+        after = read_proc_io(proc.pid)
+        return_code = proc.wait(timeout=5)
+        record_proc_io_delta(io_category, before, after)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        killed = True
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+        return_code = 124
+        if proc is not None:
+            record_proc_io_delta(io_category, None, None)
+    except Exception as exc:
+        if proc is not None:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+            record_proc_io_delta(io_category, None, None)
+        return {
+            'returncode': 125,
+            'stdout': read_tempfile_bytes(stdout_file),
+            'stderr': read_tempfile_bytes(stderr_file),
+            'latency_ms': int((time.monotonic() - start) * 1000),
+            'timed_out': False,
+            'killed': proc is not None,
+            'error_type': type(exc).__name__,
+        }
+    finally:
+        try:
+            if proc is not None and proc.stdin is not None and not proc.stdin.closed:
+                proc.stdin.close()
+        except Exception:
+            pass
+
+    elapsed = int((time.monotonic() - start) * 1000)
+    return {
+        'returncode': 124 if timed_out else return_code,
+        'stdout': read_tempfile_bytes(stdout_file),
+        'stderr': read_tempfile_bytes(stderr_file),
+        'latency_ms': elapsed,
+        'timed_out': timed_out,
+        'killed': killed,
+    }
+
+
+def child_io_blocks_snapshot() -> dict[str, int]:
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return {'ru_inblock': int(usage.ru_inblock), 'ru_oublock': int(usage.ru_oublock)}
+
+
+def child_io_blocks_delta(before: dict[str, int], after: dict[str, int]) -> dict[str, int]:
+    return {key: after.get(key, 0) - before.get(key, 0) for key in sorted(set(before) | set(after))}
+
+
+def json_shape(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {'type': 'object', 'field_count': len(value), 'fields': sorted(value.keys())[:30]}
+        # Count common collection fields without exposing values.
+        for key in ('results', 'drawers', 'entries', 'facts', 'tools', 'system_warnings'):
+            if isinstance(value.get(key), list):
+                out[f'{key}_count'] = len(value[key])
+        return out
+    if isinstance(value, list):
+        return {'type': 'array', 'count': len(value)}
+    return {'type': type(value).__name__}
+
+
+def parse_json_bytes(data: bytes) -> tuple[Any | None, dict[str, Any]]:
+    text = data.decode('utf-8', errors='replace')
+    try:
+        value = json.loads(text or 'null')
+        return value, {'ok': True, **json_shape(value)}
+    except Exception as exc:
+        lines = [line for line in text.splitlines() if line.strip()]
+        parsed = []
+        try:
+            for line in lines:
+                parsed.append(json.loads(line))
+            return parsed, {'ok': True, 'type': 'ndjson', 'line_count': len(parsed)}
+        except Exception:
+            return None, {'ok': False, 'error_type': type(exc).__name__, 'line_count': len(lines)}
+
+
+def run_cli(name: str, args: list[str], *, input_text: str | None = None, expect_json: bool = False, timeout: int = 120) -> tuple[int, bytes, bytes, Any | None, dict[str, Any]]:
+    result = run_child_process(
+        args,
+        input_text=input_text,
+        timeout=timeout,
+        io_category='cli_child_processes',
+    )
+    parsed = None
+    shape: dict[str, Any] = {}
+    if expect_json:
+        parsed, shape = parse_json_bytes(result['stdout'])
+    ok = result['returncode'] == 0 and (not expect_json or shape.get('ok') is True)
+    note(
+        name,
+        ok,
+        exit_code=result['returncode'],
+        latency_ms=result['latency_ms'],
+        stdout_bytes=len(result['stdout']),
+        stderr_bytes=len(result['stderr']),
+        timeout=result.get('timed_out') or None,
+        killed=result.get('killed') or None,
+        json=shape or None,
+    )
+    return result['returncode'], result['stdout'], result['stderr'], parsed, shape
+
+
+def created_ids_from(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    ids = value.get('created_drawer_ids')
+    if isinstance(ids, list):
+        return list(dict.fromkeys(x for x in ids if isinstance(x, str) and x))
+    return []
+
+
+def terminal_state(value: Any) -> bool:
+    return isinstance(value, dict) and value.get('state') in {'completed', 'rejected', 'failed'}
+
+
+def count_marker_matches(value: Any, room: str) -> int:
+    if isinstance(value, dict):
+        results = value.get('results')
+    else:
+        results = value
+    if not isinstance(results, list):
+        return 0
+    count = 0
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        if item.get('wing') == 'smoke' and item.get('room') == room and MARKER in str(item.get('content', '')):
+            count += 1
+    return count
+
+
+def delete_exact_ids_cli(drawer_ids: list[str], label: str) -> dict[str, Any]:
+    unique_ids = list(dict.fromkeys(drawer_ids))
+    deleted = 0
+    failed = 0
+    stdout_bytes = 0
+    stderr_bytes = 0
+    for drawer_id in unique_ids:
+        proc = run_child_process(
+            ['mempal', 'delete', drawer_id],
+            timeout=60,
+            io_category='cli_child_processes',
+        )
+        stdout_bytes += len(proc['stdout'])
+        stderr_bytes += len(proc['stderr'])
+        if proc['returncode'] == 0:
+            deleted += 1
+        else:
+            failed += 1
+    result = {
+        'attempted_count': len(unique_ids),
+        'deleted_count': deleted,
+        'failed_count': failed,
+        'stdout_bytes': stdout_bytes,
+        'stderr_bytes': stderr_bytes,
+    }
+    note(label, failed == 0 or deleted > 0 or not unique_ids, **result)
+    return result
+
+
+def wait_operation(operation_id: str, name: str) -> Any | None:
+    rc, out, _err, parsed, _shape = run_cli(name, ['mempal', 'operation', 'wait', operation_id, '--timeout-secs', '300', '--json'], expect_json=True, timeout=330)
+    if rc != 0 or not terminal_state(parsed):
+        rc, out, _err, parsed, _shape = run_cli(name + '_status', ['mempal', 'operation', 'status', operation_id, '--json'], expect_json=True, timeout=30)
+    return parsed
+
+
+def cli_crud() -> list[str]:
+    cleanup_ids: list[str] = []
+    content = json.dumps({'content': f'{MARKER} reversible CLI smoke drawer; nonce {NONCE}; lexical tokens quorvax nimbledrift zettaplum; safe to delete', 'wing': 'smoke', 'room': 'cli', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke'}) + '\n'
+    rc, _out, _err, parsed, _shape = run_cli(
+        'cli_create',
+        ['mempal', 'ingest', '--stdin', '--wing', 'smoke', '--room', 'cli', '--source-type', 'agent_inference', '--memory-kind', 'evidence', '--domain', 'project', '--field', 'smoke', '--no-gate', '--wait', '--wait-timeout-secs', '90', '--json'],
+        input_text=content,
+        expect_json=True,
+        timeout=130,
+    )
+    ids = created_ids_from(parsed)
+    if not ids and isinstance(parsed, dict) and parsed.get('operation_id'):
+        parsed2 = wait_operation(parsed['operation_id'], 'cli_create_wait')
+        ids = created_ids_from(parsed2)
+    if not ids:
+        note('cli_crud', False, reason='create_missing_created_drawer_ids')
+        return cleanup_ids
+    cleanup_ids.extend(ids)
+    created_id = ids[0]
+    SUMMARY['created_counts']['cli'] = len(cleanup_ids)
+
+    run_cli('cli_read_view', ['mempal', 'view', created_id, '--all-projects'], timeout=60)
+    _rc, _out, _err, search_parsed, _shape = run_cli('cli_search_created', ['mempal', 'search', MARKER, '--top-k', '5', '--json'], expect_json=True, timeout=180)
+    matches = count_marker_matches(search_parsed, 'cli')
+    note('cli_search_created_match', matches > 0, active_matches=matches)
+    run_cli('cli_context_created', ['mempal', 'context', MARKER, '--format', 'json', '--max-items', '3', '--no-distill-suggestions'], expect_json=True, timeout=150)
+    run_cli('cli_pinned_before', ['mempal', 'pinned', '--json'], expect_json=True, timeout=60)
+    run_cli('cli_pin', ['mempal', 'pin', created_id], timeout=60)
+    run_cli('cli_unpin', ['mempal', 'unpin', created_id], timeout=60)
+    run_cli('cli_pinned_after', ['mempal', 'pinned', '--json'], expect_json=True, timeout=60)
+
+    update_content = json.dumps({'content': f'{MARKER} reversible CLI smoke drawer updated; nonce {NONCE[::-1]}; lexical tokens ploverquartz rivetmint yondercoil; safe to delete', 'wing': 'smoke', 'room': 'cli', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke'}) + '\n'
+    rc, _out, _err, upd_parsed, _shape = run_cli(
+        'cli_update',
+        ['mempal', 'ingest', '--stdin', '--wing', 'smoke', '--room', 'cli', '--source-type', 'agent_inference', '--memory-kind', 'evidence', '--domain', 'project', '--field', 'smoke', '--no-gate', '--supersedes', created_id, '--wait', '--wait-timeout-secs', '90', '--json'],
+        input_text=update_content,
+        expect_json=True,
+        timeout=130,
+    )
+    upd_ids = created_ids_from(upd_parsed)
+    if not upd_ids and isinstance(upd_parsed, dict) and upd_parsed.get('operation_id'):
+        upd_parsed2 = wait_operation(upd_parsed['operation_id'], 'cli_update_wait')
+        upd_ids = created_ids_from(upd_parsed2)
+    if not upd_ids:
+        delete_exact_ids_cli(cleanup_ids, 'cli_cleanup_after_update_failure')
+        note('cli_crud', False, reason='update_missing_created_drawer_ids', cleanup_id_count=len(cleanup_ids))
+        return cleanup_ids
+    cleanup_ids.extend(upd_ids)
+    SUMMARY['created_counts']['cli'] = len(cleanup_ids)
+    run_cli('cli_read_updated', ['mempal', 'view', upd_ids[0], '--all-projects'], timeout=60)
+
+    delete_result = delete_exact_ids_cli(cleanup_ids, 'cli_delete_batch')
+    deleted = int(delete_result['deleted_count'])
+    delete_failures = int(delete_result['failed_count'])
+    SUMMARY['cleanup']['cli_deleted_count'] = deleted
+    _rc, _out, _err, post_parsed, _shape = run_cli('cli_search_post_delete', ['mempal', 'search', MARKER, '--top-k', '5', '--json'], expect_json=True, timeout=180)
+    post_matches = count_marker_matches(post_parsed, 'cli')
+    if post_matches > 0:
+        SUMMARY['cleanup']['failures'] += delete_failures
+    note('cli_crud', post_matches == 0 and deleted > 0, created_id_count=len(cleanup_ids), deleted_count=deleted, delete_failed_attempt_count=delete_failures, post_delete_active_matches=post_matches)
+    return cleanup_ids
+
+
+class McpClient:
+    def __init__(self) -> None:
+        self.stderr_file = tempfile.TemporaryFile()
+        self.proc_io_before: dict[str, int] | None = None
+        self.proc = subprocess.Popen(
+            ['mempal', 'serve', '--mcp'],
+            cwd=str(REPO),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=self.stderr_file,
+            text=True,
+            bufsize=1,
+        )
+        self.proc_io_before = read_proc_io(self.proc.pid)
+        self.next_id = 1
+
+    def send(self, msg: dict[str, Any]) -> None:
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(json.dumps(msg, separators=(',', ':')) + '\n')
+        self.proc.stdin.flush()
+
+    def call(self, method: str, params: dict[str, Any] | None = None, timeout: int = 120) -> dict[str, Any]:
+        msg_id = self.next_id
+        self.next_id += 1
+        self.send({'jsonrpc': '2.0', 'id': msg_id, 'method': method, 'params': params or {}})
+        return self.read_response(msg_id, timeout)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        msg: dict[str, Any] = {'jsonrpc': '2.0', 'method': method}
+        if params is not None:
+            msg['params'] = params
+        self.send(msg)
+
+    def read_response(self, msg_id: int, timeout: int) -> dict[str, Any]:
+        assert self.proc.stdout is not None
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            remaining = max(0.1, end - time.monotonic())
+            ready, _, _ = select.select([self.proc.stdout], [], [], remaining)
+            if not ready:
+                continue
+            line = self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError('mcp eof')
+            msg = json.loads(line)
+            if msg.get('id') == msg_id:
+                return msg
+        raise TimeoutError(f'mcp response timeout for {msg_id}')
+
+    def tool(self, name: str, arguments: dict[str, Any], timeout: int = 120) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+        start = time.monotonic()
+        try:
+            msg = self.call('tools/call', {'name': name, 'arguments': arguments}, timeout=timeout)
+            elapsed = int((time.monotonic() - start) * 1000)
+            if 'error' in msg:
+                return None, {'ok': False, 'latency_ms': elapsed, 'error_code': msg['error'].get('code'), 'error_message_bytes': len(json.dumps(msg['error']).encode())}
+            result = msg.get('result', {})
+            structured = result.get('structuredContent')
+            return structured, {'ok': isinstance(structured, dict), 'latency_ms': elapsed, 'shape': json_shape(structured)}
+        except Exception as exc:
+            return None, {'ok': False, 'error_type': type(exc).__name__}
+
+    def close(self) -> None:
+        killed = False
+        exited = False
+        try:
+            self.call('shutdown', {}, timeout=5)
+        except Exception:
+            pass
+        try:
+            self.notify('notifications/exit')
+        except Exception:
+            pass
+        try:
+            waited = wait_exited_without_reap(self.proc.pid, 5)
+            exited = waited is True
+        except Exception:
+            exited = False
+        proc_io_after = read_proc_io(self.proc.pid)
+        try:
+            self.proc.wait(timeout=5)
+        except Exception:
+            try:
+                killed = True
+                self.proc.kill()
+            except Exception:
+                pass
+            try:
+                wait_exited_without_reap(self.proc.pid, 5)
+                proc_io_after = proc_io_after or read_proc_io(self.proc.pid)
+                self.proc.wait(timeout=5)
+                exited = True
+            except Exception:
+                pass
+        record_proc_io_delta('mcp_stdio_child_processes', self.proc_io_before, proc_io_after)
+        lifecycle = SUMMARY.setdefault('mcp_stdio_lifecycle', {'process_count': 0, 'exited_count': 0, 'killed_count': 0})
+        lifecycle['process_count'] += 1
+        if exited or self.proc.returncode is not None:
+            lifecycle['exited_count'] += 1
+        if killed:
+            lifecycle['killed_count'] += 1
+        try:
+            self.stderr_file.close()
+        except Exception:
+            pass
+
+
+def mcp_start_initialized() -> McpClient:
+    client = McpClient()
+    init = client.call('initialize', {'protocolVersion': '2024-11-05', 'capabilities': {}, 'clientInfo': {'name': 'mempal-skill-smoke', 'version': '0'}}, timeout=15)
+    note('mcp_initialize', 'result' in init, result_fields=sorted(init.get('result', {}).keys()) if isinstance(init.get('result'), dict) else [])
+    client.notify('notifications/initialized')
+    return client
+
+
+def mcp_call_isolated(tool_names: list[str], name: str, args: dict[str, Any], timeout: int) -> tuple[Any | None, dict[str, Any]]:
+    label = 'mcp_read_' + name.removeprefix('mempal_')
+    if name not in tool_names:
+        note(label, True, skipped='tool_not_advertised')
+        return None, {'ok': True, 'skipped': True}
+    client: McpClient | None = None
+    try:
+        client = mcp_start_initialized()
+        structured, info = client.tool(name, args, timeout=timeout)
+        note(label, bool(info.get('ok')), **without_ok(info))
+        return structured, info
+    except Exception as exc:
+        note(label, False, error_type=type(exc).__name__)
+        return None, {'ok': False, 'error_type': type(exc).__name__}
+    finally:
+        if client is not None:
+            client.close()
+
+
+def mcp_crud() -> list[str]:
+    cleanup_ids: list[str] = []
+    # Discover tools in a throwaway server, then close it so status/read-only
+    # probes cannot leave the CRUD server holding a stale read lock.
+    discover: McpClient | None = None
+    try:
+        discover = mcp_start_initialized()
+        tools_msg = discover.call('tools/list', {}, timeout=30)
+        tools = tools_msg.get('result', {}).get('tools', [])
+        tool_names = sorted(t.get('name') for t in tools if isinstance(t, dict) and isinstance(t.get('name'), str))
+        required = {'mempal_ingest', 'mempal_operation_status', 'mempal_search', 'mempal_read_drawer', 'mempal_delete'}
+        note('mcp_tools_list', required.issubset(set(tool_names)), tool_count=len(tool_names), required_missing=sorted(required - set(tool_names)))
+    except Exception as exc:
+        note('mcp_crud', False, error_type=type(exc).__name__, stage='tools_list')
+        return cleanup_ids
+    finally:
+        if discover is not None:
+            discover.close()
+
+    for name, args, timeout in [
+        ('mempal_pinned_facts', {'budget_chars': 512}, 30),
+        ('mempal_timeline', {'top_k': 3, 'since': '1h'}, 30),
+        ('mempal_doctor', {}, 30),
+        ('mempal_field_taxonomy', {}, 30),
+        ('mempal_taxonomy', {'action': 'list'}, 30),
+        ('mempal_kg', {'action': 'stats'}, 30),
+        ('mempal_skill', {'action': 'list'}, 30),
+    ]:
+        mcp_call_isolated(tool_names, name, args, timeout)
+
+    client: McpClient | None = None
+    try:
+        client = mcp_start_initialized()
+        create_args = {'content': f'{MARKER} reversible MCP smoke drawer; nonce {NONCE}; lexical tokens azurequill basaltfern cobaltlyric; safe to delete', 'wing': 'smoke', 'room': 'mcp', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke', 'smoke': True, 'wait': True, 'wait_timeout_secs': 90}
+        create, info = client.tool('mempal_ingest', create_args, timeout=130)
+        ids = created_ids_from(create)
+        if not ids and isinstance(create, dict) and create.get('operation_id'):
+            status, sinfo = client.tool('mempal_operation_status', {'operation_id': create['operation_id']}, timeout=30)
+            note('mcp_create_status', bool(sinfo.get('ok')), **without_ok(sinfo))
+            ids = created_ids_from(status)
+            if not ids:
+                client.close()
+                client = None
+                waited = wait_operation(create['operation_id'], 'mcp_create_cli_wait')
+                ids = created_ids_from(waited)
+        note('mcp_create', bool(info.get('ok')) and bool(ids), created_id_count=len(ids), **without_ok(info))
+        if not ids:
+            note(
+                'mcp_inconclusive_no_cleanup_id',
+                False,
+                reason='create_missing_created_drawer_ids',
+                product_issue='https://github.com/RyderFreeman4Logos/mempal/issues/545',
+            )
+            return cleanup_ids
+        cleanup_ids.extend(ids)
+        created_id = ids[0]
+        SUMMARY['created_counts']['mcp'] = len(cleanup_ids)
+        if client is None:
+            client = mcp_start_initialized()
+
+        for name, args, timeout in [
+            ('mempal_search', {'query': MARKER, 'top_k': 5, 'all_projects': True}, 180),
+            ('mempal_read_drawer', {'drawer_id': created_id, 'all_projects': True}, 60),
+            ('mempal_read_drawers', {'drawer_ids': [created_id], 'max_count': 2, 'all_projects': True}, 60),
+            ('mempal_context', {'query': MARKER, 'all_projects': True, 'max_items': 3, 'include_distill_suggestions': False}, 150),
+            ('mempal_brief', {'query': MARKER, 'domain': 'project', 'field': 'smoke', 'cwd': str(REPO), 'max_items': 3}, 150),
+        ]:
+            if name in tool_names:
+                structured, info = client.tool(name, args, timeout=timeout)
+                note('mcp_' + name.removeprefix('mempal_'), bool(info.get('ok')), **without_ok(info))
+                if name == 'mempal_search':
+                    matches = count_marker_matches(structured, 'mcp')
+                    note('mcp_search_created_match', matches > 0, active_matches=matches)
+            else:
+                note('mcp_' + name.removeprefix('mempal_'), True, skipped='tool_not_advertised')
+
+        update_args = {'content': f'{MARKER} reversible MCP smoke drawer updated; nonce {NONCE[::-1]}; lexical tokens deltaorchid embervault frostcairn; safe to delete', 'wing': 'smoke', 'room': 'mcp', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke', 'smoke': True, 'supersedes': created_id, 'wait': True, 'wait_timeout_secs': 90}
+        update, uinfo = client.tool('mempal_ingest', update_args, timeout=130)
+        upd_ids = created_ids_from(update)
+        if not upd_ids and isinstance(update, dict) and update.get('operation_id'):
+            status, sinfo = client.tool('mempal_operation_status', {'operation_id': update['operation_id']}, timeout=30)
+            note('mcp_update_status', bool(sinfo.get('ok')), **without_ok(sinfo))
+            upd_ids = created_ids_from(status)
+            if not upd_ids:
+                client.close()
+                client = None
+                waited = wait_operation(update['operation_id'], 'mcp_update_cli_wait')
+                upd_ids = created_ids_from(waited)
+        note('mcp_update', bool(uinfo.get('ok')) and bool(upd_ids), created_id_count=len(upd_ids), **without_ok(uinfo))
+        if not upd_ids:
+            delete_exact_ids_cli(cleanup_ids, 'mcp_cleanup_after_update_failure')
+            note(
+                'mcp_inconclusive_no_cleanup_id',
+                False,
+                reason='update_missing_created_drawer_ids',
+                product_issue='https://github.com/RyderFreeman4Logos/mempal/issues/545',
+            )
+            return cleanup_ids
+        cleanup_ids.extend(upd_ids)
+        SUMMARY['created_counts']['mcp'] = len(cleanup_ids)
+        if client is None:
+            client = mcp_start_initialized()
+        structured, info = client.tool('mempal_read_drawer', {'drawer_id': upd_ids[0], 'all_projects': True}, timeout=60)
+        note('mcp_read_updated', bool(info.get('ok')), **without_ok(info))
+
+        deleted = 0
+        delete_false_count = 0
+        for drawer_id in list(dict.fromkeys(cleanup_ids)):
+            structured, dinfo = client.tool('mempal_delete', {'drawer_id': drawer_id}, timeout=60)
+            ok = bool(dinfo.get('ok')) and isinstance(structured, dict) and structured.get('deleted') is True
+            if ok:
+                deleted += 1
+            else:
+                delete_false_count += 1
+        SUMMARY['cleanup']['mcp_deleted_count'] = deleted
+        post, pinfo = client.tool('mempal_search', {'query': MARKER, 'top_k': 5, 'all_projects': True}, timeout=180)
+        post_matches = count_marker_matches(post, 'mcp')
+        if post_matches > 0:
+            SUMMARY['cleanup']['failures'] += delete_false_count
+        note('mcp_delete_batch', post_matches == 0, attempted_count=len(set(cleanup_ids)), deleted_count=deleted, delete_false_count=delete_false_count)
+        note('mcp_crud', post_matches == 0 and deleted > 0, created_id_count=len(cleanup_ids), deleted_count=deleted, delete_false_count=delete_false_count, post_delete_active_matches=post_matches)
+        if 'mempal_status' in tool_names:
+            structured, sinfo = client.tool('mempal_status', {}, timeout=30)
+            note('mcp_status_last', bool(sinfo.get('ok')), **without_ok(sinfo))
+        return cleanup_ids
+    except Exception as exc:
+        note('mcp_crud', False, error_type=type(exc).__name__)
+        return cleanup_ids
+    finally:
+        if client is not None:
+            client.close()
+        # If MCP CRUD failed after exposing cleanup-safe IDs, clean them by exact ID.
+        if SUMMARY['groups'].get('mcp_crud', {}).get('ok') is not True and cleanup_ids:
+            cleaned = 0
+            for drawer_id in list(dict.fromkeys(cleanup_ids)):
+                proc = run_child_process(
+                    ['mempal', 'delete', drawer_id],
+                    timeout=60,
+                    io_category='cli_child_processes',
+                )
+                if proc['returncode'] == 0:
+                    cleaned += 1
+            note('mcp_fallback_cli_cleanup', True, exact_id_count=len(set(cleanup_ids)), deleted_count=cleaned)
+
+
+def holder_summary() -> dict[str, Any]:
+    try:
+        proc = run_child_process(
+            ['mempal', 'daemon', 'status'],
+            timeout=30,
+            io_category='cli_child_processes',
+        )
+        text = (proc['stdout'] + proc['stderr']).decode('utf-8', errors='replace')
+        parsed: dict[str, Any] = {
+            'exit_ok': proc['returncode'] == 0,
+            'bytes': len(proc['stdout']) + len(proc['stderr']),
+            'status': None,
+            'total_holders': None,
+            'extra_holders': None,
+            'stale_mcp_servers': None,
+            'orphan_daemons': None,
+        }
+        for line in text.splitlines():
+            if line.startswith('status:'):
+                parsed['status'] = line.split(':', 1)[1].strip()
+            for key in ('total', 'extra_holders', 'stale_mcp_servers', 'orphan_daemons'):
+                if line.startswith(key + ':'):
+                    try:
+                        value = int(line.split(':', 1)[1].strip().split()[0])
+                    except Exception:
+                        value = None
+                    parsed['total_holders' if key == 'total' else key] = value
+        return {
+            **parsed,
+            'unmanaged_mcp_holder_state': 'clear'
+            if (parsed.get('stale_mcp_servers') in (0, None) and parsed.get('extra_holders') in (0, None))
+            else 'present',
+        }
+    except Exception as exc:
+        return {'exit_ok': False, 'error_type': type(exc).__name__}
+
+
+def classify_daemon(pid_before: int | None, pid_after: int | None) -> dict[str, Any]:
+    if pid_before and pid_after and pid_before == pid_after:
+        state = 'stable'
+    elif pid_before and pid_after:
+        state = 'restarted'
+    elif pid_before and not pid_after:
+        state = 'exited_or_stopped'
+    elif not pid_before and pid_after:
+        state = 'started'
+    else:
+        state = 'not_running'
+    return {
+        'pid_before': pid_before,
+        'pid_after': pid_after,
+        'state': state,
+        'pid_stable': bool(pid_before and pid_after and pid_before == pid_after),
+    }
+
+
+def append_io_history() -> None:
+    record = {
+        'schema': 'mempal_smoke_io_history_v1',
+        'timestamp_unix': int(time.time()),
+        'marker_hash': SUMMARY.get('marker_hash'),
+        'overall_ok': SUMMARY.get('overall_ok'),
+        'duration_ms': SUMMARY.get('duration_ms'),
+        'failure_count': len(SUMMARY.get('failures', [])),
+        'cleanup': SUMMARY.get('cleanup'),
+        'created_counts': SUMMARY.get('created_counts'),
+        'daemon': SUMMARY.get('daemon'),
+        'holders_after': SUMMARY.get('holders_after'),
+        'io': SUMMARY.get('io'),
+    }
+    path = REPO / 'target' / 'smoke-io-history.jsonl'
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open('a', encoding='utf-8') as handle:
+            handle.write(json.dumps(record, sort_keys=True) + '\n')
+        SUMMARY['io_history'] = {'appended': True, 'path': str(path.relative_to(REPO))}
+    except Exception as exc:
+        SUMMARY['io_history'] = {'appended': False, 'error_type': type(exc).__name__}
+
+
+def main() -> int:
+    import hashlib
+    SUMMARY['marker_hash'] = hashlib.sha256(MARKER.encode()).hexdigest()[:16]
+    daemon_pid_before = daemon_main_pid()
+    daemon_io_before = read_proc_io(daemon_pid_before)
+    child_io_before = child_io_blocks_snapshot()
+    SUMMARY['io']['daemon_pid_before'] = daemon_pid_before
+    start = time.monotonic()
+    run_cli('version', ['mempal', '--version'], timeout=30)
+    run_cli('daemon_status_pre', ['mempal', 'daemon', 'status'], timeout=30)
+    run_cli('doctor_rest', ['mempal', 'doctor', 'rest', '--format', 'json'], expect_json=True, timeout=60)
+    run_cli('status', ['mempal', 'status'], timeout=60)
+    run_cli('timeline_json', ['mempal', 'timeline', '--since', '1h', '--format', 'json'], expect_json=True, timeout=60)
+    run_cli('pinned_json', ['mempal', 'pinned', '--json'], expect_json=True, timeout=60)
+    run_cli('field_taxonomy_json', ['mempal', 'field-taxonomy', '--format', 'json'], expect_json=True, timeout=60)
+    run_cli('patterns_json', ['mempal', 'patterns', 'list', '--json'], expect_json=True, timeout=60)
+    run_cli('skills_json', ['mempal', 'skills', 'list', '--json'], expect_json=True, timeout=60)
+    run_cli('repair_json', ['mempal', 'repair', 'list', '--json'], expect_json=True, timeout=60)
+
+    cli_ids = cli_crud()
+    mcp_ids = mcp_crud()
+
+    SUMMARY['holders_after'] = holder_summary()
+    daemon_pid_after = daemon_main_pid()
+    daemon_io_after = read_proc_io(daemon_pid_after)
+    child_io_after = child_io_blocks_snapshot()
+    SUMMARY['daemon'] = classify_daemon(daemon_pid_before, daemon_pid_after)
+    SUMMARY['io']['daemon_pid_after'] = daemon_pid_after
+    SUMMARY['io']['daemon_proc_io_delta'] = io_delta(daemon_io_before, daemon_io_after) if daemon_pid_before == daemon_pid_after else None
+    SUMMARY['io']['child_block_io_delta'] = child_io_blocks_delta(child_io_before, child_io_after)
+    SUMMARY['duration_ms'] = int((time.monotonic() - start) * 1000)
+    SUMMARY['overall_ok'] = not SUMMARY['failures'] and SUMMARY['cleanup']['failures'] == 0
+    append_io_history()
+    print(json.dumps(SUMMARY, sort_keys=True))
+    return 0 if SUMMARY['overall_ok'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5071,6 +5071,7 @@ impl ResolvedStdinIngest {
             wait: Some(true),
             wait_timeout_secs: Some(wait_timeout_secs),
             diary_rollup: Some(false),
+            smoke: None,
             importance: Some(self.drawer_importance),
             memory_kind: Some(memory_kind_slug(&self.memory_kind).to_string()),
             domain: Some(domain_slug(&self.domain).to_string()),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1943,9 +1943,55 @@ impl ValidatedIngestMetadata {
 }
 
 const MAX_WAIT_TIMEOUT_SECS: u64 = 86_400;
+const MCP_SMOKE_CONTENT_MAX_BYTES: usize = 4 * 1024;
 
 fn clamp_wait_timeout(timeout: Duration) -> Duration {
     timeout.min(Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
+}
+
+fn resolve_mcp_ingest_controls(
+    request: &IngestRequest,
+    controls: IngestControls,
+) -> std::result::Result<IngestControls, ErrorData> {
+    if !request.smoke.unwrap_or(false) {
+        return Ok(controls);
+    }
+
+    validate_mcp_smoke_ingest_request(request)?;
+    Ok(IngestControls {
+        no_gate: true,
+        bypass_novelty: true,
+    })
+}
+
+fn validate_mcp_smoke_ingest_request(
+    request: &IngestRequest,
+) -> std::result::Result<(), ErrorData> {
+    if request.wing != "smoke" {
+        return Err(ErrorData::invalid_params(
+            "smoke ingest requires wing=\"smoke\"",
+            None,
+        ));
+    }
+    if request.room.as_deref() != Some("mcp") {
+        return Err(ErrorData::invalid_params(
+            "smoke ingest requires room=\"mcp\"",
+            None,
+        ));
+    }
+    if request.content.len() > MCP_SMOKE_CONTENT_MAX_BYTES {
+        return Err(ErrorData::invalid_params(
+            format!("smoke ingest content must be <= {MCP_SMOKE_CONTENT_MAX_BYTES} bytes"),
+            None,
+        ));
+    }
+    if request.diary_rollup.unwrap_or(false) {
+        return Err(ErrorData::invalid_params(
+            "smoke ingest cannot use diary_rollup",
+            None,
+        ));
+    }
+    Ok(())
 }
 
 #[allow(dead_code)]
@@ -4687,7 +4733,7 @@ impl MempalMcpServer {
 
     #[tool(
         name = "mempal_ingest",
-        description = "Persist a decision, bug fix, design insight, profile fact, or typed knowledge/evidence drawer to project memory. Call this when a durable fact is reached in conversation and include the rationale, not just the outcome. Wing is required; room is optional. Supports typed metadata params (`memory_kind`, `domain`, `field`, `statement`, `tier`, `status`, anchors), pinned facts (`is_pinned`), supersession (`supersedes`/`replace_text`), validity windows, confidence/source_type, dry_run preview, and receipt-based waiting via `wait`/`wait_timeout_secs` (wait=true blocks to a terminal state or returns a timed_out receipt you can poll with `mempal_operation_status`)."
+        description = "Persist a decision, bug fix, design insight, profile fact, or typed knowledge/evidence drawer to project memory. Call this when a durable fact is reached in conversation and include the rationale, not just the outcome. Wing is required; room is optional. Supports typed metadata params (`memory_kind`, `domain`, `field`, `statement`, `tier`, `status`, anchors), pinned facts (`is_pinned`), supersession (`supersedes`/`replace_text`), validity windows, confidence/source_type, dry_run preview, and receipt-based waiting via `wait`/`wait_timeout_secs` (wait=true blocks to a terminal state or returns a timed_out receipt you can poll with `mempal_operation_status`). Constrained smoke writes may set `smoke=true` only for small synthetic `wing=\"smoke\"`, `room=\"mcp\"` payloads."
     )]
     pub async fn mempal_ingest(
         &self,
@@ -4728,6 +4774,7 @@ impl MempalMcpServer {
         worker_mode: IngestWaitWorkerMode,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let dry_run = request.dry_run.unwrap_or(false);
+        let controls = resolve_mcp_ingest_controls(&request, controls)?;
         if !dry_run && global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
         }
@@ -5035,6 +5082,7 @@ impl MempalMcpServer {
         compiled_privacy: &crate::core::config::CompiledPrivacyConfig,
         project_id: Option<String>,
     ) -> std::result::Result<PreparedIngestOperation, ErrorData> {
+        let controls = resolve_mcp_ingest_controls(request, controls)?;
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy);
         let scrubbed_source = request
@@ -5125,6 +5173,7 @@ impl MempalMcpServer {
         runtime_writer_lease: Option<&RuntimeWriterLease>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let dry_run = request.dry_run.unwrap_or(false);
+        let controls = resolve_mcp_ingest_controls(&request, controls)?;
         if !dry_run && global_embed_status().should_block_writes() {
             return Err(degraded_write_error());
         }
@@ -12376,7 +12425,7 @@ pattern_boost = 0.2
             .and_then(|value| value.as_object())
             .expect("mempal_ingest must have a properties object");
 
-        for field in ["wait", "wait_timeout_secs"] {
+        for field in ["wait", "wait_timeout_secs", "smoke"] {
             assert!(
                 props.get(field).is_some(),
                 "mempal_ingest must expose {field} in tools/list"
@@ -15432,6 +15481,7 @@ reject_on_contradiction = true
                     importance: None,
                     dry_run: None,
                     diary_rollup: None,
+                    smoke: None,
                     supersedes: None,
                     replace_text: None,
                     valid_from: None,
@@ -15550,6 +15600,157 @@ enabled = false
             .await
             .expect("cleanup ingest completion");
         assert_eq!(completed.state, Some(IngestOperationState::Completed));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_smoke_mode_rejects_non_smoke_scope() {
+        let (_tempdir, _db_path, server) = setup_server();
+
+        let error = match server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "smoke validation must not include request content in errors".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("mcp".to_string()),
+                smoke: Some(true),
+                ..IngestRequest::default()
+            }))
+            .await
+        {
+            Ok(_) => panic!("smoke mode must reject non-smoke wing"),
+            Err(error) => error,
+        };
+
+        let error_text = error.to_string();
+        assert!(error_text.contains("wing=\"smoke\""), "error={error_text}");
+        assert!(
+            !error_text.contains("request content"),
+            "smoke validation errors must not echo content: {error_text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_smoke_mode_sets_internal_controls() {
+        let _tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = _tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let _config_guard = ConfigOverrideGuard::install(&format!(
+            r#"
+db_path = "{}"
+
+[privacy]
+enabled = false
+
+[ingest_gating]
+enabled = false
+"#,
+            db_path.display()
+        ))
+        .await;
+        let gate = Arc::new(Notify::new());
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let server = MempalMcpServer::new_with_factory(
+            db_path.clone(),
+            Arc::new(BlockingEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+                call_count: Arc::clone(&call_count),
+                gate: Arc::clone(&gate),
+                released: Arc::new(AtomicBool::new(false)),
+            }),
+        )
+        .expect("create MCP server");
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "bounded MCP smoke write should bypass gates for cleanup authority"
+                    .to_string(),
+                wing: "smoke".to_string(),
+                room: Some("mcp".to_string()),
+                source_type: Some("agent_inference".to_string()),
+                memory_kind: Some("evidence".to_string()),
+                domain: Some("project".to_string()),
+                field: Some("smoke".to_string()),
+                smoke: Some(true),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("smoke ingest should queue")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while call_count.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker should reach embed");
+        let db = Database::open(&db_path).expect("open db");
+        let payload: String = db
+            .conn()
+            .query_row(
+                "SELECT payload FROM pending_messages WHERE id = ?1",
+                [operation_id],
+                |row| row.get(0),
+            )
+            .expect("read queued ingest payload");
+        let decoded: PreparedIngestOperation =
+            serde_json::from_str(&payload).expect("decode queued ingest payload");
+
+        assert_eq!(decoded.request.smoke, Some(true));
+        assert!(decoded.controls.no_gate);
+        assert!(decoded.controls.bypass_novelty);
+
+        gate.notify_one();
+
+        let completed = server
+            .wait_for_operation_completion(operation_id)
+            .await
+            .expect("cleanup ingest completion");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_smoke_ingest_wait_and_status_return_created_ids() {
+        let (_tempdir, _db_path, server) = setup_server();
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "cleanup-authoritative MCP smoke write one".to_string(),
+                wing: "smoke".to_string(),
+                room: Some("mcp".to_string()),
+                source_type: Some("agent_inference".to_string()),
+                memory_kind: Some("evidence".to_string()),
+                domain: Some("project".to_string()),
+                field: Some("smoke".to_string()),
+                smoke: Some(true),
+                wait: Some(true),
+                wait_timeout_secs: Some(5),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("smoke ingest should complete")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "smoke wait response must expose cleanup authority"
+        );
+        assert_eq!(response.drawer_ids, response.created_drawer_ids);
+
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let status = server
+            .operation_status_json_for_test(operation_id)
+            .await
+            .expect("operation status should load");
+
+        assert_eq!(status.state, Some(IngestOperationState::Completed));
+        assert_eq!(status.created_drawer_ids, response.created_drawer_ids);
+        assert_eq!(status.drawer_ids, status.created_drawer_ids);
+        assert!(!status.dropped);
+        assert!(status.rejected_reason.is_none());
     }
 
     // =========================================================================

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1683,6 +1683,12 @@ pub struct IngestRequest {
     /// UTC day. Requires wing="agent-diary" and an explicit room.
     pub diary_rollup: Option<bool>,
 
+    /// If true, enable the constrained MCP smoke-test write path. This is only
+    /// accepted for small synthetic writes under wing="smoke", room="mcp";
+    /// accepted smoke writes bypass gating/novelty so cleanup can rely on
+    /// operation-scoped created_drawer_ids.
+    pub smoke: Option<bool>,
+
     /// Importance ranking (0-5). Higher values appear first in wake-up context.
     /// Default 0. Use 3-5 for key decisions, architecture choices, and lessons learned.
     pub importance: Option<i32>,


### PR DESCRIPTION
## Summary
- Add a constrained MCP smoke ingest mode for cleanup-safe CRUD smoke coverage.
- Extend the repo-local full smoke runner with MCP CRUD, exact created-ID cleanup, daemon/MCP holder checks, and aggregate I/O telemetry.
- Keep smoke output content-free and aggregate-only.

## Verification
- CSA-Codex writer committed `909fd85 fix(smoke): add MCP smoke CRUD path and I/O telemetry`.
- Exact-head CSA-Codex review PASS/CLEAN: session `01KVS6EN1Y5R9H99B1KCTWZKJP`, range `main...HEAD`, SHA `909fd85f7da`.
- `csa review --check-verdict --sa-mode true --range 'main...HEAD'` passed.
- `python3 -m py_compile skills/smoke-test/scripts/full_smoke.py` passed.
- `just pre-commit` passed locally with `/ssd` target and Cargo/test jobs capped at 1.
- Pre-push hooks passed: branch-protection, local-gates, release/rest/package builds, and review-check.

Closes #545
