### PR TITLE
fix(mcp): preserve receipts for uncertain daemon enqueue

### DIFF
--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -333,7 +333,7 @@ def count_marker_matches(value: Any, room: str) -> int:
     return count
 
 
-def delete_exact_ids_cli(drawer_ids: list[str], label: str) -> dict[str, Any]:
+def delete_exact_ids_cli(drawer_ids: list[str], label: str, room: str | None = None) -> dict[str, Any]:
     unique_ids = list(dict.fromkeys(drawer_ids))
     deleted = 0
     failed = 0
@@ -351,6 +351,16 @@ def delete_exact_ids_cli(drawer_ids: list[str], label: str) -> dict[str, Any]:
             deleted += 1
         else:
             failed += 1
+    active_matches_after_failed_deletes: int | None = None
+    if failed > 0 and deleted == 0 and room is not None:
+        rc, _out, _err, parsed, _shape = run_cli(
+            label + '_post_cleanup_search',
+            ['mempal', 'search', MARKER, '--top-k', '5', '--json'],
+            expect_json=True,
+            timeout=180,
+        )
+        if rc == 0:
+            active_matches_after_failed_deletes = count_marker_matches(parsed, room)
     result = {
         'attempted_count': len(unique_ids),
         'deleted_count': deleted,
@@ -358,7 +368,16 @@ def delete_exact_ids_cli(drawer_ids: list[str], label: str) -> dict[str, Any]:
         'stdout_bytes': stdout_bytes,
         'stderr_bytes': stderr_bytes,
     }
-    note(label, failed == 0 or deleted > 0 or not unique_ids, **result)
+    if active_matches_after_failed_deletes is not None:
+        result['active_matches_after_failed_deletes'] = active_matches_after_failed_deletes
+    note(
+        label,
+        failed == 0
+        or deleted > 0
+        or not unique_ids
+        or active_matches_after_failed_deletes == 0,
+        **result,
+    )
     return result
 
 
@@ -413,7 +432,7 @@ def cli_crud() -> list[str]:
         upd_parsed2 = wait_operation(upd_parsed['operation_id'], 'cli_update_wait')
         upd_ids = created_ids_from(upd_parsed2)
     if not upd_ids:
-        delete_exact_ids_cli(cleanup_ids, 'cli_cleanup_after_update_failure')
+        delete_exact_ids_cli(cleanup_ids, 'cli_cleanup_after_update_failure', room='cli')
         note('cli_crud', False, reason='update_missing_created_drawer_ids', cleanup_id_count=len(cleanup_ids))
         return cleanup_ids
     cleanup_ids.extend(upd_ids)
@@ -656,7 +675,7 @@ def mcp_crud() -> list[str]:
                 upd_ids = created_ids_from(waited)
         note('mcp_update', bool(uinfo.get('ok')) and bool(upd_ids), created_id_count=len(upd_ids), **without_ok(uinfo))
         if not upd_ids:
-            delete_exact_ids_cli(cleanup_ids, 'mcp_cleanup_after_update_failure')
+            delete_exact_ids_cli(cleanup_ids, 'mcp_cleanup_after_update_failure', room='mcp')
             note(
                 'mcp_inconclusive_no_cleanup_id',
                 False,

--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -36,6 +36,7 @@ SUMMARY: dict[str, Any] = {
         ],
     },
 }
+OWNED_MCP_CHILDREN: dict[int, subprocess.Popen[Any]] = {}
 
 PROC_IO_KEYS = ('read_bytes', 'write_bytes', 'cancelled_write_bytes', 'rchar', 'wchar')
 
@@ -464,6 +465,7 @@ class McpClient:
             text=True,
             bufsize=1,
         )
+        OWNED_MCP_CHILDREN[self.proc.pid] = self.proc
         self.proc_io_before = read_proc_io(self.proc.pid)
         self.next_id = 1
 
@@ -556,6 +558,32 @@ class McpClient:
             self.stderr_file.close()
         except Exception:
             pass
+        if self.proc.returncode is not None:
+            OWNED_MCP_CHILDREN.pop(self.proc.pid, None)
+
+
+def wait_owned_mcp_children_reaped(timeout: float = 5.0) -> dict[str, Any]:
+    initial_pids = sorted(OWNED_MCP_CHILDREN)
+    deadline = time.monotonic() + timeout
+    while OWNED_MCP_CHILDREN and time.monotonic() < deadline:
+        for pid, proc in list(OWNED_MCP_CHILDREN.items()):
+            try:
+                proc.wait(timeout=0)
+            except subprocess.TimeoutExpired:
+                continue
+            except Exception:
+                OWNED_MCP_CHILDREN.pop(pid, None)
+                continue
+            if proc.returncode is not None:
+                OWNED_MCP_CHILDREN.pop(pid, None)
+        if OWNED_MCP_CHILDREN:
+            time.sleep(0.05)
+    remaining_pids = sorted(OWNED_MCP_CHILDREN)
+    return {
+        'initial_count': len(initial_pids),
+        'remaining_count': len(remaining_pids),
+        'reaped_count': len(initial_pids) - len(remaining_pids),
+    }
 
 
 def mcp_start_initialized() -> McpClient:
@@ -832,6 +860,7 @@ def main() -> int:
     cli_ids = cli_crud()
     mcp_ids = mcp_crud()
 
+    SUMMARY['mcp_owned_children_after_wait'] = wait_owned_mcp_children_reaped()
     SUMMARY['holders_after'] = holder_summary()
     daemon_pid_after = daemon_main_pid()
     daemon_io_after = read_proc_io(daemon_pid_after)

--- a/src/core/async_db.rs
+++ b/src/core/async_db.rs
@@ -96,11 +96,11 @@ impl ConnPool {
     }
 
     fn open_one(path: &Path, query_only: bool) -> Result<Database, DbError> {
-        let db = Database::open(path)?;
         if query_only {
-            db.conn().pragma_update(None, "query_only", "ON")?;
+            Database::open_query_only(path)
+        } else {
+            Database::open(path)
         }
-        Ok(db)
     }
 
     /// Pop an idle connection; reopen a fresh one if the pool was transiently
@@ -159,8 +159,8 @@ impl AsyncDb {
             });
         }
 
-        let readers = ConnPool::open(path, n_read, true)?;
         let writer = ConnPool::open(path, 1, false)?;
