### PR TITLE
fix(mcp): preserve wait receipts through DB lock races

### DIFF
--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -309,10 +309,12 @@ def run_cli(name: str, args: list[str], *, input_text: str | None = None, expect
 def created_ids_from(value: Any) -> list[str]:
     if not isinstance(value, dict):
         return []
-    ids = value.get('created_drawer_ids')
-    if isinstance(ids, list):
-        return list(dict.fromkeys(x for x in ids if isinstance(x, str) and x))
-    return []
+    ids: list[str] = []
+    for key in ('created_drawer_ids', 'cleanup_drawer_ids'):
+        values = value.get(key)
+        if isinstance(values, list):
+            ids.extend(x for x in values if isinstance(x, str) and x)
+    return list(dict.fromkeys(ids))
 
 
 def terminal_state(value: Any) -> bool:
@@ -524,22 +526,34 @@ class McpClient:
         killed = False
         exited = False
         try:
-            self.call('shutdown', {}, timeout=5)
-        except Exception:
-            pass
-        try:
             self.notify('notifications/exit')
         except Exception:
             pass
         try:
-            waited = wait_exited_without_reap(self.proc.pid, 5)
+            if self.proc.stdin is not None and not self.proc.stdin.closed:
+                self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            waited = wait_exited_without_reap(self.proc.pid, 1)
             exited = waited is True
         except Exception:
             exited = False
         proc_io_after = read_proc_io(self.proc.pid)
         try:
-            self.proc.wait(timeout=5)
+            self.proc.wait(timeout=1)
         except Exception:
+            try:
+                killed = True
+                self.proc.terminate()
+            except Exception:
+                pass
+            try:
+                self.proc.wait(timeout=1)
+                exited = True
+            except Exception:
+                pass
+        if self.proc.returncode is None:
             try:
                 killed = True
                 self.proc.kill()
@@ -601,6 +615,16 @@ def mcp_start_initialized() -> McpClient:
 
 def mcp_call_isolated(tool_names: list[str], name: str, args: dict[str, Any], timeout: int) -> tuple[Any | None, dict[str, Any]]:
     label = 'mcp_read_' + name.removeprefix('mempal_')
+    return mcp_call_isolated_labeled(tool_names, label, name, args, timeout)
+
+
+def mcp_call_isolated_labeled(
+    tool_names: list[str],
+    label: str,
+    name: str,
+    args: dict[str, Any],
+    timeout: int,
+) -> tuple[Any | None, dict[str, Any]]:
     if name not in tool_names:
         note(label, True, skipped='tool_not_advertised')
         return None, {'ok': True, 'skipped': True}
@@ -655,14 +679,14 @@ def mcp_crud() -> list[str]:
         create, info = client.tool('mempal_ingest', create_args, timeout=130)
         ids = created_ids_from(create)
         if not ids and isinstance(create, dict) and create.get('operation_id'):
-            status, sinfo = client.tool('mempal_operation_status', {'operation_id': create['operation_id']}, timeout=30)
-            note('mcp_create_status', bool(sinfo.get('ok')), **without_ok(sinfo))
-            ids = created_ids_from(status)
-            if not ids:
-                client.close()
-                client = None
-                waited = wait_operation(create['operation_id'], 'mcp_create_cli_wait')
-                ids = created_ids_from(waited)
+            # A non-terminal MCP ingest receipt means the daemon may still be
+            # processing the write. Close this stdio server before following the
+            # operation via CLI so the smoke runner never observes a result while
+            # its own MCP process is still an extra SQLite holder.
+            client.close()
+            client = None
+            waited = wait_operation(create['operation_id'], 'mcp_create_cli_wait')
+            ids = created_ids_from(waited)
         note('mcp_create', bool(info.get('ok')) and bool(ids), created_id_count=len(ids), **without_ok(info))
         if not ids:
             note(
@@ -675,8 +699,10 @@ def mcp_crud() -> list[str]:
         cleanup_ids.extend(ids)
         created_id = ids[0]
         SUMMARY['created_counts']['mcp'] = len(cleanup_ids)
-        if client is None:
-            client = mcp_start_initialized()
+
+        if client is not None:
+            client.close()
+            client = None
 
         for name, args, timeout in [
             ('mempal_search', {'query': MARKER, 'top_k': 5, 'all_projects': True}, 180),
@@ -685,27 +711,27 @@ def mcp_crud() -> list[str]:
             ('mempal_context', {'query': MARKER, 'all_projects': True, 'max_items': 3, 'include_distill_suggestions': False}, 150),
             ('mempal_brief', {'query': MARKER, 'domain': 'project', 'field': 'smoke', 'cwd': str(REPO), 'max_items': 3}, 150),
         ]:
-            if name in tool_names:
-                structured, info = client.tool(name, args, timeout=timeout)
-                note('mcp_' + name.removeprefix('mempal_'), bool(info.get('ok')), **without_ok(info))
-                if name == 'mempal_search':
-                    matches = count_marker_matches(structured, 'mcp')
-                    note('mcp_search_created_match', matches > 0, active_matches=matches)
-            else:
-                note('mcp_' + name.removeprefix('mempal_'), True, skipped='tool_not_advertised')
+            structured, info = mcp_call_isolated_labeled(
+                tool_names,
+                'mcp_' + name.removeprefix('mempal_'),
+                name,
+                args,
+                timeout,
+            )
+            if name == 'mempal_search' and bool(info.get('ok')):
+                matches = count_marker_matches(structured, 'mcp')
+                note('mcp_search_created_match', matches > 0, active_matches=matches)
+
+        client = mcp_start_initialized()
 
         update_args = {'content': f'{MARKER} reversible MCP smoke drawer updated; nonce {NONCE[::-1]}; lexical tokens deltaorchid embervault frostcairn; safe to delete', 'wing': 'smoke', 'room': 'mcp', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke', 'smoke': True, 'supersedes': created_id, 'wait': True, 'wait_timeout_secs': 90}
         update, uinfo = client.tool('mempal_ingest', update_args, timeout=130)
         upd_ids = created_ids_from(update)
         if not upd_ids and isinstance(update, dict) and update.get('operation_id'):
-            status, sinfo = client.tool('mempal_operation_status', {'operation_id': update['operation_id']}, timeout=30)
-            note('mcp_update_status', bool(sinfo.get('ok')), **without_ok(sinfo))
-            upd_ids = created_ids_from(status)
-            if not upd_ids:
-                client.close()
-                client = None
-                waited = wait_operation(update['operation_id'], 'mcp_update_cli_wait')
-                upd_ids = created_ids_from(waited)
+            client.close()
+            client = None
+            waited = wait_operation(update['operation_id'], 'mcp_update_cli_wait')
+            upd_ids = created_ids_from(waited)
         note('mcp_update', bool(uinfo.get('ok')) and bool(upd_ids), created_id_count=len(upd_ids), **without_ok(uinfo))
         if not upd_ids:
             delete_exact_ids_cli(cleanup_ids, 'mcp_cleanup_after_update_failure', room='mcp')

--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -45,6 +45,7 @@ def note(name: str, ok: bool, **fields: Any) -> None:
     safe = {'ok': ok}
     safe.update(fields)
     SUMMARY['groups'][name] = safe
+    SUMMARY['failures'] = [failure for failure in SUMMARY['failures'] if failure != name]
     if not ok:
         SUMMARY['failures'].append(name)
 
@@ -403,6 +404,8 @@ def cli_crud() -> list[str]:
     if not ids and isinstance(parsed, dict) and parsed.get('operation_id'):
         parsed2 = wait_operation(parsed['operation_id'], 'cli_create_wait')
         ids = created_ids_from(parsed2)
+        if ids:
+            note('cli_create', True, recovered_via='cli_create_wait', created_id_count=len(ids))
     if not ids:
         note('cli_crud', False, reason='create_missing_created_drawer_ids')
         return cleanup_ids
@@ -432,6 +435,8 @@ def cli_crud() -> list[str]:
     if not upd_ids and isinstance(upd_parsed, dict) and upd_parsed.get('operation_id'):
         upd_parsed2 = wait_operation(upd_parsed['operation_id'], 'cli_update_wait')
         upd_ids = created_ids_from(upd_parsed2)
+        if upd_ids:
+            note('cli_update', True, recovered_via='cli_update_wait', created_id_count=len(upd_ids))
     if not upd_ids:
         delete_exact_ids_cli(cleanup_ids, 'cli_cleanup_after_update_failure', room='cli')
         note('cli_crud', False, reason='update_missing_created_drawer_ids', cleanup_id_count=len(cleanup_ids))

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -260,6 +260,25 @@ pub(crate) fn ensure_wal_journal_mode(conn: &Connection) -> rusqlite::Result<()>
     Ok(())
 }
 
+pub fn rusqlite_error_is_lock(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(sqlite, _)
+            if matches!(
+                sqlite.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+                || matches!(
+                    sqlite.extended_code & 0xff,
+                    rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+                )
+    )
+}
+
+pub fn db_error_is_sqlite_lock(error: &DbError) -> bool {
+    matches!(error, DbError::Sqlite(sqlite) if rusqlite_error_is_lock(sqlite))
+}
+
 #[derive(Debug, Error)]
 pub enum DbError {
     #[error("failed to create database directory for {path}")]

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -5359,6 +5359,39 @@ impl Database {
         Ok(leases)
     }
 
+    pub fn runtime_writer_lease_has_live_daemon(&self, name: &str) -> Result<bool, DbError> {
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs() as i64)
+            .unwrap_or(0);
+        let mut stmt = self.conn.prepare(
+            "SELECT pid, boot_id, expires_at \
+             FROM runtime_writer_leases \
+             WHERE name = ?1 AND mode = 'daemon'",
+        )?;
+        let rows = stmt.query_map([name], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+        for row in rows {
+            let (pid_i64, boot_id, expires_at) = row?;
+            let remaining_secs = crate::cowork::peek::parse_rfc3339(&expires_at)
+                .map(|expires| expires - now_secs)
+                .unwrap_or(0);
+            if remaining_secs > 0
+                && u32::try_from(pid_i64).ok().is_some_and(|pid| {
+                    runtime_writer_process_is_live_holder(pid, boot_id.as_deref())
+                })
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     pub fn runtime_writer_lease_cleanup_expired(&self) -> Result<usize, DbError> {
         self.with_immediate_tx(|| self.runtime_writer_lease_cleanup_expired_tx(false))
     }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -9,12 +9,15 @@ use thiserror::Error;
 use tokio::sync::Semaphore;
 
 use super::config::scrub_sensitive_text;
-use super::db::ensure_wal_journal_mode;
+use super::db::{ensure_wal_journal_mode, rusqlite_error_is_lock};
 
 static ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 const STARTUP_RECLAIM_STALE_SECS: i64 = 60;
 const COMPLETION_METRICS_WINDOW_MINS: u64 = 10;
 const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
+const CLAIM_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
+const CLAIM_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(2);
+const CLAIM_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 pub const LAST_ERROR_MAX_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Error)]
@@ -35,18 +38,7 @@ pub enum QueueError {
 
 impl QueueError {
     pub fn is_sqlite_lock(&self) -> bool {
-        matches!(
-            self,
-            Self::Sqlite(rusqlite::Error::SqliteFailure(sqlite, _))
-                if matches!(
-                    sqlite.code,
-                    rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
-                )
-                    || matches!(
-                        sqlite.extended_code & 0xff,
-                        rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
-                    )
-        )
+        matches!(self, Self::Sqlite(error) if rusqlite_error_is_lock(error))
     }
 }
 
@@ -514,7 +506,15 @@ impl PendingMessageStore {
         worker_id: &str,
         claim_ttl_secs: i64,
     ) -> Result<Option<ClaimedMessage>> {
-        let mut conn = self.open_connection()?;
+        self.with_claim_lock_retry(|| self.claim_next_once(worker_id, claim_ttl_secs))
+    }
+
+    fn claim_next_once(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+    ) -> Result<Option<ClaimedMessage>> {
+        let mut conn = self.open_claim_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         reclaim_stale_tx(&tx, saturating_cutoff(now_secs(), claim_ttl_secs))?;
 
@@ -586,7 +586,18 @@ impl PendingMessageStore {
         claim_ttl_secs: i64,
         kind_filter: &str,
     ) -> Result<Option<ClaimedMessage>> {
-        let mut conn = self.open_connection()?;
+        self.with_claim_lock_retry(|| {
+            self.claim_next_by_kind_once(worker_id, claim_ttl_secs, kind_filter)
+        })
+    }
+
+    fn claim_next_by_kind_once(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+        kind_filter: &str,
+    ) -> Result<Option<ClaimedMessage>> {
+        let mut conn = self.open_claim_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         reclaim_stale_tx(&tx, saturating_cutoff(now_secs(), claim_ttl_secs))?;
 
@@ -658,7 +669,19 @@ impl PendingMessageStore {
         id_filter: &str,
         kind_filter: &str,
     ) -> Result<Option<ClaimedMessage>> {
-        let mut conn = self.open_connection()?;
+        self.with_claim_lock_retry(|| {
+            self.claim_by_id_and_kind_once(worker_id, claim_ttl_secs, id_filter, kind_filter)
+        })
+    }
+
+    fn claim_by_id_and_kind_once(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+        id_filter: &str,
+        kind_filter: &str,
+    ) -> Result<Option<ClaimedMessage>> {
+        let mut conn = self.open_claim_connection()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         reclaim_stale_tx(&tx, saturating_cutoff(now_secs(), claim_ttl_secs))?;
 
@@ -1032,6 +1055,25 @@ impl PendingMessageStore {
 
     fn open_connection(&self) -> Result<Connection> {
         self.open_connection_with_busy_timeout(None)
+    }
+
+    fn open_claim_connection(&self) -> Result<Connection> {
+        self.open_connection_with_busy_timeout(Some(CLAIM_BUSY_TIMEOUT))
+    }
+
+    fn with_claim_lock_retry<T>(&self, mut op: impl FnMut() -> Result<T>) -> Result<T> {
+        let started = std::time::Instant::now();
+        loop {
+            match op() {
+                Ok(value) => return Ok(value),
+                Err(error)
+                    if error.is_sqlite_lock() && started.elapsed() < CLAIM_LOCK_RETRY_DEADLINE =>
+                {
+                    std::thread::sleep(CLAIM_LOCK_RETRY_DELAY);
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     fn open_connection_with_busy_timeout(
@@ -1732,6 +1774,41 @@ mod tests {
         assert!(
             DEFAULT_BUSY_TIMEOUT >= Duration::from_secs(30),
             "async ingest queue writes must outwait transient full-smoke read/write contention"
+        );
+    }
+
+    #[test]
+    fn claim_next_uses_bounded_sqlite_lock_budget() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        let store = PendingMessageStore::new(&db_path).expect("open queue");
+        store
+            .enqueue("hook", r#"{"request":{}}"#)
+            .expect("enqueue async ingest");
+
+        let lock_holder = Connection::open(&db_path).expect("open lock holder");
+        lock_holder
+            .busy_timeout(Duration::ZERO)
+            .expect("set fail-fast lock holder timeout");
+        lock_holder
+            .execute_batch("BEGIN IMMEDIATE;")
+            .expect("hold write lock");
+
+        let started = std::time::Instant::now();
+        let error = store
+            .claim_next("worker-a", 60)
+            .expect_err("claim should exhaust the bounded lock budget");
+        let elapsed = started.elapsed();
+
+        lock_holder
+            .execute_batch("ROLLBACK;")
+            .expect("release write lock");
+
+        assert!(error.is_sqlite_lock());
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "claim lock budget must not monopolize queue blocking workers for the 30s default busy timeout"
         );
     }
 }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+#[cfg(any(test, feature = "db-test-seam"))]
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use blake3::Hasher;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
@@ -16,7 +18,7 @@ const STARTUP_RECLAIM_STALE_SECS: i64 = 60;
 const COMPLETION_METRICS_WINDOW_MINS: u64 = 10;
 const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 const CLAIM_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
-const CLAIM_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(2);
+pub(crate) const CLAIM_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(2);
 const CLAIM_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 pub const LAST_ERROR_MAX_BYTES: usize = 4 * 1024;
 
@@ -40,6 +42,17 @@ impl QueueError {
     pub fn is_sqlite_lock(&self) -> bool {
         matches!(self, Self::Sqlite(error) if rusqlite_error_is_lock(error))
     }
+}
+
+#[cfg(any(test, feature = "db-test-seam"))]
+fn sqlite_busy_queue_error() -> QueueError {
+    QueueError::Sqlite(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error {
+            code: rusqlite::ErrorCode::DatabaseBusy,
+            extended_code: rusqlite::ffi::SQLITE_BUSY,
+        },
+        Some("database is locked".to_string()),
+    ))
 }
 
 pub type Result<T> = std::result::Result<T, QueueError>;
@@ -136,7 +149,11 @@ pub struct AsyncPendingMessageStore {
     #[cfg(any(test, feature = "db-test-seam"))]
     blocking_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
+    enqueue_lock_failures: Arc<AtomicUsize>,
+    #[cfg(any(test, feature = "db-test-seam"))]
     claim_blocking_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    release_lock_failures: Arc<AtomicUsize>,
 }
 
 impl AsyncPendingMessageStore {
@@ -157,7 +174,11 @@ impl AsyncPendingMessageStore {
             #[cfg(any(test, feature = "db-test-seam"))]
             blocking_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            enqueue_lock_failures: Arc::new(AtomicUsize::new(0)),
+            #[cfg(any(test, feature = "db-test-seam"))]
             claim_blocking_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            release_lock_failures: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -168,8 +189,20 @@ impl AsyncPendingMessageStore {
     }
 
     #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_enqueue_lock_failures_for_test(self, failures: usize) -> Self {
+        self.enqueue_lock_failures.store(failures, Ordering::SeqCst);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_claim_blocking_delay(mut self, delay: Duration) -> Self {
         self.claim_blocking_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_release_lock_failures_for_test(self, failures: usize) -> Self {
+        self.release_lock_failures.store(failures, Ordering::SeqCst);
         self
     }
 
@@ -229,6 +262,16 @@ impl AsyncPendingMessageStore {
         payload: String,
         idempotency_key: String,
     ) -> Result<String> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .enqueue_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         self.run(move |store| {
             store.enqueue_idempotent_with_key_fail_fast(&kind, &payload, &idempotency_key)
         })
@@ -267,6 +310,33 @@ impl AsyncPendingMessageStore {
         let delay = None;
         self.run_with_delay(
             move |store| store.claim_by_id_and_kind(&worker_id, claim_ttl_secs, &id, &kind_filter),
+            delay,
+        )
+        .await
+    }
+
+    pub async fn claim_by_id_and_kind_with_lock_retry_deadline(
+        &self,
+        worker_id: String,
+        claim_ttl_secs: i64,
+        id: String,
+        kind_filter: String,
+        retry_deadline: Duration,
+    ) -> Result<Option<ClaimedMessage>> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.claim_blocking_delay.or(self.blocking_delay);
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay = None;
+        self.run_with_delay(
+            move |store| {
+                store.claim_by_id_and_kind_with_lock_retry_deadline(
+                    &worker_id,
+                    claim_ttl_secs,
+                    &id,
+                    &kind_filter,
+                    retry_deadline,
+                )
+            },
             delay,
         )
         .await
@@ -323,7 +393,36 @@ impl AsyncPendingMessageStore {
     }
 
     pub async fn release_claim(&self, claim: ClaimedMessage) -> Result<()> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .release_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         self.run(move |store| store.release_claim(&claim)).await
+    }
+
+    pub async fn release_claim_with_busy_timeout(
+        &self,
+        claim: ClaimedMessage,
+        busy_timeout: Duration,
+    ) -> Result<()> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .release_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
+        self.run(move |store| store.release_claim_with_busy_timeout(&claim, Some(busy_timeout)))
+            .await
     }
 
     pub async fn refresh_heartbeat(&self, id: String, worker_id: String) -> Result<()> {
@@ -697,6 +796,19 @@ impl PendingMessageStore {
         })
     }
 
+    pub fn claim_by_id_and_kind_with_lock_retry_deadline(
+        &self,
+        worker_id: &str,
+        claim_ttl_secs: i64,
+        id_filter: &str,
+        kind_filter: &str,
+        retry_deadline: Duration,
+    ) -> Result<Option<ClaimedMessage>> {
+        self.with_claim_lock_retry_deadline(retry_deadline, || {
+            self.claim_by_id_and_kind_once(worker_id, claim_ttl_secs, id_filter, kind_filter)
+        })
+    }
+
     fn claim_by_id_and_kind_once(
         &self,
         worker_id: &str,
@@ -1008,7 +1120,15 @@ impl PendingMessageStore {
     /// Used by LLM workers cancelled due to a config hot-reload so the task is
     /// retried with the new configuration rather than charged a retry.
     pub fn release_claim(&self, claim: &ClaimedMessage) -> Result<()> {
-        let mut conn = self.open_connection()?;
+        self.release_claim_with_busy_timeout(claim, None)
+    }
+
+    fn release_claim_with_busy_timeout(
+        &self,
+        claim: &ClaimedMessage,
+        busy_timeout: Option<Duration>,
+    ) -> Result<()> {
+        let mut conn = self.open_connection_with_busy_timeout(busy_timeout)?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let updated = tx.execute(
             r#"
@@ -1084,15 +1204,22 @@ impl PendingMessageStore {
         self.open_connection_with_busy_timeout(Some(CLAIM_BUSY_TIMEOUT))
     }
 
-    fn with_claim_lock_retry<T>(&self, mut op: impl FnMut() -> Result<T>) -> Result<T> {
-        let started = std::time::Instant::now();
+    fn with_claim_lock_retry<T>(&self, op: impl FnMut() -> Result<T>) -> Result<T> {
+        self.with_claim_lock_retry_deadline(CLAIM_LOCK_RETRY_DEADLINE, op)
+    }
+
+    fn with_claim_lock_retry_deadline<T>(
+        &self,
+        retry_deadline: Duration,
+        mut op: impl FnMut() -> Result<T>,
+    ) -> Result<T> {
+        let started = Instant::now();
         loop {
             match op() {
                 Ok(value) => return Ok(value),
-                Err(error)
-                    if error.is_sqlite_lock() && started.elapsed() < CLAIM_LOCK_RETRY_DEADLINE =>
-                {
-                    std::thread::sleep(CLAIM_LOCK_RETRY_DELAY);
+                Err(error) if error.is_sqlite_lock() && started.elapsed() < retry_deadline => {
+                    let remaining = retry_deadline.saturating_sub(started.elapsed());
+                    std::thread::sleep(CLAIM_LOCK_RETRY_DELAY.min(remaining));
                 }
                 Err(error) => return Err(error),
             }

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -135,6 +135,8 @@ pub struct AsyncPendingMessageStore {
     permits: Arc<Semaphore>,
     #[cfg(any(test, feature = "db-test-seam"))]
     blocking_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    claim_blocking_delay: Option<Duration>,
 }
 
 impl AsyncPendingMessageStore {
@@ -154,12 +156,20 @@ impl AsyncPendingMessageStore {
             permits: Arc::new(Semaphore::new(Self::DEFAULT_BLOCKING_PERMITS)),
             #[cfg(any(test, feature = "db-test-seam"))]
             blocking_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
+            claim_blocking_delay: None,
         }
     }
 
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_blocking_delay(mut self, delay: Duration) -> Self {
         self.blocking_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_claim_blocking_delay(mut self, delay: Duration) -> Self {
+        self.claim_blocking_delay = Some(delay);
         self
     }
 
@@ -251,9 +261,14 @@ impl AsyncPendingMessageStore {
         id: String,
         kind_filter: String,
     ) -> Result<Option<ClaimedMessage>> {
-        self.run(move |store| {
-            store.claim_by_id_and_kind(&worker_id, claim_ttl_secs, &id, &kind_filter)
-        })
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.claim_blocking_delay.or(self.blocking_delay);
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay = None;
+        self.run_with_delay(
+            move |store| store.claim_by_id_and_kind(&worker_id, claim_ttl_secs, &id, &kind_filter),
+            delay,
+        )
         .await
     }
 
@@ -329,15 +344,23 @@ impl AsyncPendingMessageStore {
         F: FnOnce(PendingMessageStore) -> Result<R> + Send + 'static,
         R: Send + 'static,
     {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let delay = self.blocking_delay;
+        #[cfg(not(any(test, feature = "db-test-seam")))]
+        let delay = None;
+        self.run_with_delay(f, delay).await
+    }
+
+    async fn run_with_delay<F, R>(&self, f: F, delay: Option<Duration>) -> Result<R>
+    where
+        F: FnOnce(PendingMessageStore) -> Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
         let permit =
             self.permits.clone().acquire_owned().await.map_err(|_| {
                 QueueError::BlockingTaskFailed("queue semaphore closed".to_string())
             })?;
         let store = self.inner.clone();
-        #[cfg(any(test, feature = "db-test-seam"))]
-        let delay = self.blocking_delay;
-        #[cfg(not(any(test, feature = "db-test-seam")))]
-        let delay: Option<Duration> = None;
         let dispatch = tracing::dispatcher::get_default(Clone::clone);
         let join = tokio::task::spawn_blocking(move || {
             let permit = permit;

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -151,6 +151,8 @@ pub struct AsyncPendingMessageStore {
     #[cfg(any(test, feature = "db-test-seam"))]
     enqueue_lock_failures: Arc<AtomicUsize>,
     #[cfg(any(test, feature = "db-test-seam"))]
+    claim_lock_failures: Arc<AtomicUsize>,
+    #[cfg(any(test, feature = "db-test-seam"))]
     claim_blocking_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     release_lock_failures: Arc<AtomicUsize>,
@@ -176,6 +178,8 @@ impl AsyncPendingMessageStore {
             #[cfg(any(test, feature = "db-test-seam"))]
             enqueue_lock_failures: Arc::new(AtomicUsize::new(0)),
             #[cfg(any(test, feature = "db-test-seam"))]
+            claim_lock_failures: Arc::new(AtomicUsize::new(0)),
+            #[cfg(any(test, feature = "db-test-seam"))]
             claim_blocking_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             release_lock_failures: Arc::new(AtomicUsize::new(0)),
@@ -191,6 +195,12 @@ impl AsyncPendingMessageStore {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_enqueue_lock_failures_for_test(self, failures: usize) -> Self {
         self.enqueue_lock_failures.store(failures, Ordering::SeqCst);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_claim_lock_failures_for_test(self, failures: usize) -> Self {
+        self.claim_lock_failures.store(failures, Ordering::SeqCst);
         self
     }
 
@@ -323,6 +333,16 @@ impl AsyncPendingMessageStore {
         kind_filter: String,
         retry_deadline: Duration,
     ) -> Result<Option<ClaimedMessage>> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .claim_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         #[cfg(any(test, feature = "db-test-seam"))]
         let delay = self.claim_blocking_delay.or(self.blocking_delay);
         #[cfg(not(any(test, feature = "db-test-seam")))]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{future::Future, pin::Pin};
 
 use crate::bootstrap_events::BootstrapEvent;
@@ -58,6 +58,9 @@ const AUTOMATIC_HOOK_LLM_GATE_MAX_SECS: u64 = 30;
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const DAEMON_WRITER_LEASE_TTL_SECS: u64 = 120;
 const DAEMON_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
+const DAEMON_WRITER_LEASE_RENEW_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
+const DAEMON_WRITER_LEASE_RENEW_RETRY_DEADLINE: Duration = Duration::from_secs(5);
+const DAEMON_WRITER_LEASE_RENEW_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 pub fn run_command(config_path: PathBuf, foreground: bool) -> Result<()> {
     run_command_with_bootstrap_events(config_path, foreground, None)
@@ -440,15 +443,7 @@ fn spawn_runtime_writer_lease_heartbeat(
             let db_path = db_path.clone();
             let lease_for_renew = lease.clone();
             let result = tokio::task::spawn_blocking(move || -> Result<bool> {
-                let db =
-                    Database::open(&db_path).context("failed to open DB for writer lease renew")?;
-                db.runtime_writer_lease_renew(
-                    &lease_for_renew.name,
-                    &lease_for_renew.owner,
-                    &lease_for_renew.session_id,
-                    DAEMON_WRITER_LEASE_TTL_SECS,
-                )
-                .context("failed to renew daemon writer lease")
+                renew_daemon_writer_lease_with_retry(&db_path, &lease_for_renew)
             })
             .await;
             match result {
@@ -471,6 +466,48 @@ fn spawn_runtime_writer_lease_heartbeat(
                 }
             }
         }
+    })
+}
+
+fn renew_daemon_writer_lease_with_retry(
+    db_path: &Path,
+    lease: &RuntimeWriterLease,
+) -> Result<bool> {
+    let started = Instant::now();
+    loop {
+        match renew_daemon_writer_lease_once(db_path, lease) {
+            Ok(renewed) => return Ok(renewed),
+            Err(error)
+                if anyhow_error_is_sqlite_lock(&error)
+                    && started.elapsed() < DAEMON_WRITER_LEASE_RENEW_RETRY_DEADLINE =>
+            {
+                std::thread::sleep(DAEMON_WRITER_LEASE_RENEW_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn renew_daemon_writer_lease_once(db_path: &Path, lease: &RuntimeWriterLease) -> Result<bool> {
+    let db = Database::open_with_busy_timeout(db_path, DAEMON_WRITER_LEASE_RENEW_BUSY_TIMEOUT)
+        .context("failed to open DB for writer lease renew")?;
+    db.runtime_writer_lease_renew(
+        &lease.name,
+        &lease.owner,
+        &lease.session_id,
+        DAEMON_WRITER_LEASE_TTL_SECS,
+    )
+    .context("failed to renew daemon writer lease")
+}
+
+fn anyhow_error_is_sqlite_lock(error: &anyhow::Error) -> bool {
+    error.chain().any(|error| {
+        error
+            .downcast_ref::<rusqlite::Error>()
+            .is_some_and(crate::core::db::rusqlite_error_is_lock)
+            || error
+                .downcast_ref::<DbError>()
+                .is_some_and(crate::core::db::db_error_is_sqlite_lock)
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3486,6 +3486,18 @@ fn run() -> Result<()> {
     }
 
     let db_path = expand_home(&config.db_path);
+    if matches!(&cli.command, Commands::Operation { .. }) {
+        let Commands::Operation { command } = cli.command else {
+            unreachable!("operation command preflight matched")
+        };
+        if !db_path.exists() {
+            bail!(
+                "no palace.db found at {}; run `mempal init` first",
+                display_path_for_user(&db_path)
+            );
+        }
+        return block_on_result(operation_command(&db_path, config.as_ref(), command));
+    }
     let read_only_database = command_uses_read_only_database(&cli.command);
     if read_only_database {
         validate_read_only_command_args(&cli.command)?;
@@ -3597,7 +3609,7 @@ fn run() -> Result<()> {
             },
         )),
         Commands::Operation { command } => {
-            block_on_result(operation_command(&db, config.as_ref(), command))
+            block_on_result(operation_command(db.path(), config.as_ref(), command))
         }
         Commands::Export { command } => export_command(&db, config.as_ref(), command),
         Commands::Wiki { command } => wiki_command(&db, config.as_ref(), command),
@@ -5844,12 +5856,81 @@ fn finish_operation_wait_response(
     }
 }
 
+fn operation_wait_status_error_is_recoverable(error: &str) -> bool {
+    let message = error.to_ascii_lowercase();
+    let operation_lookup = message.contains("queue lookup")
+        || message.contains("mempal_operation_status")
+        || message.contains("operation status");
+    let transient = message.contains("database is locked")
+        || message.contains("database locked")
+        || message.contains("database is busy")
+        || message.contains("database busy")
+        || message.contains("sqlite_busy")
+        || message.contains("sqlite_locked")
+        || message.contains("locked_or_busy")
+        || (message.contains("exceeded") && message.contains("queue lookup"));
+    operation_lookup && transient
+}
+
+const OPERATION_WAIT_STATUS_PROBE_MAX: std::time::Duration = std::time::Duration::from_secs(5);
+
+fn operation_wait_status_probe_deadline_from_elapsed(
+    wait_timeout: std::time::Duration,
+    elapsed: std::time::Duration,
+) -> std::time::Duration {
+    wait_timeout
+        .saturating_sub(elapsed)
+        .min(OPERATION_WAIT_STATUS_PROBE_MAX)
+}
+
+fn operation_wait_status_probe_deadline(
+    wait_timeout: std::time::Duration,
+    started_at: std::time::Instant,
+) -> std::time::Duration {
+    operation_wait_status_probe_deadline_from_elapsed(wait_timeout, started_at.elapsed())
+}
+
+fn operation_wait_timeout_response_from_refresh(
+    initial_status: IngestResponse,
+    refresh_result: std::result::Result<Option<IngestResponse>, String>,
+) -> Result<IngestResponse> {
+    match refresh_result {
+        Ok(Some(response)) => Ok(response),
+        Ok(None) => Ok(initial_status),
+        Err(error) if operation_wait_status_error_is_recoverable(&error) => Ok(initial_status),
+        Err(error) => Err(anyhow::anyhow!(error)),
+    }
+}
+
+fn operation_wait_queued_status(operation_id: &str) -> IngestResponse {
+    IngestResponse {
+        operation_id: Some(operation_id.to_string()),
+        accepted_at: Some(iso_timestamp()),
+        state: Some(IngestOperationState::Queued),
+        ..IngestResponse::default()
+    }
+}
+
+fn operation_wait_initial_response_from_snapshot(
+    operation_id: &str,
+    snapshot_result: std::result::Result<Option<IngestResponse>, String>,
+) -> Result<IngestResponse> {
+    match snapshot_result {
+        Ok(Some(response)) => Ok(response),
+        Ok(None) => Ok(operation_wait_queued_status(operation_id)),
+        Err(error) if operation_wait_status_error_is_recoverable(&error) => {
+            Ok(operation_wait_queued_status(operation_id))
+        }
+        Err(error) => Err(anyhow::anyhow!(error)),
+    }
+}
+
 async fn operation_command(
-    db: &Database,
+    db_path: &Path,
     config: &Config,
     command: OperationCommands,
 ) -> Result<()> {
-    let server = MempalMcpServer::new(db.path().to_path_buf(), config.clone())?;
+    let server = MempalMcpServer::new(db_path.to_path_buf(), config.clone())?;
     match command {
         OperationCommands::Status { operation_id, json } => {
             let response = server
@@ -5871,15 +5952,19 @@ async fn operation_command(
                 "waiting for operation_id={} timeout_secs={timeout_secs}",
                 operation_id
             );
-            let initial_status = server
-                .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
-                    OperationStatusRequest {
-                        operation_id: operation_id.clone(),
-                    },
-                ))
+            let wait_timeout = std::time::Duration::from_secs(timeout_secs);
+            let wait_started_at = std::time::Instant::now();
+            let initial_status_result = server
+                .operation_status_snapshot_lightweight(
+                    &operation_id,
+                    operation_wait_status_probe_deadline(wait_timeout, wait_started_at),
+                )
                 .await
-                .context("failed to load initial operation status")?
-                .0;
+                .map_err(|error| error.to_string());
+            let initial_status = operation_wait_initial_response_from_snapshot(
+                &operation_id,
+                initial_status_result,
+            )?;
             eprintln!(
                 "waiting operation_id={} state={}",
                 operation_id,
@@ -5895,26 +5980,39 @@ async fn operation_command(
             {
                 return finish_operation_wait_response(initial_status, &operation_id, json);
             }
-            let wait_result = server
-                .wait_for_operation_status_with_scoped_worker(
-                    &operation_id,
-                    std::time::Duration::from_secs(timeout_secs),
-                    std::time::Duration::from_millis(150),
-                )
-                .await
-                .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            let wait_remaining = wait_timeout.saturating_sub(wait_started_at.elapsed());
+            let wait_result = if timeout_secs == u64::MAX {
+                server
+                    .wait_for_operation_status_with_scoped_worker_until_terminal(
+                        &operation_id,
+                        wait_remaining,
+                        std::time::Duration::from_millis(150),
+                    )
+                    .await
+            } else {
+                server
+                    .wait_for_operation_status_with_scoped_worker(
+                        &operation_id,
+                        wait_remaining,
+                        std::time::Duration::from_millis(150),
+                    )
+                    .await
+            }
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
             match wait_result {
                 Some(response) => finish_operation_wait_response(response, &operation_id, json),
                 None => {
-                    let mut response = server
-                        .mempal_operation_status(rmcp::handler::server::wrapper::Parameters(
-                            OperationStatusRequest {
-                                operation_id: operation_id.clone(),
-                            },
-                        ))
+                    let refresh_result = server
+                        .operation_status_snapshot_lightweight(
+                            &operation_id,
+                            operation_wait_status_probe_deadline(wait_timeout, wait_started_at),
+                        )
                         .await
-                        .context("failed to load timed-out operation status")?
-                        .0;
+                        .map_err(|error| error.to_string());
+                    let mut response = operation_wait_timeout_response_from_refresh(
+                        initial_status,
+                        refresh_result,
+                    )?;
                     if response
                         .state
                         .map(IngestOperationState::is_terminal)
@@ -5924,7 +6022,7 @@ async fn operation_command(
                     }
                     response.timed_out = true;
                     print_operation_response_format(json, &response)?;
-                    bail!("timed out waiting for operation {operation_id}")
+                    Err(IngestWaitTimedOut::new(Some(&operation_id)).into())
                 }
             }
         }
@@ -21169,6 +21267,87 @@ api_model = "text-embedding-3-large"
         let rendered = embed_last_error_for_status(&config, &endpoints, last_error);
 
         assert_eq!(rendered.as_deref(), Some("connection refused"));
+    }
+
+    fn queued_operation_wait_response(operation_id: &str) -> IngestResponse {
+        IngestResponse {
+            operation_id: Some(operation_id.to_string()),
+            state: Some(IngestOperationState::Queued),
+            drawer_id: operation_id.to_string(),
+            ..IngestResponse::default()
+        }
+    }
+
+    #[test]
+    fn test_operation_wait_timeout_refresh_keeps_initial_receipt_on_transient_lookup_error() {
+        let initial = queued_operation_wait_response("op-timeout-transient");
+        let response = operation_wait_timeout_response_from_refresh(
+            initial.clone(),
+            Err("queue lookup exceeded timeout while database is locked".to_string()),
+        )
+        .expect("transient lookup error should keep initial receipt");
+
+        assert_eq!(response.operation_id, initial.operation_id);
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+    }
+
+    #[test]
+    fn test_operation_wait_timeout_refresh_rejects_unrelated_error() {
+        let initial = queued_operation_wait_response("op-timeout-fatal");
+        let error = operation_wait_timeout_response_from_refresh(
+            initial,
+            Err("operation status failed: malformed operation id".to_string()),
+        )
+        .expect_err("unrelated status errors remain fatal");
+
+        assert!(format!("{error:#}").contains("malformed operation id"));
+    }
+
+    #[test]
+    fn test_operation_wait_initial_probe_timeout_keeps_waiting_with_queued_receipt() {
+        let response =
+            operation_wait_initial_response_from_snapshot("op-initial-timeout", Ok(None))
+                .expect("initial probe timeout should degrade to queued receipt");
+
+        assert_eq!(response.operation_id.as_deref(), Some("op-initial-timeout"));
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(!response.timed_out);
+    }
+
+    #[test]
+    fn test_operation_wait_initial_probe_rejects_missing_operation_error() {
+        let error = operation_wait_initial_response_from_snapshot(
+            "op-missing",
+            Err("operation not found: op-missing".to_string()),
+        )
+        .expect_err("missing operation remains fatal");
+
+        assert!(format!("{error:#}").contains("operation not found"));
+    }
+
+    #[test]
+    fn test_operation_wait_status_probe_deadline_respects_remaining_timeout() {
+        assert_eq!(
+            operation_wait_status_probe_deadline_from_elapsed(
+                std::time::Duration::from_secs(1),
+                std::time::Duration::from_millis(250),
+            ),
+            std::time::Duration::from_millis(750)
+        );
+        assert_eq!(
+            operation_wait_status_probe_deadline_from_elapsed(
+                std::time::Duration::from_secs(10),
+                std::time::Duration::from_millis(250),
+            ),
+            OPERATION_WAIT_STATUS_PROBE_MAX
+        );
+        assert_eq!(
+            operation_wait_status_probe_deadline_from_elapsed(
+                std::time::Duration::from_secs(1),
+                std::time::Duration::from_secs(2),
+            ),
+            std::time::Duration::ZERO
+        );
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -29,7 +29,10 @@ use crate::core::{
         runtime_adoption_instrumentation_policy, should_write_checked_record,
     },
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
-    queue::{AsyncPendingMessageStore, ClaimedMessage, PendingMessageStore, QueueError},
+    queue::{
+        AsyncPendingMessageStore, CLAIM_LOCK_RETRY_DEADLINE, ClaimedMessage, PendingMessageStore,
+        QueueError,
+    },
     reindex::ReindexProgressStore,
     remote_calls::{
         RemoteCallService, endpoint_policy_diagnostic_label, endpoint_policy_global_runtime_error,
@@ -178,6 +181,10 @@ const MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::fro
 const MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT: Duration =
     MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE;
 const MCP_INGEST_QUEUE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
+const MCP_INGEST_CLAIM_RELEASE_RETRY_DEADLINE: Duration = Duration::from_secs(300);
+const MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(50);
+const MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT: Duration = Duration::ZERO;
+const MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN: Duration = Duration::from_millis(250);
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
@@ -186,6 +193,19 @@ const MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30
 const MCP_WRITER_LEASE_RENEW_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
 const MCP_WRITER_LEASE_RENEW_RETRY_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_WRITER_LEASE_RENEW_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+fn scoped_ingest_claim_retry_deadline(remaining: Duration) -> Option<Duration> {
+    remaining
+        .checked_sub(MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN)
+        .map(|deadline| deadline.min(CLAIM_LOCK_RETRY_DEADLINE))
+        .filter(|deadline| !deadline.is_zero())
+}
+
+fn scoped_ingest_processing_budget(remaining: Duration) -> Option<Duration> {
+    remaining
+        .checked_sub(MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN)
+        .filter(|budget| !budget.is_zero())
+}
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
     let now_ns = match SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -231,6 +251,8 @@ pub struct MempalMcpServer {
     ingest_processing_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     operation_status_probe_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    ingest_warning_snapshot_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_error: Option<String>,
     #[cfg(any(test, feature = "db-test-seam"))]
@@ -474,6 +496,8 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             operation_status_probe_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            ingest_warning_snapshot_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_error: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_lock_failures: Arc::new(AtomicUsize::new(0)),
@@ -525,6 +549,12 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_operation_status_probe_delay_for_test(mut self, delay: Duration) -> Self {
         self.operation_status_probe_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_ingest_warning_snapshot_delay_for_test(mut self, delay: Duration) -> Self {
+        self.ingest_warning_snapshot_delay = Some(delay);
         self
     }
 
@@ -863,8 +893,7 @@ impl MempalMcpServer {
                 Ok(Some(lease)) => Some(lease),
                 Ok(None) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    queue
-                        .release_claim(claim)
+                    Self::release_claim_with_lock_retry(queue, claim)
                         .await
                         .context("failed to release ingest claim after writer lease conflict")?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
@@ -872,9 +901,11 @@ impl MempalMcpServer {
                 }
                 Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    queue.release_claim(claim).await.context(
-                        "failed to release ingest claim after transient writer lease lock",
-                    )?;
+                    Self::release_claim_with_lock_retry(queue, claim)
+                        .await
+                        .context(
+                            "failed to release ingest claim after transient writer lease lock",
+                        )?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
                 }
@@ -939,15 +970,17 @@ impl MempalMcpServer {
                 Ok(Some(lease)) => Some(lease),
                 Ok(None) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    queue.release_claim(claim).await.context(
-                        "failed to release scoped ingest claim after writer lease conflict",
-                    )?;
+                    Self::release_claim_with_lock_retry(queue, claim)
+                        .await
+                        .context(
+                            "failed to release scoped ingest claim after writer lease conflict",
+                        )?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
                 }
                 Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    queue.release_claim(claim).await.context(
+                    Self::release_claim_with_lock_retry(queue, claim).await.context(
                         "failed to release scoped ingest claim after transient writer lease lock",
                     )?;
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
@@ -959,6 +992,10 @@ impl MempalMcpServer {
             }
         };
         let pre_resolved_superseded_drawer_id = prepared.superseded_drawer_id.clone();
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(delay) = self.ingest_processing_delay {
+            tokio::time::sleep(delay).await;
+        }
         let outcome = match self
             .mempal_ingest_sync_with_superseded_override(
                 prepared.request.clone(),
@@ -1651,35 +1688,27 @@ impl MempalMcpServer {
                 return Ok(None);
             }
 
-            let mut claim_task = tokio::spawn({
-                let queue = queue.clone();
-                let worker_id = worker_id.clone();
-                let operation_id = operation_id.to_string();
-                async move {
-                    queue
-                        .claim_by_id_and_kind(
-                            worker_id,
-                            INGEST_CLAIM_TTL_SECS,
-                            operation_id,
-                            INGEST_ASYNC_KIND.to_string(),
-                        )
-                        .await
-                }
-            });
-            tokio::select! {
-                result = &mut claim_task => match result {
-                    Err(error) => {
-                        return Err(ErrorData::internal_error(
-                            format!("scoped async ingest worker claim task failed: {error}"),
-                            None,
-                        ));
-                    }
-                    Ok(Ok(Some(claim))) => {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let Some(claim_retry_deadline) = scoped_ingest_claim_retry_deadline(remaining) else {
+                return Ok(None);
+            };
+
+            match queue
+                .claim_by_id_and_kind_with_lock_retry_deadline(
+                    worker_id.clone(),
+                    INGEST_CLAIM_TTL_SECS,
+                    operation_id.to_string(),
+                    INGEST_ASYNC_KIND.to_string(),
+                    claim_retry_deadline,
+                )
+                .await
+            {
+                Ok(Some(claim)) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
-                    if remaining.is_zero() {
-                        Self::release_scoped_claim_after_timeout(&queue, claim).await?;
+                    let Some(process_budget) = scoped_ingest_processing_budget(remaining) else {
+                        Self::release_scoped_claim_after_timeout(&queue, claim, remaining).await?;
                         return Ok(None);
-                    }
+                    };
 
                     let process =
                         self.process_ingest_claim_inline(&queue, &worker_id, claim.clone());
@@ -1693,74 +1722,90 @@ impl MempalMcpServer {
                                 )
                             })?;
                         }
-                        _ = tokio::time::sleep(remaining) => {
-                            Self::release_scoped_claim_after_timeout(&queue, claim).await?;
+                        _ = tokio::time::sleep(process_budget) => {
+                            let release_budget = deadline.saturating_duration_since(Instant::now());
+                            Self::release_scoped_claim_after_timeout(&queue, claim, release_budget).await?;
                             return Ok(None);
                         }
                     }
                 }
-                    Ok(Ok(None)) => {
+                Ok(None) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
                         return Ok(None);
                     }
                     tokio::time::sleep(poll_interval.min(remaining)).await;
                 }
-                    Ok(Err(error)) => {
+                Err(error) if error.is_sqlite_lock() => return Ok(None),
+                Err(error) => {
                     return Err(ErrorData::internal_error(
                         format!("scoped async ingest worker claim failed: {error}"),
                         None,
                     ));
                 }
-                },
-                _ = tokio::time::sleep(remaining) => {
-                    Self::release_late_scoped_claim_after_timeout(queue.clone(), claim_task);
-                    return Ok(None);
-                }
             }
         }
-    }
-
-    fn release_late_scoped_claim_after_timeout(
-        queue: AsyncPendingMessageStore,
-        claim_task: tokio::task::JoinHandle<crate::core::queue::Result<Option<ClaimedMessage>>>,
-    ) {
-        let _release_task = tokio::spawn(async move {
-            match claim_task.await {
-                Ok(Ok(Some(claim))) => {
-                    if let Err(error) =
-                        Self::release_scoped_claim_after_timeout(&queue, claim).await
-                    {
-                        tracing::warn!(?error, "failed to release late scoped ingest claim");
-                    }
-                }
-                Ok(Ok(None)) => {}
-                Ok(Err(error)) => {
-                    tracing::warn!(
-                        ?error,
-                        "late scoped ingest claim failed after caller timeout"
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        ?error,
-                        "late scoped ingest claim task failed after caller timeout"
-                    );
-                }
-            }
-        });
     }
 
     async fn release_scoped_claim_after_timeout(
         queue: &AsyncPendingMessageStore,
         claim: ClaimedMessage,
+        retry_deadline: Duration,
     ) -> std::result::Result<(), ErrorData> {
-        match queue.release_claim(claim).await {
-            Ok(()) | Err(QueueError::ClaimLost(_)) => Ok(()),
+        match Self::release_claim_with_lock_retry_deadline(queue, claim, retry_deadline).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.is_sqlite_lock() => {
+                tracing::warn!(
+                    ?error,
+                    "timed-out scoped ingest claim release exceeded caller wait budget"
+                );
+                Ok(())
+            }
             Err(error) => Err(ErrorData::internal_error(
                 format!("failed to release timed-out scoped ingest claim: {error}"),
                 None,
             )),
+        }
+    }
+
+    async fn release_claim_with_lock_retry(
+        queue: &AsyncPendingMessageStore,
+        claim: ClaimedMessage,
+    ) -> crate::core::queue::Result<()> {
+        Self::release_claim_with_lock_retry_deadline(
+            queue,
+            claim,
+            MCP_INGEST_CLAIM_RELEASE_RETRY_DEADLINE,
+        )
+        .await
+    }
+
+    async fn release_claim_with_lock_retry_deadline(
+        queue: &AsyncPendingMessageStore,
+        claim: ClaimedMessage,
+        retry_deadline: Duration,
+    ) -> crate::core::queue::Result<()> {
+        let started = Instant::now();
+        loop {
+            match queue
+                .release_claim_with_busy_timeout(
+                    claim.clone(),
+                    MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT,
+                )
+                .await
+            {
+                Ok(()) | Err(QueueError::ClaimLost(_)) => return Ok(()),
+                Err(error) if error.is_sqlite_lock() && started.elapsed() < retry_deadline => {
+                    let remaining = retry_deadline.saturating_sub(started.elapsed());
+                    tracing::warn!(
+                        ?error,
+                        operation_id = %claim.id,
+                        "retrying ingest claim release after SQLite lock"
+                    );
+                    tokio::time::sleep(MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY.min(remaining)).await;
+                }
+                Err(error) => return Err(error),
+            }
         }
     }
 
@@ -1869,12 +1914,21 @@ impl MempalMcpServer {
         &self,
         deadline: Duration,
     ) -> std::result::Result<Vec<SystemWarning>, ErrorData> {
-        match self
-            .run_read_anyhow_bounded(|db| Ok(system_warnings_with_stale_index(db)), deadline)
-            .await
-        {
-            Ok(Some(warnings)) => Ok(warnings),
-            Ok(None) => {
+        let db_path = self.db_path.clone();
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let ingest_warning_snapshot_delay = self.ingest_warning_snapshot_delay;
+        let read = tokio::task::spawn_blocking(move || {
+            #[cfg(any(test, feature = "db-test-seam"))]
+            if let Some(delay) = ingest_warning_snapshot_delay {
+                std::thread::sleep(delay);
+            }
+            let db = Database::open_query_only(&db_path)
+                .map_err(|error| anyhow::anyhow!("failed to open query-only database: {error}"))?;
+            Ok::<Vec<SystemWarning>, anyhow::Error>(system_warnings_with_stale_index(&db))
+        });
+        match tokio::time::timeout(deadline, read).await {
+            Ok(Ok(Ok(warnings))) => Ok(warnings),
+            Err(_) => {
                 let mut warnings = current_system_warnings();
                 warnings.push(SystemWarning {
                     level: "warn".to_string(),
@@ -1883,12 +1937,22 @@ impl MempalMcpServer {
                 });
                 Ok(warnings)
             }
-            Err(error) => Ok(database_warning_snapshot(
+            Ok(Ok(Err(error))) => Ok(database_warning_snapshot(
                 current_system_warnings(),
                 &self.db_path,
                 "stale vector index check",
                 error.as_ref(),
             )),
+            Ok(Err(error)) => {
+                let error =
+                    anyhow::anyhow!("stale vector index check database task failed: {error}");
+                Ok(database_warning_snapshot(
+                    current_system_warnings(),
+                    &self.db_path,
+                    "stale vector index check",
+                    error.as_ref(),
+                ))
+            }
         }
     }
 
@@ -5411,35 +5475,46 @@ impl MempalMcpServer {
                 may_have_reached_daemon,
             } => may_have_reached_daemon,
         };
-        let operation_id = match self
-            .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key.clone())
-            .await
-        {
-            Ok(operation_id) => operation_id,
-            Err(error) => {
-                if let Some(admission) = queue_admission_for_uncertain_daemon_enqueue(
-                    &idempotency_key,
+        if daemon_enqueue_may_have_reached {
+            return match self
+                .async_queue
+                .enqueue_idempotent_with_key_fail_fast(
+                    INGEST_ASYNC_KIND.to_string(),
+                    payload.clone(),
+                    idempotency_key.clone(),
+                )
+                .await
+            {
+                Ok(operation_id) => Ok(IngestQueueAdmission {
+                    operation_id,
+                    processor: IngestQueueProcessor::Local,
                     daemon_enqueue_may_have_reached,
-                    &error,
-                ) {
-                    if !self
-                        .daemon_admitted_operation_is_visible(&admission.operation_id)
-                        .await?
-                    {
-                        return Err(error.context(
-                            "daemon enqueue may have reached daemon but no queryable operation row was visible",
-                        ));
-                    }
+                }),
+                Err(error) if error.is_sqlite_lock() => {
+                    let error = anyhow::Error::new(error).context(
+                        "SQLite queue admission after daemon enqueue may have reached daemon",
+                    );
+                    let Some(admission) = queue_admission_for_uncertain_daemon_enqueue(
+                        &idempotency_key,
+                        daemon_enqueue_may_have_reached,
+                        &error,
+                    ) else {
+                        return Err(error);
+                    };
                     tracing::warn!(
                         operation_id = %admission.operation_id,
                         error = %error,
-                        "local ingest queue admission failed after daemon enqueue may have reached daemon; returning verified operation receipt"
+                        "local ingest queue admission hit SQLite lock after daemon enqueue may have reached daemon; returning pending operation receipt"
                     );
-                    return Ok(admission);
+                    Ok(admission)
                 }
-                return Err(error);
-            }
-        };
+                Err(error) => Err(error.into()),
+            };
+        }
+
+        let operation_id = self
+            .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key.clone())
+            .await?;
         Ok(IngestQueueAdmission {
             operation_id,
             processor: IngestQueueProcessor::Local,
@@ -10844,47 +10919,6 @@ mod tests {
     }
 
     #[test]
-    fn test_uncertain_daemon_enqueue_admission_preserves_operation_id_after_local_lock() {
-        let lock_error = anyhow::Error::new(QueueError::Sqlite(rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error {
-                code: rusqlite::ErrorCode::DatabaseBusy,
-                extended_code: rusqlite::ffi::SQLITE_BUSY,
-            },
-            Some("database is locked".to_string()),
-        )))
-        .context("SQLite queue admission known-runtime-holder retry exhausted");
-
-        let admission =
-            queue_admission_for_uncertain_daemon_enqueue("uncertain-daemon-key", true, &lock_error)
-                .expect("lock after may-have-reached daemon enqueue should preserve receipt");
-
-        assert_eq!(
-            admission.operation_id,
-            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, "uncertain-daemon-key")
-        );
-        assert_eq!(admission.processor, IngestQueueProcessor::Local);
-        assert!(admission.daemon_enqueue_may_have_reached);
-        assert!(
-            queue_admission_for_uncertain_daemon_enqueue(
-                "uncertain-daemon-key",
-                false,
-                &lock_error,
-            )
-            .is_none()
-        );
-
-        let non_lock_error = anyhow::anyhow!("local admission rejected malformed payload");
-        assert!(
-            queue_admission_for_uncertain_daemon_enqueue(
-                "uncertain-daemon-key",
-                true,
-                &non_lock_error,
-            )
-            .is_none()
-        );
-    }
-
-    #[test]
     fn test_ingest_heartbeat_retries_transient_sqlite_lock() {
         let busy = QueueError::Sqlite(rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error {
@@ -11044,6 +11078,31 @@ api_key = "sk-secret-should-not-print"
                 "MCP ingest should reject unadvertised source_type {value}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_warning_snapshot_does_not_initialize_persistent_async_db_pool() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open database");
+        let server = MempalMcpServer::new_with_factory_and_config(
+            db_path,
+            Config::parse("").expect("empty config"),
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server");
+
+        server
+            .ingest_system_warnings_with_stale_index_bounded(Duration::from_secs(5))
+            .await
+            .expect("warning snapshot");
+
+        assert!(
+            server.async_db.get().is_none(),
+            "ingest admission warning snapshots must not keep a persistent MCP AsyncDb pool open"
+        );
     }
 
     #[tokio::test]
@@ -11221,6 +11280,59 @@ quality_policy = "llm_required_for_keep"
             .expect("returned operation id must be queryable");
         assert_eq!(record.id, operation_id);
         assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_uncertain_daemon_lock_returns_pending_receipt() {
+        let (tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_enqueue_lock_failures_for_test(1);
+        let server = server.with_async_queue_for_test(async_queue);
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            drop(stream);
+            request
+        });
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "uncertain daemon enqueue with local SQLite lock returns pending receipt"
+                    .to_string(),
+                wing: "mcp".to_string(),
+                room: Some("receipt".to_string()),
+                wait: Some(true),
+                wait_timeout_secs: Some(0),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("uncertain daemon lock path must not spend the normal local retry budget")
+        .expect("uncertain daemon lock should return a pending operation receipt")
+        .0;
+
+        let request = daemon.await.expect("daemon IPC task");
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.created_drawer_ids.is_empty());
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(
+            operation_id,
+            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &request.idempotency_key)
+        );
+        assert!(
+            PendingMessageStore::new_without_reclaim(&db_path)
+                .operation_status(operation_id)
+                .expect("query operation")
+                .is_none(),
+            "the pending receipt must tolerate a daemon-owned operation row that is not visible yet"
+        );
     }
 
     #[tokio::test]
@@ -11895,11 +12007,8 @@ pattern_boost = 0.2
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_mcp_ingest_admission_db_work_runs_off_runtime() {
-        let (_tempdir, db_path, server) = setup_server();
-        let async_db = AsyncDb::open(&db_path, 4)
-            .expect("open async db")
-            .with_read_delay(Duration::from_millis(300));
-        let server = server.with_async_db_for_test(async_db);
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_ingest_warning_snapshot_delay_for_test(Duration::from_millis(300));
         let (ticks, ticker) = spawn_runtime_ticker();
 
         let response = server
@@ -11923,12 +12032,9 @@ pattern_boost = 0.2
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_mcp_ingest_admission_warning_timeout_still_returns_receipt() {
-        let (_tempdir, db_path, server) = setup_server();
-        let async_db = AsyncDb::open(&db_path, 4)
-            .expect("open async db")
-            .with_read_delay(Duration::from_millis(150));
+        let (_tempdir, _db_path, server) = setup_server();
         let server = server
-            .with_async_db_for_test(async_db)
+            .with_ingest_warning_snapshot_delay_for_test(Duration::from_millis(150))
             .with_mcp_deadline_for_test(Duration::from_millis(20));
 
         let result = tokio::time::timeout(
@@ -12159,17 +12265,19 @@ pattern_boost = 0.2
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_mcp_ingest_scoped_late_claim_is_released_after_timeout() {
+    async fn test_mcp_ingest_scoped_late_claim_release_retries_before_timeout_receipt() {
         let (_tempdir, db_path, server) = setup_server();
         let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
-            .with_claim_blocking_delay(Duration::from_millis(1500));
-        let server = server.with_async_queue_for_test(async_queue);
+            .with_release_lock_failures_for_test(2);
+        let server = server
+            .with_async_queue_for_test(async_queue)
+            .with_ingest_processing_delay_for_test(Duration::from_millis(1500));
 
         let response = tokio::time::timeout(
-            Duration::from_millis(1300),
+            Duration::from_millis(2500),
             server.mempal_ingest_with_controls_scoped_worker(
                 IngestRequest {
-                    content: "scoped wait must release a late queue claim after timeout"
+                    content: "scoped wait must release a late queue claim before timeout receipt"
                         .to_string(),
                     wing: "mcp".to_string(),
                     room: Some("receipt".to_string()),
@@ -12182,7 +12290,7 @@ pattern_boost = 0.2
             ),
         )
         .await
-        .expect("scoped ingest must respect the caller wait timeout while claim is slow")
+        .expect("scoped ingest should release a late claim before returning a timeout receipt")
         .expect("scoped ingest should return a timeout receipt")
         .0;
         let operation_id = response
@@ -12194,22 +12302,65 @@ pattern_boost = 0.2
         assert!(response.timed_out);
         assert!(response.created_drawer_ids.is_empty());
 
-        tokio::time::timeout(Duration::from_secs(3), async {
-            loop {
-                let record = PendingMessageStore::new_without_reclaim(&db_path)
-                    .operation_status(&operation_id)
-                    .expect("load operation status")
-                    .expect("operation must stay queryable");
-                if record.claimed_at.is_none()
-                    && record.op_state == IngestOperationState::Queued.as_str()
-                {
-                    return;
-                }
-                tokio::time::sleep(Duration::from_millis(25)).await;
-            }
-        })
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation status")
+            .expect("operation must stay queryable");
+        assert!(
+            record.claimed_at.is_none(),
+            "timeout receipt must not depend on a detached cleanup task that stdio shutdown can abort"
+        );
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_scoped_timeout_release_lock_budget_does_not_block_receipt() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_release_lock_failures_for_test(100);
+        let server = server
+            .with_async_queue_for_test(async_queue)
+            .with_ingest_processing_delay_for_test(Duration::from_millis(1500));
+
+        let started = Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_millis(1800),
+            server.mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped wait release must honor caller timeout budget".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("receipt".to_string()),
+                    dry_run: Some(false),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(1),
+                    ..IngestRequest::default()
+                },
+                IngestControls::default(),
+            ),
+        )
         .await
-        .expect("late scoped claim should be released instead of waiting for claim TTL");
+        .expect("scoped timeout release must not retry until the 300s claim TTL")
+        .expect(
+            "scoped ingest should return a timeout receipt when cleanup lock budget is exhausted",
+        )
+        .0;
+
+        assert!(response.timed_out);
+        assert!(response.operation_id.is_some());
+        assert!(
+            started.elapsed() < Duration::from_millis(1500),
+            "timeout cleanup exceeded the caller wait budget"
+        );
+
+        let operation_id = response
+            .operation_id
+            .expect("timeout receipt must include operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation status")
+            .expect("operation must stay queryable");
+        assert_eq!(record.op_state, IngestOperationState::Running.as_str());
+        assert!(record.claimed_at.is_some());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
+#[cfg(any(test, feature = "db-test-seam"))]
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -229,6 +231,8 @@ pub struct MempalMcpServer {
     ingest_processing_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_error: Option<String>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    async_db_open_lock_failures: Arc<AtomicUsize>,
     #[cfg(any(test, feature = "db-test-seam"))]
     content_writer_lease_ttl_secs: u64,
     #[cfg(any(test, feature = "db-test-seam"))]
@@ -468,6 +472,8 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_error: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            async_db_open_lock_failures: Arc::new(AtomicUsize::new(0)),
+            #[cfg(any(test, feature = "db-test-seam"))]
             content_writer_lease_ttl_secs: MCP_CONTENT_WRITER_LEASE_TTL_SECS,
             #[cfg(any(test, feature = "db-test-seam"))]
             content_writer_lease_renew_interval: MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL,
@@ -515,6 +521,13 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_async_db_open_error_for_test(mut self, error: impl Into<String>) -> Self {
         self.async_db_open_error = Some(error.into());
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_async_db_open_lock_failures_for_test(self, failures: usize) -> Self {
+        self.async_db_open_lock_failures
+            .store(failures, Ordering::SeqCst);
         self
     }
 
@@ -1310,7 +1323,22 @@ impl MempalMcpServer {
         if let Some(error) = self.async_db_open_error.as_deref() {
             anyhow::bail!("{error}");
         }
-
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .async_db_open_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(anyhow::Error::new(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error {
+                    code: rusqlite::ErrorCode::DatabaseBusy,
+                    extended_code: rusqlite::ffi::SQLITE_BUSY,
+                },
+                Some("database is locked".to_string()),
+            )));
+        }
         let db_path = self.db_path.clone();
         let async_db = self
             .async_db
@@ -5485,25 +5513,60 @@ impl MempalMcpServer {
             return Ok(None);
         }
 
-        let async_db = self.async_db().await.map_err(|error| {
-            database_write_refused_error(
-                &self.db_path,
-                "resolve replacement target",
-                error.as_ref(),
-            )
-        })?;
-        async_db
-            .run_read(move |db| {
-                db.resolve_replacement_target(
-                    supersedes.as_deref(),
-                    replace_text.as_deref(),
-                    &wing,
-                    room.as_deref(),
-                    project_id.as_deref(),
-                )
-            })
-            .await
-            .map_err(replacement_db_error)
+        let deadline = Instant::now() + self.ingest_admission_deadline;
+        loop {
+            let async_db = match self.async_db().await {
+                Ok(async_db) => async_db,
+                Err(error)
+                    if anyhow_chain_contains_sqlite_lock(&error) && Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(
+                        MCP_INGEST_QUEUE_LOCK_RETRY_DELAY
+                            .min(deadline.saturating_duration_since(Instant::now())),
+                    )
+                    .await;
+                    continue;
+                }
+                Err(error) => {
+                    return Err(database_write_refused_error(
+                        &self.db_path,
+                        "resolve replacement target",
+                        error.as_ref(),
+                    ));
+                }
+            };
+
+            let supersedes = supersedes.clone();
+            let replace_text = replace_text.clone();
+            let wing = wing.clone();
+            let room = room.clone();
+            let project_id = project_id.clone();
+            match async_db
+                .run_read(move |db| {
+                    db.resolve_replacement_target(
+                        supersedes.as_deref(),
+                        replace_text.as_deref(),
+                        &wing,
+                        room.as_deref(),
+                        project_id.as_deref(),
+                    )
+                })
+                .await
+            {
+                Ok(target) => return Ok(target),
+                Err(error)
+                    if crate::core::db::db_error_is_sqlite_lock(&error)
+                        && Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(
+                        MCP_INGEST_QUEUE_LOCK_RETRY_DELAY
+                            .min(deadline.saturating_duration_since(Instant::now())),
+                    )
+                    .await;
+                }
+                Err(error) => return Err(replacement_db_error(error)),
+            }
+        }
     }
 
     #[cfg(test)]
@@ -11659,6 +11722,53 @@ pattern_boost = 0.2
         );
 
         tokio::time::sleep(Duration::from_millis(180)).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_replacement_target_retries_transient_sqlite_lock() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("palace.db");
+        Database::open(&db_path).expect("open db");
+        insert_drawer(
+            &db_path,
+            "replacement-transient-lock-target",
+            "replacement target before transient lock",
+            "mcp",
+            Some("deadline"),
+            "/tmp/replacement-transient-lock.md",
+            2,
+        );
+        let server = MempalMcpServer::new_with_factory(
+            db_path,
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server")
+        .with_async_db_open_lock_failures_for_test(1);
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(2),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "replacement target transient lock should still enqueue".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("deadline".to_string()),
+                supersedes: Some("replacement-transient-lock-target".to_string()),
+                dry_run: Some(false),
+                wait: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP ingest should return before client timeout")
+        .expect("transient replacement target lock should be retried")
+        .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(
+            response.operation_id.is_some(),
+            "durable receipt must be preserved after transient replacement lookup lock"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -230,6 +230,8 @@ pub struct MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_processing_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
+    operation_status_probe_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_error: Option<String>,
     #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_lock_failures: Arc<AtomicUsize>,
@@ -470,6 +472,8 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_processing_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            operation_status_probe_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_error: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_lock_failures: Arc::new(AtomicUsize::new(0)),
@@ -515,6 +519,12 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_ingest_processing_delay_for_test(mut self, delay: Duration) -> Self {
         self.ingest_processing_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_operation_status_probe_delay_for_test(mut self, delay: Duration) -> Self {
+        self.operation_status_probe_delay = Some(delay);
         self
     }
 
@@ -1501,6 +1511,10 @@ impl MempalMcpServer {
         &self,
         operation_id: &str,
     ) -> std::result::Result<IngestResponse, ErrorData> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(delay) = self.operation_status_probe_delay {
+            tokio::time::sleep(delay).await;
+        }
         self.mempal_operation_status(Parameters(OperationStatusRequest {
             operation_id: operation_id.to_string(),
         }))
@@ -5293,16 +5307,14 @@ impl MempalMcpServer {
             }
 
             let mut timed_out_response = if matches!(worker_mode, IngestWaitWorkerMode::Scoped) {
+                let refresh_remaining = wait_timeout
+                    .checked_sub(request_started_at.elapsed())
+                    .unwrap_or_default();
                 match self
-                    .operation_status_json_for_test(
-                        queued_response
-                            .operation_id
-                            .as_deref()
-                            .expect("queued receipt must include operation id"),
-                    )
+                    .operation_status_json_within(operation_id, refresh_remaining)
                     .await
                 {
-                    Ok(refreshed) => {
+                    Ok(Some(refreshed)) => {
                         if refreshed
                             .state
                             .map(IngestOperationState::is_terminal)
@@ -5312,6 +5324,7 @@ impl MempalMcpServer {
                         }
                         refreshed
                     }
+                    Ok(None) => queued_response,
                     Err(error)
                         if mcp_operation_wait_error_is_ignorable_during_wait(
                             &error,
@@ -12061,6 +12074,42 @@ pattern_boost = 0.2
         assert!(response.timed_out);
         assert!(response.operation_id.is_some());
         assert!(response.created_drawer_ids.is_empty());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_scoped_zero_wait_skips_status_refresh_after_budget() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_operation_status_probe_delay_for_test(Duration::from_millis(500));
+
+        let started = tokio::time::Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_millis(250),
+            server.mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped zero wait must not refresh status after budget".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("receipt".to_string()),
+                    dry_run: Some(false),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(0),
+                    ..IngestRequest::default()
+                },
+                IngestControls::default(),
+            ),
+        )
+        .await
+        .expect("scoped ingest must not run a status refresh after wait budget is exhausted")
+        .expect("scoped zero-wait ingest should return a receipt")
+        .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.operation_id.is_some());
+        assert!(response.created_drawer_ids.is_empty());
+        assert!(
+            started.elapsed() < Duration::from_millis(250),
+            "scoped ingest performed an unbudgeted status refresh after wait budget exhaustion"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -185,6 +185,10 @@ const MCP_INGEST_CLAIM_RELEASE_RETRY_DEADLINE: Duration = Duration::from_secs(30
 const MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(50);
 const MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT: Duration = Duration::ZERO;
 const MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN: Duration = Duration::from_millis(250);
+// Caller-bounded scoped waits may claim only when this much budget remains. The
+// cleanup margin is reserved for releasing the claim if processing hits the
+// caller's deadline.
+const MCP_SCOPED_INGEST_MIN_PROCESSING_BUDGET: Duration = Duration::from_secs(5);
 const SQLITE_WRITER_LEASE_NAME: &str = "sqlite-writer";
 const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
@@ -204,7 +208,12 @@ fn scoped_ingest_claim_retry_deadline(remaining: Duration) -> Option<Duration> {
 fn scoped_ingest_processing_budget(remaining: Duration) -> Option<Duration> {
     remaining
         .checked_sub(MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN)
-        .filter(|budget| !budget.is_zero())
+        .filter(|budget| *budget >= MCP_SCOPED_INGEST_MIN_PROCESSING_BUDGET)
+}
+
+fn scoped_process_remaining(started: Instant, budget: Duration) -> Option<Duration> {
+    let remaining = budget.saturating_sub(started.elapsed());
+    (!remaining.is_zero()).then_some(remaining)
 }
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
@@ -255,6 +264,8 @@ pub struct MempalMcpServer {
     ingest_warning_snapshot_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_error: Option<String>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    daemon_writer_lease_check_error: Option<String>,
     #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_lock_failures: Arc<AtomicUsize>,
     #[cfg(any(test, feature = "db-test-seam"))]
@@ -500,6 +511,8 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_error: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            daemon_writer_lease_check_error: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_lock_failures: Arc::new(AtomicUsize::new(0)),
             #[cfg(any(test, feature = "db-test-seam"))]
             content_writer_lease_ttl_secs: MCP_CONTENT_WRITER_LEASE_TTL_SECS,
@@ -561,6 +574,15 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_async_db_open_error_for_test(mut self, error: impl Into<String>) -> Self {
         self.async_db_open_error = Some(error.into());
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_daemon_writer_lease_check_error_for_test(
+        mut self,
+        error: impl Into<String>,
+    ) -> Self {
+        self.daemon_writer_lease_check_error = Some(error.into());
         self
     }
 
@@ -962,7 +984,7 @@ impl MempalMcpServer {
 
         let (stop_tx, heartbeat) =
             Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
-        let external_writer_lease = self.external_ingest_writer_lease.as_ref();
+        let external_writer_lease = self.external_ingest_writer_lease.clone();
         let writer_lease = if external_writer_lease.is_some() {
             None
         } else {
@@ -996,17 +1018,19 @@ impl MempalMcpServer {
         if let Some(delay) = self.ingest_processing_delay {
             tokio::time::sleep(delay).await;
         }
+        let runtime_writer_lease = external_writer_lease
+            .or_else(|| writer_lease.as_ref().map(|lease| lease.lease().clone()));
         let outcome = match self
-            .mempal_ingest_sync_with_superseded_override(
+            .run_prepared_ingest_off_runtime(
                 prepared.request.clone(),
                 prepared.controls,
-                external_writer_lease
-                    .or_else(|| writer_lease.as_ref().map(McpIngestWriterLeaseGuard::lease)),
+                runtime_writer_lease,
                 pre_resolved_superseded_drawer_id,
             )
             .await
         {
-            Ok(response) => Ok(response.0),
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(error)) => Err(error.to_string()),
             Err(error) => Err(error.to_string()),
         };
 
@@ -1021,6 +1045,148 @@ impl MempalMcpServer {
         };
         completed?;
         released
+    }
+
+    async fn process_ingest_claim_inline_with_budget(
+        &self,
+        queue: &AsyncPendingMessageStore,
+        worker_id: &str,
+        claim: ClaimedMessage,
+        budget: Duration,
+    ) -> anyhow::Result<ScopedIngestProcessResult> {
+        let started = Instant::now();
+        let queue_wait_ms = queue_wait_ms(claim.created_at, claim.claimed_at);
+        let prepared: PreparedIngestOperation = match serde_json::from_str(&claim.payload) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                let detail = format!("failed to decode ingest operation {}: {error}", claim.id);
+                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
+                return Ok(ScopedIngestProcessResult::Processed);
+            }
+        };
+
+        let (stop_tx, heartbeat) =
+            Self::spawn_ingest_claim_heartbeat(queue.clone(), claim.id.clone(), worker_id);
+        let external_writer_lease = self.external_ingest_writer_lease.clone();
+        let writer_lease = if external_writer_lease.is_some() {
+            None
+        } else {
+            let Some(remaining) = scoped_process_remaining(started, budget) else {
+                Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                Self::release_scoped_claim_after_timeout(queue, claim, Duration::ZERO).await?;
+                return Ok(ScopedIngestProcessResult::TimedOut);
+            };
+            match tokio::time::timeout(remaining, self.acquire_ingest_writer_lease(worker_id)).await
+            {
+                Ok(Ok(Some(lease))) => Some(lease),
+                Ok(Ok(None)) => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    Self::release_claim_with_lock_retry_deadline(
+                        queue,
+                        claim,
+                        remaining.min(CLAIM_LOCK_RETRY_DEADLINE),
+                    )
+                    .await
+                    .context("failed to release scoped ingest claim after writer lease conflict")?;
+                    return Ok(ScopedIngestProcessResult::ReleasedForRetry);
+                }
+                Ok(Err(error)) if anyhow_chain_contains_sqlite_lock(&error) => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    Self::release_claim_with_lock_retry_deadline(
+                        queue,
+                        claim,
+                        remaining.min(CLAIM_LOCK_RETRY_DEADLINE),
+                    )
+                    .await
+                    .context(
+                        "failed to release scoped ingest claim after transient writer lease lock",
+                    )?;
+                    return Ok(ScopedIngestProcessResult::ReleasedForRetry);
+                }
+                Ok(Err(error)) => {
+                    return Err(error).context("failed to acquire scoped MCP ingest writer lease");
+                }
+                Err(_) => {
+                    Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                    Self::release_scoped_claim_after_timeout(queue, claim, Duration::ZERO).await?;
+                    return Ok(ScopedIngestProcessResult::TimedOut);
+                }
+            }
+        };
+
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(delay) = self.ingest_processing_delay {
+            let Some(remaining) = scoped_process_remaining(started, budget) else {
+                Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                if let Some(writer_lease) = writer_lease {
+                    let _ = writer_lease.release().await;
+                }
+                Self::release_scoped_claim_after_timeout(queue, claim, Duration::ZERO).await?;
+                return Ok(ScopedIngestProcessResult::TimedOut);
+            };
+            if tokio::time::timeout(remaining, tokio::time::sleep(delay))
+                .await
+                .is_err()
+            {
+                Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                if let Some(writer_lease) = writer_lease {
+                    let _ = writer_lease.release().await;
+                }
+                let release_deadline =
+                    scoped_process_remaining(started, budget).unwrap_or_default();
+                Self::release_scoped_claim_after_timeout(queue, claim, release_deadline).await?;
+                return Ok(ScopedIngestProcessResult::TimedOut);
+            }
+        }
+
+        let pre_resolved_superseded_drawer_id = prepared.superseded_drawer_id.clone();
+        let runtime_writer_lease = external_writer_lease
+            .or_else(|| writer_lease.as_ref().map(|lease| lease.lease().clone()));
+        let Some(remaining) = scoped_process_remaining(started, budget) else {
+            Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+            if let Some(writer_lease) = writer_lease {
+                let _ = writer_lease.release().await;
+            }
+            Self::release_scoped_claim_after_timeout(queue, claim, Duration::ZERO).await?;
+            return Ok(ScopedIngestProcessResult::TimedOut);
+        };
+        let outcome = match tokio::time::timeout(
+            remaining,
+            self.mempal_ingest_sync_with_superseded_override(
+                prepared.request.clone(),
+                prepared.controls,
+                runtime_writer_lease.as_ref(),
+                pre_resolved_superseded_drawer_id,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(response)) => Ok(response.0),
+            Ok(Err(error)) => Err(error.to_string()),
+            Err(_) => {
+                Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+                if let Some(writer_lease) = writer_lease {
+                    let _ = writer_lease.release().await;
+                }
+                let release_deadline =
+                    scoped_process_remaining(started, budget).unwrap_or_default();
+                Self::release_scoped_claim_after_timeout(queue, claim, release_deadline).await?;
+                return Ok(ScopedIngestProcessResult::TimedOut);
+            }
+        };
+
+        Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
+        let completed = self
+            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .await;
+        Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+        let released = match writer_lease {
+            Some(writer_lease) => writer_lease.release().await,
+            None => Ok(()),
+        };
+        completed?;
+        released?;
+        Ok(ScopedIngestProcessResult::Processed)
     }
 
     async fn complete_ingest_claim_outcome(
@@ -1365,6 +1531,39 @@ impl MempalMcpServer {
         }
     }
 
+    async fn daemon_writer_lease_visible_for_ingest_wait(&self) -> bool {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(error) = self.daemon_writer_lease_check_error.as_deref() {
+            tracing::warn!(
+                error,
+                "failed to check daemon writer lease before MCP ingest wait; daemon ownership is not proven"
+            );
+            return false;
+        }
+
+        match self
+            .run_query_only_read_bounded(
+                "daemon writer lease check",
+                self.operation_status_deadline
+                    .min(Duration::from_millis(500)),
+                |db| {
+                    db.runtime_writer_lease_has_live_daemon(SQLITE_WRITER_LEASE_NAME)
+                        .map_err(db_error)
+                },
+            )
+            .await
+        {
+            Ok(visible) => visible,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to check daemon writer lease before MCP ingest wait; daemon ownership is not proven"
+                );
+                false
+            }
+        }
+    }
+
     async fn async_db(&self) -> anyhow::Result<AsyncDb> {
         #[cfg(any(test, feature = "db-test-seam"))]
         if let Some(error) = self.async_db_open_error.as_deref() {
@@ -1568,13 +1767,69 @@ impl MempalMcpServer {
         if timeout.is_zero() {
             return Ok(None);
         }
+        let started_at = Instant::now();
 
-        match tokio::time::timeout(timeout, self.operation_status_json_for_test(operation_id)).await
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(delay) = self.operation_status_probe_delay {
+            match tokio::time::timeout(timeout, tokio::time::sleep(delay)).await {
+                Ok(()) => {}
+                Err(_) => return Ok(None),
+            }
+        }
+
+        let remaining_timeout = timeout
+            .checked_sub(started_at.elapsed())
+            .unwrap_or_default();
+        if remaining_timeout.is_zero() {
+            return Ok(None);
+        }
+        match tokio::time::timeout(
+            remaining_timeout,
+            self.async_queue.operation_status(operation_id.to_string()),
+        )
+        .await
         {
-            Ok(Ok(response)) => Ok(Some(response)),
-            Ok(Err(error)) => Err(error),
+            Ok(Ok(Some(record))) => {
+                let is_terminal = record
+                    .op_state
+                    .parse::<IngestOperationState>()
+                    .map(|state| state.is_terminal())
+                    .unwrap_or(false);
+                let system_warnings = if is_terminal {
+                    let warning_budget = remaining_timeout
+                        .checked_sub(started_at.elapsed())
+                        .unwrap_or_default();
+                    if warning_budget.is_zero() {
+                        current_system_warnings()
+                    } else {
+                        self.system_warnings_with_stale_index_bounded(warning_budget)
+                            .await?
+                    }
+                } else {
+                    current_system_warnings()
+                };
+                Ok(Some(operation_record_to_response(record, system_warnings)))
+            }
+            Ok(Ok(None)) => Err(ErrorData::invalid_params(
+                format!("operation not found: {operation_id}"),
+                None,
+            )),
+            Ok(Err(error)) => Err(ErrorData::internal_error(
+                format!("queue lookup failed: {error}"),
+                None,
+            )),
             Err(_) => Ok(None),
         }
+    }
+
+    #[doc(hidden)]
+    pub async fn operation_status_snapshot_lightweight(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        self.operation_status_json_within(operation_id, timeout)
+            .await
     }
 
     pub async fn wait_for_operation_status(
@@ -1637,6 +1892,40 @@ impl MempalMcpServer {
         }
     }
 
+    async fn wait_for_operation_status_unbounded_with_lookup_policy(
+        &self,
+        operation_id: &str,
+        poll_interval: Duration,
+        allow_pending_admission_lookup: bool,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        let probe_timeout = self.operation_status_deadline.max(Duration::from_millis(1));
+        loop {
+            match self
+                .operation_status_json_within(operation_id, probe_timeout)
+                .await
+            {
+                Ok(Some(response)) => {
+                    if response
+                        .state
+                        .map(IngestOperationState::is_terminal)
+                        .unwrap_or(false)
+                    {
+                        return Ok(Some(response));
+                    }
+                }
+                Ok(None) => {}
+                Err(error)
+                    if mcp_operation_wait_error_is_ignorable_during_wait(
+                        &error,
+                        allow_pending_admission_lookup,
+                    ) => {}
+                Err(error) => return Err(error),
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
+
     #[doc(hidden)]
     pub async fn wait_for_operation_status_with_scoped_worker(
         &self,
@@ -1644,7 +1933,41 @@ impl MempalMcpServer {
         timeout: Duration,
         poll_interval: Duration,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
-        if !should_claim_scoped_ingest_worker(self.daemon_ingest_ipc_available()) {
+        self.wait_for_operation_status_with_scoped_worker_mode(
+            operation_id,
+            timeout,
+            poll_interval,
+            ScopedIngestClaimPolicy::InlineWithinDeadline,
+        )
+        .await
+    }
+
+    #[doc(hidden)]
+    pub async fn wait_for_operation_status_with_scoped_worker_until_terminal(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+        poll_interval: Duration,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        self.wait_for_operation_status_with_scoped_worker_mode(
+            operation_id,
+            timeout,
+            poll_interval,
+            ScopedIngestClaimPolicy::InlineUntilTerminal,
+        )
+        .await
+    }
+
+    async fn wait_for_operation_status_with_scoped_worker_mode(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+        poll_interval: Duration,
+        claim_policy: ScopedIngestClaimPolicy,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        if claim_policy == ScopedIngestClaimPolicy::PollOnly
+            || !should_claim_scoped_ingest_worker(self.daemon_ingest_ipc_available())
+        {
             return self
                 .wait_for_operation_status(operation_id, timeout, poll_interval)
                 .await;
@@ -1687,12 +2010,19 @@ impl MempalMcpServer {
             if remaining.is_zero() {
                 return Ok(None);
             }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            if scoped_ingest_processing_budget(remaining).is_none() {
+                tokio::time::sleep(poll_interval.min(remaining)).await;
+                continue;
+            }
+            if self.daemon_ingest_ipc_available()
+                || self.daemon_writer_lease_visible_for_ingest_wait().await
+            {
+                tokio::time::sleep(poll_interval.min(remaining)).await;
+                continue;
+            }
             let Some(claim_retry_deadline) = scoped_ingest_claim_retry_deadline(remaining) else {
                 return Ok(None);
             };
-
             match queue
                 .claim_by_id_and_kind_with_lock_retry_deadline(
                     worker_id.clone(),
@@ -1705,27 +2035,68 @@ impl MempalMcpServer {
             {
                 Ok(Some(claim)) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
-                    let Some(process_budget) = scoped_ingest_processing_budget(remaining) else {
+                    if scoped_ingest_processing_budget(remaining).is_none() {
                         Self::release_scoped_claim_after_timeout(&queue, claim, remaining).await?;
                         return Ok(None);
-                    };
+                    }
 
-                    let process =
-                        self.process_ingest_claim_inline(&queue, &worker_id, claim.clone());
-                    tokio::pin!(process);
-                    tokio::select! {
-                        result = &mut process => {
-                            result.map_err(|error| {
-                                ErrorData::internal_error(
-                                    format!("scoped async ingest worker failed: {error}"),
-                                    None,
+                    let scoped_worker = self.clone();
+                    let scoped_queue = queue.clone();
+                    let scoped_worker_id = worker_id.clone();
+                    let result = match claim_policy {
+                        ScopedIngestClaimPolicy::InlineUntilTerminal => scoped_worker
+                            .process_ingest_claim_inline(&scoped_queue, &scoped_worker_id, claim)
+                            .await
+                            .map(|()| ScopedIngestProcessResult::Processed),
+                        ScopedIngestClaimPolicy::InlineWithinDeadline => {
+                            scoped_worker
+                                .process_ingest_claim_inline_with_budget(
+                                    &scoped_queue,
+                                    &scoped_worker_id,
+                                    claim,
+                                    scoped_ingest_processing_budget(remaining)
+                                        .expect("processing budget was checked before claiming"),
                                 )
-                            })?;
+                                .await
                         }
-                        _ = tokio::time::sleep(process_budget) => {
-                            let release_budget = deadline.saturating_duration_since(Instant::now());
-                            Self::release_scoped_claim_after_timeout(&queue, claim, release_budget).await?;
-                            return Ok(None);
+                        ScopedIngestClaimPolicy::PollOnly => {
+                            unreachable!("poll-only scoped wait returns before attempting a claim")
+                        }
+                    };
+                    if let Err(error) = &result {
+                        tracing::warn!(
+                            error = %error,
+                            worker_id = %scoped_worker_id,
+                            "scoped async ingest worker failed"
+                        );
+                    }
+                    let process_result = result.map_err(|error| {
+                        ErrorData::internal_error(
+                            format!("scoped async ingest worker failed: {error}"),
+                            None,
+                        )
+                    })?;
+                    if process_result == ScopedIngestProcessResult::TimedOut {
+                        return Ok(None);
+                    }
+                    match self
+                        .operation_status_json_within(operation_id, self.operation_status_deadline)
+                        .await?
+                    {
+                        Some(response)
+                            if response
+                                .state
+                                .map(IngestOperationState::is_terminal)
+                                .unwrap_or(false) =>
+                        {
+                            return Ok(Some(response));
+                        }
+                        _ => {
+                            let remaining = deadline.saturating_duration_since(Instant::now());
+                            if remaining.is_zero() {
+                                return Ok(None);
+                            }
+                            tokio::time::sleep(poll_interval.min(remaining)).await;
                         }
                     }
                 }
@@ -1736,7 +2107,18 @@ impl MempalMcpServer {
                     }
                     tokio::time::sleep(poll_interval.min(remaining)).await;
                 }
-                Err(error) if error.is_sqlite_lock() => return Ok(None),
+                Err(error) if error.is_sqlite_lock() => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Ok(None);
+                    }
+                    tracing::warn!(
+                        ?error,
+                        operation_id,
+                        "retrying scoped ingest claim after SQLite lock"
+                    );
+                    tokio::time::sleep(poll_interval.min(remaining)).await;
+                }
                 Err(error) => {
                     return Err(ErrorData::internal_error(
                         format!("scoped async ingest worker claim failed: {error}"),
@@ -1752,20 +2134,14 @@ impl MempalMcpServer {
         claim: ClaimedMessage,
         retry_deadline: Duration,
     ) -> std::result::Result<(), ErrorData> {
-        match Self::release_claim_with_lock_retry_deadline(queue, claim, retry_deadline).await {
-            Ok(()) => Ok(()),
-            Err(error) if error.is_sqlite_lock() => {
-                tracing::warn!(
-                    ?error,
-                    "timed-out scoped ingest claim release exceeded caller wait budget"
-                );
-                Ok(())
-            }
-            Err(error) => Err(ErrorData::internal_error(
-                format!("failed to release timed-out scoped ingest claim: {error}"),
-                None,
-            )),
-        }
+        Self::release_claim_with_lock_retry_deadline(queue, claim, retry_deadline)
+            .await
+            .map_err(|error| {
+                ErrorData::internal_error(
+                    format!("failed to release timed-out scoped ingest claim: {error}"),
+                    None,
+                )
+            })
     }
 
     async fn release_claim_with_lock_retry(
@@ -1887,12 +2263,25 @@ impl MempalMcpServer {
         &self,
         deadline: Duration,
     ) -> std::result::Result<Vec<SystemWarning>, ErrorData> {
-        match self
-            .run_read_anyhow_bounded(|db| Ok(system_warnings_with_stale_index(db)), deadline)
-            .await
-        {
-            Ok(Some(warnings)) => Ok(warnings),
-            Ok(None) => {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(error) = self.async_db_open_error.clone() {
+            let error = anyhow::anyhow!(error);
+            return Ok(database_warning_snapshot(
+                current_system_warnings(),
+                &self.db_path,
+                "stale vector index check",
+                error.as_ref(),
+            ));
+        }
+        let db_path = self.db_path.clone();
+        let read = tokio::task::spawn_blocking(move || {
+            let db = Database::open_query_only(&db_path)
+                .map_err(|error| anyhow::anyhow!("failed to open database read-only: {error}"))?;
+            Ok::<Vec<SystemWarning>, anyhow::Error>(system_warnings_with_stale_index(&db))
+        });
+        match tokio::time::timeout(deadline, read).await {
+            Ok(Ok(Ok(warnings))) => Ok(warnings),
+            Err(_) => {
                 let mut warnings = current_system_warnings();
                 warnings.push(SystemWarning {
                     level: "warn".to_string(),
@@ -1901,12 +2290,22 @@ impl MempalMcpServer {
                 });
                 Ok(warnings)
             }
-            Err(error) => Ok(database_warning_snapshot(
+            Ok(Ok(Err(error))) => Ok(database_warning_snapshot(
                 current_system_warnings(),
                 &self.db_path,
                 "stale vector index check",
                 error.as_ref(),
             )),
+            Ok(Err(error)) => {
+                let error =
+                    anyhow::anyhow!("stale vector index check database task failed: {error}");
+                Ok(database_warning_snapshot(
+                    current_system_warnings(),
+                    &self.db_path,
+                    "stale vector index check",
+                    error.as_ref(),
+                ))
+            }
         }
     }
 
@@ -1914,6 +2313,16 @@ impl MempalMcpServer {
         &self,
         deadline: Duration,
     ) -> std::result::Result<Vec<SystemWarning>, ErrorData> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(error) = self.async_db_open_error.clone() {
+            let error = anyhow::anyhow!(error);
+            return Ok(database_warning_snapshot(
+                current_system_warnings(),
+                &self.db_path,
+                "stale vector index check",
+                error.as_ref(),
+            ));
+        }
         let db_path = self.db_path.clone();
         #[cfg(any(test, feature = "db-test-seam"))]
         let ingest_warning_snapshot_delay = self.ingest_warning_snapshot_delay;
@@ -1923,7 +2332,7 @@ impl MempalMcpServer {
                 std::thread::sleep(delay);
             }
             let db = Database::open_query_only(&db_path)
-                .map_err(|error| anyhow::anyhow!("failed to open query-only database: {error}"))?;
+                .map_err(|error| anyhow::anyhow!("failed to open database read-only: {error}"))?;
             Ok::<Vec<SystemWarning>, anyhow::Error>(system_warnings_with_stale_index(&db))
         });
         match tokio::time::timeout(deadline, read).await {
@@ -2611,6 +3020,30 @@ const INGEST_DRAIN_RESTART_BACKOFF_MAX_MS: u64 = 5_000;
 enum IngestWaitWorkerMode {
     Background,
     Scoped,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScopedIngestClaimPolicy {
+    PollOnly,
+    InlineWithinDeadline,
+    InlineUntilTerminal,
+}
+
+fn scoped_ingest_claim_policy(wait_timeout_secs: u64) -> ScopedIngestClaimPolicy {
+    if wait_timeout_secs == u64::MAX {
+        ScopedIngestClaimPolicy::InlineUntilTerminal
+    } else if wait_timeout_secs == 0 {
+        ScopedIngestClaimPolicy::PollOnly
+    } else {
+        ScopedIngestClaimPolicy::InlineWithinDeadline
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScopedIngestProcessResult {
+    Processed,
+    ReleasedForRetry,
+    TimedOut,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -5340,10 +5773,16 @@ impl MempalMcpServer {
                 ));
             }
         };
+        let daemon_writer_lease_visible =
+            if matches!(queue_admission.processor, IngestQueueProcessor::Local) {
+                self.daemon_writer_lease_visible_for_ingest_wait().await
+            } else {
+                false
+            };
         let defer_to_daemon_ingest_worker =
             matches!(queue_admission.processor, IngestQueueProcessor::Local)
                 && should_defer_local_ingest_to_daemon(
-                    self.daemon_ingest_ipc_available(),
+                    self.daemon_ingest_ipc_available() || daemon_writer_lease_visible,
                     queue_admission.daemon_enqueue_may_have_reached,
                 );
         let use_local_ingest_worker = should_start_local_ingest_worker(
@@ -5386,6 +5825,7 @@ impl MempalMcpServer {
             let wait_remaining = wait_timeout
                 .checked_sub(request_started_at.elapsed())
                 .unwrap_or_default();
+            let claim_policy = scoped_ingest_claim_policy(wait_timeout_secs);
             let wait_result = if wait_timeout_secs == 0 {
                 self.wait_for_operation_status_with_lookup_policy(
                     operation_id,
@@ -5394,15 +5834,26 @@ impl MempalMcpServer {
                     queue_admission.daemon_enqueue_may_have_reached,
                 )
                 .await
-            } else if wait_remaining.is_zero() {
-                Ok(None)
-            } else if use_local_ingest_worker {
-                self.wait_for_operation_status_with_scoped_worker(
+            } else if use_local_ingest_worker
+                && matches!(worker_mode, IngestWaitWorkerMode::Scoped)
+                && claim_policy != ScopedIngestClaimPolicy::PollOnly
+            {
+                self.wait_for_operation_status_with_scoped_worker_mode(
                     operation_id,
                     wait_remaining,
                     Duration::from_millis(150),
+                    claim_policy,
                 )
                 .await
+            } else if wait_timeout_secs == u64::MAX {
+                self.wait_for_operation_status_unbounded_with_lookup_policy(
+                    operation_id,
+                    Duration::from_millis(150),
+                    queue_admission.daemon_enqueue_may_have_reached,
+                )
+                .await
+            } else if wait_remaining.is_zero() {
+                Ok(None)
             } else {
                 self.wait_for_operation_status_with_lookup_policy(
                     operation_id,
@@ -6828,7 +7279,11 @@ impl MempalMcpServer {
         Parameters(request): Parameters<DeleteRequest>,
     ) -> std::result::Result<Json<DeleteResponse>, ErrorData> {
         let db = self.open_db()?;
-        let _writer_lease = self.acquire_content_writer_lease(&db, "mempal_delete")?;
+        // Match CLI `mempal delete`: exact cleanup deletes are short SQLite writes
+        // that must still work while the daemon owns the long-lived runtime writer
+        // lease. Taking an MCP content-writer lease here makes daemon-backed full
+        // smoke cleanup impossible because the live daemon intentionally holds
+        // `sqlite-writer` for queue ownership.
         let deleted = db
             .soft_delete_drawer(&request.drawer_id)
             .map_err(db_error)?;
@@ -10681,6 +11136,43 @@ mod tests {
         (tempdir, db_path, server)
     }
 
+    async fn enqueue_prepared_test_ingest_operation(
+        server: &MempalMcpServer,
+        db_path: &Path,
+        content: &str,
+        room: &str,
+    ) -> String {
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: content.to_string(),
+            wing: "mcp".to_string(),
+            room: Some(room.to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        PendingMessageStore::new_without_reclaim(db_path)
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue prepared async ingest")
+    }
+
     #[tokio::test]
     async fn test_query_only_read_preserves_mcp_error_data() {
         let (_tempdir, _db_path, server) = setup_server();
@@ -10698,6 +11190,94 @@ mod tests {
 
         assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
         assert_eq!(error.message, "preserve caller error");
+    }
+
+    #[tokio::test]
+    async fn test_daemon_writer_lease_check_failure_does_not_prove_daemon_ownership() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let missing_db_path = tempdir.path().join("missing-parent/palace.db");
+        let server = MempalMcpServer::new_with_factory(
+            missing_db_path,
+            Arc::new(StubEmbedderFactory {
+                vector: vec![0.1, 0.2, 0.3],
+            }),
+        )
+        .expect("create MCP server with missing db path");
+
+        assert!(
+            !server.daemon_writer_lease_visible_for_ingest_wait().await,
+            "lease visibility check failures must not silently prove daemon ownership"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_background_ingest_starts_local_worker_when_daemon_lease_probe_fails() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server =
+            server.with_daemon_writer_lease_check_error_for_test("forced daemon lease probe error");
+
+        let response = server
+            .mempal_ingest_with_controls(
+                IngestRequest {
+                    content: "background local worker must own queue after lease probe failure"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("lease-probe".to_string()),
+                    wait: Some(false),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("ingest should return a durable receipt")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let completed = tokio::time::timeout(
+            Duration::from_secs(2),
+            server.wait_for_operation_completion(operation_id),
+        )
+        .await
+        .expect("local background worker should complete the operation")
+        .expect("operation should complete");
+
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(!completed.created_drawer_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_scoped_unbounded_wait_processes_locally_when_daemon_lease_probe_fails() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server =
+            server.with_daemon_writer_lease_check_error_for_test("forced daemon lease probe error");
+
+        let response = server
+            .mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped unbounded wait must own queue after lease probe failure"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("lease-probe".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(u64::MAX),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("scoped unbounded wait should complete locally")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(!response.created_drawer_ids.is_empty());
     }
 
     fn hold_sqlite_write_lock(db_path: PathBuf, hold_for: Duration) -> thread::JoinHandle<()> {
@@ -11392,7 +11972,94 @@ quality_policy = "llm_required_for_keep"
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_mcp_ingest_wait_polls_daemon_admitted_operation() {
+    async fn test_mcp_ingest_wait_polls_daemon_admitted_operation_until_terminal() {
+        let (tempdir, db_path, server) = setup_server();
+        let daemon_lease = hold_daemon_writer_lease(&db_path);
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon_db_path = db_path.clone();
+        let daemon_worker = server
+            .clone()
+            .with_external_ingest_writer_lease(daemon_lease.clone());
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            let operation_id = PendingMessageStore::new_without_reclaim(&daemon_db_path)
+                .enqueue_idempotent_with_key(
+                    &request.kind,
+                    &request.payload,
+                    &request.idempotency_key,
+                )
+                .expect("persist daemon-admitted operation");
+            crate::hook_ipc::write_enqueue_response(
+                &mut stream,
+                &crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            )
+            .await
+            .expect("write daemon IPC response");
+            drop(stream);
+
+            let async_queue = AsyncPendingMessageStore::new_without_reclaim(&daemon_db_path);
+            let claim = async_queue
+                .claim_by_id_and_kind_with_lock_retry_deadline(
+                    "test-daemon-ingest-worker".to_string(),
+                    INGEST_CLAIM_TTL_SECS,
+                    operation_id.clone(),
+                    INGEST_ASYNC_KIND.to_string(),
+                    Duration::from_secs(1),
+                )
+                .await
+                .expect("claim daemon-admitted operation")
+                .expect("daemon-admitted operation remains claimable");
+            daemon_worker
+                .process_ingest_claim(&async_queue, "test-daemon-ingest-worker", claim)
+                .await
+                .expect("daemon worker completes admitted operation");
+            (request, operation_id)
+        });
+
+        let response = server
+            .mempal_ingest_with_controls(
+                IngestRequest {
+                    content: "daemon-admitted MCP wait returns terminal status".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("daemon-complete".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(u64::MAX),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("daemon-admitted wait should poll until terminal")
+            .0;
+
+        let (request, operation_id) = daemon.await.expect("daemon IPC task");
+        let response_operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        assert_eq!(response_operation_id, operation_id);
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "terminal daemon-backed wait should include created drawer ids"
+        );
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(response_operation_id)
+            .expect("query completed operation")
+            .expect("completed operation");
+        assert_eq!(record.op_state, IngestOperationState::Completed.as_str());
+        release_test_ingest_writer_lease(&db_path, &daemon_lease);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_daemon_admitted_timeout_uses_caller_budget() {
         let (tempdir, db_path, server) = setup_server();
         let daemon_lease = hold_daemon_writer_lease(&db_path);
         let (listener, _socket_guard) =
@@ -11419,11 +12086,12 @@ quality_policy = "llm_required_for_keep"
             (request, operation_id)
         });
 
+        let started = tokio::time::Instant::now();
         let response = server
             .mempal_ingest(Parameters(IngestRequest {
-                content: "daemon-admitted MCP wait must not self-claim".to_string(),
+                content: "daemon-admitted MCP wait timeout honors caller budget".to_string(),
                 wing: "mcp".to_string(),
-                room: Some("busy".to_string()),
+                room: Some("daemon-timeout".to_string()),
                 wait: Some(true),
                 wait_timeout_secs: Some(1),
                 ..IngestRequest::default()
@@ -11439,12 +12107,253 @@ quality_policy = "llm_required_for_keep"
         assert_eq!(response.state, Some(IngestOperationState::Queued));
         assert!(response.timed_out);
         assert!(response.created_drawer_ids.is_empty());
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(750),
+            "daemon-backed MCP wait returned before spending the caller timeout budget: {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "daemon-backed MCP wait exceeded the caller timeout budget by too much: {elapsed:?}"
+        );
         let record = PendingMessageStore::new_without_reclaim(&db_path)
             .operation_status(response_operation_id)
             .expect("query queued operation")
             .expect("queued operation");
         assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
         release_test_ingest_writer_lease(&db_path, &daemon_lease);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_defers_local_admission_to_live_daemon_lease() {
+        let (_tempdir, db_path, server) = setup_server();
+        let daemon_lease = hold_daemon_writer_lease(&db_path);
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "local fallback under daemon lease must not self-claim".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(true),
+                wait_timeout_secs: Some(1),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("wait should return a receipt instead of locally processing under daemon lease")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.created_drawer_ids.is_empty());
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query queued operation")
+            .expect("queued operation");
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        release_test_ingest_writer_lease(&db_path, &daemon_lease);
+    }
+
+    #[tokio::test]
+    async fn test_unbounded_scoped_wait_keeps_polling_after_writer_lease_conflict() {
+        let (_tempdir, db_path, server) = setup_server();
+        let daemon_lease = hold_daemon_writer_lease(&db_path);
+        let operation_id = enqueue_prepared_test_ingest_operation(
+            &server,
+            &db_path,
+            "unbounded wait must not report queued success under writer lease conflict",
+            "lease-conflict",
+        )
+        .await;
+        let waiter = {
+            let server = server.clone();
+            let operation_id = operation_id.clone();
+            tokio::spawn(async move {
+                server
+                    .wait_for_operation_status_with_scoped_worker_until_terminal(
+                        &operation_id,
+                        Duration::from_secs(8),
+                        Duration::from_millis(25),
+                    )
+                    .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        assert!(
+            !waiter.is_finished(),
+            "unbounded terminal wait must not return a queued status as success"
+        );
+
+        release_test_ingest_writer_lease(&db_path, &daemon_lease);
+        let response = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should finish after writer lease releases")
+            .expect("waiter task should not panic")
+            .expect("wait should not error")
+            .expect("operation should reach a terminal response");
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "terminal recovery must expose cleanup-safe drawer ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unbounded_scoped_wait_retries_transient_claim_sqlite_lock() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_claim_lock_failures_for_test(2);
+        let server = server.with_async_queue_for_test(async_queue);
+        let operation_id = enqueue_prepared_test_ingest_operation(
+            &server,
+            &db_path,
+            "unbounded wait must retry transient claim SQLite locks",
+            "claim-lock",
+        )
+        .await;
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(10),
+            server.wait_for_operation_status_with_scoped_worker_until_terminal(
+                &operation_id,
+                Duration::from_secs(10),
+                Duration::from_millis(25),
+            ),
+        )
+        .await
+        .expect("unbounded wait should keep retrying after transient claim locks")
+        .expect("wait should not error")
+        .expect("operation should reach a terminal response");
+
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "terminal response must expose cleanup-safe drawer ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_scoped_finite_wait_processes_local_queue() {
+        let (_tempdir, db_path, server) = setup_server();
+
+        let response = server
+            .mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "finite scoped wait should process local queued work".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("finite-wait".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(30),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("finite scoped wait should complete local work")
+            .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "finite wait must return cleanup-safe created ids"
+        );
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query completed operation")
+            .expect("completed operation");
+        assert_eq!(record.op_state, IngestOperationState::Completed.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_scoped_wait_over_processing_threshold_returns_timeout_receipt() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server.with_ingest_processing_delay_for_test(Duration::from_secs(7));
+
+        let started = Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_millis(6_800),
+            server.mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped wait timeout must not start slow inline processing"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("scoped-timeout".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(6),
+                    ..IngestRequest::default()
+                },
+                IngestControls::default(),
+            ),
+        )
+        .await
+        .expect("scoped wait must return within the caller timeout budget")
+        .expect("scoped wait should return a timeout receipt")
+        .0;
+
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(
+            started.elapsed() < Duration::from_millis(6_800),
+            "scoped wait blocked until slow processing completed"
+        );
+
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query operation")
+            .expect("operation should still exist");
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        assert!(
+            record.claimed_at.is_none(),
+            "caller-bounded scoped wait must not leave a claim it cannot finish safely"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_scoped_wait_rejects_timeout_receipt_when_claim_release_is_locked() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_release_lock_failures_for_test(100);
+        let server = server
+            .with_async_queue_for_test(async_queue)
+            .with_ingest_processing_delay_for_test(Duration::from_secs(7));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(6_800),
+            server.mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped wait must not return receipt when release is locked"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("scoped-timeout".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(6),
+                    ..IngestRequest::default()
+                },
+                IngestControls::default(),
+            ),
+        )
+        .await
+        .expect("scoped wait must stay within the caller timeout budget");
+        let error = match result {
+            Ok(_) => panic!("release lock failure must not return a timeout receipt"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .message
+                .contains("failed to release timed-out scoped ingest claim"),
+            "{}",
+            error.message
+        );
     }
 
     #[tokio::test]
@@ -12265,19 +13174,14 @@ pattern_boost = 0.2
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_mcp_ingest_scoped_late_claim_release_retries_before_timeout_receipt() {
+    async fn test_mcp_ingest_scoped_short_budget_skips_claim_before_timeout_receipt() {
         let (_tempdir, db_path, server) = setup_server();
-        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
-            .with_release_lock_failures_for_test(2);
-        let server = server
-            .with_async_queue_for_test(async_queue)
-            .with_ingest_processing_delay_for_test(Duration::from_millis(1500));
 
         let response = tokio::time::timeout(
             Duration::from_millis(2500),
             server.mempal_ingest_with_controls_scoped_worker(
                 IngestRequest {
-                    content: "scoped wait must release a late queue claim before timeout receipt"
+                    content: "scoped wait must skip local claim when timeout budget is too short"
                         .to_string(),
                     wing: "mcp".to_string(),
                     room: Some("receipt".to_string()),
@@ -12290,7 +13194,7 @@ pattern_boost = 0.2
             ),
         )
         .await
-        .expect("scoped ingest should release a late claim before returning a timeout receipt")
+        .expect("scoped ingest should skip local claim before returning a timeout receipt")
         .expect("scoped ingest should return a timeout receipt")
         .0;
         let operation_id = response
@@ -12308,26 +13212,24 @@ pattern_boost = 0.2
             .expect("operation must stay queryable");
         assert!(
             record.claimed_at.is_none(),
-            "timeout receipt must not depend on a detached cleanup task that stdio shutdown can abort"
+            "short-budget timeout receipt must not claim work that stdio shutdown can abort"
         );
         assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn test_mcp_ingest_scoped_timeout_release_lock_budget_does_not_block_receipt() {
+    async fn test_mcp_ingest_scoped_short_budget_ignores_release_lock_failures() {
         let (_tempdir, db_path, server) = setup_server();
         let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
             .with_release_lock_failures_for_test(100);
-        let server = server
-            .with_async_queue_for_test(async_queue)
-            .with_ingest_processing_delay_for_test(Duration::from_millis(1500));
+        let server = server.with_async_queue_for_test(async_queue);
 
         let started = Instant::now();
         let response = tokio::time::timeout(
             Duration::from_millis(1800),
             server.mempal_ingest_with_controls_scoped_worker(
                 IngestRequest {
-                    content: "scoped wait release must honor caller timeout budget".to_string(),
+                    content: "scoped wait short budget must avoid claim release work".to_string(),
                     wing: "mcp".to_string(),
                     room: Some("receipt".to_string()),
                     dry_run: Some(false),
@@ -12339,17 +13241,15 @@ pattern_boost = 0.2
             ),
         )
         .await
-        .expect("scoped timeout release must not retry until the 300s claim TTL")
-        .expect(
-            "scoped ingest should return a timeout receipt when cleanup lock budget is exhausted",
-        )
+        .expect("scoped short-budget wait must not enter claim release retry")
+        .expect("scoped ingest should return a timeout receipt")
         .0;
 
         assert!(response.timed_out);
         assert!(response.operation_id.is_some());
         assert!(
             started.elapsed() < Duration::from_millis(1500),
-            "timeout cleanup exceeded the caller wait budget"
+            "short-budget timeout exceeded the caller wait budget"
         );
 
         let operation_id = response
@@ -12359,8 +13259,8 @@ pattern_boost = 0.2
             .operation_status(&operation_id)
             .expect("load operation status")
             .expect("operation must stay queryable");
-        assert_eq!(record.op_state, IngestOperationState::Running.as_str());
-        assert!(record.claimed_at.is_some());
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        assert!(record.claimed_at.is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -15415,7 +16315,7 @@ pattern_boost = 0.2
                     wing: "mempal".to_string(),
                     room: Some("replace".to_string()),
                     wait: Some(true),
-                    wait_timeout_secs: Some(30),
+                    wait_timeout_secs: Some(u64::MAX),
                     ..IngestRequest::default()
                 },
                 IngestControls {
@@ -15467,7 +16367,7 @@ pattern_boost = 0.2
                 room: Some("replace".to_string()),
                 supersedes: Some(old.drawer_id.clone()),
                 wait: Some(true),
-                wait_timeout_secs: Some(30),
+                wait_timeout_secs: Some(u64::MAX),
                 ..IngestRequest::default()
             }))
             .await
@@ -15506,12 +16406,12 @@ pattern_boost = 0.2
     }
 
     #[tokio::test]
-    async fn test_mcp_delete_rejects_existing_content_writer_lease() {
+    async fn test_mcp_delete_succeeds_under_daemon_writer_lease() {
         let (_tempdir, db_path, server) = setup_server();
         insert_drawer(
             &db_path,
             "mcp-delete-lease-target",
-            "delete target must survive lease conflict",
+            "delete target should be cleanup-safe under daemon lease",
             "mcp",
             Some("lease"),
             "/tmp/mcp-delete.md",
@@ -15519,20 +16419,18 @@ pattern_boost = 0.2
         );
         let _daemon_lease = hold_daemon_writer_lease(&db_path);
 
-        let error = match server
+        let delete = server
             .mempal_delete(Parameters(DeleteRequest {
                 drawer_id: "mcp-delete-lease-target".to_string(),
             }))
             .await
-        {
-            Ok(_) => panic!("delete must reject under daemon writer lease"),
-            Err(error) => error,
-        };
+            .expect("MCP delete should not require the runtime writer lease")
+            .0;
 
-        assert_writer_lease_conflict(&error);
+        assert!(delete.deleted);
         let db = Database::open(&db_path).expect("open db");
         assert!(
-            db.drawer_exists("mcp-delete-lease-target")
+            !db.drawer_exists("mcp-delete-lease-target")
                 .expect("drawer exists")
         );
     }
@@ -16749,7 +17647,7 @@ pattern_boost = 0.2
                     wing: "mcp".to_string(),
                     room: Some("current-lock".to_string()),
                     wait: Some(true),
-                    wait_timeout_secs: Some(5),
+                    wait_timeout_secs: Some(u64::MAX),
                     ..IngestRequest::default()
                 },
                 IngestControls {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -181,6 +181,9 @@ const MCP_INGEST_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_CONTENT_WRITER_LEASE_TTL_SECS: u64 = 120;
 const MCP_INGEST_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
 const MCP_CONTENT_WRITER_LEASE_RENEW_INTERVAL: Duration = Duration::from_secs(30);
+const MCP_WRITER_LEASE_RENEW_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
+const MCP_WRITER_LEASE_RENEW_RETRY_DEADLINE: Duration = Duration::from_secs(5);
+const MCP_WRITER_LEASE_RENEW_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn mcp_ingest_idempotency_key(payload: &str) -> String {
     let now_ns = match SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -1202,13 +1205,7 @@ impl MempalMcpServer {
                         let db_path = db_path.clone();
                         let lease_for_renew = lease.clone();
                         let renew_result = tokio::task::spawn_blocking(move || {
-                            let db = Database::open(&db_path)?;
-                            db.runtime_writer_lease_renew(
-                                &lease_for_renew.name,
-                                &lease_for_renew.owner,
-                                &lease_for_renew.session_id,
-                                ttl_secs,
-                            )
+                            renew_mcp_writer_lease_with_retry(&db_path, &lease_for_renew, ttl_secs)
                         })
                         .await;
                         match renew_result {
@@ -2130,6 +2127,35 @@ fn anyhow_chain_contains_sqlite_lock(error: &anyhow::Error) -> bool {
                     matches!(db_error, crate::core::db::DbError::Sqlite(error) if rusqlite_error_is_lock(error))
                 })
     })
+}
+
+fn renew_mcp_writer_lease_with_retry(
+    db_path: &Path,
+    lease: &RuntimeWriterLease,
+    ttl_secs: u64,
+) -> anyhow::Result<bool> {
+    let started = Instant::now();
+    loop {
+        match renew_mcp_writer_lease_once(db_path, lease, ttl_secs) {
+            Ok(renewed) => return Ok(renewed),
+            Err(error)
+                if anyhow_chain_contains_sqlite_lock(&error)
+                    && started.elapsed() < MCP_WRITER_LEASE_RENEW_RETRY_DEADLINE =>
+            {
+                std::thread::sleep(MCP_WRITER_LEASE_RENEW_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn renew_mcp_writer_lease_once(
+    db_path: &Path,
+    lease: &RuntimeWriterLease,
+    ttl_secs: u64,
+) -> anyhow::Result<bool> {
+    let db = Database::open_with_busy_timeout(db_path, MCP_WRITER_LEASE_RENEW_BUSY_TIMEOUT)?;
+    Ok(db.runtime_writer_lease_renew(&lease.name, &lease.owner, &lease.session_id, ttl_secs)?)
 }
 
 fn resolve_mcp_ingest_controls(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2451,22 +2451,10 @@ enum IngestQueueProcessor {
     Local,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum DaemonIngestEnqueue {
-    Accepted,
+    Accepted { operation_id: String },
     Fallback { may_have_reached_daemon: bool },
-}
-
-impl DaemonIngestEnqueue {
-    fn may_have_reached_daemon(self) -> bool {
-        matches!(
-            self,
-            Self::Accepted
-                | Self::Fallback {
-                    may_have_reached_daemon: true
-                }
-        )
-    }
 }
 
 fn should_defer_local_ingest_to_daemon(
@@ -5308,17 +5296,18 @@ impl MempalMcpServer {
         let daemon_enqueue = self
             .try_enqueue_ingest_operation_via_daemon(payload.clone(), idempotency_key.clone())
             .await?;
-        if matches!(daemon_enqueue, DaemonIngestEnqueue::Accepted) {
-            let operation_id =
-                PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
-            return Ok(IngestQueueAdmission {
-                operation_id,
-                processor: IngestQueueProcessor::Daemon,
-                daemon_enqueue_may_have_reached: true,
-            });
-        }
-
-        let daemon_enqueue_may_have_reached = daemon_enqueue.may_have_reached_daemon();
+        let daemon_enqueue_may_have_reached = match daemon_enqueue {
+            DaemonIngestEnqueue::Accepted { operation_id } => {
+                return Ok(IngestQueueAdmission {
+                    operation_id,
+                    processor: IngestQueueProcessor::Daemon,
+                    daemon_enqueue_may_have_reached: true,
+                });
+            }
+            DaemonIngestEnqueue::Fallback {
+                may_have_reached_daemon,
+            } => may_have_reached_daemon,
+        };
         let operation_id = match self
             .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key.clone())
             .await
@@ -5330,10 +5319,18 @@ impl MempalMcpServer {
                     daemon_enqueue_may_have_reached,
                     &error,
                 ) {
+                    if !self
+                        .daemon_admitted_operation_is_visible(&admission.operation_id)
+                        .await?
+                    {
+                        return Err(error.context(
+                            "daemon enqueue may have reached daemon but no queryable operation row was visible",
+                        ));
+                    }
                     tracing::warn!(
                         operation_id = %admission.operation_id,
                         error = %error,
-                        "local ingest queue admission failed after daemon enqueue may have reached daemon; preserving operation receipt"
+                        "local ingest queue admission failed after daemon enqueue may have reached daemon; returning verified operation receipt"
                     );
                     return Ok(admission);
                 }
@@ -5429,7 +5426,7 @@ impl MempalMcpServer {
         let request = crate::hook_ipc::HookIpcEnqueueRequest {
             kind: INGEST_ASYNC_KIND.to_string(),
             payload,
-            idempotency_key,
+            idempotency_key: idempotency_key.clone(),
         };
         let outcome = tokio::task::spawn_blocking(move || {
             crate::hook_ipc::enqueue_with_timeout(
@@ -5442,7 +5439,24 @@ impl MempalMcpServer {
         .context("blocking daemon ingest enqueue IPC failed")?;
 
         match outcome {
-            crate::hook_ipc::HookIpcClientOutcome::Accepted => Ok(DaemonIngestEnqueue::Accepted),
+            crate::hook_ipc::HookIpcClientOutcome::Accepted => {
+                let operation_id =
+                    PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
+                if self
+                    .daemon_admitted_operation_is_visible(&operation_id)
+                    .await?
+                {
+                    Ok(DaemonIngestEnqueue::Accepted { operation_id })
+                } else {
+                    tracing::warn!(
+                        operation_id,
+                        "daemon ingest enqueue ACK did not expose a queryable operation row; falling back to local idempotent admission"
+                    );
+                    Ok(DaemonIngestEnqueue::Fallback {
+                        may_have_reached_daemon: true,
+                    })
+                }
+            }
             crate::hook_ipc::HookIpcClientOutcome::Fallback(reason) => {
                 let may_have_reached_daemon = reason.may_have_reached_daemon();
                 tracing::debug!(
@@ -5453,6 +5467,35 @@ impl MempalMcpServer {
                 Ok(DaemonIngestEnqueue::Fallback {
                     may_have_reached_daemon,
                 })
+            }
+        }
+    }
+
+    async fn daemon_admitted_operation_is_visible(
+        &self,
+        operation_id: &str,
+    ) -> anyhow::Result<bool> {
+        let deadline = Instant::now() + MCP_OPERATION_STATUS_DEADLINE;
+        loop {
+            match self
+                .async_queue
+                .operation_status(operation_id.to_string())
+                .await
+            {
+                Ok(Some(_)) => return Ok(true),
+                Ok(None) => return Ok(false),
+                Err(error) if error.is_sqlite_lock() && Instant::now() < deadline => {
+                    tokio::time::sleep(
+                        MCP_INGEST_QUEUE_LOCK_RETRY_DELAY
+                            .min(deadline.saturating_duration_since(Instant::now())),
+                    )
+                    .await;
+                }
+                Err(error) if error.is_sqlite_lock() => return Ok(false),
+                Err(error) => {
+                    return Err(anyhow::Error::new(error)
+                        .context("failed to verify daemon-admitted ingest operation"));
+                }
             }
         }
     }
@@ -10968,6 +11011,62 @@ quality_policy = "llm_required_for_keep"
         let (tempdir, db_path, server) = setup_server();
         let (listener, _socket_guard) =
             crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon_db_path = db_path.clone();
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            let operation_id = PendingMessageStore::new_without_reclaim(&daemon_db_path)
+                .enqueue_idempotent_with_key(
+                    &request.kind,
+                    &request.payload,
+                    &request.idempotency_key,
+                )
+                .expect("persist daemon-admitted operation");
+            crate::hook_ipc::write_enqueue_response(
+                &mut stream,
+                &crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            )
+            .await
+            .expect("write daemon IPC response");
+            (request, operation_id)
+        });
+
+        let response = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "daemon-owned MCP queue admission".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("busy".to_string()),
+                wait: Some(false),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("ingest admission should succeed")
+            .0;
+
+        let (request, persisted_operation_id) = daemon.await.expect("daemon IPC task");
+        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        assert_eq!(operation_id, persisted_operation_id);
+        assert_eq!(
+            operation_id,
+            PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &request.idempotency_key)
+        );
+        let local_record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query queue")
+            .expect("daemon-accepted operation must be status-queryable");
+        assert_eq!(local_record.id, operation_id);
+        assert_eq!(local_record.op_state, IngestOperationState::Queued.as_str());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_falls_back_when_daemon_ack_lacks_queryable_operation() {
+        let (tempdir, db_path, server) = setup_server();
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
         let daemon = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
             let request = crate::hook_ipc::read_enqueue_request(&mut stream)
@@ -10984,30 +11083,32 @@ quality_policy = "llm_required_for_keep"
 
         let response = server
             .mempal_ingest(Parameters(IngestRequest {
-                content: "daemon-owned MCP queue admission".to_string(),
+                content: "daemon ACK without durable operation must use local admission"
+                    .to_string(),
                 wing: "mcp".to_string(),
-                room: Some("busy".to_string()),
-                wait: Some(false),
+                room: Some("receipt".to_string()),
+                wait: Some(true),
+                wait_timeout_secs: Some(0),
                 ..IngestRequest::default()
             }))
             .await
-            .expect("ingest admission should succeed")
+            .expect("ingest admission should recover with local idempotent enqueue")
             .0;
 
         let request = daemon.await.expect("daemon IPC task");
-        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
         let operation_id = response.operation_id.as_deref().expect("operation id");
         assert_eq!(
             operation_id,
             PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &request.idempotency_key)
         );
-        let local_record = PendingMessageStore::new_without_reclaim(&db_path)
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
             .operation_status(operation_id)
-            .expect("query local queue");
-        assert!(
-            local_record.is_none(),
-            "MCP admission should not write the local queue when daemon IPC accepts"
-        );
+            .expect("query operation")
+            .expect("returned operation id must be queryable");
+        assert_eq!(record.id, operation_id);
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
     }
 
     #[cfg(unix)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1651,19 +1651,30 @@ impl MempalMcpServer {
                 return Ok(None);
             }
 
-            match tokio::time::timeout(
-                remaining,
-                queue.claim_by_id_and_kind(
-                    worker_id.clone(),
-                    INGEST_CLAIM_TTL_SECS,
-                    operation_id.to_string(),
-                    INGEST_ASYNC_KIND.to_string(),
-                ),
-            )
-            .await
-            {
-                Err(_) => return Ok(None),
-                Ok(Ok(Some(claim))) => {
+            let mut claim_task = tokio::spawn({
+                let queue = queue.clone();
+                let worker_id = worker_id.clone();
+                let operation_id = operation_id.to_string();
+                async move {
+                    queue
+                        .claim_by_id_and_kind(
+                            worker_id,
+                            INGEST_CLAIM_TTL_SECS,
+                            operation_id,
+                            INGEST_ASYNC_KIND.to_string(),
+                        )
+                        .await
+                }
+            });
+            tokio::select! {
+                result = &mut claim_task => match result {
+                    Err(error) => {
+                        return Err(ErrorData::internal_error(
+                            format!("scoped async ingest worker claim task failed: {error}"),
+                            None,
+                        ));
+                    }
+                    Ok(Ok(Some(claim))) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
                         Self::release_scoped_claim_after_timeout(&queue, claim).await?;
@@ -1688,21 +1699,56 @@ impl MempalMcpServer {
                         }
                     }
                 }
-                Ok(Ok(None)) => {
+                    Ok(Ok(None)) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
                         return Ok(None);
                     }
                     tokio::time::sleep(poll_interval.min(remaining)).await;
                 }
-                Ok(Err(error)) => {
+                    Ok(Err(error)) => {
                     return Err(ErrorData::internal_error(
                         format!("scoped async ingest worker claim failed: {error}"),
                         None,
                     ));
                 }
+                },
+                _ = tokio::time::sleep(remaining) => {
+                    Self::release_late_scoped_claim_after_timeout(queue.clone(), claim_task);
+                    return Ok(None);
+                }
             }
         }
+    }
+
+    fn release_late_scoped_claim_after_timeout(
+        queue: AsyncPendingMessageStore,
+        claim_task: tokio::task::JoinHandle<crate::core::queue::Result<Option<ClaimedMessage>>>,
+    ) {
+        let _release_task = tokio::spawn(async move {
+            match claim_task.await {
+                Ok(Ok(Some(claim))) => {
+                    if let Err(error) =
+                        Self::release_scoped_claim_after_timeout(&queue, claim).await
+                    {
+                        tracing::warn!(?error, "failed to release late scoped ingest claim");
+                    }
+                }
+                Ok(Ok(None)) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        ?error,
+                        "late scoped ingest claim failed after caller timeout"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "late scoped ingest claim task failed after caller timeout"
+                    );
+                }
+            }
+        });
     }
 
     async fn release_scoped_claim_after_timeout(
@@ -12110,6 +12156,60 @@ pattern_boost = 0.2
             started.elapsed() < Duration::from_millis(250),
             "scoped ingest performed an unbudgeted status refresh after wait budget exhaustion"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_scoped_late_claim_is_released_after_timeout() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_claim_blocking_delay(Duration::from_millis(1500));
+        let server = server.with_async_queue_for_test(async_queue);
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(1300),
+            server.mempal_ingest_with_controls_scoped_worker(
+                IngestRequest {
+                    content: "scoped wait must release a late queue claim after timeout"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("receipt".to_string()),
+                    dry_run: Some(false),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(1),
+                    ..IngestRequest::default()
+                },
+                IngestControls::default(),
+            ),
+        )
+        .await
+        .expect("scoped ingest must respect the caller wait timeout while claim is slow")
+        .expect("scoped ingest should return a timeout receipt")
+        .0;
+        let operation_id = response
+            .operation_id
+            .as_deref()
+            .expect("timeout receipt must include operation id")
+            .to_string();
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.created_drawer_ids.is_empty());
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let record = PendingMessageStore::new_without_reclaim(&db_path)
+                    .operation_status(&operation_id)
+                    .expect("load operation status")
+                    .expect("operation must stay queryable");
+                if record.claimed_at.is_none()
+                    && record.op_state == IngestOperationState::Queued.as_str()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("late scoped claim should be released instead of waiting for claim TTL");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5475,27 +5475,36 @@ impl MempalMcpServer {
         &self,
         operation_id: &str,
     ) -> anyhow::Result<bool> {
-        let deadline = Instant::now() + MCP_OPERATION_STATUS_DEADLINE;
+        let deadline = Instant::now() + self.operation_status_deadline;
         loop {
-            match self
-                .async_queue
-                .operation_status(operation_id.to_string())
-                .await
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
+
+            match tokio::time::timeout(
+                remaining,
+                self.async_queue.operation_status(operation_id.to_string()),
+            )
+            .await
             {
-                Ok(Some(_)) => return Ok(true),
-                Ok(None) => return Ok(false),
-                Err(error) if error.is_sqlite_lock() && Instant::now() < deadline => {
-                    tokio::time::sleep(
-                        MCP_INGEST_QUEUE_LOCK_RETRY_DELAY
-                            .min(deadline.saturating_duration_since(Instant::now())),
-                    )
-                    .await;
-                }
-                Err(error) if error.is_sqlite_lock() => return Ok(false),
-                Err(error) => {
-                    return Err(anyhow::Error::new(error)
-                        .context("failed to verify daemon-admitted ingest operation"));
-                }
+                Err(_) => return Ok(false),
+                Ok(result) => match result {
+                    Ok(Some(_)) => return Ok(true),
+                    Ok(None) => return Ok(false),
+                    Err(error) if error.is_sqlite_lock() && Instant::now() < deadline => {
+                        tokio::time::sleep(
+                            MCP_INGEST_QUEUE_LOCK_RETRY_DELAY
+                                .min(deadline.saturating_duration_since(Instant::now())),
+                        )
+                        .await;
+                    }
+                    Err(error) if error.is_sqlite_lock() => return Ok(false),
+                    Err(error) => {
+                        return Err(anyhow::Error::new(error)
+                            .context("failed to verify daemon-admitted ingest operation"));
+                    }
+                },
             }
         }
     }
@@ -11109,6 +11118,31 @@ quality_policy = "llm_required_for_keep"
             .expect("returned operation id must be queryable");
         assert_eq!(record.id, operation_id);
         assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_daemon_admitted_operation_visibility_uses_status_deadline() {
+        let (_tempdir, db_path, server) = setup_server();
+        let delayed_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_blocking_delay(Duration::from_millis(500));
+        let server = server
+            .with_async_queue_for_test(delayed_queue)
+            .with_mcp_deadline_for_test(Duration::from_millis(25));
+
+        let started = tokio::time::Instant::now();
+        let visible = tokio::time::timeout(
+            Duration::from_millis(200),
+            server.daemon_admitted_operation_is_visible("missing-operation"),
+        )
+        .await
+        .expect("visibility check must not inherit the queue busy/blocking budget")
+        .expect("visibility check should return a bounded fallback result");
+
+        assert!(!visible);
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "visibility check exceeded its MCP status deadline budget"
+        );
     }
 
     #[cfg(unix)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5073,6 +5073,7 @@ impl MempalMcpServer {
         controls: IngestControls,
         worker_mode: IngestWaitWorkerMode,
     ) -> std::result::Result<Json<IngestResponse>, ErrorData> {
+        let request_started_at = Instant::now();
         let dry_run = request.dry_run.unwrap_or(false);
         let controls = resolve_mcp_ingest_controls(&request, controls)?;
         if !dry_run && global_embed_status().should_block_writes() {
@@ -5225,17 +5226,31 @@ impl MempalMcpServer {
                 .operation_id
                 .as_deref()
                 .expect("queued receipt must include operation id");
-            let wait_result = if wait_timeout_secs > 0 && use_local_ingest_worker {
+            let wait_timeout = Duration::from_secs(wait_timeout_secs);
+            let wait_remaining = wait_timeout
+                .checked_sub(request_started_at.elapsed())
+                .unwrap_or_default();
+            let wait_result = if wait_timeout_secs == 0 {
+                self.wait_for_operation_status_with_lookup_policy(
+                    operation_id,
+                    Duration::ZERO,
+                    Duration::from_millis(150),
+                    queue_admission.daemon_enqueue_may_have_reached,
+                )
+                .await
+            } else if wait_remaining.is_zero() {
+                Ok(None)
+            } else if use_local_ingest_worker {
                 self.wait_for_operation_status_with_scoped_worker(
                     operation_id,
-                    Duration::from_secs(wait_timeout_secs),
+                    wait_remaining,
                     Duration::from_millis(150),
                 )
                 .await
             } else {
                 self.wait_for_operation_status_with_lookup_policy(
                     operation_id,
-                    Duration::from_secs(wait_timeout_secs),
+                    wait_remaining,
                     Duration::from_millis(150),
                     queue_admission.daemon_enqueue_may_have_reached,
                 )
@@ -11807,6 +11822,36 @@ pattern_boost = 0.2
             .expect("operation must be durable when receipt is returned");
         assert_eq!(record.id, operation_id);
         assert_eq!(record.kind, INGEST_ASYNC_KIND);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_ingest_wait_budget_includes_queue_admission() {
+        let (_tempdir, db_path, server) = setup_server();
+        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_blocking_delay(Duration::from_millis(1200));
+        let server = server.with_async_queue_for_test(async_queue);
+
+        let response = tokio::time::timeout(
+            Duration::from_millis(1700),
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "slow queue admission should not extend MCP wait budget".to_string(),
+                wing: "mcp".to_string(),
+                room: Some("receipt".to_string()),
+                dry_run: Some(false),
+                wait: Some(true),
+                wait_timeout_secs: Some(1),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("MCP ingest should return the queued receipt without a second slow status lookup")
+        .expect("slow queue admission should still return a receipt")
+        .0;
+
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.operation_id.is_some());
+        assert!(response.created_drawer_ids.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1508,6 +1508,24 @@ impl MempalMcpServer {
         .map(|response| response.0)
     }
 
+    async fn operation_status_json_within(
+        &self,
+        operation_id: &str,
+        timeout: Duration,
+    ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
+        let timeout = clamp_wait_timeout(timeout);
+        if timeout.is_zero() {
+            return Ok(None);
+        }
+
+        match tokio::time::timeout(timeout, self.operation_status_json_for_test(operation_id)).await
+        {
+            Ok(Ok(response)) => Ok(Some(response)),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Ok(None),
+        }
+    }
+
     pub async fn wait_for_operation_status(
         &self,
         operation_id: &str,
@@ -1530,10 +1548,19 @@ impl MempalMcpServer {
         poll_interval: Duration,
         allow_pending_admission_lookup: bool,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
-        let deadline = Instant::now() + clamp_wait_timeout(timeout);
+        let timeout = clamp_wait_timeout(timeout);
+        let deadline = Instant::now() + timeout;
         loop {
-            match self.operation_status_json_for_test(operation_id).await {
-                Ok(response) => {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+
+            match self
+                .operation_status_json_within(operation_id, remaining)
+                .await
+            {
+                Ok(Some(response)) => {
                     if response
                         .state
                         .map(IngestOperationState::is_terminal)
@@ -1542,6 +1569,7 @@ impl MempalMcpServer {
                         return Ok(Some(response));
                     }
                 }
+                Ok(None) => return Ok(None),
                 Err(error)
                     if mcp_operation_wait_error_is_ignorable_during_wait(
                         &error,
@@ -1549,10 +1577,12 @@ impl MempalMcpServer {
                     ) => {}
                 Err(error) => return Err(error),
             }
-            if timeout.is_zero() || Instant::now() >= deadline {
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
                 return Ok(None);
             }
-            tokio::time::sleep(poll_interval).await;
+            tokio::time::sleep(poll_interval.min(remaining)).await;
         }
     }
 
@@ -1579,8 +1609,16 @@ impl MempalMcpServer {
         let queue = self.async_queue.clone();
 
         loop {
-            match self.operation_status_json_for_test(operation_id).await {
-                Ok(response) => {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+
+            match self
+                .operation_status_json_within(operation_id, remaining)
+                .await
+            {
+                Ok(Some(response)) => {
                     if response
                         .state
                         .map(IngestOperationState::is_terminal)
@@ -1589,23 +1627,29 @@ impl MempalMcpServer {
                         return Ok(Some(response));
                     }
                 }
+                Ok(None) => return Ok(None),
                 Err(error) if mcp_operation_wait_error_is_transient_lookup(&error) => {}
                 Err(error) => return Err(error),
             }
-            if timeout.is_zero() || Instant::now() >= deadline {
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
                 return Ok(None);
             }
 
-            match queue
-                .claim_by_id_and_kind(
+            match tokio::time::timeout(
+                remaining,
+                queue.claim_by_id_and_kind(
                     worker_id.clone(),
                     INGEST_CLAIM_TTL_SECS,
                     operation_id.to_string(),
                     INGEST_ASYNC_KIND.to_string(),
-                )
-                .await
+                ),
+            )
+            .await
             {
-                Ok(Some(claim)) => {
+                Err(_) => return Ok(None),
+                Ok(Ok(Some(claim))) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
                         Self::release_scoped_claim_after_timeout(&queue, claim).await?;
@@ -1630,14 +1674,14 @@ impl MempalMcpServer {
                         }
                     }
                 }
-                Ok(None) => {
+                Ok(Ok(None)) => {
                     let remaining = deadline.saturating_duration_since(Instant::now());
                     if remaining.is_zero() {
                         return Ok(None);
                     }
                     tokio::time::sleep(poll_interval.min(remaining)).await;
                 }
-                Err(error) => {
+                Ok(Err(error)) => {
                     return Err(ErrorData::internal_error(
                         format!("scoped async ingest worker claim failed: {error}"),
                         None,
@@ -11142,6 +11186,36 @@ quality_policy = "llm_required_for_keep"
         assert!(
             started.elapsed() < Duration::from_millis(200),
             "visibility check exceeded its MCP status deadline budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_operation_wait_bounds_status_probe_by_wait_timeout() {
+        let (_tempdir, db_path, server) = setup_server();
+        let operation_id = PendingMessageStore::new_without_reclaim(&db_path)
+            .enqueue(INGEST_ASYNC_KIND, "{}")
+            .expect("enqueue operation");
+        let delayed_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
+            .with_blocking_delay(Duration::from_millis(500));
+        let server = server.with_async_queue_for_test(delayed_queue);
+
+        let started = tokio::time::Instant::now();
+        let response = tokio::time::timeout(
+            Duration::from_millis(200),
+            server.wait_for_operation_status(
+                &operation_id,
+                Duration::from_millis(25),
+                Duration::from_millis(5),
+            ),
+        )
+        .await
+        .expect("operation wait must stay within the caller budget")
+        .expect("operation wait should return a bounded timeout receipt state");
+
+        assert!(response.is_none());
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "operation wait inherited the slower status lookup budget"
         );
     }
 

--- a/tests/write_wait_cli.rs
+++ b/tests/write_wait_cli.rs
@@ -457,7 +457,7 @@ async fn test_ingest_wait_matches_non_wait_plain_output() {
     handle.set_embedding_fill(1.0).await;
     let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
     let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
-    let wait_timeout = u64::MAX.to_string();
+    let wait_timeout = "30".to_string();
     let payload = br#"{"content":"cli wait content"}"#;
 
     let direct_output = run_cli_with_stdin(
@@ -534,7 +534,7 @@ async fn test_ingest_wait_json_matches_non_wait_json_output() {
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let _wait_config = write_config(wait_home.path(), &format!("http://{addr}/v1"));
     let _direct_config = write_config(direct_home.path(), &format!("http://{addr}/v1"));
-    let wait_timeout = u64::MAX.to_string();
+    let wait_timeout = "30".to_string();
     let payload = br#"{"content":"cli wait json content"}"#;
 
     let direct_output = run_cli_with_stdin(
@@ -629,7 +629,7 @@ async fn test_ingest_wait_json_cleanup_ids_delete_exact_drawers() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let _config = write_config(home.path(), &format!("http://{addr}/v1"));
-    let wait_timeout = u64::MAX.to_string();
+    let wait_timeout = "30".to_string();
     let payload = br#"{"content":"cli wait cleanup-safe drawer id content"}"#;
 
     let output = run_cli_with_stdin(
@@ -774,10 +774,10 @@ async fn test_ingest_wait_json_cleanup_id_writes_under_daemon_lease() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
+async fn test_ingest_wait_json_timeout_returns_receipt_and_leaves_claim_queued() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
-    let _config = write_config(home.path(), &format!("http://{addr}/v1"));
+    let _config_path = write_config(home.path(), &format!("http://{addr}/v1"));
     let db_path = home.path().join(".mempal/palace.db");
     handle.pause();
 
@@ -798,7 +798,7 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
             "--no-gate",
             "--wait",
             "--wait-timeout-secs",
-            "1",
+            "6",
             "--json",
         ])
         .env("HOME", home.path())
@@ -818,24 +818,30 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     let operation_id = loop {
-        if let Some((operation_id, state)) = first_ingest_async_operation(&db_path)
-            && state == "running"
-        {
+        if let Some((operation_id, state)) = first_ingest_async_operation(&db_path) {
+            assert!(
+                matches!(state.as_str(), "queued" | "running"),
+                "finite wait may claim local work while the caller timeout is still open, got {state}"
+            );
             break operation_id;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "ingest wait worker did not claim operation"
+            "ingest wait worker did not enqueue operation"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     };
-    let running = PendingMessageStore::new_without_reclaim(&db_path)
+    let initial = PendingMessageStore::new_without_reclaim(&db_path)
         .operation_status(&operation_id)
-        .expect("load running status")
+        .expect("load initial status")
         .expect("operation record exists");
-    assert_eq!(running.op_state, "running");
+    assert!(
+        matches!(initial.op_state.as_str(), "queued" | "running"),
+        "finite wait may claim local work while the caller timeout is still open, got {}",
+        initial.op_state
+    );
 
-    let output = wait_child_output_timeout(child, Duration::from_secs(4));
+    let output = wait_child_output_timeout(child, Duration::from_secs(9));
     assert!(
         !output.status.success(),
         "stdout={}, stderr={}",
@@ -863,8 +869,10 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
         .expect("load queued status")
         .expect("operation record exists");
     assert_eq!(queued.op_state, "queued");
+    assert!(queued.claimed_at.is_none());
 
     handle.resume();
+    let unbounded_timeout = u64::MAX.to_string();
     let recovery = run_cli(
         home.path(),
         &[
@@ -872,7 +880,7 @@ async fn test_ingest_wait_json_timeout_returns_receipt_and_requeues_claim() {
             "wait",
             &operation_id,
             "--timeout-secs",
-            "10",
+            unbounded_timeout.as_str(),
             "--json",
         ],
     );
@@ -1096,6 +1104,7 @@ async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
     })
     .to_string();
 
+    let wait_timeout = u64::MAX.to_string();
     let output = run_cli_with_stdin(
         home.path(),
         &[
@@ -1108,7 +1117,7 @@ async fn test_ingest_wait_preserves_stdin_semantics_and_audit() {
             "--no-gate",
             "--wait",
             "--wait-timeout-secs",
-            "30",
+            wait_timeout.as_str(),
         ],
         payload.as_bytes(),
     );
@@ -1358,6 +1367,7 @@ async fn test_ingest_wait_rejected_matches_non_wait_output_and_audit() {
     })
     .to_string();
 
+    let wait_timeout = u64::MAX.to_string();
     let direct_output = run_cli_with_stdin(
         direct_home.path(),
         &["ingest", "--stdin", "--json"],
@@ -1370,7 +1380,7 @@ async fn test_ingest_wait_rejected_matches_non_wait_output_and_audit() {
             "--stdin",
             "--wait",
             "--wait-timeout-secs",
-            "30",
+            wait_timeout.as_str(),
             "--json",
         ],
         payload.as_bytes(),
@@ -1474,7 +1484,7 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
 
     let operation_id =
         enqueue_prepared_operation(&db_path, "wait cli content", "mcp", Some("wait"));
-    let wait_timeout = u64::MAX.to_string();
+    let wait_timeout = "30".to_string();
 
     handle.pause();
     let child = spawn_cli(
@@ -1517,7 +1527,7 @@ async fn test_operation_wait_exits_zero_and_prints_progress() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_operation_wait_timeout_returns_receipt_and_requeues_claim() {
+async fn test_operation_wait_timeout_returns_receipt_and_leaves_finite_budget_queued() {
     let home = setup_home();
     let (addr, handle) = start_embed_mock(0).await.expect("start embed mock");
     let config_path = write_config(home.path(), &format!("http://{addr}/v1"));
@@ -1534,27 +1544,10 @@ async fn test_operation_wait_timeout_returns_receipt_and_requeues_claim() {
     handle.pause();
     let child = spawn_cli(
         home.path(),
-        &["operation", "wait", &operation_id, "--timeout-secs", "1"],
+        &["operation", "wait", &operation_id, "--timeout-secs", "6"],
     );
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while std::time::Instant::now() < deadline {
-        let record = PendingMessageStore::new_without_reclaim(&db_path)
-            .operation_status(&operation_id)
-            .expect("load operation status")
-            .expect("operation record exists");
-        if record.op_state == "running" {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
-    let running = PendingMessageStore::new_without_reclaim(&db_path)
-        .operation_status(&operation_id)
-        .expect("load running status")
-        .expect("operation record exists");
-    assert_eq!(running.op_state, "running");
-
-    let output = wait_child_output_timeout(child, Duration::from_secs(4));
+    let output = wait_child_output_timeout(child, Duration::from_secs(9));
     assert!(
         !output.status.success(),
         "stdout={}, stderr={}",
@@ -1572,11 +1565,19 @@ async fn test_operation_wait_timeout_returns_receipt_and_requeues_claim() {
         .expect("load queued status")
         .expect("operation record exists");
     assert_eq!(queued.op_state, "queued");
+    assert!(queued.claimed_at.is_none());
 
     handle.resume();
+    let unbounded_timeout = u64::MAX.to_string();
     let recovery = run_cli(
         home.path(),
-        &["operation", "wait", &operation_id, "--timeout-secs", "10"],
+        &[
+            "operation",
+            "wait",
+            &operation_id,
+            "--timeout-secs",
+            unbounded_timeout.as_str(),
+        ],
     );
     handle.shutdown().await;
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "73e61f30948b3cf9a2e0f88ab5f37618da522673"
+commit = "323353527c21f28dd8a5b8c6efc071cb21bdd8dd"
 source_kind = "git"


### PR DESCRIPTION
## Summary

Fixes #552.

This PR preserves reliable MCP/CLI wait receipts through SQLite lock races and smoke DB-holder interactions by tightening queue ownership, bounded wait behavior, and smoke client cleanup.

## What changed

- Preserve operation wait/status receipts across MCP ingest paths instead of returning unresolvable queued/non-terminal success shapes.
- Bound finite wait paths by caller budgets while still progressing local queued work when no daemon owns the operation.
- Keep unbounded/terminal scoped waits from treating transient SQLite claim/release lock failures as success.
- Ensure scoped timeout receipts are returned only after the queue claim has been released; release lock failures propagate as MCP internal errors instead of leaving rows claimed until stale reclaim.
- Treat daemon writer lease probe read/open failures as “daemon ownership not proven” rather than assuming daemon visibility.
- Close/null smoke MCP clients before isolated reads/update-client phases to avoid extra stdio DB holders.

## Verification

Local / CSA evidence:

- Fresh range CSA-Codex tier4 review PASS/CLEAN for `main...HEAD` at `aed842f852c1aa3227a0f7bfdbb783a04d6b7db7`.
  - Session: `01KVY6H8T6WWQAWS0A9CT6MHX0`
  - Severity counts: critical=0, high=0, medium=0, low=0
- Pre-push hook passed:
  - branch-protection
  - local-gates
  - review-check
- Pre-push gate verified review session `01KVY6H8T6WWQAWS0A9CT6MHX0` for `main...HEAD`.
- Focused tests reported during CSA fix/review loop included operation wait, MCP ingest wait, scoped wait timeout/retry, daemon lease/probe, smoke script py_compile, cargo fmt, and `git diff --check`.

## Notes

- No GitHub Actions/pr-bot/cloud-bot dependency; this repo flow uses local gates + exact-head CSA review.
- The `core2 v0.4.0` yanked-lockfile warning remains pre-existing dependency metadata surfaced during `cargo package --locked`.
