### PR TITLE
fix(mcp): bound ingest duplicate vector checks

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1762,6 +1762,81 @@ impl Database {
         Ok(rows)
     }
 
+    pub fn count_novelty_candidate_drawers(
+        &self,
+        wing: Option<&str>,
+        room: Option<&str>,
+        project_id: Option<&str>,
+    ) -> Result<i64, DbError> {
+        let vectors_exist: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+            [],
+            |row| row.get(0),
+        )?;
+        if !vectors_exist {
+            return Ok(0);
+        }
+
+        self.conn
+            .query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM drawer_vectors v
+                JOIN drawers d ON d.id = v.id
+                WHERE d.deleted_at IS NULL
+                  AND (?1 IS NULL OR d.wing = ?1)
+                  AND (?2 IS NULL OR d.room = ?2)
+                  AND (?3 IS NULL OR d.project_id = ?3)
+                "#,
+                (wing, room, project_id),
+                |row| row.get(0),
+            )
+            .map_err(DbError::from)
+    }
+
+    pub fn novelty_candidates_exact(
+        &self,
+        query_vector: &[f32],
+        wing: Option<&str>,
+        room: Option<&str>,
+        project_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>, DbError> {
+        let vectors_exist: bool = self.conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
+            [],
+            |row| row.get(0),
+        )?;
+        if !vectors_exist || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let query_json = serde_json::to_string(query_vector)?;
+        let limit =
+            i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT d.id,
+                   CAST(1.0 - vec_distance_cosine(v.embedding, vec_f32(?1)) AS REAL) AS similarity
+            FROM drawer_vectors v
+            JOIN drawers d ON d.id = v.id
+            WHERE d.deleted_at IS NULL
+              AND (?2 IS NULL OR d.wing = ?2)
+              AND (?3 IS NULL OR d.room = ?3)
+              AND (?4 IS NULL OR d.project_id = ?4)
+            ORDER BY similarity DESC
+            LIMIT ?5
+            "#,
+        )?;
+        statement
+            .query_map(
+                (query_json.as_str(), wing, room, project_id, limit),
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, f32>(1)?)),
+            )?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(DbError::from)
+    }
+
     /// Ensure drawer_vectors table exists with the right dimension.
     /// Creates it on first call; errors on dimension mismatch.
     fn ensure_vectors_table(&self, dim: usize) -> Result<(), DbError> {

--- a/src/ingest/novelty.rs
+++ b/src/ingest/novelty.rs
@@ -54,7 +54,7 @@ pub fn evaluate(
     vector: &[f32],
     config: &NoveltyConfig,
 ) -> NoveltyDecision {
-    if !config.enabled || candidate.wing == "agent-diary" {
+    if !config.enabled || config.top_k_candidates == 0 || candidate.wing == "agent-diary" {
         return NoveltyDecision {
             should_audit: false,
             ..NoveltyDecision::insert()
@@ -71,17 +71,21 @@ pub fn evaluate(
             return NoveltyDecision::insert();
         }
     };
-    if candidate.project_id.is_some() && fork_ext_version < 5 {
-        tracing::warn!(
-            fork_ext_version,
-            wing = %candidate.wing,
-            room = ?candidate.room,
-            "shared palace detected, project isolation unavailable; novelty disabled"
-        );
-        return NoveltyDecision {
-            should_audit: false,
-            ..NoveltyDecision::insert()
-        };
+    if !novelty_vector_search_has_pushed_project_scope(candidate, config, fork_ext_version) {
+        if candidate.project_id.is_some() {
+            tracing::warn!(
+                fork_ext_version,
+                wing = %candidate.wing,
+                room = ?candidate.room,
+                "shared palace detected, project isolation unavailable; novelty disabled"
+            );
+            return NoveltyDecision {
+                should_audit: false,
+                ..NoveltyDecision::insert()
+            };
+        }
+
+        return evaluate_no_project_novelty(db, candidate, vector, config);
     }
 
     let (wing, room) = novelty_scope(candidate, config);
@@ -99,6 +103,84 @@ pub fn evaluate(
         }
     };
 
+    novelty_decision_from_results(results, config)
+}
+
+pub fn novelty_vector_search_has_pushed_project_scope(
+    candidate: &NoveltyCandidate,
+    config: &NoveltyConfig,
+    fork_ext_version: u32,
+) -> bool {
+    config.enabled
+        && config.top_k_candidates > 0
+        && candidate.wing != "agent-diary"
+        && candidate.project_id.is_some()
+        && fork_ext_version >= 5
+}
+
+fn evaluate_no_project_novelty(
+    db: &Database,
+    candidate: &NoveltyCandidate,
+    vector: &[f32],
+    config: &NoveltyConfig,
+) -> NoveltyDecision {
+    let (wing, room) = novelty_scope(candidate, config);
+    let candidate_count =
+        match db.count_novelty_candidate_drawers(wing.as_deref(), room.as_deref(), None) {
+            Ok(count) => count,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "no-project novelty candidate count failed; fail-open insert"
+                );
+                return NoveltyDecision::insert();
+            }
+        };
+
+    if candidate_count > crate::search::EXACT_VECTOR_CANDIDATE_LIMIT {
+        tracing::warn!(
+            wing = %candidate.wing,
+            room = ?candidate.room,
+            candidate_count,
+            limit = crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
+            "no-project novelty disabled because scoped candidate count exceeds exact vector limit"
+        );
+        return NoveltyDecision {
+            should_audit: false,
+            ..NoveltyDecision::insert()
+        };
+    }
+
+    tracing::warn!(
+        wing = %candidate.wing,
+        room = ?candidate.room,
+        candidate_count,
+        "no-project novelty using bounded exact vector scan because sqlite-vec KNN has no pushed-down project scope"
+    );
+    let results = match db.novelty_candidates_exact(
+        vector,
+        wing.as_deref(),
+        room.as_deref(),
+        None,
+        config.top_k_candidates,
+    ) {
+        Ok(results) => results,
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                "bounded no-project novelty search failed; fail-open insert"
+            );
+            return NoveltyDecision::insert();
+        }
+    };
+
+    novelty_decision_from_results(results, config)
+}
+
+fn novelty_decision_from_results(
+    results: Vec<(String, f32)>,
+    config: &NoveltyConfig,
+) -> NoveltyDecision {
     let Some(top) = results.first() else {
         return NoveltyDecision::insert();
     };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -65,7 +65,10 @@ use crate::ingest::{
         evaluate_tier2, should_route_to_llm_judge,
     },
     normalize::CURRENT_NORMALIZE_VERSION,
-    novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty},
+    novelty::{
+        NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty,
+        novelty_vector_search_has_pushed_project_scope,
+    },
 };
 use crate::knowledge_anchor::{PublishAnchorRequest as CorePublishAnchorRequest, publish_anchor};
 use crate::knowledge_card_lifecycle::{
@@ -6307,7 +6310,7 @@ impl MempalMcpServer {
         // consistent set from a single `sqlite_master` read. A mid-request embed transition
         // to degraded is not lost: the degraded-write guard above rejects before any
         // success response that would carry this snapshot is built.
-        let request_system_warnings = system_warnings_with_stale_index(&db);
+        let mut request_system_warnings = system_warnings_with_stale_index(&db);
         let no_gate = controls.no_gate;
         let bypass_novelty = controls.bypass_novelty;
         let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
@@ -6726,12 +6729,29 @@ impl MempalMcpServer {
 
         let first_vector_ref = &vectors[0];
         let novelty_started = Instant::now();
-        let duplicate_warning = check_semantic_duplicate(&db, first_vector_ref, first_chunk);
         let novelty_candidate = NoveltyCandidate {
             wing: request.wing.clone(),
             room: request.room.clone(),
             project_id: project_id.clone(),
         };
+        let duplicate_warning = check_semantic_duplicate(
+            &db,
+            first_vector_ref,
+            first_chunk,
+            SemanticDuplicateCheckContext {
+                wing: &request.wing,
+                room: request.room.as_deref(),
+                project_id: project_id.as_deref(),
+                strict_project_isolation: config.search.strict_project_isolation,
+                skip_for_ingest_policy: superseded_drawer_id.is_some() || bypass_novelty,
+                novelty_will_search: novelty_vector_search_will_run(
+                    &db,
+                    &novelty_candidate,
+                    &config.ingest_gating.novelty,
+                ),
+            },
+            &mut request_system_warnings,
+        );
         let novelty = if superseded_drawer_id.is_some() || bypass_novelty {
             crate::ingest::novelty::NoveltyDecision {
                 should_audit: false,
@@ -10897,21 +10917,103 @@ fn read_drawer_response(details: crate::core::types::DrawerDetails) -> ReadDrawe
 
 const DEDUP_THRESHOLD: f32 = 0.85;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticDuplicateCheckPlan {
+    Search,
+    Skip(SemanticDuplicateSkipReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticDuplicateSkipReason {
+    IngestPolicy,
+    NoveltyVectorSearch,
+    CandidateLimitExceeded,
+    CandidateCountUnavailable,
+    VectorSearchFailed,
+}
+
+struct SemanticDuplicateCheckContext<'a> {
+    wing: &'a str,
+    room: Option<&'a str>,
+    project_id: Option<&'a str>,
+    strict_project_isolation: bool,
+    skip_for_ingest_policy: bool,
+    novelty_will_search: bool,
+}
+
 fn check_semantic_duplicate(
     db: &Database,
     vector: &[f32],
     _content: &str,
+    context: SemanticDuplicateCheckContext<'_>,
+    system_warnings: &mut Vec<SystemWarning>,
 ) -> Option<DuplicateWarning> {
     use crate::core::types::RouteDecision;
 
+    if let Some(reason) = pre_count_semantic_duplicate_skip_reason(
+        context.skip_for_ingest_policy,
+        context.novelty_will_search,
+    ) {
+        system_warnings.push(semantic_duplicate_skip_warning(reason, None));
+        return None;
+    }
+
     let route = RouteDecision {
-        wing: None,
-        room: None,
+        wing: Some(context.wing.to_string()),
+        room: context.room.map(ToOwned::to_owned),
         confidence: 0.0,
         reason: "dedup check".to_string(),
     };
-    let scope = ProjectSearchScope::all_projects();
-    let results = crate::search::search_by_vector(db, vector, route, &scope, 1).ok()?;
+    let scope = ProjectSearchScope::from_request(
+        context.project_id.map(ToOwned::to_owned),
+        false,
+        false,
+        context.strict_project_isolation,
+    );
+    let filters = SearchFilters::default();
+    let candidate_count =
+        match crate::search::count_vector_candidate_drawers(db, &route, &scope, &filters) {
+            Ok(count) => count,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "semantic duplicate candidate count failed; fail-open without duplicate warning"
+                );
+                system_warnings.push(semantic_duplicate_skip_warning(
+                    SemanticDuplicateSkipReason::CandidateCountUnavailable,
+                    None,
+                ));
+                return None;
+            }
+        };
+    match plan_semantic_duplicate_check(
+        candidate_count,
+        crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
+    ) {
+        SemanticDuplicateCheckPlan::Search => {}
+        SemanticDuplicateCheckPlan::Skip(reason) => {
+            system_warnings.push(semantic_duplicate_skip_warning(
+                reason,
+                Some(candidate_count),
+            ));
+            return None;
+        }
+    }
+
+    let results = match crate::search::search_by_vector(db, vector, route, &scope, 1) {
+        Ok(results) => results,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "bounded semantic duplicate search failed; fail-open without duplicate warning"
+            );
+            system_warnings.push(semantic_duplicate_skip_warning(
+                SemanticDuplicateSkipReason::VectorSearchFailed,
+                Some(candidate_count),
+            ));
+            return None;
+        }
+    };
     let top = results.first()?;
     if top.similarity >= DEDUP_THRESHOLD {
         Some(DuplicateWarning {
@@ -10921,6 +11023,74 @@ fn check_semantic_duplicate(
         })
     } else {
         None
+    }
+}
+
+fn pre_count_semantic_duplicate_skip_reason(
+    skip_for_ingest_policy: bool,
+    novelty_will_search: bool,
+) -> Option<SemanticDuplicateSkipReason> {
+    if skip_for_ingest_policy {
+        return Some(SemanticDuplicateSkipReason::IngestPolicy);
+    }
+    if novelty_will_search {
+        return Some(SemanticDuplicateSkipReason::NoveltyVectorSearch);
+    }
+    None
+}
+
+fn plan_semantic_duplicate_check(candidate_count: i64, limit: i64) -> SemanticDuplicateCheckPlan {
+    if candidate_count > limit {
+        SemanticDuplicateCheckPlan::Skip(SemanticDuplicateSkipReason::CandidateLimitExceeded)
+    } else {
+        SemanticDuplicateCheckPlan::Search
+    }
+}
+
+fn novelty_vector_search_will_run(
+    db: &Database,
+    candidate: &NoveltyCandidate,
+    config: &crate::core::config::NoveltyConfig,
+) -> bool {
+    read_fork_ext_version(db.conn()).is_ok_and(|version| {
+        novelty_vector_search_has_pushed_project_scope(candidate, config, version)
+    })
+}
+
+fn semantic_duplicate_skip_warning(
+    reason: SemanticDuplicateSkipReason,
+    candidate_count: Option<i64>,
+) -> SystemWarning {
+    let limit = crate::search::EXACT_VECTOR_CANDIDATE_LIMIT;
+    let (level, message) = match reason {
+        SemanticDuplicateSkipReason::IngestPolicy => (
+            "info",
+            "semantic duplicate warning skipped: ingest controls disabled vector deduplication for this write".to_string(),
+        ),
+        SemanticDuplicateSkipReason::NoveltyVectorSearch => (
+            "info",
+            "semantic duplicate warning skipped: novelty policy already performs the scoped vector candidate search for this ingest".to_string(),
+        ),
+        SemanticDuplicateSkipReason::CandidateLimitExceeded => (
+            "warn",
+            format!(
+                "semantic duplicate warning skipped: scoped candidate_count={} exceeds limit={limit}",
+                candidate_count.unwrap_or_default()
+            ),
+        ),
+        SemanticDuplicateSkipReason::CandidateCountUnavailable => (
+            "warn",
+            "semantic duplicate warning skipped: scoped candidate count failed before vector search".to_string(),
+        ),
+        SemanticDuplicateSkipReason::VectorSearchFailed => (
+            "warn",
+            "semantic duplicate warning skipped: bounded vector search failed".to_string(),
+        ),
+    };
+    SystemWarning {
+        level: level.to_string(),
+        message,
+        source: "ingest_duplicate".to_string(),
     }
 }
 
@@ -11134,6 +11304,81 @@ mod tests {
         .expect("create MCP server")
         .with_async_db_for_test(async_db);
         (tempdir, db_path, server)
+    }
+
+    #[test]
+    fn test_semantic_duplicate_plan_skips_large_candidate_scope() {
+        assert_eq!(
+            plan_semantic_duplicate_check(
+                crate::search::EXACT_VECTOR_CANDIDATE_LIMIT + 1,
+                crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
+            ),
+            SemanticDuplicateCheckPlan::Skip(SemanticDuplicateSkipReason::CandidateLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn test_semantic_duplicate_plan_searches_bounded_candidate_scope() {
+        assert_eq!(
+            plan_semantic_duplicate_check(
+                crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
+                crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
+            ),
+            SemanticDuplicateCheckPlan::Search
+        );
+    }
+
+    #[test]
+    fn test_semantic_duplicate_pre_count_skip_avoids_redundant_vector_search() {
+        assert_eq!(
+            pre_count_semantic_duplicate_skip_reason(false, true),
+            Some(SemanticDuplicateSkipReason::NoveltyVectorSearch)
+        );
+        assert_eq!(
+            pre_count_semantic_duplicate_skip_reason(true, false),
+            Some(SemanticDuplicateSkipReason::IngestPolicy)
+        );
+    }
+
+    #[test]
+    fn test_novelty_vector_search_replacement_requires_project_pushdown() {
+        let (_tempdir, db_path, _server) = setup_server();
+        let db = Database::open(&db_path).expect("open db");
+        let config = crate::core::config::NoveltyConfig {
+            enabled: true,
+            top_k_candidates: 5,
+            ..Default::default()
+        };
+        let no_project = NoveltyCandidate {
+            wing: "mcp".to_string(),
+            room: Some("decision".to_string()),
+            project_id: None,
+        };
+        let scoped_project = NoveltyCandidate {
+            wing: "mcp".to_string(),
+            room: Some("decision".to_string()),
+            project_id: Some("proj-a".to_string()),
+        };
+
+        assert!(!novelty_vector_search_will_run(&db, &no_project, &config));
+        assert!(novelty_vector_search_will_run(
+            &db,
+            &scoped_project,
+            &config
+        ));
+    }
+
+    #[test]
+    fn test_semantic_duplicate_skip_warning_is_content_free() {
+        let warning = semantic_duplicate_skip_warning(
+            SemanticDuplicateSkipReason::CandidateLimitExceeded,
+            Some(50_000),
+        );
+
+        assert_eq!(warning.source, "ingest_duplicate");
+        assert!(warning.message.contains("candidate_count=50000"));
+        assert!(!warning.message.contains("payload"));
+        assert!(!warning.message.contains("content"));
     }
 
     async fn enqueue_prepared_test_ingest_operation(

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -27,7 +27,7 @@ pub mod rerank;
 pub mod route;
 pub mod tiered;
 
-const EXACT_VECTOR_CANDIDATE_LIMIT: i64 = 4_096;
+pub const EXACT_VECTOR_CANDIDATE_LIMIT: i64 = 4_096;
 const ACCESS_WRITEBACK_BUSY_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub type Result<T> = std::result::Result<T, SearchError>;
@@ -1389,43 +1389,7 @@ fn search_by_vector_with_filters(
     let applied_wing = route.wing.as_deref();
     let applied_room = route.room.as_deref();
 
-    let count_sql = format!(
-        "SELECT COUNT(*) FROM drawers d {}",
-        build_retrieval_filter_clause(
-            "d",
-            RetrievalFilterParamIndexes {
-                wing: 1,
-                room: 2,
-                project_mode: 3,
-                project_id: 4,
-                memory_kind: 5,
-                domain: 6,
-                field: 7,
-                tier: 8,
-                status: 9,
-                anchor_kind: 10,
-            },
-        )
-    );
-    let candidate_count: i64 = db
-        .conn()
-        .query_row(
-            &count_sql,
-            (
-                applied_wing,
-                applied_room,
-                scope.mode_param(),
-                scope.project_id.as_deref(),
-                filters.memory_kind.as_deref(),
-                filters.domain.as_deref(),
-                filters.field.as_deref(),
-                filters.tier.as_deref(),
-                filters.status.as_deref(),
-                filters.anchor_kind.as_deref(),
-            ),
-            |row| row.get(0),
-        )
-        .map_err(SearchError::CountCandidateDrawers)?;
+    let candidate_count = count_vector_candidate_drawers(db, &route, scope, filters)?;
     if candidate_count == 0 {
         return Ok(Vec::new());
     }
@@ -1535,6 +1499,55 @@ fn search_by_vector_with_filters(
         .into_iter()
         .map(|result| hydrate_result_metadata(db, result))
         .collect())
+}
+
+pub fn count_vector_candidate_drawers(
+    db: &Database,
+    route: &RouteDecision,
+    scope: &ProjectSearchScope,
+    filters: &SearchFilters,
+) -> Result<i64> {
+    let applied_wing = route.wing.as_deref();
+    let applied_room = route.room.as_deref();
+
+    let count_sql = format!(
+        "SELECT COUNT(*) FROM drawers d {}",
+        build_retrieval_filter_clause(
+            "d",
+            RetrievalFilterParamIndexes {
+                wing: 1,
+                room: 2,
+                project_mode: 3,
+                project_id: 4,
+                memory_kind: 5,
+                domain: 6,
+                field: 7,
+                tier: 8,
+                status: 9,
+                anchor_kind: 10,
+            },
+        )
+    );
+    let candidate_count: i64 = db
+        .conn()
+        .query_row(
+            &count_sql,
+            (
+                applied_wing,
+                applied_room,
+                scope.mode_param(),
+                scope.project_id.as_deref(),
+                filters.memory_kind.as_deref(),
+                filters.domain.as_deref(),
+                filters.field.as_deref(),
+                filters.tier.as_deref(),
+                filters.status.as_deref(),
+                filters.anchor_kind.as_deref(),
+            ),
+            |row| row.get(0),
+        )
+        .map_err(SearchError::CountCandidateDrawers)?;
+    Ok(candidate_count)
 }
 
 struct ExactVectorSearchRequest<'a> {

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -553,6 +553,55 @@ async fn test_fts_finds_merged_supplementary() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn test_no_project_novelty_uses_exact_same_wing_scope_not_global_knn_window() {
+    let _guard = test_guard().await;
+    let env = TestEnv::new(true);
+    for idx in 0..5 {
+        let id = format!("other-wing-{idx}");
+        insert_drawer(
+            &env.db_path,
+            DrawerSeed {
+                id: &id,
+                content: "closer item from another wing",
+                wing: "other-wing",
+                room: DEFAULT_ROOM,
+                project_id: None,
+            },
+            &[1.0, 0.0],
+        );
+    }
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "same-wing-existing",
+            content: "Decision: keep same-wing novelty exact",
+            wing: DEFAULT_WING,
+            room: DEFAULT_ROOM,
+            project_id: None,
+        },
+        &[0.9, 0.4358899],
+    );
+    let candidate = "Also: same-wing novelty must not use global KNN";
+    let server = env.server(&[(candidate, vec![1.0, 0.0])], &[]);
+
+    let response = ingest(&server, DEFAULT_WING, DEFAULT_ROOM, candidate, None).await;
+
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Merge)
+    );
+    assert_eq!(
+        response.near_drawer_id.as_deref(),
+        Some("same-wing-existing")
+    );
+    assert_eq!(
+        drawer_count(&env.db_path),
+        6,
+        "bounded exact no-project novelty should merge instead of inserting"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn test_high_similarity_candidate_dropped() {
     let _guard = test_guard().await;
     let env = TestEnv::new(true);


### PR DESCRIPTION
## Summary

Closes #554.

This PR bounds MCP ingest duplicate/novelty vector work so small ingests do not trigger broad all-project sqlite-vec scans.

Changes:
- Bound semantic duplicate checks with scoped candidate counting before sqlite-vec search.
- Skip duplicate vector work when novelty already performs a project-scoped pushed-down vector search.
- Prevent no-project novelty from substituting for bounded duplicate search unless a pushed-down project scope exists.
- For no-project novelty, count scoped candidates first and degrade with content-free warnings when the scope is too large.
- Add regression coverage for no-project same-wing novelty so it does not depend on a global KNN window.

## Verification

CSA-Codex writer/fix verification:
- `mise x rust@stable -- cargo fmt --all`
- `mise x rust@stable -- cargo test test_novelty_vector_search_replacement_requires_project_pushdown`
- `mise x rust@stable -- cargo test test_no_project_novelty_uses_exact_same_wing_scope_not_global_knn_window`
- `mise x rust@stable -- cargo test --test novelty_filter`
- `mise x rust@stable -- cargo test test_semantic_duplicate`
- `mise x rust@stable -- cargo fmt --all --check`
- `git diff --check main...HEAD`
- pre-commit quality gates passed during amend

Fresh exact-head review:
- CSA-Codex tier4 range review session: `01KVYCTJDJGTBVSNDWX1DBVWT2`
- Reviewed SHA: `1babc9654814425c0122427655f707b1a710266a`
- Range: `main...HEAD`
- Verdict: PASS / CLEAN

Pre-push local gates:
- branch-protection passed
- local-gates passed
- review-check validated session `01KVYCTJDJGTBVSNDWX1DBVWT2`

## Notes

Large-database smoke was intentionally not run before this fix to avoid reproducing SSD read amplification. Concurrent IO attribution showed mempal read IO dropping to near-idle in the 20:32–20:46 sample window while this fix was in progress.