+        let readers = ConnPool::open(path, n_read, true)?;
         Ok(Self {
             readers: Arc::new(readers),
             writer: Arc::new(writer),

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -200,6 +200,14 @@ CREATE INDEX IF NOT EXISTS idx_triples_object ON triples(object);
 
 static SQLITE_VEC_AUTO_EXTENSION: OnceLock<Result<(), String>> = OnceLock::new();
 
+pub(crate) fn ensure_wal_journal_mode(conn: &Connection) -> rusqlite::Result<()> {
+    let mode = conn.query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0))?;
+    if !mode.eq_ignore_ascii_case("wal") {
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+    }
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 pub enum DbError {
     #[error("failed to create database directory for {path}")]
@@ -494,7 +502,7 @@ impl Database {
             conn.pragma_update(None, "query_only", "ON")?;
         }
         if mode.allows_write() {
-            conn.pragma_update(None, "journal_mode", "WAL")?;
+            ensure_wal_journal_mode(&conn)?;
             conn.pragma_update(None, "synchronous", "NORMAL")?;
             conn.execute_batch("PRAGMA foreign_keys = ON;")?;
             apply_migrations(&conn)?;

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -367,6 +367,7 @@ pub struct HistoricalRejudgeCandidate {
 #[derive(Clone, Copy)]
 enum OpenMode {
     ReadOnly,
+    QueryOnly,
     ReadWrite,
 }
 
@@ -448,6 +449,12 @@ impl Database {
         Self::open_with_mode(path, OpenMode::ReadOnly)
     }
 
+    /// Open a non-mutating connection for read paths that must not run startup
+    /// writes such as WAL mode changes or migrations.
+    pub fn open_query_only(path: &Path) -> Result<Self, DbError> {
+        Self::open_with_mode(path, OpenMode::QueryOnly)
+    }
+
     fn open_with_mode(path: &Path, mode: OpenMode) -> Result<Self, DbError> {
         Self::open_with_mode_and_busy_timeout(path, mode, Duration::from_secs(5))
     }
@@ -475,11 +482,17 @@ impl Database {
             OpenMode::ReadOnly => {
                 Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?
             }
+            OpenMode::QueryOnly => {
+                Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?
+            }
             OpenMode::ReadWrite => Connection::open(path)?,
         };
         conn.busy_timeout(busy_timeout)?;
         conn.pragma_update(None, "cache_size", SQLITE_CACHE_SIZE_KIB_DEFAULT)?;
         register_math_functions(&conn)?;
+        if matches!(mode, OpenMode::QueryOnly) {
+            conn.pragma_update(None, "query_only", "ON")?;
+        }
         if mode.allows_write() {
             conn.pragma_update(None, "journal_mode", "WAL")?;
             conn.pragma_update(None, "synchronous", "NORMAL")?;
@@ -7439,6 +7452,41 @@ mod tests {
 
         assert_eq!(cache_size, SQLITE_CACHE_SIZE_KIB_DEFAULT);
         assert_eq!(mmap_size, 0, "issue #311 must not add multi-GiB mmap");
+    }
+
+    #[test]
+    fn query_only_connection_opens_while_writer_lock_is_held() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("initialize db");
+
+        let lock_holder = Connection::open(&db_path).expect("open lock holder");
+        lock_holder
+            .busy_timeout(Duration::from_millis(25))
+            .expect("set lock holder busy timeout");
+        lock_holder
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold write lock");
+
+        let reader = Database::open_with_mode_and_busy_timeout(
+            &db_path,
+            OpenMode::QueryOnly,
+            Duration::from_millis(25),
+        )
+        .expect("query-only reader opens without startup writes");
+        let query_only: i64 = reader
+            .conn()
+            .query_row("PRAGMA query_only", [], |row| row.get(0))
+            .expect("read query_only pragma");
+
+        assert_eq!(query_only, 1);
+        reader
+            .drawer_count()
+            .expect("query-only reader can read while writer lock is held");
+        reader
+            .conn()
+            .execute("CREATE TABLE query_only_must_not_write(id INTEGER)", [])
+            .expect_err("query-only connection must reject mutations");
     }
 
     fn insert_test_source_drawer_with_vector(

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -96,6 +96,58 @@ fn runtime_boot_id() -> Option<String> {
     None
 }
 
+#[cfg(target_os = "linux")]
+fn runtime_writer_process_is_live_holder(pid: u32, boot_id: Option<&str>) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let Some(expected_boot_id) = boot_id else {
+        return false;
+    };
+    if runtime_boot_id().as_deref() != Some(expected_boot_id) {
+        return false;
+    }
+
+    let proc_dir = PathBuf::from(format!("/proc/{pid}"));
+    if !proc_dir.exists() {
+        return false;
+    }
+    if pid == std::process::id() {
+        return true;
+    }
+
+    let exe_matches = fs::read_link(proc_dir.join("exe"))
+        .ok()
+        .as_deref()
+        .is_some_and(runtime_writer_path_is_mempal_holder);
+    if exe_matches {
+        return true;
+    }
+
+    fs::read(proc_dir.join("cmdline"))
+        .ok()
+        .and_then(|cmdline| {
+            cmdline
+                .split(|byte| *byte == 0)
+                .find(|part| !part.is_empty())
+                .map(|part| PathBuf::from(String::from_utf8_lossy(part).into_owned()))
+        })
+        .as_deref()
+        .is_some_and(runtime_writer_path_is_mempal_holder)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn runtime_writer_process_is_live_holder(_pid: u32, _boot_id: Option<&str>) -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn runtime_writer_path_is_mempal_holder(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "mempal")
+}
+
 fn truncate_preview(content: &str, max_chars: usize) -> String {
     let mut chars = content.chars();
     let mut preview = chars.by_ref().take(max_chars).collect::<String>();
@@ -5088,6 +5140,43 @@ impl Database {
         ttl_secs: u64,
         metadata_json: Option<&str>,
     ) -> Result<Option<RuntimeWriterLease>, DbError> {
+        self.runtime_writer_lease_acquire_with_cleanup_policy(
+            name,
+            owner,
+            mode,
+            ttl_secs,
+            metadata_json,
+            false,
+        )
+    }
+
+    pub fn runtime_writer_lease_acquire_preserving_live_holders(
+        &self,
+        name: &str,
+        owner: &str,
+        mode: &str,
+        ttl_secs: u64,
+        metadata_json: Option<&str>,
+    ) -> Result<Option<RuntimeWriterLease>, DbError> {
+        self.runtime_writer_lease_acquire_with_cleanup_policy(
+            name,
+            owner,
+            mode,
+            ttl_secs,
+            metadata_json,
+            true,
+        )
+    }
+
+    fn runtime_writer_lease_acquire_with_cleanup_policy(
+        &self,
+        name: &str,
+        owner: &str,
+        mode: &str,
+        ttl_secs: u64,
+        metadata_json: Option<&str>,
+        preserve_live_holders: bool,
+    ) -> Result<Option<RuntimeWriterLease>, DbError> {
         let mut session_id = String::new();
         let mut acquired = false;
         let mut acquired_at = String::new();
@@ -5095,7 +5184,7 @@ impl Database {
         let pid = std::process::id();
         let boot_id = runtime_boot_id();
         self.with_immediate_tx(|| {
-            self.runtime_writer_lease_cleanup_expired_tx()?;
+            self.runtime_writer_lease_cleanup_expired_tx(preserve_live_holders)?;
             session_id = runtime_writer_session_id(name, owner);
             let now_time = SystemTime::now();
             acquired_at = crate::cowork::peek::format_rfc3339(now_time);
@@ -5150,7 +5239,7 @@ impl Database {
     ) -> Result<bool, DbError> {
         let mut renewed = false;
         self.with_immediate_tx(|| {
-            self.runtime_writer_lease_cleanup_expired_tx()?;
+            self.runtime_writer_lease_cleanup_expired_tx(true)?;
             let now = crate::cowork::peek::format_rfc3339(SystemTime::now());
             let expires_at = crate::cowork::peek::format_rfc3339(
                 SystemTime::now() + std::time::Duration::from_secs(ttl_secs),
@@ -5173,7 +5262,7 @@ impl Database {
         owner: &str,
         session_id: &str,
     ) -> Result<bool, DbError> {
-        self.runtime_writer_lease_cleanup_expired()?;
+        self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx(true))?;
         let active = self.conn.query_row(
             "SELECT EXISTS(
                  SELECT 1 FROM runtime_writer_leases
@@ -5205,7 +5294,7 @@ impl Database {
         &self,
         name: Option<&str>,
     ) -> Result<Vec<RuntimeWriterLease>, DbError> {
-        self.runtime_writer_lease_cleanup_expired()?;
+        self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx(true))?;
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|duration| duration.as_secs() as i64)
@@ -5252,16 +5341,47 @@ impl Database {
     }
 
     pub fn runtime_writer_lease_cleanup_expired(&self) -> Result<usize, DbError> {
-        self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx())
+        self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx(false))
     }
 
-    fn runtime_writer_lease_cleanup_expired_tx(&self) -> Result<usize, DbError> {
-        let rows = self.conn.execute(
-            "DELETE FROM runtime_writer_leases \
-             WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now')",
-            [],
-        )?;
-        Ok(rows)
+    fn runtime_writer_lease_cleanup_expired_tx(
+        &self,
+        preserve_live_holders: bool,
+    ) -> Result<usize, DbError> {
+        let expired = {
+            let mut stmt = self.conn.prepare(
+                "SELECT name, owner, pid, boot_id, session_id \
+                 FROM runtime_writer_leases \
+                 WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now')",
+            )?;
+            stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?
+        };
+
+        let mut removed = 0;
+        for (name, owner, pid, boot_id, session_id) in expired {
+            let preserve_live_holder = preserve_live_holders
+                && u32::try_from(pid).ok().is_some_and(|pid| {
+                    runtime_writer_process_is_live_holder(pid, boot_id.as_deref())
+                });
+            if preserve_live_holder {
+                continue;
+            }
+            removed += self.conn.execute(
+                "DELETE FROM runtime_writer_leases \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![name, owner, session_id],
+            )?;
+        }
+        Ok(removed)
     }
 }
 
@@ -7353,6 +7473,93 @@ mod tests {
     fn insert_test_drawer(db: &Database, id: &str, content: &str, project_id: Option<&str>) {
         db.insert_drawer_with_project(&test_drawer(id, content), project_id)
             .expect("insert drawer");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn runtime_writer_status_preserves_and_renews_expired_live_current_process_lease() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("test.db");
+        let db = Database::open(&db_path).expect("open db");
+        let lease = db
+            .runtime_writer_lease_acquire("sqlite-writer", "live-daemon", "daemon", 1, None)
+            .expect("acquire runtime writer lease")
+            .expect("runtime writer lease");
+
+        db.conn()
+            .execute(
+                "UPDATE runtime_writer_leases \
+                 SET expires_at = '1970-01-01T00:00:00Z', heartbeat_at = '1970-01-01T00:00:00Z' \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![&lease.name, &lease.owner, &lease.session_id],
+            )
+            .expect("force lease expiry");
+
+        assert!(
+            db.runtime_writer_lease_is_active(&lease.name, &lease.owner, &lease.session_id)
+                .expect("check runtime writer lease active"),
+            "current live process must retain its runtime writer lease after delayed heartbeat"
+        );
+        let expired_status = db
+            .runtime_writer_lease_status(Some(&lease.name))
+            .expect("load runtime writer lease status");
+        assert_eq!(expired_status.len(), 1);
+        assert_eq!(expired_status[0].remaining_secs, 0);
+        assert!(
+            db.runtime_writer_lease_renew(&lease.name, &lease.owner, &lease.session_id, 300)
+                .expect("renew delayed live runtime writer lease"),
+            "delayed live runtime writer lease must be renewable after expiry"
+        );
+        let renewed_status = db
+            .runtime_writer_lease_status(Some(&lease.name))
+            .expect("load renewed runtime writer lease status");
+        assert_eq!(renewed_status.len(), 1);
+        assert!(renewed_status[0].remaining_secs > 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn runtime_writer_cooperative_acquire_preserves_expired_live_current_process_lease() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("test.db");
+        let db = Database::open(&db_path).expect("open db");
+        let lease = db
+            .runtime_writer_lease_acquire("sqlite-writer", "live-daemon", "daemon", 1, None)
+            .expect("acquire runtime writer lease")
+            .expect("runtime writer lease");
+
+        db.conn()
+            .execute(
+                "UPDATE runtime_writer_leases \
+                 SET expires_at = '1970-01-01T00:00:00Z', heartbeat_at = '1970-01-01T00:00:00Z' \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![&lease.name, &lease.owner, &lease.session_id],
+            )
+            .expect("force lease expiry");
+
+        assert!(
+            db.runtime_writer_lease_acquire_preserving_live_holders(
+                "sqlite-writer",
+                "cooperative-mcp-worker",
+                "mcp-ingest-worker",
+                300,
+                None,
+            )
+            .expect("cooperative acquire")
+            .is_none(),
+            "cooperative writer must not steal an expired lease from a live holder"
+        );
+        let preserved = db
+            .runtime_writer_lease_status(Some("sqlite-writer"))
+            .expect("load preserved runtime writer lease status");
+        assert_eq!(preserved.len(), 1);
+        assert_eq!(preserved[0].owner, "live-daemon");
+
+        let maintenance = db
+            .runtime_writer_lease_acquire("sqlite-writer", "maintenance", "maintenance", 300, None)
+            .expect("maintenance acquire")
+            .expect("maintenance can reclaim expired lease");
+        assert_eq!(maintenance.owner, "maintenance");
     }
 
     #[test]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -5069,12 +5069,18 @@ impl Database {
     ) -> Result<Option<RuntimeWriterLease>, DbError> {
         let mut session_id = String::new();
         let mut acquired = false;
+        let mut acquired_at = String::new();
+        let mut expires_at = String::new();
+        let pid = std::process::id();
+        let boot_id = runtime_boot_id();
         self.with_immediate_tx(|| {
             self.runtime_writer_lease_cleanup_expired_tx()?;
             session_id = runtime_writer_session_id(name, owner);
-            let now = crate::cowork::peek::format_rfc3339(SystemTime::now());
-            let expires_at =
-                crate::cowork::peek::format_rfc3339(SystemTime::now() + std::time::Duration::from_secs(ttl_secs));
+            let now_time = SystemTime::now();
+            acquired_at = crate::cowork::peek::format_rfc3339(now_time);
+            expires_at = crate::cowork::peek::format_rfc3339(
+                now_time + std::time::Duration::from_secs(ttl_secs),
+            );
             let rows = self.conn.execute(
                 "INSERT OR IGNORE INTO runtime_writer_leases \
                  (name, owner, pid, boot_id, session_id, acquired_at, expires_at, heartbeat_at, mode, metadata_json) \
@@ -5082,10 +5088,10 @@ impl Database {
                 params![
                     name,
                     owner,
-                    std::process::id() as i64,
-                    runtime_boot_id(),
+                    pid as i64,
+                    &boot_id,
                     &session_id,
-                    &now,
+                    &acquired_at,
                     &expires_at,
                     mode,
                     metadata_json
@@ -5095,8 +5101,20 @@ impl Database {
             Ok(())
         })?;
         if acquired {
-            self.runtime_writer_lease_status(Some(name))
-                .map(|mut leases| leases.pop())
+            let remaining_secs = i64::try_from(ttl_secs).unwrap_or(i64::MAX);
+            Ok(Some(RuntimeWriterLease {
+                name: name.to_string(),
+                owner: owner.to_string(),
+                pid,
+                boot_id,
+                session_id,
+                acquired_at: acquired_at.clone(),
+                expires_at,
+                heartbeat_at: acquired_at,
+                mode: mode.to_string(),
+                metadata_json: metadata_json.map(ToOwned::to_owned),
+                remaining_secs,
+            }))
         } else {
             Ok(None)
         }

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -1057,9 +1057,14 @@ fn apply_fork_ext_migrations_with_hook_and_target(
     hook: Option<&dyn MigrationHook>,
     target_version: Option<u32>,
 ) -> rusqlite::Result<()> {
+    let current_version = read_fork_ext_version(conn)?;
+    let effective_target = target_version.unwrap_or(CURRENT_FORK_EXT_VERSION);
+    if current_version >= effective_target {
+        return Ok(());
+    }
+
     conn.execute_batch(FORK_EXT_META_DDL)?;
 
-    let current_version = read_fork_ext_version(conn)?;
     for migration in fork_ext_migrations().iter().filter(|migration| {
         migration.version > current_version
             && target_version.is_none_or(|target| migration.version <= target)
@@ -1090,4 +1095,37 @@ fn apply_fork_ext_migrations_with_hook_and_target(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn up_to_date_migration_check_does_not_take_schema_write_lock() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("fork-ext.db");
+        let setup = Connection::open(&db_path).expect("open setup db");
+        setup
+            .execute_batch(FORK_EXT_META_DDL)
+            .expect("create fork ext meta");
+        set_fork_ext_version(&setup, CURRENT_FORK_EXT_VERSION).expect("set current version");
+        drop(setup);
+
+        let reader = Connection::open(&db_path).expect("open reader");
+        reader
+            .execute_batch(
+                "BEGIN; SELECT value FROM fork_ext_meta WHERE key = 'fork_ext_version';",
+            )
+            .expect("hold read transaction");
+
+        let writer = Connection::open(&db_path).expect("open writer");
+        writer
+            .busy_timeout(Duration::ZERO)
+            .expect("set zero busy timeout");
+        apply_fork_ext_migrations(&writer).expect("up-to-date check must be read-only");
+
+        reader.execute_batch("ROLLBACK").expect("release reader");
+    }
 }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -772,7 +772,7 @@ impl PendingMessageStore {
     }
 
     pub fn operation_status(&self, id: &str) -> Result<Option<PendingOperationRecord>> {
-        let conn = self.open_connection()?;
+        let conn = self.open_query_connection()?;
         if let Some(record) = operation_status_from_pending(&conn, id)? {
             return Ok(Some(record));
         }
@@ -1025,7 +1025,7 @@ impl PendingMessageStore {
     }
 
     pub fn stats(&self) -> Result<QueueStats> {
-        let conn = self.open_connection()?;
+        let conn = self.open_query_connection()?;
         compute_queue_stats(&conn)
     }
 
@@ -1041,6 +1041,13 @@ impl PendingMessageStore {
         conn.busy_timeout(busy_timeout.unwrap_or(DEFAULT_BUSY_TIMEOUT))?;
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
+        Ok(conn)
+    }
+
+    fn open_query_connection(&self) -> Result<Connection> {
+        let conn = Connection::open_with_flags(&self.db_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+        conn.busy_timeout(DEFAULT_BUSY_TIMEOUT)?;
+        conn.pragma_update(None, "query_only", "ON")?;
         Ok(conn)
     }
 
@@ -1689,5 +1696,33 @@ mod tests {
             .expect("async ingest row remains visible");
         assert_eq!(ingest_status.op_state, "queued");
         assert!(ingest_status.claimed_at.is_none());
+    }
+
+    #[test]
+    fn status_and_stats_read_through_writer_lock() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let store = PendingMessageStore::new(&db_path).expect("open queue");
+        let ingest_id = store
+            .enqueue("ingest_async", r#"{"request":{}}"#)
+            .expect("enqueue async ingest");
+
+        let lock_holder = Connection::open(&db_path).expect("open lock holder");
+        lock_holder
+            .busy_timeout(Duration::from_millis(25))
+            .expect("set lock holder busy timeout");
+        lock_holder
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold write lock");
+
+        let status = store
+            .operation_status(&ingest_id)
+            .expect("operation status should not need startup writes")
+            .expect("operation remains visible");
+        let stats = store.stats().expect("stats should not need startup writes");
+
+        assert_eq!(status.op_state, "queued");
+        assert_eq!(stats.pending, 1);
     }
 }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 
 use super::config::scrub_sensitive_text;
+use super::db::ensure_wal_journal_mode;
 
 static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 const STARTUP_RECLAIM_STALE_SECS: i64 = 60;
@@ -1039,7 +1040,7 @@ impl PendingMessageStore {
     ) -> Result<Connection> {
         let conn = Connection::open(&self.db_path)?;
         conn.busy_timeout(busy_timeout.unwrap_or(DEFAULT_BUSY_TIMEOUT))?;
-        conn.pragma_update(None, "journal_mode", "WAL")?;
+        ensure_wal_journal_mode(&conn)?;
         conn.pragma_update(None, "synchronous", "NORMAL")?;
         Ok(conn)
     }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -14,7 +14,7 @@ use super::db::ensure_wal_journal_mode;
 static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 const STARTUP_RECLAIM_STALE_SECS: i64 = 60;
 const COMPLETION_METRICS_WINDOW_MINS: u64 = 10;
-const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 pub const LAST_ERROR_MAX_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Error)]
@@ -1725,5 +1725,13 @@ mod tests {
 
         assert_eq!(status.op_state, "queued");
         assert_eq!(stats.pending, 1);
+    }
+
+    #[test]
+    fn queue_busy_timeout_covers_smoke_read_write_contention() {
+        assert!(
+            DEFAULT_BUSY_TIMEOUT >= Duration::from_secs(30),
+            "async ingest queue writes must outwait transient full-smoke read/write contention"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,6 +30,7 @@ use crate::ingest::gating::{
     evaluate_tier1, tier2_enabled,
 };
 use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
+use crate::llm::LlmError;
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use serde_json::{Value, json};
@@ -53,6 +54,7 @@ const SESSION_REVIEW_REJECTED_TOTAL_KEY: &str = "session_review.rejected.total";
 pub const DAEMON_DRAIN_BUDGET: Duration = Duration::from_secs(30);
 const DAEMON_HOOK_WORKER_LIMIT: usize = 4;
 const ENDPOINT_RECOVERY_REQUEUE_INTERVAL: Duration = Duration::from_secs(30);
+const AUTOMATIC_HOOK_LLM_GATE_MAX_SECS: u64 = 30;
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const DAEMON_WRITER_LEASE_TTL_SECS: u64 = 120;
 const DAEMON_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
@@ -1808,11 +1810,37 @@ fn queue_failure_disposition(error: &anyhow::Error) -> QueueFailureDisposition {
                 QueueFailureDisposition::Terminal
             };
         }
+        if cause
+            .downcast_ref::<AutomaticHookLlmGateTerminalFailure>()
+            .is_some()
+        {
+            return QueueFailureDisposition::Terminal;
+        }
+        if let Some(llm_error) = cause.downcast_ref::<LlmError>() {
+            if !llm_error.is_retryable() {
+                return QueueFailureDisposition::Terminal;
+            }
+            return llm_error
+                .retry_after()
+                .map(queue_retry_delay_from_duration)
+                .unwrap_or(QueueFailureDisposition::Retryable);
+        }
         if cause.downcast_ref::<serde_json::Error>().is_some() {
             return QueueFailureDisposition::Terminal;
         }
     }
     QueueFailureDisposition::Retryable
+}
+
+fn queue_retry_delay_from_duration(duration: Duration) -> QueueFailureDisposition {
+    let delay_ms = i64::try_from(duration.as_millis()).unwrap_or(i64::MAX);
+    QueueFailureDisposition::RetryableAfter { delay_ms }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("automatic hook LLM gate terminal failure: {reason}")]
+struct AutomaticHookLlmGateTerminalFailure {
+    reason: String,
 }
 
 #[derive(Debug, Clone)]
@@ -2680,7 +2708,17 @@ async fn judge_automatic_content_llm_gate(
             .as_ref()
             .and_then(|judge| judge.system_prompt.clone()),
     };
-    let outcome = match gate.judge(config, &task, heartbeat).await {
+    let deadline = automatic_hook_llm_gate_deadline(config);
+    let outcome = match tokio::time::timeout(deadline, gate.judge(config, &task, heartbeat)).await {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            return Err(anyhow::Error::new(AutomaticHookLlmGateTerminalFailure {
+                reason: format!("timed out after {}s", deadline.as_secs()),
+            })
+            .context("automatic hook LLM gate failed before durable insert"));
+        }
+    };
+    let outcome = match outcome {
         Ok(outcome) => outcome,
         Err(error) => {
             let error_chain = format!("{error:#}");
@@ -2690,6 +2728,15 @@ async fn judge_automatic_content_llm_gate(
         }
     };
     Ok(gating_decision_from_llm_outcome(outcome))
+}
+
+fn automatic_hook_llm_gate_deadline(config: &crate::core::config::Config) -> Duration {
+    Duration::from_secs(
+        config
+            .llm
+            .request_timeout_secs
+            .clamp(1, AUTOMATIC_HOOK_LLM_GATE_MAX_SECS),
+    )
 }
 
 fn gating_decision_from_llm_outcome(
@@ -3513,6 +3560,7 @@ mod tests {
     use crate::embed::{EmbedError, Embedder};
     use crate::endpoint_health::{EndpointHealthSnapshot, ProbeStatus};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
+    use crate::llm::LlmError;
     use arc_swap::ArcSwap;
     use std::pin::Pin;
     use tokio::sync::Notify;
@@ -3521,13 +3569,58 @@ mod tests {
     use crate::core::config::DaemonEmbedderMode;
 
     use super::{
-        ClaimNextSource, ClaimPollResult, DaemonEmbedder, DaemonIngestContext,
-        EndpointRecoveryConfigProvider, EndpointRecoveryRequeuePlan, EndpointRecoveryRequeueState,
-        HookWorkerState, build_drawer_records, compile_classifier_from_embedder,
-        llm_worker_claim_enabled, poll_claim_next, process_claimed_message_with_embedder,
+        AutomaticHookLlmGateTerminalFailure, ClaimNextSource, ClaimPollResult, DaemonEmbedder,
+        DaemonIngestContext, EndpointRecoveryConfigProvider, EndpointRecoveryRequeuePlan,
+        EndpointRecoveryRequeueState, HookWorkerState, automatic_hook_llm_gate_deadline,
+        build_drawer_records, compile_classifier_from_embedder, llm_worker_claim_enabled,
+        poll_claim_next, process_claimed_message_with_embedder, queue_failure_disposition,
         request_shutdown, reset_shutdown_request, run_hook_worker, wait_for_hook_worker_or_tick,
         wing_from_cwd,
     };
+
+    #[test]
+    fn queue_failure_disposition_dead_letters_non_retryable_llm_errors() {
+        let decode_error = anyhow::Error::new(LlmError::DecodeResponse(
+            "error decoding response body".to_string(),
+        ))
+        .context("LLM gating request failed")
+        .context("automatic hook LLM gate failed before durable insert");
+
+        assert_eq!(
+            queue_failure_disposition(&decode_error),
+            QueueFailureDisposition::Terminal
+        );
+    }
+
+    #[test]
+    fn queue_failure_disposition_dead_letters_automatic_hook_llm_gate_deadline() {
+        let timeout_error = anyhow::Error::new(AutomaticHookLlmGateTerminalFailure {
+            reason: "timed out after 30s".to_string(),
+        })
+        .context("automatic hook LLM gate failed before durable insert");
+
+        assert_eq!(
+            queue_failure_disposition(&timeout_error),
+            QueueFailureDisposition::Terminal
+        );
+    }
+
+    #[test]
+    fn automatic_hook_llm_gate_deadline_caps_global_llm_timeout() {
+        let mut config = Config::default();
+
+        config.llm.request_timeout_secs = 3_000;
+        assert_eq!(
+            automatic_hook_llm_gate_deadline(&config),
+            Duration::from_secs(30)
+        );
+
+        config.llm.request_timeout_secs = 2;
+        assert_eq!(
+            automatic_hook_llm_gate_deadline(&config),
+            Duration::from_secs(2)
+        );
+    }
 
     #[tokio::test]
     async fn daemon_embedder_from_config_defers_explicit_model2vec_construction() {

--- a/src/hook_ipc.rs
+++ b/src/hook_ipc.rs
@@ -127,6 +127,14 @@ pub(crate) fn enqueue_with_default_timeout(
     mempal_home: &Path,
     request: HookIpcEnqueueRequest,
 ) -> HookIpcClientOutcome {
+    enqueue_with_timeout(mempal_home, request, HOOK_IPC_TIMEOUT)
+}
+
+pub(crate) fn enqueue_with_timeout(
+    mempal_home: &Path,
+    request: HookIpcEnqueueRequest,
+    timeout: Duration,
+) -> HookIpcClientOutcome {
     let path = socket_path(mempal_home);
     if !path.exists() {
         return HookIpcClientOutcome::Fallback(HookIpcFallbackReason::SocketUnavailable);
@@ -146,7 +154,7 @@ pub(crate) fn enqueue_with_default_timeout(
     };
 
     runtime.block_on(async move {
-        match tokio::time::timeout(HOOK_IPC_TIMEOUT, enqueue_once(&path, request)).await {
+        match tokio::time::timeout(timeout, enqueue_once(&path, request)).await {
             Ok(outcome) => outcome,
             Err(_) => HookIpcClientOutcome::Fallback(HookIpcFallbackReason::Timeout),
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -142,7 +142,7 @@ fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool
 }
 
 const MCP_SEARCH_ROUTE_DEADLINE: Duration = Duration::from_secs(5);
-const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
+pub(super) const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
 const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
 const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
@@ -1204,6 +1204,37 @@ impl MempalMcpServer {
         Database::open(&self.db_path).map_err(|error| {
             ErrorData::internal_error(format!("failed to open database: {error}"), None)
         })
+    }
+
+    pub(super) async fn run_query_only_read_bounded<F, R>(
+        &self,
+        stage: &'static str,
+        deadline: Duration,
+        f: F,
+    ) -> std::result::Result<R, ErrorData>
+    where
+        F: FnOnce(&Database) -> std::result::Result<R, ErrorData> + Send + 'static,
+        R: Send + 'static,
+    {
+        let db_path = self.db_path.clone();
+        let read = tokio::task::spawn_blocking(move || {
+            let db = Database::open_query_only(&db_path).map_err(|error| {
+                ErrorData::internal_error(format!("{stage} failed to open database: {error}"), None)
+            })?;
+            f(&db)
+        });
+        match tokio::time::timeout(deadline, read).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => Err(ErrorData::internal_error(
+                format!("{stage} database task failed: {error}"),
+                None,
+            )),
+            Err(_) => Err(mcp_stage_timeout_error(
+                stage,
+                "query-only database read",
+                deadline,
+            )),
+        }
     }
 
     async fn async_db(&self) -> anyhow::Result<AsyncDb> {
@@ -3681,10 +3712,17 @@ impl MempalMcpServer {
             .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
             .await?;
         let budget_chars = request.budget_chars.unwrap_or(4_000);
-        let db = self.open_db()?;
-        let drawers = db
-            .get_pinned_facts(project_id.as_deref(), budget_chars)
-            .map_err(db_error)?;
+        let facts_project_id = project_id.clone();
+        let drawers = self
+            .run_query_only_read_bounded(
+                "mempal_pinned_facts",
+                self.search_db_deadline,
+                move |db| {
+                    db.get_pinned_facts(facts_project_id.as_deref(), budget_chars)
+                        .map_err(db_error)
+                },
+            )
+            .await?;
         let used_chars = drawers
             .iter()
             .map(|drawer| drawer.content.chars().count())
@@ -4160,19 +4198,22 @@ impl MempalMcpServer {
             request.all_projects.unwrap_or(false),
             config.search.strict_project_isolation,
         );
-        let db = self.open_db()?;
-        let details = db
-            .get_drawer_details(&request.drawer_id)
-            .map_err(db_error)?
-            .ok_or_else(|| {
-                ErrorData::resource_not_found(
-                    "drawer not found",
-                    Some(serde_json::json!({
-                        "error": "not_found",
-                        "drawer_id": request.drawer_id,
-                    })),
-                )
-            })?;
+        let drawer_id = request.drawer_id.clone();
+        let details = self
+            .run_query_only_read_bounded("mempal_read_drawer", self.search_db_deadline, move |db| {
+                db.get_drawer_details(&drawer_id)
+                    .map_err(db_error)?
+                    .ok_or_else(|| {
+                        ErrorData::resource_not_found(
+                            "drawer not found",
+                            Some(serde_json::json!({
+                                "error": "not_found",
+                                "drawer_id": drawer_id,
+                            })),
+                        )
+                    })
+            })
+            .await?;
         if !scope.allows_row(details.project_id.as_deref()) {
             return Err(ErrorData::invalid_params(
                 format!(
@@ -4248,10 +4289,14 @@ impl MempalMcpServer {
         } else {
             deduped_ids
         };
-        let db = self.open_db()?;
-        let details = db
-            .get_drawer_details_batch(&requested_ids)
-            .map_err(db_error)?;
+        let details_ids = requested_ids.clone();
+        let details = self
+            .run_query_only_read_bounded(
+                "mempal_read_drawers",
+                self.search_db_deadline,
+                move |db| db.get_drawer_details_batch(&details_ids).map_err(db_error),
+            )
+            .await?;
         let mut drawers = Vec::with_capacity(details.len());
         let mut found_ids = std::collections::HashSet::new();
         for detail in details {
@@ -4344,28 +4389,28 @@ impl MempalMcpServer {
             .next()
             .ok_or_else(|| ErrorData::internal_error("embedder returned no query vector", None))?;
 
-        let db = self.open_db()?;
-        let pack = assemble_context_with_vector(
-            &db,
-            crate::context::ContextRequest {
-                query: request.query,
-                domain,
-                field: request_scope
-                    .field
-                    .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
-                cwd,
-                include_evidence: request.include_evidence.unwrap_or(false),
-                include_cards,
-                max_items,
-                dao_tian_limit,
-                project_id,
-                trigger,
-                context_cfg_override: None,
-                include_distill_suggestions: request.include_distill_suggestions.unwrap_or(true),
-            },
-            &query_vector,
-        )
-        .map_err(context_error)?;
+        let context_request = crate::context::ContextRequest {
+            query: request.query,
+            domain,
+            field: request_scope
+                .field
+                .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
+            cwd,
+            include_evidence: request.include_evidence.unwrap_or(false),
+            include_cards,
+            max_items,
+            dao_tian_limit,
+            project_id,
+            trigger,
+            context_cfg_override: None,
+            include_distill_suggestions: request.include_distill_suggestions.unwrap_or(true),
+        };
+        let pack = self
+            .run_query_only_read_bounded("mempal_context", self.search_db_deadline, move |db| {
+                assemble_context_with_vector(db, context_request, &query_vector)
+                    .map_err(context_error)
+            })
+            .await?;
 
         Ok(Json(ContextResponse::from(pack)))
     }
@@ -6401,12 +6446,15 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<TaxonomyRequest>,
     ) -> std::result::Result<Json<TaxonomyResponse>, ErrorData> {
-        let db = self.open_db()?;
         match request.action.as_str() {
             "list" => {
-                let entries = db
-                    .taxonomy_entries()
-                    .map_err(db_error)?
+                let entries = self
+                    .run_query_only_read_bounded(
+                        "mempal_taxonomy list",
+                        self.search_db_deadline,
+                        |db| db.taxonomy_entries().map_err(db_error),
+                    )
+                    .await?
                     .into_iter()
                     .map(TaxonomyEntryDto::from)
                     .collect();
@@ -6417,6 +6465,7 @@ impl MempalMcpServer {
                 }))
             }
             "edit" => {
+                let db = self.open_db()?;
                 let _writer_lease =
                     self.acquire_content_writer_lease(&db, "mempal_taxonomy edit")?;
                 let wing = request
@@ -6471,13 +6520,12 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<KgRequest>,
     ) -> std::result::Result<Json<KgResponse>, ErrorData> {
-        let block_writes = global_embed_status().should_block_writes();
-        let db = self.open_db()?;
         match request.action.as_str() {
             "add" => {
-                if block_writes {
+                if global_embed_status().should_block_writes() {
                     return Err(degraded_write_error());
                 }
+                let db = self.open_db()?;
                 let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_kg add")?;
                 let subject = request
                     .subject
@@ -6509,14 +6557,24 @@ impl MempalMcpServer {
             }
             "query" => {
                 let active_only = request.active_only.unwrap_or(true);
-                let triples = db
-                    .query_triples(
-                        request.subject.as_deref(),
-                        request.predicate.as_deref(),
-                        request.object.as_deref(),
-                        active_only,
+                let subject = request.subject;
+                let predicate = request.predicate;
+                let object = request.object;
+                let triples = self
+                    .run_query_only_read_bounded(
+                        "mempal_kg query",
+                        self.search_db_deadline,
+                        move |db| {
+                            db.query_triples(
+                                subject.as_deref(),
+                                predicate.as_deref(),
+                                object.as_deref(),
+                                active_only,
+                            )
+                            .map_err(db_error)
+                        },
                     )
-                    .map_err(db_error)?;
+                    .await?;
                 Ok(Json(KgResponse {
                     action: "query".to_string(),
                     triples: triples.iter().map(triple_to_dto).collect(),
@@ -6525,9 +6583,10 @@ impl MempalMcpServer {
                 }))
             }
             "invalidate" => {
-                if block_writes {
+                if global_embed_status().should_block_writes() {
                     return Err(degraded_write_error());
                 }
+                let db = self.open_db()?;
                 let _writer_lease =
                     self.acquire_content_writer_lease(&db, "mempal_kg invalidate")?;
                 let triple_id = request
@@ -6550,16 +6609,27 @@ impl MempalMcpServer {
                 let entity = request.subject.ok_or_else(|| {
                     ErrorData::invalid_params("missing subject for timeline", None)
                 })?;
-                let triples = db.timeline_for_entity(&entity).map_err(db_error)?;
+                let action = format!("timeline for {entity}");
+                let triples = self
+                    .run_query_only_read_bounded(
+                        "mempal_kg timeline",
+                        self.search_db_deadline,
+                        move |db| db.timeline_for_entity(&entity).map_err(db_error),
+                    )
+                    .await?;
                 Ok(Json(KgResponse {
-                    action: format!("timeline for {entity}"),
+                    action,
                     triples: triples.iter().map(triple_to_dto).collect(),
                     stats: None,
                     system_warnings: current_system_warnings(),
                 }))
             }
             "stats" => {
-                let stats = db.triple_stats().map_err(db_error)?;
+                let stats = self
+                    .run_query_only_read_bounded("mempal_kg stats", self.search_db_deadline, |db| {
+                        db.triple_stats().map_err(db_error)
+                    })
+                    .await?;
                 Ok(Json(KgResponse {
                     action: "stats".to_string(),
                     triples: vec![],
@@ -6900,28 +6970,29 @@ impl MempalMcpServer {
             .into_iter()
             .next()
             .ok_or_else(|| ErrorData::internal_error("embedder returned no query vector", None))?;
-        let db = self.open_db()?;
-        let context = assemble_context_with_vector(
-            &db,
-            crate::context::ContextRequest {
-                query: request.query,
-                domain,
-                field: request
-                    .field
-                    .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
-                cwd,
-                include_evidence: true,
-                include_cards: true,
-                max_items,
-                dao_tian_limit: request.dao_tian_limit.unwrap_or(1),
-                project_id: None,
-                trigger: None,
-                context_cfg_override: None,
-                include_distill_suggestions: false,
-            },
-            &query_vector,
-        )
-        .map_err(|error| ErrorData::internal_error(format!("brief failed: {error}"), None))?;
+        let context_request = crate::context::ContextRequest {
+            query: request.query,
+            domain,
+            field: request
+                .field
+                .unwrap_or_else(|| anchor::DEFAULT_FIELD.to_string()),
+            cwd,
+            include_evidence: true,
+            include_cards: true,
+            max_items,
+            dao_tian_limit: request.dao_tian_limit.unwrap_or(1),
+            project_id: None,
+            trigger: None,
+            context_cfg_override: None,
+            include_distill_suggestions: false,
+        };
+        let context = self
+            .run_query_only_read_bounded("mempal_brief", self.search_db_deadline, move |db| {
+                assemble_context_with_vector(db, context_request, &query_vector).map_err(|error| {
+                    ErrorData::internal_error(format!("brief failed: {error}"), None)
+                })
+            })
+            .await?;
         let brief = brief_from_context(context);
         Ok(Json(BriefMcpResponse::from(brief)))
     }
@@ -7559,29 +7630,32 @@ impl MempalMcpServer {
         &self,
         Parameters(request): Parameters<SkillRequest>,
     ) -> std::result::Result<Json<SkillResponse>, ErrorData> {
-        let db = self.open_db()?;
         let config = ConfigHandle::current();
         let project_id = self
             .resolve_mcp_project_id(request.project_id.as_deref(), &config)
             .await?;
 
-        if !crate::core::skills::skills_table_exists(db.conn()) {
-            return Err(ErrorData::internal_error(
-                "skills table not yet created — run `mempal init` to apply migrations",
-                None,
-            ));
-        }
-
         match request.action.as_str() {
             "list" => {
-                let skills = tokio::task::block_in_place(|| {
-                    crate::core::skills::list_skills(
-                        db.conn(),
-                        request.status.as_deref(),
-                        project_id.as_deref(),
+                let status = request.status;
+                let list_project_id = project_id.clone();
+                let skills = self
+                    .run_query_only_read_bounded(
+                        "mempal_skill list",
+                        self.search_db_deadline,
+                        move |db| {
+                            ensure_mcp_skills_table(db)?;
+                            crate::core::skills::list_skills(
+                                db.conn(),
+                                status.as_deref(),
+                                list_project_id.as_deref(),
+                            )
+                            .map_err(|e| {
+                                ErrorData::internal_error(format!("list_skills failed: {e}"), None)
+                            })
+                        },
                     )
-                })
-                .map_err(|e| ErrorData::internal_error(format!("list_skills failed: {e}"), None))?;
+                    .await?;
 
                 let dtos: Vec<SkillSummaryDto> = skills
                     .iter()
@@ -7606,16 +7680,31 @@ impl MempalMcpServer {
             }
 
             "show" => {
-                let skill_id = request.skill_id.as_deref().ok_or_else(|| {
+                let skill_id = request.skill_id.ok_or_else(|| {
                     ErrorData::invalid_params("skill_id is required for show", None)
                 })?;
-                let skill = tokio::task::block_in_place(|| {
-                    crate::core::skills::get_skill(db.conn(), skill_id)
-                })
-                .map_err(|e| ErrorData::internal_error(format!("get_skill failed: {e}"), None))?
-                .ok_or_else(|| {
-                    ErrorData::invalid_params(format!("skill not found: {skill_id}"), None)
-                })?;
+                let skill = self
+                    .run_query_only_read_bounded(
+                        "mempal_skill show",
+                        self.search_db_deadline,
+                        move |db| {
+                            ensure_mcp_skills_table(db)?;
+                            crate::core::skills::get_skill(db.conn(), &skill_id)
+                                .map_err(|e| {
+                                    ErrorData::internal_error(
+                                        format!("get_skill failed: {e}"),
+                                        None,
+                                    )
+                                })?
+                                .ok_or_else(|| {
+                                    ErrorData::invalid_params(
+                                        format!("skill not found: {skill_id}"),
+                                        None,
+                                    )
+                                })
+                        },
+                    )
+                    .await?;
 
                 Ok(Json(SkillResponse {
                     action: "show".to_string(),
@@ -7627,6 +7716,8 @@ impl MempalMcpServer {
             }
 
             "promote" => {
+                let db = self.open_db()?;
+                ensure_mcp_skills_table(&db)?;
                 let pattern_id = request.pattern_id.as_deref().ok_or_else(|| {
                     ErrorData::invalid_params("pattern_id is required for promote", None)
                 })?;
@@ -7680,6 +7771,8 @@ impl MempalMcpServer {
             }
 
             "adopt" => {
+                let db = self.open_db()?;
+                ensure_mcp_skills_table(&db)?;
                 let skill_id = request.skill_id.as_deref().ok_or_else(|| {
                     ErrorData::invalid_params("skill_id is required for adopt", None)
                 })?;
@@ -7706,6 +7799,8 @@ impl MempalMcpServer {
             }
 
             "reject" => {
+                let db = self.open_db()?;
+                ensure_mcp_skills_table(&db)?;
                 let skill_id = request.skill_id.as_deref().ok_or_else(|| {
                     ErrorData::invalid_params("skill_id is required for reject", None)
                 })?;
@@ -7733,6 +7828,8 @@ impl MempalMcpServer {
             }
 
             "retire" => {
+                let db = self.open_db()?;
+                ensure_mcp_skills_table(&db)?;
                 let skill_id = request.skill_id.as_deref().ok_or_else(|| {
                     ErrorData::invalid_params("skill_id is required for retire", None)
                 })?;
@@ -8598,6 +8695,16 @@ fn skill_to_dto(skill: &crate::core::skills::Skill) -> SkillDto {
         updated_at_unix_ms: skill.updated_at,
         project_id: skill.project_id.clone(),
     }
+}
+
+fn ensure_mcp_skills_table(db: &Database) -> std::result::Result<(), ErrorData> {
+    if crate::core::skills::skills_table_exists(db.conn()) {
+        return Ok(());
+    }
+    Err(ErrorData::internal_error(
+        "skills table not yet created — run `mempal init` to apply migrations",
+        None,
+    ))
 }
 
 fn required_bus_field(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2281,6 +2281,18 @@ enum IngestWaitWorkerMode {
     Scoped,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IngestQueueProcessor {
+    Daemon,
+    Local,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct IngestQueueAdmission {
+    operation_id: String,
+    processor: IngestQueueProcessor,
+}
+
 #[doc(hidden)]
 pub struct IngestDrainWorkerHandle {
     shutdown_tx: tokio::sync::watch::Sender<bool>,
@@ -4876,9 +4888,6 @@ impl MempalMcpServer {
             .await?;
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
-        if matches!(worker_mode, IngestWaitWorkerMode::Background) {
-            self.spawn_ingest_drain_worker();
-        }
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
@@ -4957,8 +4966,8 @@ impl MempalMcpServer {
         let payload = serde_json::to_string(&prepared).map_err(|error| {
             ErrorData::internal_error(format!("failed to serialize ingest request: {error}"), None)
         })?;
-        let operation_id = match self.enqueue_ingest_operation(payload).await {
-            Ok(operation_id) => operation_id,
+        let queue_admission = match self.enqueue_ingest_operation(payload).await {
+            Ok(admission) => admission,
             Err(error) => {
                 if let Some(error) = maybe_database_write_refused_error(
                     &self.db_path,
@@ -4973,9 +4982,14 @@ impl MempalMcpServer {
                 ));
             }
         };
+        if matches!(worker_mode, IngestWaitWorkerMode::Background)
+            && matches!(queue_admission.processor, IngestQueueProcessor::Local)
+        {
+            self.spawn_ingest_drain_worker();
+        }
 
         let queued_response = IngestResponse {
-            operation_id: Some(operation_id),
+            operation_id: Some(queue_admission.operation_id.clone()),
             accepted_at: Some(crate::core::utils::iso_timestamp()),
             state: Some(IngestOperationState::Queued),
             timed_out: false,
@@ -5002,7 +5016,9 @@ impl MempalMcpServer {
                 .operation_id
                 .as_deref()
                 .expect("queued receipt must include operation id");
-            let wait_result = if wait_timeout_secs > 0 {
+            let wait_result = if wait_timeout_secs > 0
+                && matches!(queue_admission.processor, IngestQueueProcessor::Local)
+            {
                 self.wait_for_operation_status_with_scoped_worker(
                     operation_id,
                     Duration::from_secs(wait_timeout_secs),
@@ -5048,17 +5064,28 @@ impl MempalMcpServer {
         Ok(Json(queued_response))
     }
 
-    async fn enqueue_ingest_operation(&self, payload: String) -> anyhow::Result<String> {
+    async fn enqueue_ingest_operation(
+        &self,
+        payload: String,
+    ) -> anyhow::Result<IngestQueueAdmission> {
         let idempotency_key = mcp_ingest_idempotency_key(&payload);
         if let Some(operation_id) = self
             .try_enqueue_ingest_operation_via_daemon(payload.clone(), idempotency_key.clone())
             .await?
         {
-            return Ok(operation_id);
+            return Ok(IngestQueueAdmission {
+                operation_id,
+                processor: IngestQueueProcessor::Daemon,
+            });
         }
 
-        self.enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
-            .await
+        let operation_id = self
+            .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
+            .await?;
+        Ok(IngestQueueAdmission {
+            operation_id,
+            processor: IngestQueueProcessor::Local,
+        })
     }
 
     async fn enqueue_ingest_operation_locally_with_retry(
@@ -10433,6 +10460,63 @@ quality_policy = "llm_required_for_keep"
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_polls_daemon_admitted_operation() {
+        let (tempdir, db_path, server) = setup_server();
+        let daemon_lease = hold_daemon_writer_lease(&db_path);
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon_db_path = db_path.clone();
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            let operation_id = PendingMessageStore::new_without_reclaim(&daemon_db_path)
+                .enqueue_idempotent_with_key(
+                    &request.kind,
+                    &request.payload,
+                    &request.idempotency_key,
+                )
+                .expect("persist daemon-admitted operation");
+            crate::hook_ipc::write_enqueue_response(
+                &mut stream,
+                &crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            )
+            .await
+            .expect("write daemon IPC response");
+            (request, operation_id)
+        });
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "daemon-admitted MCP wait must not self-claim".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(true),
+                wait_timeout_secs: Some(1),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("daemon-admitted wait should poll without local claim")
+            .0;
+
+        let (request, operation_id) = daemon.await.expect("daemon IPC task");
+        let response_operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        assert_eq!(response_operation_id, operation_id);
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.created_drawer_ids.is_empty());
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(response_operation_id)
+            .expect("query queued operation")
+            .expect("queued operation");
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        release_test_ingest_writer_lease(&db_path, &daemon_lease);
+    }
+
     #[tokio::test]
     async fn test_mcp_ingest_enqueue_waits_for_transient_sqlite_lock() {
         let (_tempdir, db_path, server) = setup_server();
@@ -10503,6 +10587,43 @@ quality_policy = "llm_required_for_keep"
             "unexpected operation state after self-held lock retry: {}",
             record.op_state
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_enqueue_skips_wal_reset_under_existing_reader() {
+        let (_tempdir, db_path, server) = setup_server();
+        let reader = rusqlite::Connection::open(&db_path).expect("open existing MCP holder");
+        reader
+            .busy_timeout(Duration::from_millis(25))
+            .expect("set reader busy timeout");
+        reader
+            .execute_batch("BEGIN; SELECT COUNT(*) FROM sqlite_master;")
+            .expect("hold read transaction");
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "existing MCP holder must not block queue admission".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest admission should not reset WAL under an existing reader")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query queued operation")
+            .expect("queued operation");
+        assert!(
+            matches!(record.op_state.as_str(), "queued" | "running" | "completed"),
+            "unexpected operation state after reader-held admission: {}",
+            record.op_state
+        );
+        reader.execute_batch("COMMIT;").expect("release reader");
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -141,13 +141,40 @@ fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool
     }
 }
 
+fn should_use_daemon_ingest_worker(socket_exists: bool, daemon_pids: &[i32]) -> bool {
+    socket_exists && !daemon_pids.is_empty()
+}
+
+fn should_continue_ingest_heartbeat_after_error(error: &QueueError) -> bool {
+    error.is_sqlite_lock()
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_ingest_ipc_available_for_db(db_path: &Path) -> bool {
+    let Some(mempal_home) = db_path.parent() else {
+        return false;
+    };
+    let socket_exists = crate::hook_ipc::socket_path(mempal_home).exists();
+    let binary =
+        crate::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
+    let daemon_pids = crate::daemon_singleton::enumerate_daemon_pids(&binary, db_path);
+    should_use_daemon_ingest_worker(socket_exists, &daemon_pids)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn daemon_ingest_ipc_available_for_db(_db_path: &Path) -> bool {
+    false
+}
+
 const MCP_SEARCH_ROUTE_DEADLINE: Duration = Duration::from_secs(5);
-pub(super) const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(30);
+pub(super) const MCP_SEARCH_DB_DEADLINE: Duration = Duration::from_secs(60);
 const MCP_SEARCH_STALE_INDEX_DEADLINE: Duration = Duration::from_secs(2);
 const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_INGEST_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(30);
+const MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT: Duration =
+    MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE;
 const MCP_INGEST_QUEUE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
@@ -578,7 +605,14 @@ impl MempalMcpServer {
                 }
             }
         });
-        self.spawn_ingest_drain_worker();
+        if self.daemon_ingest_ipc_available() {
+            tracing::debug!(
+                db_path = %self.db_path.display(),
+                "daemon ingest IPC is available; MCP stdio will not start a competing local ingest drain worker"
+            );
+        } else {
+            self.spawn_ingest_drain_worker();
+        }
         let _gating_init_task =
             self.gating_runtime
                 .spawn_initialize_from_config(Duration::from_secs(
@@ -603,6 +637,10 @@ impl MempalMcpServer {
         ReindexProgressStore::new(&self.db_path)
             .finalize_completed_running_rows(CURRENT_VECTOR_INDEX_VERSION, &target_fingerprint)
             .context("failed to finalize orphan reindex progress rows")
+    }
+
+    fn daemon_ingest_ipc_available(&self) -> bool {
+        daemon_ingest_ipc_available_for_db(&self.db_path)
     }
 
     fn current_vector_dim(db: &Database) -> anyhow::Result<Option<usize>> {
@@ -821,11 +859,13 @@ impl MempalMcpServer {
         };
         let runtime_writer_lease = external_writer_lease
             .or_else(|| writer_lease.as_ref().map(|lease| lease.lease().clone()));
+        let pre_resolved_superseded_drawer_id = prepared.superseded_drawer_id.clone();
         let outcome = match self
             .run_prepared_ingest_off_runtime(
                 prepared.request.clone(),
                 prepared.controls,
                 runtime_writer_lease,
+                pre_resolved_superseded_drawer_id,
             )
             .await
         {
@@ -834,10 +874,11 @@ impl MempalMcpServer {
             Err(error) => Err(error.to_string()),
         };
 
-        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+        Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
             .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
             .await;
+        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
         let released = match writer_lease {
             Some(writer_lease) => writer_lease.release().await,
             None => Ok(()),
@@ -891,12 +932,14 @@ impl MempalMcpServer {
                 }
             }
         };
+        let pre_resolved_superseded_drawer_id = prepared.superseded_drawer_id.clone();
         let outcome = match self
-            .mempal_ingest_sync(
+            .mempal_ingest_sync_with_superseded_override(
                 prepared.request.clone(),
                 prepared.controls,
                 external_writer_lease
                     .or_else(|| writer_lease.as_ref().map(McpIngestWriterLeaseGuard::lease)),
+                pre_resolved_superseded_drawer_id,
             )
             .await
         {
@@ -904,10 +947,11 @@ impl MempalMcpServer {
             Err(error) => Err(error.to_string()),
         };
 
-        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+        Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
             .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
             .await;
+        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
         let released = match writer_lease {
             Some(writer_lease) => writer_lease.release().await,
             None => Ok(()),
@@ -996,9 +1040,15 @@ impl MempalMcpServer {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        if let Err(error) = queue.refresh_heartbeat(claim_id.clone(), heartbeat_worker_id.clone()).await {
-                            tracing::warn!(error = %error, claim_id = %claim_id, "failed to refresh async ingest heartbeat");
-                            break;
+                        match queue.refresh_heartbeat(claim_id.clone(), heartbeat_worker_id.clone()).await {
+                            Ok(()) => {}
+                            Err(error) if should_continue_ingest_heartbeat_after_error(&error) => {
+                                tracing::warn!(error = %error, claim_id = %claim_id, "transient failure refreshing async ingest heartbeat; will retry");
+                            }
+                            Err(error) => {
+                                tracing::warn!(error = %error, claim_id = %claim_id, "failed to refresh async ingest heartbeat");
+                                break;
+                            }
                         }
                     }
                     _ = &mut stop_rx => break,
@@ -1006,6 +1056,25 @@ impl MempalMcpServer {
             }
         });
         (stop_tx, heartbeat)
+    }
+
+    async fn refresh_ingest_claim_heartbeat_once(
+        queue: &AsyncPendingMessageStore,
+        claim_id: &str,
+        worker_id: &str,
+    ) {
+        match queue
+            .refresh_heartbeat(claim_id.to_string(), worker_id.to_string())
+            .await
+        {
+            Ok(()) => {}
+            Err(error) if should_continue_ingest_heartbeat_after_error(&error) => {
+                tracing::warn!(error = %error, claim_id, "transient failure refreshing async ingest heartbeat before completion");
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, claim_id, "failed to refresh async ingest heartbeat before completion");
+            }
+        }
     }
 
     async fn stop_ingest_claim_heartbeat(
@@ -1034,7 +1103,7 @@ impl MempalMcpServer {
                     db_path.display()
                 )
             })?;
-            db.runtime_writer_lease_acquire(
+            db.runtime_writer_lease_acquire_preserving_live_holders(
                 SQLITE_WRITER_LEASE_NAME,
                 &owner,
                 "mcp-ingest-worker",
@@ -1061,7 +1130,7 @@ impl MempalMcpServer {
         })
         .to_string();
         let lease = db
-            .runtime_writer_lease_acquire(
+            .runtime_writer_lease_acquire_preserving_live_holders(
                 SQLITE_WRITER_LEASE_NAME,
                 &owner,
                 "mcp-content-write",
@@ -1172,6 +1241,7 @@ impl MempalMcpServer {
         request: IngestRequest,
         controls: IngestControls,
         runtime_writer_lease: Option<RuntimeWriterLease>,
+        pre_resolved_superseded_drawer_id: Option<String>,
     ) -> anyhow::Result<std::result::Result<IngestResponse, ErrorData>> {
         let worker = self.clone();
         #[cfg(any(test, feature = "db-test-seam"))]
@@ -1188,10 +1258,11 @@ impl MempalMcpServer {
                     .build()
                     .context("failed to build blocking ingest runtime")?;
                 Ok(runtime
-                    .block_on(worker.mempal_ingest_sync(
+                    .block_on(worker.mempal_ingest_sync_with_superseded_override(
                         request,
                         controls,
                         runtime_writer_lease.as_ref(),
+                        pre_resolved_superseded_drawer_id,
                     ))
                     .map(|response| response.0))
             })
@@ -1442,6 +1513,12 @@ impl MempalMcpServer {
         timeout: Duration,
         poll_interval: Duration,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        if !should_claim_scoped_ingest_worker(self.daemon_ingest_ipc_available()) {
+            return self
+                .wait_for_operation_status(operation_id, timeout, poll_interval)
+                .await;
+        }
+
         let timeout = clamp_wait_timeout(timeout);
         let deadline = Instant::now() + timeout;
         let worker_id = format!(
@@ -2287,10 +2364,47 @@ enum IngestQueueProcessor {
     Local,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DaemonIngestEnqueue {
+    Accepted,
+    Fallback { may_have_reached_daemon: bool },
+}
+
+impl DaemonIngestEnqueue {
+    fn may_have_reached_daemon(self) -> bool {
+        matches!(
+            self,
+            Self::Accepted
+                | Self::Fallback {
+                    may_have_reached_daemon: true
+                }
+        )
+    }
+}
+
+fn should_defer_local_ingest_to_daemon(
+    daemon_ingest_ipc_available: bool,
+    daemon_enqueue_may_have_reached: bool,
+) -> bool {
+    daemon_ingest_ipc_available || daemon_enqueue_may_have_reached
+}
+
+fn should_start_local_ingest_worker(
+    processor: IngestQueueProcessor,
+    defer_to_daemon_ingest_worker: bool,
+) -> bool {
+    matches!(processor, IngestQueueProcessor::Local) && !defer_to_daemon_ingest_worker
+}
+
+fn should_claim_scoped_ingest_worker(defer_to_daemon_ingest_worker: bool) -> bool {
+    !defer_to_daemon_ingest_worker
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct IngestQueueAdmission {
     operation_id: String,
     processor: IngestQueueProcessor,
+    daemon_enqueue_may_have_reached: bool,
 }
 
 #[doc(hidden)]
@@ -4916,7 +5030,7 @@ impl MempalMcpServer {
         if dry_run {
             let response = match tokio::time::timeout(
                 self.ingest_admission_deadline,
-                self.run_prepared_ingest_off_runtime(request, controls, None),
+                self.run_prepared_ingest_off_runtime(request, controls, None, None),
             )
             .await
             {
@@ -4982,9 +5096,17 @@ impl MempalMcpServer {
                 ));
             }
         };
-        if matches!(worker_mode, IngestWaitWorkerMode::Background)
-            && matches!(queue_admission.processor, IngestQueueProcessor::Local)
-        {
+        let defer_to_daemon_ingest_worker =
+            matches!(queue_admission.processor, IngestQueueProcessor::Local)
+                && should_defer_local_ingest_to_daemon(
+                    self.daemon_ingest_ipc_available(),
+                    queue_admission.daemon_enqueue_may_have_reached,
+                );
+        let use_local_ingest_worker = should_start_local_ingest_worker(
+            queue_admission.processor,
+            defer_to_daemon_ingest_worker,
+        );
+        if matches!(worker_mode, IngestWaitWorkerMode::Background) && use_local_ingest_worker {
             self.spawn_ingest_drain_worker();
         }
 
@@ -5016,9 +5138,7 @@ impl MempalMcpServer {
                 .operation_id
                 .as_deref()
                 .expect("queued receipt must include operation id");
-            let wait_result = if wait_timeout_secs > 0
-                && matches!(queue_admission.processor, IngestQueueProcessor::Local)
-            {
+            let wait_result = if wait_timeout_secs > 0 && use_local_ingest_worker {
                 self.wait_for_operation_status_with_scoped_worker(
                     operation_id,
                     Duration::from_secs(wait_timeout_secs),
@@ -5069,22 +5189,27 @@ impl MempalMcpServer {
         payload: String,
     ) -> anyhow::Result<IngestQueueAdmission> {
         let idempotency_key = mcp_ingest_idempotency_key(&payload);
-        if let Some(operation_id) = self
+        let daemon_enqueue = self
             .try_enqueue_ingest_operation_via_daemon(payload.clone(), idempotency_key.clone())
-            .await?
-        {
+            .await?;
+        if matches!(daemon_enqueue, DaemonIngestEnqueue::Accepted) {
+            let operation_id =
+                PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
             return Ok(IngestQueueAdmission {
                 operation_id,
                 processor: IngestQueueProcessor::Daemon,
+                daemon_enqueue_may_have_reached: true,
             });
         }
 
+        let daemon_enqueue_may_have_reached = daemon_enqueue.may_have_reached_daemon();
         let operation_id = self
             .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
             .await?;
         Ok(IngestQueueAdmission {
             operation_id,
             processor: IngestQueueProcessor::Local,
+            daemon_enqueue_may_have_reached,
         })
     }
 
@@ -5106,7 +5231,7 @@ impl MempalMcpServer {
             Err(error) => return Err(error.into()),
         };
 
-        if should_extend_ingest_admission_for_self_holder(&self.db_path) {
+        if should_extend_ingest_admission_for_known_runtime_holder(&self.db_path) {
             match self
                 .retry_enqueue_ingest_operation_locally_until(
                     payload,
@@ -5118,7 +5243,7 @@ impl MempalMcpServer {
                 Ok(operation_id) => return Ok(operation_id),
                 Err(error) if error.is_sqlite_lock() => {
                     return Err(anyhow::Error::new(error)
-                        .context("SQLite queue admission self-holder retry exhausted"));
+                        .context("SQLite queue admission known-runtime-holder retry exhausted"));
                 }
                 Err(error) => return Err(error.into()),
             }
@@ -5161,28 +5286,39 @@ impl MempalMcpServer {
         &self,
         payload: String,
         idempotency_key: String,
-    ) -> anyhow::Result<Option<String>> {
+    ) -> anyhow::Result<DaemonIngestEnqueue> {
         let Some(mempal_home) = self.db_path.parent().map(Path::to_path_buf) else {
-            return Ok(None);
+            return Ok(DaemonIngestEnqueue::Fallback {
+                may_have_reached_daemon: false,
+            });
         };
-        let operation_id =
-            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
         let request = crate::hook_ipc::HookIpcEnqueueRequest {
             kind: INGEST_ASYNC_KIND.to_string(),
             payload,
             idempotency_key,
         };
         let outcome = tokio::task::spawn_blocking(move || {
-            crate::hook_ipc::enqueue_with_default_timeout(&mempal_home, request)
+            crate::hook_ipc::enqueue_with_timeout(
+                &mempal_home,
+                request,
+                MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT,
+            )
         })
         .await
         .context("blocking daemon ingest enqueue IPC failed")?;
 
         match outcome {
-            crate::hook_ipc::HookIpcClientOutcome::Accepted => Ok(Some(operation_id)),
+            crate::hook_ipc::HookIpcClientOutcome::Accepted => Ok(DaemonIngestEnqueue::Accepted),
             crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => {
-                tracing::debug!(reason = %reason, "daemon ingest enqueue unavailable; using local queue");
-                Ok(None)
+                let may_have_reached_daemon = reason.may_have_reached_daemon();
+                tracing::debug!(
+                    reason = %reason,
+                    may_have_reached_daemon,
+                    "daemon ingest enqueue unavailable; using local queue"
+                );
+                Ok(DaemonIngestEnqueue::Fallback {
+                    may_have_reached_daemon,
+                })
             }
         }
     }
@@ -5279,11 +5415,28 @@ impl MempalMcpServer {
             .map_err(replacement_db_error)
     }
 
+    #[cfg(test)]
     async fn mempal_ingest_sync(
         &self,
         request: IngestRequest,
         controls: IngestControls,
         runtime_writer_lease: Option<&RuntimeWriterLease>,
+    ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        self.mempal_ingest_sync_with_superseded_override(
+            request,
+            controls,
+            runtime_writer_lease,
+            None,
+        )
+        .await
+    }
+
+    async fn mempal_ingest_sync_with_superseded_override(
+        &self,
+        request: IngestRequest,
+        controls: IngestControls,
+        runtime_writer_lease: Option<&RuntimeWriterLease>,
+        pre_resolved_superseded_drawer_id: Option<String>,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
         let dry_run = request.dry_run.unwrap_or(false);
         let controls = resolve_mcp_ingest_controls(&request, controls)?;
@@ -5355,18 +5508,19 @@ impl MempalMcpServer {
             .replace_text
             .as_deref()
             .map(|text| config.scrub_content_with_compiled(text, compiled_privacy.as_ref()));
-        let replacement_target = db
-            .resolve_replacement_target(
-                request.supersedes.as_deref(),
-                scrubbed_replace_text.as_deref(),
-                &request.wing,
-                room,
-                project_id.as_deref(),
-            )
-            .map_err(replacement_db_error)?;
-        let superseded_drawer_id = replacement_target
-            .as_ref()
-            .map(|summary| summary.id.clone());
+        let superseded_drawer_id = match pre_resolved_superseded_drawer_id {
+            Some(drawer_id) => Some(drawer_id),
+            None => db
+                .resolve_replacement_target(
+                    request.supersedes.as_deref(),
+                    scrubbed_replace_text.as_deref(),
+                    &request.wing,
+                    room,
+                    project_id.as_deref(),
+                )
+                .map_err(replacement_db_error)?
+                .map(|summary| summary.id),
+        };
         let superseded_drawer_id_ref = superseded_drawer_id.as_deref();
         let mut superseded_response_id: Option<String> = None;
 
@@ -9352,27 +9506,37 @@ fn database_warning_snapshot(
     warnings
 }
 
-fn should_extend_ingest_admission_for_self_holder(db_path: &Path) -> bool {
+fn should_extend_ingest_admission_for_known_runtime_holder(db_path: &Path) -> bool {
     let report = crate::process_diagnostics::inspect_db_holders(db_path);
-    ingest_admission_report_is_self_holder_only(&report)
+    ingest_admission_report_is_known_runtime_holder_only(&report)
 }
 
-fn ingest_admission_report_is_self_holder_only(
+fn ingest_admission_report_is_known_runtime_holder_only(
     report: &crate::process_diagnostics::DbHolderReport,
 ) -> bool {
-    if report.error.is_some()
-        || report.extra_holder_count > 0
-        || report.stale_mcp_server_count > 0
-        || report.orphan_daemon_count > 0
+    if report.error.is_some() || report.stale_mcp_server_count > 0 || report.orphan_daemon_count > 0
     {
         return false;
     }
 
-    report.holders.iter().any(|holder| {
-        holder.current_mcp_server
+    let mut has_known_holder = false;
+    for holder in &report.holders {
+        if holder.current_mcp_server
             || holder.classification == "current_mcp_server"
+            || holder.current_daemon
+            || holder.classification == "current_daemon"
             || holder.current_process
-    })
+        {
+            has_known_holder = true;
+            continue;
+        }
+        if holder.classification == "extra_holder" && holder.role == "mempal_readonly_cli" {
+            has_known_holder = true;
+            continue;
+        }
+        return false;
+    }
+    has_known_holder
 }
 
 fn database_write_refused_error_from_diagnostic(diagnostic: DatabaseDiagnosticDto) -> ErrorData {
@@ -10106,16 +10270,28 @@ mod tests {
     fn db_holder_for_ingest_retry(
         classification: &str,
     ) -> crate::process_diagnostics::DbHolderProcess {
+        db_holder_for_ingest_retry_with_role(
+            classification,
+            if classification == "current_mcp_server" {
+                "mempal_mcp_server"
+            } else {
+                "other"
+            },
+        )
+    }
+
+    fn db_holder_for_ingest_retry_with_role(
+        classification: &str,
+        role: &str,
+    ) -> crate::process_diagnostics::DbHolderProcess {
         crate::process_diagnostics::DbHolderProcess {
             pid: 55,
-            role: if classification == "current_mcp_server" {
-                "mempal_mcp_server".to_string()
-            } else {
-                "other".to_string()
-            },
+            role: role.to_string(),
             classification: classification.to_string(),
-            command: if classification == "current_mcp_server" {
+            command: if role == "mempal_mcp_server" {
                 "mempal serve".to_string()
+            } else if role == "mempal_readonly_cli" {
+                "mempal read-only cli".to_string()
             } else {
                 "other".to_string()
             },
@@ -10169,15 +10345,23 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_ingest_admission_self_holder_retry_classifier_rejects_external_holders() {
+    fn test_mcp_ingest_admission_known_runtime_holder_retry_classifier_rejects_external_holders() {
         let current_mcp = db_holder_report_for_ingest_retry(vec![db_holder_for_ingest_retry(
             "current_mcp_server",
         )]);
-        assert!(ingest_admission_report_is_self_holder_only(&current_mcp));
+        assert!(ingest_admission_report_is_known_runtime_holder_only(
+            &current_mcp
+        ));
+
+        let current_daemon =
+            db_holder_report_for_ingest_retry(vec![db_holder_for_ingest_retry("current_daemon")]);
+        assert!(ingest_admission_report_is_known_runtime_holder_only(
+            &current_daemon
+        ));
 
         let current_process =
             db_holder_report_for_ingest_retry(vec![db_holder_for_ingest_retry("current_process")]);
-        assert!(ingest_admission_report_is_self_holder_only(
+        assert!(ingest_admission_report_is_known_runtime_holder_only(
             &current_process
         ));
 
@@ -10185,13 +10369,79 @@ mod tests {
             db_holder_for_ingest_retry("current_mcp_server"),
             db_holder_for_ingest_retry("extra_holder"),
         ]);
-        assert!(!ingest_admission_report_is_self_holder_only(
+        assert!(!ingest_admission_report_is_known_runtime_holder_only(
             &extra_with_current
+        ));
+
+        let readonly_cli_with_current = db_holder_report_for_ingest_retry(vec![
+            db_holder_for_ingest_retry("current_mcp_server"),
+            db_holder_for_ingest_retry_with_role("extra_holder", "mempal_readonly_cli"),
+        ]);
+        assert!(ingest_admission_report_is_known_runtime_holder_only(
+            &readonly_cli_with_current
         ));
 
         let stale_mcp =
             db_holder_report_for_ingest_retry(vec![db_holder_for_ingest_retry("stale_mcp_server")]);
-        assert!(!ingest_admission_report_is_self_holder_only(&stale_mcp));
+        assert!(!ingest_admission_report_is_known_runtime_holder_only(
+            &stale_mcp
+        ));
+    }
+
+    #[test]
+    fn test_mcp_stdio_uses_daemon_ingest_worker_only_when_ipc_and_daemon_are_live() {
+        assert!(should_use_daemon_ingest_worker(true, &[1234]));
+        assert!(!should_use_daemon_ingest_worker(false, &[1234]));
+        assert!(!should_use_daemon_ingest_worker(true, &[]));
+    }
+
+    #[test]
+    fn test_mcp_local_queue_uses_daemon_worker_when_daemon_ipc_is_live() {
+        assert!(should_start_local_ingest_worker(
+            IngestQueueProcessor::Local,
+            false
+        ));
+        assert!(!should_start_local_ingest_worker(
+            IngestQueueProcessor::Local,
+            true
+        ));
+        assert!(!should_start_local_ingest_worker(
+            IngestQueueProcessor::Daemon,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_mcp_local_queue_defers_when_daemon_enqueue_may_have_arrived() {
+        assert!(should_defer_local_ingest_to_daemon(false, true));
+        assert!(should_defer_local_ingest_to_daemon(true, false));
+        assert!(!should_defer_local_ingest_to_daemon(false, false));
+        assert!(!should_start_local_ingest_worker(
+            IngestQueueProcessor::Local,
+            true
+        ));
+        assert!(!should_claim_scoped_ingest_worker(true));
+    }
+
+    #[test]
+    fn test_operation_wait_uses_daemon_worker_when_daemon_ipc_is_live() {
+        assert!(should_claim_scoped_ingest_worker(false));
+        assert!(!should_claim_scoped_ingest_worker(true));
+    }
+
+    #[test]
+    fn test_ingest_heartbeat_retries_transient_sqlite_lock() {
+        let busy = QueueError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy,
+                extended_code: rusqlite::ffi::SQLITE_BUSY,
+            },
+            Some("database is locked".to_string()),
+        ));
+        assert!(should_continue_ingest_heartbeat_after_error(&busy));
+
+        let claim_lost = QueueError::ClaimLost("msg-test".to_string());
+        assert!(!should_continue_ingest_heartbeat_after_error(&claim_lost));
     }
 
     #[tokio::test]
@@ -10552,6 +10802,27 @@ quality_policy = "llm_required_for_keep"
             ),
             "unexpected operation state after transient lock retry: {}",
             record.op_state
+        );
+    }
+
+    #[test]
+    fn test_mcp_context_database_deadline_exceeds_large_db_smoke_latency() {
+        assert!(
+            MCP_SEARCH_DB_DEADLINE >= Duration::from_secs(60),
+            "MCP context/brief database deadline must exceed observed large-DB smoke latency"
+        );
+    }
+
+    #[test]
+    fn test_mcp_daemon_ingest_enqueue_ipc_timeout_exceeds_hook_fail_fast_timeout() {
+        assert!(
+            MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT > crate::hook_ipc::HOOK_IPC_TIMEOUT,
+            "MCP daemon ingest enqueue must not reuse hook fail-fast IPC timeout"
+        );
+        assert!(
+            MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT
+                >= MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE,
+            "MCP daemon ingest enqueue IPC timeout must cover the observed SQLite holder retry budget"
         );
     }
 
@@ -11327,6 +11598,68 @@ pattern_boost = 0.2
             .expect("completed status");
         assert_eq!(completed.state, Some(IngestOperationState::Completed));
         assert!(!completed.drawer_id.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_async_ingest_uses_admission_supersedes_target_after_queue_wait() {
+        let (_tempdir, db_path, server) = setup_server();
+        let seed_id = "async-supersedes-old";
+        insert_drawer_with_project(&db_path, seed_id, "mcp", Some("runtime"), None);
+
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "new async supersedes target".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("runtime".to_string()),
+            supersedes: Some(seed_id.to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async supersedes ingest");
+        assert_eq!(prepared.superseded_drawer_id.as_deref(), Some(seed_id));
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async supersedes ingest");
+        Database::open(&db_path)
+            .expect("open db")
+            .soft_delete_drawer(seed_id)
+            .expect("simulate queue wait cleanup of target");
+        let claim = queue
+            .claim_next_by_kind("worker-supersedes", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+
+        server
+            .process_ingest_claim(&async_queue, "worker-supersedes", claim)
+            .await
+            .expect("process queued supersedes ingest");
+
+        let completed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert_eq!(completed.superseded_drawer_id.as_deref(), Some(seed_id));
+        assert!(!completed.created_drawer_ids.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -14856,6 +15189,62 @@ pattern_boost = 0.2
 
         assert!(response.timed_out, "{response:?}");
         assert_eq!(db.drawer_count().expect("drawer count"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_scoped_ingest_worker_respects_expired_live_daemon_writer_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        let db = Database::open(&db_path).expect("open db");
+        let daemon_lease = db
+            .runtime_writer_lease_acquire(
+                SQLITE_WRITER_LEASE_NAME,
+                "daemon-owner",
+                "daemon",
+                1,
+                None,
+            )
+            .expect("acquire daemon lease")
+            .expect("daemon lease");
+        db.conn()
+            .execute(
+                "UPDATE runtime_writer_leases \
+                 SET expires_at = '1970-01-01T00:00:00Z', heartbeat_at = '1970-01-01T00:00:00Z' \
+                 WHERE name = ?1 AND owner = ?2 AND session_id = ?3",
+                params![
+                    &daemon_lease.name,
+                    &daemon_lease.owner,
+                    &daemon_lease.session_id
+                ],
+            )
+            .expect("force daemon lease expiry");
+
+        let response = server
+            .mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped worker must not steal expired live daemon writer lease"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("lease".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(1),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("scoped worker response")
+            .0;
+
+        assert!(response.timed_out, "{response:?}");
+        assert_eq!(db.drawer_count().expect("drawer count"), 0);
+        let active = db
+            .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
+            .expect("load writer lease status");
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].owner, "daemon-owner");
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -795,13 +795,9 @@ impl MempalMcpServer {
         let writer_lease = if external_writer_lease.is_some() {
             None
         } else {
-            match self
-                .acquire_ingest_writer_lease(worker_id)
-                .await
-                .context("failed to acquire MCP ingest writer lease")?
-            {
-                Some(lease) => Some(lease),
-                None => {
+            match self.acquire_ingest_writer_lease(worker_id).await {
+                Ok(Some(lease)) => Some(lease),
+                Ok(None) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
                     queue
                         .release_claim(claim)
@@ -809,6 +805,17 @@ impl MempalMcpServer {
                         .context("failed to release ingest claim after writer lease conflict")?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
+                }
+                Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    queue.release_claim(claim).await.context(
+                        "failed to release ingest claim after transient writer lease lock",
+                    )?;
+                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                    return Ok(());
+                }
+                Err(error) => {
+                    return Err(error).context("failed to acquire MCP ingest writer lease");
                 }
             }
         };
@@ -861,19 +868,26 @@ impl MempalMcpServer {
         let writer_lease = if external_writer_lease.is_some() {
             None
         } else {
-            match self
-                .acquire_ingest_writer_lease(worker_id)
-                .await
-                .context("failed to acquire scoped MCP ingest writer lease")?
-            {
-                Some(lease) => Some(lease),
-                None => {
+            match self.acquire_ingest_writer_lease(worker_id).await {
+                Ok(Some(lease)) => Some(lease),
+                Ok(None) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
                     queue.release_claim(claim).await.context(
                         "failed to release scoped ingest claim after writer lease conflict",
                     )?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
+                }
+                Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    queue.release_claim(claim).await.context(
+                        "failed to release scoped ingest claim after transient writer lease lock",
+                    )?;
+                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                    return Ok(());
+                }
+                Err(error) => {
+                    return Err(error).context("failed to acquire scoped MCP ingest writer lease");
                 }
             }
         };
@@ -1947,6 +1961,34 @@ const MCP_SMOKE_CONTENT_MAX_BYTES: usize = 4 * 1024;
 
 fn clamp_wait_timeout(timeout: Duration) -> Duration {
     timeout.min(Duration::from_secs(MAX_WAIT_TIMEOUT_SECS))
+}
+
+fn rusqlite_error_is_lock(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(sqlite, _)
+            if matches!(
+                sqlite.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+                || matches!(
+                    sqlite.extended_code & 0xff,
+                    rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+                )
+    )
+}
+
+fn anyhow_chain_contains_sqlite_lock(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<rusqlite::Error>()
+            .is_some_and(rusqlite_error_is_lock)
+            || cause
+                .downcast_ref::<crate::core::db::DbError>()
+                .is_some_and(|db_error| {
+                    matches!(db_error, crate::core::db::DbError::Sqlite(error) if rusqlite_error_is_lock(error))
+                })
+    })
 }
 
 fn resolve_mcp_ingest_controls(
@@ -4915,22 +4957,21 @@ impl MempalMcpServer {
                 .operation_id
                 .as_deref()
                 .expect("queued receipt must include operation id");
-            let wait_result =
-                if matches!(worker_mode, IngestWaitWorkerMode::Scoped) && wait_timeout_secs > 0 {
-                    self.wait_for_operation_status_with_scoped_worker(
-                        operation_id,
-                        Duration::from_secs(wait_timeout_secs),
-                        Duration::from_millis(150),
-                    )
-                    .await
-                } else {
-                    self.wait_for_operation_status(
-                        operation_id,
-                        Duration::from_secs(wait_timeout_secs),
-                        Duration::from_millis(150),
-                    )
-                    .await
-                };
+            let wait_result = if wait_timeout_secs > 0 {
+                self.wait_for_operation_status_with_scoped_worker(
+                    operation_id,
+                    Duration::from_secs(wait_timeout_secs),
+                    Duration::from_millis(150),
+                )
+                .await
+            } else {
+                self.wait_for_operation_status(
+                    operation_id,
+                    Duration::from_secs(wait_timeout_secs),
+                    Duration::from_millis(150),
+                )
+                .await
+            };
             if let Some(final_response) = wait_result? {
                 return Ok(Json(final_response));
             }
@@ -13944,6 +13985,57 @@ pattern_boost = 0.2
 
         let db = Database::open(&db_path).expect("open db");
         assert_eq!(db.drawer_count().expect("drawer count"), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_wait_supersedes_returns_cleanup_ids_without_background_worker() {
+        let (_tempdir, db_path, server) = setup_server();
+        let old = ingest_manual(&server, "wait scoped supersedes old fact", None, None, None).await;
+
+        server.ingest_worker_started.store(true, Ordering::SeqCst);
+        let update = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "wait scoped supersedes new fact".to_string(),
+                wing: "mempal".to_string(),
+                room: Some("replace".to_string()),
+                supersedes: Some(old.drawer_id.clone()),
+                wait: Some(true),
+                wait_timeout_secs: Some(30),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("wait supersedes ingest")
+            .0;
+
+        assert_eq!(update.state, Some(IngestOperationState::Completed));
+        assert_eq!(
+            update.superseded_drawer_id.as_deref(),
+            Some(old.drawer_id.as_str())
+        );
+        assert_eq!(
+            update.created_drawer_ids.len(),
+            1,
+            "supersedes wait response must expose cleanup-safe new drawer id"
+        );
+        assert_eq!(update.drawer_ids, update.created_drawer_ids);
+        assert_ne!(update.created_drawer_ids[0], old.drawer_id);
+
+        let operation_id = update.operation_id.as_deref().expect("operation id");
+        let status = server
+            .operation_status_json_for_test(operation_id)
+            .await
+            .expect("wait supersedes status");
+        assert_eq!(status.state, Some(IngestOperationState::Completed));
+        assert_eq!(status.created_drawer_ids, update.created_drawer_ids);
+        assert_eq!(status.drawer_ids, status.created_drawer_ids);
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&old.drawer_id).expect("old lookup").is_none());
+        assert!(
+            db.get_drawer(&update.created_drawer_ids[0])
+                .expect("new lookup")
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1489,15 +1489,40 @@ impl MempalMcpServer {
         timeout: Duration,
         poll_interval: Duration,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        self.wait_for_operation_status_with_lookup_policy(
+            operation_id,
+            timeout,
+            poll_interval,
+            false,
+        )
+        .await
+    }
+
+    async fn wait_for_operation_status_with_lookup_policy(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+        poll_interval: Duration,
+        allow_pending_admission_lookup: bool,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
         let deadline = Instant::now() + clamp_wait_timeout(timeout);
         loop {
-            let response = self.operation_status_json_for_test(operation_id).await?;
-            if response
-                .state
-                .map(IngestOperationState::is_terminal)
-                .unwrap_or(false)
-            {
-                return Ok(Some(response));
+            match self.operation_status_json_for_test(operation_id).await {
+                Ok(response) => {
+                    if response
+                        .state
+                        .map(IngestOperationState::is_terminal)
+                        .unwrap_or(false)
+                    {
+                        return Ok(Some(response));
+                    }
+                }
+                Err(error)
+                    if mcp_operation_wait_error_is_ignorable_during_wait(
+                        &error,
+                        allow_pending_admission_lookup,
+                    ) => {}
+                Err(error) => return Err(error),
             }
             if timeout.is_zero() || Instant::now() >= deadline {
                 return Ok(None);
@@ -1529,13 +1554,18 @@ impl MempalMcpServer {
         let queue = self.async_queue.clone();
 
         loop {
-            let response = self.operation_status_json_for_test(operation_id).await?;
-            if response
-                .state
-                .map(IngestOperationState::is_terminal)
-                .unwrap_or(false)
-            {
-                return Ok(Some(response));
+            match self.operation_status_json_for_test(operation_id).await {
+                Ok(response) => {
+                    if response
+                        .state
+                        .map(IngestOperationState::is_terminal)
+                        .unwrap_or(false)
+                    {
+                        return Ok(Some(response));
+                    }
+                }
+                Err(error) if mcp_operation_wait_error_is_transient_lookup(&error) => {}
+                Err(error) => return Err(error),
             }
             if timeout.is_zero() || Instant::now() >= deadline {
                 return Ok(None);
@@ -2091,6 +2121,9 @@ fn anyhow_chain_contains_sqlite_lock(error: &anyhow::Error) -> bool {
         cause
             .downcast_ref::<rusqlite::Error>()
             .is_some_and(rusqlite_error_is_lock)
+            || cause
+                .downcast_ref::<QueueError>()
+                .is_some_and(QueueError::is_sqlite_lock)
             || cause
                 .downcast_ref::<crate::core::db::DbError>()
                 .is_some_and(|db_error| {
@@ -5146,10 +5179,11 @@ impl MempalMcpServer {
                 )
                 .await
             } else {
-                self.wait_for_operation_status(
+                self.wait_for_operation_status_with_lookup_policy(
                     operation_id,
                     Duration::from_secs(wait_timeout_secs),
                     Duration::from_millis(150),
+                    queue_admission.daemon_enqueue_may_have_reached,
                 )
                 .await
             };
@@ -5158,22 +5192,35 @@ impl MempalMcpServer {
             }
 
             let mut timed_out_response = if matches!(worker_mode, IngestWaitWorkerMode::Scoped) {
-                let refreshed = self
+                match self
                     .operation_status_json_for_test(
                         queued_response
                             .operation_id
                             .as_deref()
                             .expect("queued receipt must include operation id"),
                     )
-                    .await?;
-                if refreshed
-                    .state
-                    .map(IngestOperationState::is_terminal)
-                    .unwrap_or(false)
+                    .await
                 {
-                    return Ok(Json(refreshed));
+                    Ok(refreshed) => {
+                        if refreshed
+                            .state
+                            .map(IngestOperationState::is_terminal)
+                            .unwrap_or(false)
+                        {
+                            return Ok(Json(refreshed));
+                        }
+                        refreshed
+                    }
+                    Err(error)
+                        if mcp_operation_wait_error_is_ignorable_during_wait(
+                            &error,
+                            queue_admission.daemon_enqueue_may_have_reached,
+                        ) =>
+                    {
+                        queued_response
+                    }
+                    Err(error) => return Err(error),
                 }
-                refreshed
             } else {
                 queued_response
             };
@@ -5203,9 +5250,27 @@ impl MempalMcpServer {
         }
 
         let daemon_enqueue_may_have_reached = daemon_enqueue.may_have_reached_daemon();
-        let operation_id = self
-            .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
-            .await?;
+        let operation_id = match self
+            .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key.clone())
+            .await
+        {
+            Ok(operation_id) => operation_id,
+            Err(error) => {
+                if let Some(admission) = queue_admission_for_uncertain_daemon_enqueue(
+                    &idempotency_key,
+                    daemon_enqueue_may_have_reached,
+                    &error,
+                ) {
+                    tracing::warn!(
+                        operation_id = %admission.operation_id,
+                        error = %error,
+                        "local ingest queue admission failed after daemon enqueue may have reached daemon; preserving operation receipt"
+                    );
+                    return Ok(admission);
+                }
+                return Err(error);
+            }
+        };
         Ok(IngestQueueAdmission {
             operation_id,
             processor: IngestQueueProcessor::Local,
@@ -9684,6 +9749,57 @@ fn mcp_stage_timeout_error(operation: &str, stage: &str, deadline: Duration) -> 
     )
 }
 
+fn mcp_operation_wait_error_is_transient_lookup(error: &ErrorData) -> bool {
+    let message = error.message.to_ascii_lowercase();
+    let operation_lookup = message.contains("queue lookup")
+        || message.contains("mempal_operation_status")
+        || message.contains("operation status");
+    let transient = message.contains("database is locked")
+        || message.contains("database locked")
+        || message.contains("database is busy")
+        || message.contains("database busy")
+        || message.contains("sqlite_busy")
+        || message.contains("sqlite_locked")
+        || message.contains("locked_or_busy")
+        || (message.contains("exceeded") && message.contains("queue lookup"));
+    operation_lookup && transient
+}
+
+fn mcp_operation_wait_error_is_ignorable_during_wait(
+    error: &ErrorData,
+    allow_pending_admission_lookup: bool,
+) -> bool {
+    mcp_operation_wait_error_is_transient_lookup(error)
+        || (allow_pending_admission_lookup
+            && mcp_operation_wait_error_is_missing_pending_admission(error))
+}
+
+fn mcp_operation_wait_error_is_missing_pending_admission(error: &ErrorData) -> bool {
+    error
+        .message
+        .to_ascii_lowercase()
+        .contains("operation not found:")
+}
+
+fn queue_admission_for_uncertain_daemon_enqueue(
+    idempotency_key: &str,
+    daemon_enqueue_may_have_reached: bool,
+    error: &anyhow::Error,
+) -> Option<IngestQueueAdmission> {
+    if !daemon_enqueue_may_have_reached || !anyhow_chain_contains_sqlite_lock(error) {
+        return None;
+    }
+
+    Some(IngestQueueAdmission {
+        operation_id: PendingMessageStore::idempotent_message_id(
+            INGEST_ASYNC_KIND,
+            idempotency_key,
+        ),
+        processor: IngestQueueProcessor::Local,
+        daemon_enqueue_may_have_reached: true,
+    })
+}
+
 fn push_mcp_timeout_warning(
     response_warnings: &mut Vec<String>,
     system_warnings: &mut Vec<SystemWarning>,
@@ -10427,6 +10543,86 @@ mod tests {
     fn test_operation_wait_uses_daemon_worker_when_daemon_ipc_is_live() {
         assert!(should_claim_scoped_ingest_worker(false));
         assert!(!should_claim_scoped_ingest_worker(true));
+    }
+
+    #[test]
+    fn test_operation_wait_classifies_transient_status_lookup_errors() {
+        let locked = ErrorData::internal_error(
+            "mempal_operation_status queue lookup failed: database is locked",
+            None,
+        );
+        assert!(mcp_operation_wait_error_is_transient_lookup(&locked));
+
+        let timeout = mcp_stage_timeout_error(
+            "mempal_operation_status",
+            "queue lookup",
+            Duration::from_secs(2),
+        );
+        assert!(mcp_operation_wait_error_is_transient_lookup(&timeout));
+
+        let enqueue_lock =
+            ErrorData::internal_error("enqueue_ingest_operation failed: database is locked", None);
+        assert!(!mcp_operation_wait_error_is_transient_lookup(&enqueue_lock));
+
+        let missing_operation = ErrorData::internal_error(
+            "mempal_operation_status queue lookup failed: operation row was not found",
+            None,
+        );
+        assert!(!mcp_operation_wait_error_is_transient_lookup(
+            &missing_operation
+        ));
+
+        let pending_admission =
+            ErrorData::invalid_params("operation not found: msg-dedup-pending-admission", None);
+        assert!(!mcp_operation_wait_error_is_ignorable_during_wait(
+            &pending_admission,
+            false
+        ));
+        assert!(mcp_operation_wait_error_is_ignorable_during_wait(
+            &pending_admission,
+            true
+        ));
+    }
+
+    #[test]
+    fn test_uncertain_daemon_enqueue_admission_preserves_operation_id_after_local_lock() {
+        let lock_error = anyhow::Error::new(QueueError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::DatabaseBusy,
+                extended_code: rusqlite::ffi::SQLITE_BUSY,
+            },
+            Some("database is locked".to_string()),
+        )))
+        .context("SQLite queue admission known-runtime-holder retry exhausted");
+
+        let admission =
+            queue_admission_for_uncertain_daemon_enqueue("uncertain-daemon-key", true, &lock_error)
+                .expect("lock after may-have-reached daemon enqueue should preserve receipt");
+
+        assert_eq!(
+            admission.operation_id,
+            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, "uncertain-daemon-key")
+        );
+        assert_eq!(admission.processor, IngestQueueProcessor::Local);
+        assert!(admission.daemon_enqueue_may_have_reached);
+        assert!(
+            queue_admission_for_uncertain_daemon_enqueue(
+                "uncertain-daemon-key",
+                false,
+                &lock_error,
+            )
+            .is_none()
+        );
+
+        let non_lock_error = anyhow::anyhow!("local admission rejected malformed payload");
+        assert!(
+            queue_admission_for_uncertain_daemon_enqueue(
+                "uncertain-daemon-key",
+                true,
+                &non_lock_error,
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1225,8 +1225,8 @@ impl MempalMcpServer {
         });
         match tokio::time::timeout(deadline, read).await {
             Ok(Ok(result)) => result,
-            Ok(Err(error)) => Err(ErrorData::internal_error(
-                format!("{stage} database task failed: {error}"),
+            Ok(Err(join_error)) => Err(ErrorData::internal_error(
+                format!("{stage} database task failed: {join_error}"),
                 None,
             )),
             Err(_) => Err(mcp_stage_timeout_error(
@@ -9908,6 +9908,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use rmcp::model::ErrorCode;
     use rusqlite::params;
     use tempfile::TempDir;
     use tokio::sync::Notify;
@@ -10037,6 +10038,25 @@ mod tests {
         .expect("create MCP server")
         .with_async_db_for_test(async_db);
         (tempdir, db_path, server)
+    }
+
+    #[tokio::test]
+    async fn test_query_only_read_preserves_mcp_error_data() {
+        let (_tempdir, _db_path, server) = setup_server();
+
+        let error = server
+            .run_query_only_read_bounded(
+                "test_query_only_read",
+                Duration::from_secs(1),
+                |_db| -> std::result::Result<(), ErrorData> {
+                    Err(ErrorData::invalid_params("preserve caller error", None))
+                },
+            )
+            .await
+            .expect_err("closure ErrorData must be returned unchanged");
+
+        assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(error.message, "preserve caller error");
     }
 
     fn hold_sqlite_write_lock(db_path: PathBuf, hold_for: Duration) -> thread::JoinHandle<()> {

--- a/src/mcp/timeline.rs
+++ b/src/mcp/timeline.rs
@@ -90,23 +90,29 @@ pub(super) async fn handle(
         .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
         .await?;
     let scope = ProjectSearchScope::from_request(project_id.clone(), false, false, true);
-    let db = server.open_db()?;
-    let report = build_timeline_report(
-        &db,
-        TimelineQuery {
-            project_id,
-            scope,
-            since: request
-                .since
-                .unwrap_or_else(|| DEFAULT_TIMELINE_SINCE.to_string()),
-            until: request.until,
-            top_k,
-            min_importance,
-            wing: request.wing,
-            room: request.room,
-        },
-    )
-    .map_err(timeline_error)?;
+    let report = server
+        .run_query_only_read_bounded("mempal_timeline", super::server::MCP_SEARCH_DB_DEADLINE, {
+            let project_id = project_id.clone();
+            move |db| {
+                build_timeline_report(
+                    db,
+                    TimelineQuery {
+                        project_id,
+                        scope,
+                        since: request
+                            .since
+                            .unwrap_or_else(|| DEFAULT_TIMELINE_SINCE.to_string()),
+                        until: request.until,
+                        top_k,
+                        min_importance,
+                        wing: request.wing,
+                        room: request.room,
+                    },
+                )
+                .map_err(timeline_error)
+            }
+        })
+        .await?;
 
     Ok(Json(TimelineResponse::from_report(
         report,

--- a/src/process_diagnostics.rs
+++ b/src/process_diagnostics.rs
@@ -647,7 +647,33 @@ fn classify_role(argv: &[String], binary_name: &str) -> &'static str {
     if is_mcp_server_argv(argv) {
         return "mempal_mcp_server";
     }
+    if is_read_only_cli_argv(argv) {
+        return "mempal_readonly_cli";
+    }
     "mempal_cli"
+}
+
+#[cfg(target_os = "linux")]
+fn is_read_only_cli_argv(argv: &[String]) -> bool {
+    let Some((_, subcommand)) = crate::daemon_singleton::first_cli_subcommand(argv) else {
+        return false;
+    };
+    // Diagnostic-only classification for short-lived CLI readers that can overlap
+    // MCP write admission. Keep this conservative: write-capable subcommands must
+    // remain `mempal_cli` so busy diagnostics still fail fast on external writers.
+    matches!(
+        subcommand,
+        "status"
+            | "search"
+            | "context"
+            | "wake-up"
+            | "tail"
+            | "timeline"
+            | "stats"
+            | "view"
+            | "reflect"
+            | "field-taxonomy"
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -700,6 +726,7 @@ fn command_display(role: &str) -> String {
     match role {
         "mempal_daemon" => "mempal daemon".to_string(),
         "mempal_mcp_server" => "mempal serve".to_string(),
+        "mempal_readonly_cli" => "mempal read-only cli".to_string(),
         "mempal_cli" => "mempal cli".to_string(),
         "other" => "other process".to_string(),
         _ => "<unknown>".to_string(),
@@ -840,6 +867,15 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![33, 44, 55]
         );
+    }
+
+    #[test]
+    fn test_classify_role_distinguishes_read_only_cli_from_write_cli() {
+        let status_argv = vec!["mempal".to_string(), "status".to_string()];
+        assert_eq!(classify_role(&status_argv, "mempal"), "mempal_readonly_cli");
+
+        let ingest_argv = vec!["mempal".to_string(), "ingest".to_string()];
+        assert_eq!(classify_role(&ingest_argv, "mempal"), "mempal_cli");
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -28,6 +28,7 @@ pub mod route;
 pub mod tiered;
 
 const EXACT_VECTOR_CANDIDATE_LIMIT: i64 = 4_096;
+const ACCESS_WRITEBACK_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub type Result<T> = std::result::Result<T, SearchError>;
 
@@ -894,18 +895,23 @@ pub fn dispatch_access_update(db_path: std::path::PathBuf, drawer_ids: Vec<Strin
     let floor = config.importance.floor;
     let boost_cap = config.importance.boost_cap;
     crate::observability::record_access_writeback_scheduled();
-    tokio::task::spawn_blocking(move || match crate::core::db::Database::open(&db_path) {
-        Ok(db) => {
-            if let Err(err) =
-                db.update_access_fields_batch(&drawer_ids, now_ms, decay_rate, floor, boost_cap)
-            {
-                crate::observability::record_access_writeback_failed();
-                tracing::warn!(error = %err, "access field update failed");
+    tokio::task::spawn_blocking(move || {
+        match crate::core::db::Database::open_with_busy_timeout(
+            &db_path,
+            ACCESS_WRITEBACK_BUSY_TIMEOUT,
+        ) {
+            Ok(db) => {
+                if let Err(err) =
+                    db.update_access_fields_batch(&drawer_ids, now_ms, decay_rate, floor, boost_cap)
+                {
+                    crate::observability::record_access_writeback_failed();
+                    tracing::warn!(error = %err, "access field update failed");
+                }
             }
-        }
-        Err(err) => {
-            crate::observability::record_access_writeback_failed();
-            tracing::warn!(error = %err, "failed to open db for access update");
+            Err(err) => {
+                crate::observability::record_access_writeback_failed();
+                tracing::warn!(error = %err, "failed to open db for access update");
+            }
         }
     });
 }
@@ -2202,6 +2208,39 @@ mod tests {
         assert_eq!(counters.access_writeback_scheduled_total, 1);
         assert_eq!(counters.access_writeback_skipped_total, 0);
         assert_eq!(counters.access_writeback_failed_total, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_access_update_skips_when_sqlite_writer_is_busy() {
+        let lock = crate::core::config::global_config_test_lock();
+        let _guard = lock.lock().await;
+        let tmp = TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("test.db");
+        let db = Database::open(&db_path).expect("db");
+        let drawer = make_drawer("access-busy", "alpha", "decision");
+        db.insert_drawer(&drawer).expect("insert drawer");
+        configure_record_access(tmp.path(), &db_path, true).await;
+
+        let lock_holder = rusqlite::Connection::open(&db_path).expect("open lock holder");
+        lock_holder
+            .busy_timeout(std::time::Duration::ZERO)
+            .expect("set fail-fast lock holder timeout");
+        lock_holder
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold writer lock");
+
+        dispatch_access_update(db_path.clone(), vec![drawer.id.clone()]);
+        tokio::time::sleep(ACCESS_WRITEBACK_BUSY_TIMEOUT + std::time::Duration::from_millis(150))
+            .await;
+        lock_holder
+            .execute_batch("COMMIT;")
+            .expect("release writer lock");
+
+        assert_eq!(
+            access_count(&db_path, &drawer.id),
+            0,
+            "access writeback is best-effort and must not wait behind ingest-critical writes"
+        );
     }
 
     #[test]

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -196,6 +196,82 @@ async fn mcp_stdio_ingest_busy_after_status_keeps_transport_alive() -> Result<()
     Ok(())
 }
 
+#[tokio::test]
+async fn mcp_stdio_ingest_succeeds_with_existing_status_holder() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path)?;
+
+    let mut holder = McpStdio::start(&db_path, HashMap::new()).await?;
+    holder.initialize().await?;
+    let status = tokio::time::timeout(
+        Duration::from_secs(15),
+        holder.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_status",
+                "arguments": {},
+            }),
+        ),
+    )
+    .await??;
+    assert!(status["structuredContent"].is_object());
+
+    let mut client = McpStdio::start(&db_path, HashMap::new()).await?;
+    client.initialize().await?;
+    let ingest = tokio::time::timeout(
+        Duration::from_secs(30),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_ingest",
+                "arguments": {
+                    "content": "issue 544 MCP smoke create cleanup-id regression payload",
+                    "wing": "smoke",
+                    "room": "mcp",
+                    "source_type": "agent_inference",
+                    "memory_kind": "evidence",
+                    "domain": "project",
+                    "field": "smoke",
+                    "smoke": true,
+                    "wait": true,
+                    "wait_timeout_secs": 10
+                },
+            }),
+        ),
+    )
+    .await??;
+    let created = ingest["structuredContent"]["created_drawer_ids"]
+        .as_array()
+        .expect("created_drawer_ids array");
+    assert!(
+        !created.is_empty(),
+        "MCP create must return cleanup-safe created_drawer_ids"
+    );
+
+    for drawer_id in created.iter().filter_map(serde_json::Value::as_str) {
+        let deleted = client
+            .call(
+                "tools/call",
+                serde_json::json!({
+                    "name": "mempal_delete",
+                    "arguments": {"drawer_id": drawer_id},
+                }),
+            )
+            .await?;
+        assert_eq!(
+            deleted["structuredContent"]["deleted"].as_bool(),
+            Some(true)
+        );
+    }
+
+    client.shutdown().await?;
+    holder.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn harness_integration_smoke() -> Result<()> {
     let tmp = TempDir::new()?;

--- a/tests/mcp_timeline.rs
+++ b/tests/mcp_timeline.rs
@@ -463,6 +463,32 @@ async fn test_timeline_top_k_upper_bound() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_timeline_invalid_since_maps_to_invalid_params() {
+    let _guard = config_guard().await;
+    let env = TimelineEnv::new(Some("foo"), 10);
+
+    let error = match env
+        .server()
+        .mempal_timeline(Parameters(TimelineRequest {
+            project_id: Some("foo".to_string()),
+            since: Some("not-a-time".to_string()),
+            until: None,
+            top_k: None,
+            min_importance: None,
+            wing: None,
+            room: None,
+        }))
+        .await
+    {
+        Ok(_) => panic!("invalid since must be rejected"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+    assert!(error.message.contains("invalid since"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_timeline_rejects_all_projects() {
     let tmp = TempDir::new().expect("tempdir");
     let mempal_home = tmp.path().join(".mempal");

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -13,8 +13,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::PendingMessageStore;
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType, Triple};
 use mempal::core::utils::build_triple_id;
-use mempal::mcp::{IngestOperationState, IngestRequest, MempalMcpServer};
-use rmcp::handler::server::wrapper::Parameters;
+use mempal::mcp::{IngestDrainWorkerHandle, IngestOperationState, MempalMcpServer};
 use rusqlite::{Connection, OptionalExtension};
 use serde_json::Value;
 use serde_json::json;
@@ -446,17 +445,8 @@ fn assert_queued_status(output: &Output) {
     assert!(stdout.contains("timings={"), "{stdout}");
 }
 
-fn start_worker(server: MempalMcpServer) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let request = IngestRequest {
-            content: "worker warmup".to_string(),
-            wing: "mcp".to_string(),
-            room: Some("warmup".to_string()),
-            dry_run: Some(true),
-            ..IngestRequest::default()
-        };
-        let _ = server.mempal_ingest(Parameters(request)).await;
-    })
+fn start_worker(server: &MempalMcpServer) -> IngestDrainWorkerHandle {
+    server.spawn_scoped_ingest_drain_worker()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1452,12 +1442,10 @@ async fn test_operation_status_reports_queued_then_completed() {
     let queued_output = run_cli(home.path(), &["operation", "status", &operation_id]);
     assert_queued_status(&queued_output);
 
-    let warmup = start_worker(server.clone());
-    let completed = server
-        .wait_for_operation_completion(&operation_id)
-        .await
-        .expect("wait for completion");
-    warmup.await.expect("warmup join");
+    let warmup = start_worker(&server);
+    let completed = server.wait_for_operation_completion(&operation_id).await;
+    warmup.shutdown_and_drain().await;
+    let completed = completed.expect("wait for completion");
 
     assert_eq!(completed.state, Some(IngestOperationState::Completed));
     assert!(

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "144879f289ad40d97556e2fe67da53bcbe3d4e87"
+commit = "73e61f30948b3cf9a2e0f88ab5f37618da522673"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "f46d756aca684862210f59f987d4a8b6d048f786"
+commit = "144879f289ad40d97556e2fe67da53bcbe3d4e87"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Preserve deterministic MCP ingest operation receipts when daemon IPC may have reached the daemon but local admission retry hits a SQLite lock.
- Treat transient operation-status lookup misses as pending for that uncertain-admission path.
- Recognize `QueueError::Sqlite` in the SQLite-lock classifier so admission fallback is classified consistently.

## Verification
- `cargo fmt --check`
- `cargo test uncertain_daemon_enqueue --lib -- --nocapture`
- `cargo test operation_wait --lib -- --nocapture`
- `cargo test mcp_ingest --lib -- --nocapture`
- Installed dirty build with `just install` and restarted `mempal-daemon.service`
- Pre-merge installed full smoke: `FULL_SMOKE_550_RECEIPT_V2_DONE rc=0 overall_ok=True`
- `just clippy`
- `just test`
- dev2merge local gates / pre-push hooks, including `release-gate`, completed during push
- Exact-head CSA review PASS: `01KVVC7N9TEKBJH7T2W0SH7C73`
- `csa review --check-verdict --range main...HEAD` PASS for `e02d775985355ee6ed8a7b37b1b9607428b43a4e`

Closes #544
Closes #550
