### PR TITLE
fix(queue): classify failed work for recovery

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(any(test, feature = "db-test-seam"))]
@@ -36,6 +37,8 @@ pub enum QueueError {
     BlockingTaskFailed(String),
     #[error("unsupported model task kind for auto-requeue: {0}")]
     UnsupportedModelTaskKind(String),
+    #[error("queue failed-row mutation requires at least one explicit kind/class/reason filter")]
+    UnsafeUnfilteredQueueMutation,
 }
 
 impl QueueError {
@@ -83,20 +86,93 @@ pub struct PendingOperationRecord {
     pub result_json: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct QueueStats {
     pub pending: u64,
     pub claimed: u64,
     pub failed: u64,
     pub failed_retryable: u64,
     pub failed_terminal: u64,
+    pub failed_archived: u64,
+    pub retrying: u64,
     pub failed_retryable_embed: u64,
     pub failed_retryable_llm: u64,
     pub last_auto_requeue_at_unix_ms: Option<u64>,
+    pub next_retry_at_unix_secs: Option<u64>,
     pub oldest_pending_age_secs: Option<u64>,
     pub rate_per_min: f64,
     pub avg_processing_ms: Option<u64>,
     pub eta_secs: Option<u64>,
+    pub failed_buckets: Vec<QueueFailureBucket>,
+    pub retrying_buckets: Vec<QueueFailureBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueFailureBucket {
+    pub kind: String,
+    pub retry_class: String,
+    pub reason_code: String,
+    pub sanitized_message: String,
+    pub count: u64,
+    pub min_retry_count: u32,
+    pub max_retry_count: u32,
+    pub next_attempt_at_unix_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueueFailureFilter {
+    pub kind: Option<String>,
+    pub retry_class: Option<String>,
+    pub reason_code: Option<String>,
+}
+
+impl QueueFailureFilter {
+    pub fn is_explicit(&self) -> bool {
+        self.kind.is_some() || self.retry_class.is_some() || self.reason_code.is_some()
+    }
+
+    pub fn matches_bucket(&self, bucket: &QueueFailureBucket) -> bool {
+        self.kind
+            .as_deref()
+            .is_none_or(|value| value == bucket.kind.as_str())
+            && self
+                .retry_class
+                .as_deref()
+                .is_none_or(|value| value == bucket.retry_class.as_str())
+            && self
+                .reason_code
+                .as_deref()
+                .is_none_or(|value| value == bucket.reason_code.as_str())
+    }
+
+    fn matches_row(&self, row: &QueueFailureRow) -> bool {
+        self.kind
+            .as_deref()
+            .is_none_or(|value| value == row.kind.as_str())
+            && self
+                .retry_class
+                .as_deref()
+                .is_none_or(|value| value == row.retry_class.as_str())
+            && self
+                .reason_code
+                .as_deref()
+                .is_none_or(|value| value == row.reason_code.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueFailureActionPreview {
+    pub filter: QueueFailureFilter,
+    pub matched: u64,
+    pub buckets: Vec<QueueFailureBucket>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueFailureActionOutcome {
+    pub filter: QueueFailureFilter,
+    pub matched: u64,
+    pub changed: u64,
+    pub buckets: Vec<QueueFailureBucket>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1128,6 +1204,7 @@ impl PendingMessageStore {
                     ELSE result_json
                 END
             WHERE status = 'failed'
+              AND failure_class = 'retryable_model'
               AND kind != 'llm_task'
             "#,
             [now],
@@ -1214,6 +1291,146 @@ impl PendingMessageStore {
     pub fn stats(&self) -> Result<QueueStats> {
         let conn = self.open_query_connection()?;
         compute_queue_stats(&conn)
+    }
+
+    pub fn preview_failed_action(
+        &self,
+        filter: QueueFailureFilter,
+    ) -> Result<QueueFailureActionPreview> {
+        ensure_explicit_filter(&filter)?;
+        let conn = self.open_query_connection()?;
+        let rows = matching_failed_rows(&conn, &filter)?;
+        Ok(QueueFailureActionPreview {
+            filter,
+            matched: rows.len() as u64,
+            buckets: buckets_from_rows(rows.iter()),
+        })
+    }
+
+    pub fn retry_failed_messages(
+        &self,
+        filter: QueueFailureFilter,
+    ) -> Result<QueueFailureActionOutcome> {
+        ensure_explicit_filter(&filter)?;
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let rows = matching_failed_rows(&tx, &filter)?;
+        let ids = rows.iter().map(|row| row.id.clone()).collect::<Vec<_>>();
+
+        let now = now_secs();
+        let mut changed = 0u64;
+        for id in &ids {
+            let updated = tx.execute(
+                r#"
+                UPDATE pending_messages
+                SET status = 'pending',
+                    retry_count = 0,
+                    retry_backoff_ms = 0,
+                    next_attempt_at = MIN(created_at, ?2),
+                    claim_token = NULL,
+                    claimed_at = NULL,
+                    heartbeat_at = NULL,
+                    last_error = NULL,
+                    op_state = 'queued',
+                    failure_class = NULL,
+                    result_drawer_id = CASE
+                        WHEN kind = 'ingest_async' THEN NULL
+                        ELSE result_drawer_id
+                    END,
+                    rejected_reason = CASE
+                        WHEN kind = 'ingest_async' THEN NULL
+                        ELSE rejected_reason
+                    END,
+                    failure_detail = CASE
+                        WHEN kind = 'ingest_async' THEN NULL
+                        ELSE failure_detail
+                    END,
+                    result_json = CASE
+                        WHEN kind = 'ingest_async' THEN NULL
+                        ELSE result_json
+                    END
+                WHERE id = ?1 AND status = 'failed'
+                "#,
+                params![id, now],
+            )?;
+            changed = changed.saturating_add(updated as u64);
+        }
+        tx.commit()?;
+        Ok(QueueFailureActionOutcome {
+            filter,
+            matched: rows.len() as u64,
+            changed,
+            buckets: buckets_from_rows(rows.iter()),
+        })
+    }
+
+    pub fn archive_failed_messages(
+        &self,
+        filter: QueueFailureFilter,
+    ) -> Result<QueueFailureActionOutcome> {
+        ensure_explicit_filter(&filter)?;
+        let completed_at = now_millis();
+        let mut conn = self.open_connection()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let rows = matching_failed_rows(&tx, &filter)?;
+        let mut changed = 0u64;
+        for row in &rows {
+            let archive_reason = format!("queue_archive:{}", row.reason_code);
+            tx.execute(
+                r#"
+                INSERT INTO pending_message_completions (
+                    message_id,
+                    kind,
+                    created_at,
+                    claimed_at,
+                    completed_at,
+                    processing_ms,
+                    result_drawer_id,
+                    op_state,
+                    rejected_reason,
+                    failure_detail,
+                    result_json
+                )
+                SELECT id,
+                       kind,
+                       created_at * 1000,
+                       claimed_at,
+                       ?2,
+                       NULL,
+                       result_drawer_id,
+                       'failed',
+                       ?3,
+                       last_error,
+                       result_json
+                FROM pending_messages
+                WHERE id = ?1 AND status = 'failed'
+                ON CONFLICT(message_id) DO UPDATE SET
+                    kind = excluded.kind,
+                    created_at = excluded.created_at,
+                    claimed_at = excluded.claimed_at,
+                    completed_at = excluded.completed_at,
+                    processing_ms = excluded.processing_ms,
+                    result_drawer_id = excluded.result_drawer_id,
+                    op_state = excluded.op_state,
+                    rejected_reason = excluded.rejected_reason,
+                    failure_detail = excluded.failure_detail,
+                    result_json = excluded.result_json
+                "#,
+                params![row.id.as_str(), completed_at, archive_reason.as_str()],
+            )?;
+            let deleted = tx.execute(
+                "DELETE FROM pending_messages WHERE id = ?1 AND status = 'failed'",
+                [row.id.as_str()],
+            )?;
+            changed = changed.saturating_add(deleted as u64);
+        }
+        tx.commit()?;
+        Ok(QueueFailureActionOutcome {
+            filter,
+            matched: rows.len() as u64,
+            changed,
+            buckets: buckets_from_rows(rows.iter()),
+        })
     }
 
     fn open_connection(&self) -> Result<Connection> {
@@ -1539,50 +1756,51 @@ fn compute_queue_stats(conn: &Connection) -> Result<QueueStats> {
         }
     }
 
-    let has_failure_class = column_exists(conn, "pending_messages", "failure_class")?;
-    let (failed_retryable, failed_terminal, failed_retryable_embed, failed_retryable_llm) =
-        if has_failure_class {
-            let failed_retryable = conn.query_row(
-                r#"
-                SELECT COUNT(*)
-                FROM pending_messages
-                WHERE status = 'failed'
-                  AND failure_class = 'retryable_model'
-                "#,
-                [],
-                |row| row.get::<_, i64>(0),
-            )?;
-            let failed_retryable_embed = conn.query_row(
-                r#"
-                SELECT COUNT(*)
-                FROM pending_messages
-                WHERE status = 'failed'
-                  AND failure_class = 'retryable_model'
-                  AND kind != 'llm_task'
-                "#,
-                [],
-                |row| row.get::<_, i64>(0),
-            )?;
-            let failed_retryable_llm = conn.query_row(
-                r#"
-                SELECT COUNT(*)
-                FROM pending_messages
-                WHERE status = 'failed'
-                  AND failure_class = 'retryable_model'
-                  AND kind = 'llm_task'
-                "#,
-                [],
-                |row| row.get::<_, i64>(0),
-            )?;
-            (
-                failed_retryable,
-                failed.saturating_sub(failed_retryable),
-                failed_retryable_embed,
-                failed_retryable_llm,
-            )
-        } else {
-            (0, failed, 0, 0)
-        };
+    let failure_rows = queue_failure_rows(conn)?;
+    let failed_buckets = buckets_from_rows(
+        failure_rows
+            .iter()
+            .filter(|row| row.status == QueueFailureRowStatus::Failed),
+    );
+    let retrying_buckets = buckets_from_rows(
+        failure_rows
+            .iter()
+            .filter(|row| row.status == QueueFailureRowStatus::Retrying),
+    );
+    let failed_retryable = failure_rows
+        .iter()
+        .filter(|row| {
+            row.status == QueueFailureRowStatus::Failed && row.retry_class == "retryable_model"
+        })
+        .count() as i64;
+    let failed_retryable_embed = failure_rows
+        .iter()
+        .filter(|row| {
+            row.status == QueueFailureRowStatus::Failed
+                && row.retry_class == "retryable_model"
+                && row.kind != "llm_task"
+        })
+        .count() as i64;
+    let failed_retryable_llm = failure_rows
+        .iter()
+        .filter(|row| {
+            row.status == QueueFailureRowStatus::Failed
+                && row.retry_class == "retryable_model"
+                && row.kind == "llm_task"
+        })
+        .count() as i64;
+    let retrying = failure_rows
+        .iter()
+        .filter(|row| row.status == QueueFailureRowStatus::Retrying)
+        .count() as i64;
+    let next_retry_at_unix_secs = failure_rows
+        .iter()
+        .filter(|row| row.status == QueueFailureRowStatus::Retrying)
+        .filter_map(|row| row.next_attempt_at)
+        .min()
+        .map(i64_to_u64);
+    let failed_terminal = failed.saturating_sub(failed_retryable);
+    let failed_archived = archived_failed_count(conn)?;
     let last_auto_requeue_at_unix_ms = if table_exists(conn, "fork_ext_meta")? {
         conn.query_row(
             r#"
@@ -1643,18 +1861,339 @@ fn compute_queue_stats(conn: &Connection) -> Result<QueueStats> {
         failed: i64_to_u64(failed),
         failed_retryable: i64_to_u64(failed_retryable),
         failed_terminal: i64_to_u64(failed_terminal),
+        failed_archived,
+        retrying: i64_to_u64(retrying),
         failed_retryable_embed: i64_to_u64(failed_retryable_embed),
         failed_retryable_llm: i64_to_u64(failed_retryable_llm),
         last_auto_requeue_at_unix_ms,
+        next_retry_at_unix_secs,
         oldest_pending_age_secs,
         rate_per_min,
         avg_processing_ms,
         eta_secs,
+        failed_buckets,
+        retrying_buckets,
     })
 }
 
 pub fn failure_headline_count(live_fail_count: u64, queue_stats: &QueueStats) -> u64 {
     live_fail_count.max(queue_stats.failed)
+}
+
+fn ensure_explicit_filter(filter: &QueueFailureFilter) -> Result<()> {
+    if filter.is_explicit() {
+        Ok(())
+    } else {
+        Err(QueueError::UnsafeUnfilteredQueueMutation)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueueFailureRowStatus {
+    Failed,
+    Retrying,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QueueFailureRow {
+    id: String,
+    status: QueueFailureRowStatus,
+    kind: String,
+    retry_class: String,
+    reason_code: String,
+    sanitized_message: String,
+    retry_count: u32,
+    next_attempt_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct QueueFailureBucketKey {
+    kind: String,
+    retry_class: String,
+    reason_code: String,
+}
+
+#[derive(Debug, Clone)]
+struct QueueFailureBucketAccumulator {
+    sanitized_message: String,
+    count: u64,
+    min_retry_count: u32,
+    max_retry_count: u32,
+    next_attempt_at: Option<i64>,
+}
+
+fn queue_failure_rows(conn: &Connection) -> Result<Vec<QueueFailureRow>> {
+    let has_failure_class = column_exists(conn, "pending_messages", "failure_class")?;
+    let has_last_error = column_exists(conn, "pending_messages", "last_error")?;
+    let has_retry_count = column_exists(conn, "pending_messages", "retry_count")?;
+    let has_next_attempt_at = column_exists(conn, "pending_messages", "next_attempt_at")?;
+
+    let failure_class_expr = if has_failure_class {
+        "failure_class"
+    } else {
+        "NULL"
+    };
+    let last_error_expr = if has_last_error { "last_error" } else { "NULL" };
+    let retry_count_expr = if has_retry_count { "retry_count" } else { "0" };
+    let next_attempt_expr = if has_next_attempt_at {
+        "next_attempt_at"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
+        r#"
+        SELECT id,
+               kind,
+               status,
+               {failure_class_expr},
+               {last_error_expr},
+               {retry_count_expr},
+               {next_attempt_expr}
+        FROM pending_messages
+        WHERE status = 'failed'
+           OR (status = 'pending' AND {retry_count_expr} > 0)
+        "#
+    );
+    let mut statement = conn.prepare(&sql)?;
+    let rows = statement.query_map([], |row| {
+        let id = row.get::<_, String>(0)?;
+        let kind = row.get::<_, String>(1)?;
+        let status = row.get::<_, String>(2)?;
+        let failure_class = row.get::<_, Option<String>>(3)?;
+        let last_error = row.get::<_, Option<String>>(4)?;
+        let retry_count_i64 = row.get::<_, i64>(5)?;
+        let next_attempt_at = row.get::<_, Option<i64>>(6)?;
+        Ok((
+            id,
+            kind,
+            status,
+            failure_class,
+            last_error,
+            retry_count_i64,
+            next_attempt_at,
+        ))
+    })?;
+
+    let mut result = Vec::new();
+    for row in rows {
+        let (id, kind, status, failure_class, last_error, retry_count_i64, next_attempt_at) = row?;
+        let status = match status.as_str() {
+            "failed" => QueueFailureRowStatus::Failed,
+            "pending" => QueueFailureRowStatus::Retrying,
+            _ => continue,
+        };
+        let retry_count = u32::try_from(retry_count_i64)
+            .map_err(|_| QueueError::RetryCountOverflow { id: id.clone() })?;
+        let retry_class = retry_class_for(status, failure_class.as_deref());
+        let last_error = last_error.unwrap_or_default();
+        let reason_code = queue_failure_reason_code(&kind, &last_error);
+        result.push(QueueFailureRow {
+            id,
+            status,
+            kind,
+            retry_class,
+            sanitized_message: queue_failure_message_summary(&reason_code, &last_error),
+            reason_code,
+            retry_count,
+            next_attempt_at,
+        });
+    }
+    Ok(result)
+}
+
+fn matching_failed_rows(
+    conn: &Connection,
+    filter: &QueueFailureFilter,
+) -> Result<Vec<QueueFailureRow>> {
+    queue_failure_rows(conn).map(|rows| {
+        rows.into_iter()
+            .filter(|row| row.status == QueueFailureRowStatus::Failed)
+            .filter(|row| filter.matches_row(row))
+            .collect()
+    })
+}
+
+fn buckets_from_rows<'a>(
+    rows: impl Iterator<Item = &'a QueueFailureRow>,
+) -> Vec<QueueFailureBucket> {
+    let mut buckets = BTreeMap::<QueueFailureBucketKey, QueueFailureBucketAccumulator>::new();
+    for row in rows {
+        let key = QueueFailureBucketKey {
+            kind: row.kind.clone(),
+            retry_class: row.retry_class.clone(),
+            reason_code: row.reason_code.clone(),
+        };
+        buckets
+            .entry(key)
+            .and_modify(|bucket| {
+                bucket.count = bucket.count.saturating_add(1);
+                bucket.min_retry_count = bucket.min_retry_count.min(row.retry_count);
+                bucket.max_retry_count = bucket.max_retry_count.max(row.retry_count);
+                bucket.next_attempt_at =
+                    min_optional_i64(bucket.next_attempt_at, row.next_attempt_at);
+            })
+            .or_insert_with(|| QueueFailureBucketAccumulator {
+                sanitized_message: row.sanitized_message.clone(),
+                count: 1,
+                min_retry_count: row.retry_count,
+                max_retry_count: row.retry_count,
+                next_attempt_at: row.next_attempt_at,
+            });
+    }
+
+    let mut result = buckets
+        .into_iter()
+        .map(|(key, bucket)| QueueFailureBucket {
+            kind: key.kind,
+            retry_class: key.retry_class,
+            reason_code: key.reason_code,
+            sanitized_message: bucket.sanitized_message,
+            count: bucket.count,
+            min_retry_count: bucket.min_retry_count,
+            max_retry_count: bucket.max_retry_count,
+            next_attempt_at_unix_secs: bucket.next_attempt_at.map(i64_to_u64),
+        })
+        .collect::<Vec<_>>();
+    result.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.retry_class.cmp(&right.retry_class))
+            .then_with(|| left.reason_code.cmp(&right.reason_code))
+    });
+    result
+}
+
+fn retry_class_for(status: QueueFailureRowStatus, failure_class: Option<&str>) -> String {
+    match status {
+        QueueFailureRowStatus::Retrying => "retrying_backoff".to_string(),
+        QueueFailureRowStatus::Failed => match failure_class {
+            Some("retryable_model") => "retryable_model".to_string(),
+            Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+            _ => "terminal".to_string(),
+        },
+    }
+}
+
+fn queue_failure_reason_code(kind: &str, last_error: &str) -> String {
+    let lower = last_error.to_ascii_lowercase();
+    if lower.contains("failed to decode llm response")
+        || lower.contains("error decoding response body")
+    {
+        "llm_response_decode".to_string()
+    } else if lower.contains("automatic hook llm gate failed before durable insert") {
+        "automatic_hook_llm_gate".to_string()
+    } else if lower.contains("failed to decode queued hook envelope")
+        || (is_hook_queue_kind(kind) && lower.contains("decode"))
+    {
+        "invalid_hook_envelope".to_string()
+    } else if lower.contains("failed to reopen db for merge")
+        || lower.contains("failed to merge drawer")
+    {
+        "storage_merge_reopen".to_string()
+    } else if lower.contains("database is locked")
+        || lower.contains("database locked")
+        || lower.contains("database is busy")
+        || lower.contains("database busy")
+        || lower.contains("sqlite_busy")
+        || lower.contains("sqlite_locked")
+    {
+        "storage_locked_or_busy".to_string()
+    } else if lower.contains("too many requests")
+        || lower.contains("rate limit")
+        || lower.contains("429")
+    {
+        "model_rate_limited".to_string()
+    } else if lower.contains("timeout") || lower.contains("timed out") || lower.contains("408") {
+        "model_timeout".to_string()
+    } else if lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("remote disconnected")
+    {
+        "model_connection".to_string()
+    } else if lower.contains("unknown llm task") || lower.contains("unsupported") {
+        "unsupported_queue_task".to_string()
+    } else if lower.contains("invalid")
+        || lower.contains("missing")
+        || lower.contains("configuration")
+        || lower.contains("config")
+        || lower.contains("dimension")
+        || lower.contains("no vectors")
+    {
+        "invalid_queue_payload".to_string()
+    } else if last_error.trim().is_empty() {
+        "unknown_no_error".to_string()
+    } else {
+        "unknown_failure".to_string()
+    }
+}
+
+fn queue_failure_message_summary(reason_code: &str, last_error: &str) -> String {
+    let canonical = match reason_code {
+        "llm_response_decode" => "failed to decode LLM response",
+        "automatic_hook_llm_gate" => "automatic hook LLM gate failed before durable insert",
+        "invalid_hook_envelope" => "invalid or legacy hook envelope",
+        "storage_merge_reopen" => "failed to reopen db for merge",
+        "storage_locked_or_busy" => "database locked or busy",
+        "model_rate_limited" => "model endpoint rate limited",
+        "model_timeout" => "model endpoint timeout",
+        "model_connection" => "model endpoint connection failure",
+        "unsupported_queue_task" => "unsupported queued task",
+        "invalid_queue_payload" => "invalid queued payload",
+        "unknown_no_error" => "no last error recorded",
+        _ => "",
+    };
+    if !canonical.is_empty() {
+        return canonical.to_string();
+    }
+    truncate_to_byte_limit(sanitize_last_error(last_error), 240)
+}
+
+fn is_hook_queue_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "ingest_async"
+            | "hook_event"
+            | "hook_post_tool"
+            | "hook_user_prompt"
+            | "hook_session_start"
+            | "hook_session_end"
+            | "hook:post-tool-use"
+            | "hook:user-prompt-submit"
+            | "hook:session-start"
+            | "hook:session-end"
+    )
+}
+
+fn archived_failed_count(conn: &Connection) -> Result<u64> {
+    if !table_exists(conn, "pending_message_completions")?
+        || !column_exists(conn, "pending_message_completions", "op_state")?
+        || !column_exists(conn, "pending_message_completions", "rejected_reason")?
+    {
+        return Ok(0);
+    }
+    conn.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM pending_message_completions
+        WHERE op_state = 'failed'
+          AND rejected_reason LIKE 'queue_archive:%'
+        "#,
+        [],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(i64_to_u64)
+    .map_err(QueueError::from)
+}
+
+fn min_optional_i64(left: Option<i64>, right: Option<i64>) -> Option<i64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
 }
 
 fn reclaim_stale_tx(conn: &rusqlite::Transaction<'_>, stale_cutoff: i64) -> rusqlite::Result<u64> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -770,6 +770,11 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         full: bool,
     },
+    /// Inspect and safely recover failed queue work without exposing payloads.
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommands,
+    },
     /// List recent drawers from the CLI dashboard.
     Tail {
         #[arg(long, default_value_t = 20)]
@@ -2312,6 +2317,69 @@ enum Phase3AdoptionCommands {
         #[arg(long, default_value = "plain")]
         format: String,
     },
+}
+
+#[derive(Subcommand)]
+#[command(after_long_help = "\
+Examples:
+  mempal queue failed
+  mempal queue failed --reason invalid_hook_envelope
+  mempal queue failed --reason automatic_hook_llm_gate
+  mempal queue failed --reason llm_response_decode
+  mempal queue failed --reason storage_merge_reopen
+  mempal queue retry-failed --kind hook_post_tool --reason storage_merge_reopen
+  mempal queue retry-failed --kind hook_post_tool --reason storage_merge_reopen --execute
+  mempal queue archive-failed --kind ingest_async --reason invalid_hook_envelope
+  mempal queue archive-failed --kind ingest_async --reason invalid_hook_envelope --execute
+
+Failed queue output is aggregate-only. It never prints raw queued payloads.
+Malformed or legacy hook envelopes usually classify as invalid_hook_envelope and should be archived rather than retried.
+LLM gate failures classify as automatic_hook_llm_gate or llm_response_decode.
+Storage reopen failures classify as storage_merge_reopen; retry only with an explicit filter after checking the dry-run count.")]
+enum QueueCommands {
+    /// Summarize failed queue rows by kind/class/reason without payloads.
+    Failed(QueueFailedArgs),
+    /// Requeue matching failed rows. Dry-run unless --execute is present.
+    #[command(name = "retry-failed")]
+    RetryFailed(QueueMutationArgs),
+    /// Archive matching failed rows into completion history. Dry-run unless --execute is present.
+    #[command(name = "archive-failed")]
+    ArchiveFailed(QueueMutationArgs),
+}
+
+#[derive(Args, Clone)]
+struct QueueFailedArgs {
+    /// Match one queue kind, such as hook_post_tool, hook_user_prompt, ingest_async, or llm_task.
+    #[arg(long)]
+    kind: Option<String>,
+    /// Match retry class, such as terminal, retryable_model, or retrying_backoff.
+    #[arg(long = "class")]
+    retry_class: Option<String>,
+    /// Match stable reason code, such as invalid_hook_envelope, llm_response_decode, automatic_hook_llm_gate, or storage_merge_reopen.
+    #[arg(long)]
+    reason: Option<String>,
+    /// Do not escape terminal control characters in aggregate labels.
+    #[arg(long, default_value_t = false)]
+    raw: bool,
+}
+
+#[derive(Args, Clone)]
+struct QueueMutationArgs {
+    /// Match one queue kind, such as hook_post_tool, hook_user_prompt, ingest_async, or llm_task.
+    #[arg(long)]
+    kind: Option<String>,
+    /// Match retry class, such as terminal or retryable_model.
+    #[arg(long = "class")]
+    retry_class: Option<String>,
+    /// Match stable reason code, such as invalid_hook_envelope, llm_response_decode, automatic_hook_llm_gate, or storage_merge_reopen.
+    #[arg(long)]
+    reason: Option<String>,
+    /// Actually mutate matching rows. Omit for dry-run.
+    #[arg(long, default_value_t = false)]
+    execute: bool,
+    /// Do not escape terminal control characters in aggregate labels.
+    #[arg(long, default_value_t = false)]
+    raw: bool,
 }
 
 #[derive(Subcommand)]
@@ -4046,6 +4114,7 @@ fn run() -> Result<()> {
         Commands::FieldTaxonomy { format } => field_taxonomy_command(&format),
         Commands::Serve { mcp } => block_on_result(serve_command(config.as_ref(), mcp)),
         Commands::Status { full } => status_command(&db, config.as_ref(), full),
+        Commands::Queue { command } => queue_command(&db, command),
         Commands::Gating { command } => gating_command(&db, config.as_ref(), command),
         Commands::Tail {
             limit,
@@ -4417,6 +4486,12 @@ fn command_uses_read_only_database(command: &Commands) -> bool {
         ),
         Commands::Taxonomy { command } => matches!(command, TaxonomyCommands::List),
         Commands::Gating { command } => matches!(command, GatingCommands::Stats { .. }),
+        Commands::Queue { command } => matches!(
+            command,
+            QueueCommands::Failed(_)
+                | QueueCommands::RetryFailed(QueueMutationArgs { execute: false, .. })
+                | QueueCommands::ArchiveFailed(QueueMutationArgs { execute: false, .. })
+        ),
         Commands::Checkpoint { command } => matches!(
             command,
             CheckpointCommands::Latest { .. }
@@ -8126,6 +8201,177 @@ fn reindex_failed_queue_command(db: &Database) -> Result<()> {
         .context("failed to requeue failed embed messages")?;
     println!("requeued failed embed queue items: {retried}");
     Ok(())
+}
+
+fn queue_command(db: &Database, command: QueueCommands) -> Result<()> {
+    let store = mempal::core::queue::PendingMessageStore::new_without_reclaim(db.path());
+    match command {
+        QueueCommands::Failed(args) => queue_failed_command(&store, args),
+        QueueCommands::RetryFailed(args) => queue_retry_failed_command(db, &store, args),
+        QueueCommands::ArchiveFailed(args) => queue_archive_failed_command(db, &store, args),
+    }
+}
+
+fn queue_failed_command(
+    store: &mempal::core::queue::PendingMessageStore,
+    args: QueueFailedArgs,
+) -> Result<()> {
+    let filter = queue_filter(args.kind, args.retry_class, args.reason);
+    let stats = store.stats().context("failed to summarize failed queue")?;
+    let failed_buckets = filter_queue_buckets(&stats.failed_buckets, &filter);
+    let retrying_buckets = filter_queue_buckets(&stats.retrying_buckets, &filter);
+    let failed_matched = failed_buckets
+        .iter()
+        .map(|bucket| bucket.count)
+        .sum::<u64>();
+    let retrying_matched = retrying_buckets
+        .iter()
+        .map(|bucket| bucket.count)
+        .sum::<u64>();
+
+    println!("queue_failed_summary:");
+    println!("  filter: {}", queue_filter_display(&filter, args.raw));
+    println!("  pending: {}", stats.pending);
+    println!("  claimed: {}", stats.claimed);
+    println!("  failed: {}", stats.failed);
+    println!("  failed_retryable: {}", stats.failed_retryable);
+    println!("  failed_terminal: {}", stats.failed_terminal);
+    println!("  failed_archived: {}", stats.failed_archived);
+    println!("  retrying: {}", stats.retrying);
+    println!("  matched_failed: {failed_matched}");
+    println!("  matched_retrying: {retrying_matched}");
+    println!(
+        "  next_retry_at_unix_secs: {}",
+        stats
+            .next_retry_at_unix_secs
+            .map_or_else(|| "none".to_string(), |value| value.to_string())
+    );
+    print_queue_failure_buckets("  failed_by_kind_class_reason", &failed_buckets, args.raw);
+    print_queue_failure_buckets(
+        "  retrying_by_kind_class_reason",
+        &retrying_buckets,
+        args.raw,
+    );
+    Ok(())
+}
+
+fn queue_retry_failed_command(
+    db: &Database,
+    store: &mempal::core::queue::PendingMessageStore,
+    args: QueueMutationArgs,
+) -> Result<()> {
+    let filter = queue_filter(args.kind, args.retry_class, args.reason);
+    ensure_queue_mutation_filter(&filter)?;
+    let preview = store
+        .preview_failed_action(filter.clone())
+        .context("failed to preview queue retry")?;
+    print_queue_action_preview("retry_failed", args.execute, &preview, args.raw);
+    if !args.execute {
+        return Ok(());
+    }
+    let _writer_lease = acquire_maintenance_writer_lease(db, "queue-retry-failed")?;
+    let outcome = store
+        .retry_failed_messages(filter)
+        .context("failed to retry failed queue rows")?;
+    print_queue_action_outcome("retry_failed", &outcome, args.raw);
+    Ok(())
+}
+
+fn queue_archive_failed_command(
+    db: &Database,
+    store: &mempal::core::queue::PendingMessageStore,
+    args: QueueMutationArgs,
+) -> Result<()> {
+    let filter = queue_filter(args.kind, args.retry_class, args.reason);
+    ensure_queue_mutation_filter(&filter)?;
+    let preview = store
+        .preview_failed_action(filter.clone())
+        .context("failed to preview queue archive")?;
+    print_queue_action_preview("archive_failed", args.execute, &preview, args.raw);
+    if !args.execute {
+        return Ok(());
+    }
+    let _writer_lease = acquire_maintenance_writer_lease(db, "queue-archive-failed")?;
+    let outcome = store
+        .archive_failed_messages(filter)
+        .context("failed to archive failed queue rows")?;
+    print_queue_action_outcome("archive_failed", &outcome, args.raw);
+    Ok(())
+}
+
+fn queue_filter(
+    kind: Option<String>,
+    retry_class: Option<String>,
+    reason_code: Option<String>,
+) -> mempal::core::queue::QueueFailureFilter {
+    mempal::core::queue::QueueFailureFilter {
+        kind,
+        retry_class,
+        reason_code,
+    }
+}
+
+fn ensure_queue_mutation_filter(filter: &mempal::core::queue::QueueFailureFilter) -> Result<()> {
+    if filter.is_explicit() {
+        Ok(())
+    } else {
+        bail!(
+            "queue retry/archive requires at least one explicit --kind, --class, or --reason filter"
+        )
+    }
+}
+
+fn filter_queue_buckets(
+    buckets: &[mempal::core::queue::QueueFailureBucket],
+    filter: &mempal::core::queue::QueueFailureFilter,
+) -> Vec<mempal::core::queue::QueueFailureBucket> {
+    buckets
+        .iter()
+        .filter(|bucket| filter.matches_bucket(bucket))
+        .cloned()
+        .collect()
+}
+
+fn queue_filter_display(filter: &mempal::core::queue::QueueFailureFilter, raw: bool) -> String {
+    let parts = [
+        ("kind", filter.kind.as_deref()),
+        ("class", filter.retry_class.as_deref()),
+        ("reason", filter.reason_code.as_deref()),
+    ]
+    .into_iter()
+    .filter_map(|(key, value)| value.map(|value| format!("{key}={}", queue_display(value, raw))))
+    .collect::<Vec<_>>();
+    if parts.is_empty() {
+        "none".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn print_queue_action_preview(
+    action: &str,
+    execute: bool,
+    preview: &mempal::core::queue::QueueFailureActionPreview,
+    raw: bool,
+) {
+    println!("{action}:");
+    println!("  dry_run: {}", !execute);
+    println!("  execute: {execute}");
+    println!("  filter: {}", queue_filter_display(&preview.filter, raw));
+    println!("  matched: {}", preview.matched);
+    print_queue_failure_buckets("  matched_by_kind_class_reason", &preview.buckets, raw);
+}
+
+fn print_queue_action_outcome(
+    action: &str,
+    outcome: &mempal::core::queue::QueueFailureActionOutcome,
+    raw: bool,
+) {
+    println!("{action}_result:");
+    println!("  filter: {}", queue_filter_display(&outcome.filter, raw));
+    println!("  matched: {}", outcome.matched);
+    println!("  changed: {}", outcome.changed);
+    print_queue_failure_buckets("  changed_by_kind_class_reason", &outcome.buckets, raw);
 }
 
 fn audit_stale_command(db: &Database, threshold: f64) -> Result<()> {
@@ -12240,6 +12486,8 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     println!("  failed: {}", queue_stats.failed);
     println!("  failed_retryable: {}", queue_stats.failed_retryable);
     println!("  failed_terminal: {}", queue_stats.failed_terminal);
+    println!("  failed_archived: {}", queue_stats.failed_archived);
+    println!("  retrying: {}", queue_stats.retrying);
     println!(
         "  failed_retryable_model: embedding={} llm={}",
         queue_stats.failed_retryable_embed, queue_stats.failed_retryable_llm
@@ -12247,6 +12495,10 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
     match queue_stats.last_auto_requeue_at_unix_ms {
         Some(ts) => println!("  last_auto_requeue_at_unix_ms: {ts}"),
         None => println!("  last_auto_requeue_at_unix_ms: none"),
+    }
+    match queue_stats.next_retry_at_unix_secs {
+        Some(ts) => println!("  next_retry_at_unix_secs: {ts}"),
+        None => println!("  next_retry_at_unix_secs: none"),
     }
     println!("  rate_per_min: {:.1}", queue_stats.rate_per_min);
     match queue_stats.oldest_pending_age_secs {
@@ -12261,6 +12513,16 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         Some(eta) => println!("  eta_secs: {eta}"),
         None => println!("  eta_secs: n/a"),
     }
+    print_queue_failure_buckets(
+        "  failed_by_kind_class_reason",
+        &queue_stats.failed_buckets,
+        false,
+    );
+    print_queue_failure_buckets(
+        "  retrying_by_kind_class_reason",
+        &queue_stats.retrying_buckets,
+        false,
+    );
     println!("Historical Rejudge:");
     if let Some(checkpoint) = historical_rejudge_checkpoint.as_ref() {
         let backlog_counts = historical_rejudge_backlog_counts(db, &checkpoint.run_id)
@@ -12551,12 +12813,25 @@ fn push_model_backend_runtime_warnings(
         });
     }
     if queue_stats.failed > 0 {
+        let top_reason = queue_stats
+            .failed_buckets
+            .first()
+            .map(|bucket| {
+                format!(
+                    " top_failed_reason={} kind={} class={} count={}",
+                    bucket.reason_code, bucket.kind, bucket.retry_class, bucket.count
+                )
+            })
+            .unwrap_or_else(|| " run `mempal queue failed` for aggregate details.".to_string());
         warnings.push(mempal::core::config::RuntimeWarning {
             level: "warn",
             source: "queue",
             message: format!(
-                "queue has failed work (retryable_model={}, terminal={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require manual action.",
-                queue_stats.failed_retryable, queue_stats.failed_terminal
+                "queue has failed work (retryable_model={}, terminal={}, archived={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require filtered queue action.{}",
+                queue_stats.failed_retryable,
+                queue_stats.failed_terminal,
+                queue_stats.failed_archived,
+                top_reason
             ),
         });
     }
@@ -12567,6 +12842,45 @@ fn display_list_or_none(values: &[String]) -> String {
         "none".to_string()
     } else {
         values.join(", ")
+    }
+}
+
+fn print_queue_failure_buckets(
+    label: &str,
+    buckets: &[mempal::core::queue::QueueFailureBucket],
+    raw: bool,
+) {
+    println!("{label}:");
+    if buckets.is_empty() {
+        println!("    none");
+        return;
+    }
+    for bucket in buckets.iter().take(10) {
+        let next_attempt = bucket
+            .next_attempt_at_unix_secs
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        println!(
+            "    kind={} class={} reason={} count={} retry_count={}..{} next_attempt_at={} last_error_summary={}",
+            queue_display(&bucket.kind, raw),
+            queue_display(&bucket.retry_class, raw),
+            queue_display(&bucket.reason_code, raw),
+            bucket.count,
+            bucket.min_retry_count,
+            bucket.max_retry_count,
+            next_attempt,
+            queue_display(&bucket.sanitized_message, raw)
+        );
+    }
+    if buckets.len() > 10 {
+        println!("    ... {} more bucket(s)", buckets.len() - 10);
+    }
+}
+
+fn queue_display(value: &str, raw: bool) -> String {
+    if raw {
+        value.to_string()
+    } else {
+        mempal::observability::escape_terminal_text(value)
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -127,15 +127,15 @@ use super::tools::{
     MAX_READ_DRAWERS_MAX_COUNT, MAX_READ_DRAWERS_REQUEST_IDS, OperationStatusRequest,
     PeekMessageDto, PeekPartnerRequest, PeekPartnerResponse, Phase3GateDto, Phase3Request,
     Phase3Response, PinnedFactDto, PinnedFactProjectCount, PinnedFactsRequest, PinnedFactsResponse,
-    ProcessResourceUsageDto, QueueStatsDto, ReadDrawerRequest, ReadDrawerResponse,
-    ReadDrawersRequest, ReadDrawersResponse, ResearchAdapterPlanDto, ResearchIngestPlanDto,
-    ResourceCounterDto, ResourceUsageDto, RetrievalScopeRequest, RetrievedKnowledgeCardDto,
-    RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto, RuntimeAdoptionStatsDto,
-    ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse, SearchResultDto, SkillDto,
-    SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount, SqliteResourceUsageDto,
-    StatusDetail, StatusRequest, StatusResponse, StatusScope, SystemWarning, TaxonomyEntryDto,
-    TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto, TunnelDto, TunnelEndpointDto,
-    TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
+    ProcessResourceUsageDto, QueueFailureBucketDto, QueueStatsDto, ReadDrawerRequest,
+    ReadDrawerResponse, ReadDrawersRequest, ReadDrawersResponse, ResearchAdapterPlanDto,
+    ResearchIngestPlanDto, ResourceCounterDto, ResourceUsageDto, RetrievalScopeRequest,
+    RetrievedKnowledgeCardDto, RollbackRequest, RollbackResponse, RuntimeAdoptionEventDto,
+    RuntimeAdoptionStatsDto, ScopeCount, ScrubStatsDto, SearchRequest, SearchResponse,
+    SearchResultDto, SkillDto, SkillRequest, SkillResponse, SkillSummaryDto, SourceTypeCount,
+    SqliteResourceUsageDto, StatusDetail, StatusRequest, StatusResponse, StatusScope,
+    SystemWarning, TaxonomyEntryDto, TaxonomyRequest, TaxonomyResponse, TriggerHintsDto, TripleDto,
+    TunnelDto, TunnelEndpointDto, TunnelsRequest, TunnelsResponse, TurnStorageStatusDto,
 };
 
 fn config_db_path_matches_server(config: &Config, server_db_path: &Path) -> bool {
@@ -3159,13 +3159,33 @@ fn default_queue_stats() -> crate::core::queue::QueueStats {
         failed: 0,
         failed_retryable: 0,
         failed_terminal: 0,
+        failed_archived: 0,
+        retrying: 0,
         failed_retryable_embed: 0,
         failed_retryable_llm: 0,
         last_auto_requeue_at_unix_ms: None,
+        next_retry_at_unix_secs: None,
         oldest_pending_age_secs: None,
         rate_per_min: 0.0,
         avg_processing_ms: None,
         eta_secs: None,
+        failed_buckets: Vec::new(),
+        retrying_buckets: Vec::new(),
+    }
+}
+
+fn queue_failure_bucket_dto(
+    bucket: &crate::core::queue::QueueFailureBucket,
+) -> QueueFailureBucketDto {
+    QueueFailureBucketDto {
+        kind: bucket.kind.clone(),
+        retry_class: bucket.retry_class.clone(),
+        reason_code: bucket.reason_code.clone(),
+        sanitized_message: bucket.sanitized_message.clone(),
+        count: bucket.count,
+        min_retry_count: bucket.min_retry_count,
+        max_retry_count: bucket.max_retry_count,
+        next_attempt_at_unix_secs: bucket.next_attempt_at_unix_secs,
     }
 }
 
@@ -4451,13 +4471,26 @@ impl MempalMcpServer {
                 failed: queue_stats.failed,
                 failed_retryable: queue_stats.failed_retryable,
                 failed_terminal: queue_stats.failed_terminal,
+                failed_archived: queue_stats.failed_archived,
+                retrying: queue_stats.retrying,
                 failed_retryable_embed: queue_stats.failed_retryable_embed,
                 failed_retryable_llm: queue_stats.failed_retryable_llm,
                 last_auto_requeue_at_unix_ms: queue_stats.last_auto_requeue_at_unix_ms,
+                next_retry_at_unix_secs: queue_stats.next_retry_at_unix_secs,
                 rate_per_min: queue_stats.rate_per_min,
                 oldest_pending_age_secs: queue_stats.oldest_pending_age_secs,
                 avg_processing_ms: queue_stats.avg_processing_ms,
                 eta_secs: queue_stats.eta_secs,
+                failed_buckets: queue_stats
+                    .failed_buckets
+                    .iter()
+                    .map(queue_failure_bucket_dto)
+                    .collect(),
+                retrying_buckets: queue_stats
+                    .retrying_buckets
+                    .iter()
+                    .map(queue_failure_bucket_dto)
+                    .collect(),
             },
             db_holders,
             resource_usage,
@@ -10521,11 +10554,24 @@ fn push_model_backend_warnings(
         });
     }
     if queue_stats.failed > 0 {
+        let top_reason = queue_stats
+            .failed_buckets
+            .first()
+            .map(|bucket| {
+                format!(
+                    " top_failed_reason={} kind={} class={} count={}",
+                    bucket.reason_code, bucket.kind, bucket.retry_class, bucket.count
+                )
+            })
+            .unwrap_or_else(|| " run `mempal queue failed` for aggregate details.".to_string());
         system_warnings.push(SystemWarning {
             level: "warn".to_string(),
             message: format!(
-                "queue has failed work (retryable_model={}, terminal={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require manual action.",
-                queue_stats.failed_retryable, queue_stats.failed_terminal
+                "queue has failed work (retryable_model={}, terminal={}, archived={}); retryable model tasks are auto-requeued when their endpoint recovers, terminal failures require filtered queue action.{}",
+                queue_stats.failed_retryable,
+                queue_stats.failed_terminal,
+                queue_stats.failed_archived,
+                top_reason
             ),
             source: "queue".to_string(),
         });

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2326,10 +2326,14 @@ pub struct QueueStatsDto {
     pub failed: u64,
     pub failed_retryable: u64,
     pub failed_terminal: u64,
+    pub failed_archived: u64,
+    pub retrying: u64,
     pub failed_retryable_embed: u64,
     pub failed_retryable_llm: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_auto_requeue_at_unix_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_retry_at_unix_secs: Option<u64>,
     pub rate_per_min: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_pending_age_secs: Option<u64>,
@@ -2337,6 +2341,23 @@ pub struct QueueStatsDto {
     pub avg_processing_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eta_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed_buckets: Vec<QueueFailureBucketDto>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub retrying_buckets: Vec<QueueFailureBucketDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct QueueFailureBucketDto {
+    pub kind: String,
+    pub retry_class: String,
+    pub reason_code: String,
+    pub sanitized_message: String,
+    pub count: u64,
+    pub min_retry_count: u32,
+    pub max_retry_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_attempt_at_unix_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -643,7 +643,8 @@ pub fn stats_command(db: &Database, config: &Config, options: StatsOptions) -> R
         importance_total as f64 / records.len() as f64
     };
 
-    let queue_stats = query_queue_stats(db).context("failed to query queue stats")?;
+    let queue_stats = crate::core::queue::queue_stats_readonly(db.path())
+        .context("failed to query queue stats")?;
     let gating = load_audit_records(db, "gating", &scope, None)?;
     let novelty = load_audit_records(db, "novelty", &scope, None)?;
     let embed_count = db
@@ -688,12 +689,25 @@ pub fn stats_command(db: &Database, config: &Config, options: StatsOptions) -> R
     println!("  pending: {}", queue_stats.pending);
     println!("  claimed: {}", queue_stats.claimed);
     println!("  failed: {}", queue_stats.failed);
-    println!("  heartbeat: {}", queue_stats.heartbeat_state);
+    println!("  failed_retryable: {}", queue_stats.failed_retryable);
+    println!("  failed_terminal: {}", queue_stats.failed_terminal);
+    println!("  failed_archived: {}", queue_stats.failed_archived);
+    println!("  retrying: {}", queue_stats.retrying);
     println!(
-        "  heartbeat_age_secs: {}",
+        "  next_retry_at_unix_secs: {}",
         queue_stats
-            .heartbeat_age_secs
+            .next_retry_at_unix_secs
             .map_or_else(|| "none".to_string(), |value| value.to_string())
+    );
+    print_queue_failure_buckets(
+        "  failed_by_kind_class_reason",
+        &queue_stats.failed_buckets,
+        options.raw,
+    );
+    print_queue_failure_buckets(
+        "  retrying_by_kind_class_reason",
+        &queue_stats.retrying_buckets,
+        options.raw,
     );
     println!("gating:");
     print_decision_counts(&gating);
@@ -1937,65 +1951,35 @@ struct TimelineJsonLine {
     preview: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct DashboardQueueStats {
-    pending: i64,
-    claimed: i64,
-    failed: i64,
-    heartbeat_age_secs: Option<i64>,
-    heartbeat_state: &'static str,
-}
-
-fn query_queue_stats(db: &Database) -> Result<DashboardQueueStats> {
-    let has_pending_messages = db.conn().query_row(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='pending_messages'",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    if has_pending_messages == 0 {
-        return Ok(DashboardQueueStats {
-            pending: 0,
-            claimed: 0,
-            failed: 0,
-            heartbeat_age_secs: None,
-            heartbeat_state: "none",
-        });
+fn print_queue_failure_buckets(
+    label: &str,
+    buckets: &[crate::core::queue::QueueFailureBucket],
+    raw: bool,
+) {
+    println!("{label}:");
+    if buckets.is_empty() {
+        println!("    none");
+        return;
     }
-
-    let pending = db.conn().query_row(
-        "SELECT COUNT(*) FROM pending_messages WHERE status = 'pending'",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    let claimed = db.conn().query_row(
-        "SELECT COUNT(*) FROM pending_messages WHERE status = 'claimed'",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    let failed = db.conn().query_row(
-        "SELECT COUNT(*) FROM pending_messages WHERE status = 'failed'",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    let last_heartbeat = db.conn().query_row(
-        "SELECT MAX(heartbeat_at) FROM pending_messages WHERE heartbeat_at IS NOT NULL",
-        [],
-        |row| row.get::<_, Option<i64>>(0),
-    )?;
-    let heartbeat_age_secs =
-        last_heartbeat.map(|heartbeat| now_unix_secs().saturating_sub(heartbeat));
-    let heartbeat_state = match heartbeat_age_secs {
-        Some(age) if age <= 120 => "healthy",
-        Some(_) => "stale",
-        None => "none",
-    };
-    Ok(DashboardQueueStats {
-        pending,
-        claimed,
-        failed,
-        heartbeat_age_secs,
-        heartbeat_state,
-    })
+    for bucket in buckets.iter().take(10) {
+        let next_attempt = bucket
+            .next_attempt_at_unix_secs
+            .map_or_else(|| "none".to_string(), |value| value.to_string());
+        println!(
+            "    kind={} class={} reason={} count={} retry_count={}..{} next_attempt_at={} last_error_summary={}",
+            maybe_escape(&bucket.kind, raw),
+            maybe_escape(&bucket.retry_class, raw),
+            maybe_escape(&bucket.reason_code, raw),
+            bucket.count,
+            bucket.min_retry_count,
+            bucket.max_retry_count,
+            next_attempt,
+            maybe_escape(&bucket.sanitized_message, raw)
+        );
+    }
+    if buckets.len() > 10 {
+        println!("    ... {} more bucket(s)", buckets.len() - 10);
+    }
 }
 
 fn maybe_escape(value: &str, raw: bool) -> String {

--- a/tests/cli_dashboard.rs
+++ b/tests/cli_dashboard.rs
@@ -623,7 +623,12 @@ fn test_stats_shows_all_sections() {
     assert!(stdout.contains("schema_version:"), "{stdout}");
     assert!(stdout.contains("fork_ext_version:"), "{stdout}");
     assert!(stdout.contains("queue:"), "{stdout}");
-    assert!(stdout.contains("  heartbeat:"), "{stdout}");
+    assert!(stdout.contains("  failed_retryable:"), "{stdout}");
+    assert!(stdout.contains("  failed_terminal:"), "{stdout}");
+    assert!(
+        stdout.contains("  failed_by_kind_class_reason:"),
+        "{stdout}"
+    );
     assert!(stdout.contains("gating:"), "{stdout}");
     assert!(stdout.contains("novelty:"), "{stdout}");
     assert!(stdout.contains("privacy scrub:"), "{stdout}");

--- a/tests/mcp_status_queue_stats.rs
+++ b/tests/mcp_status_queue_stats.rs
@@ -19,6 +19,7 @@ use mempal::core::db::Database;
 use mempal::core::queue::{PendingMessageStore, QueueConfig, QueueFailureDisposition};
 use mempal::core::types::{BootstrapEvidenceArgs, CompactionStrategy, Drawer, SourceType};
 use mempal::mcp::MempalMcpServer;
+use rusqlite::params;
 #[cfg(feature = "integration")]
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -344,6 +345,91 @@ async fn test_mcp_status_headline_reflects_failed_queue() {
             warning.source == "queue"
                 && warning.message.contains("retryable_model=1")
                 && warning.message.contains("terminal=1")
+        }),
+        "{:?}",
+        response.system_warnings
+    );
+}
+
+#[tokio::test]
+async fn test_mcp_status_queue_stats_match_shared_summary_buckets() {
+    let (_tmp, db_path, config) = setup_env();
+    let store = PendingMessageStore::new(&db_path).expect("create store");
+    let storage_a = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage a");
+    let storage_b = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage b");
+    let llm_gate = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue llm gate");
+    let conn = rusqlite::Connection::open(&db_path).expect("open sqlite");
+    for id in [&storage_a, &storage_b] {
+        conn.execute(
+            "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 3, last_error = 'failed to reopen db for merge drawer_hooks_raw_bash_69633781', op_state = 'failed' WHERE id = ?1",
+            params![id],
+        )
+        .expect("mark storage failed");
+    }
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 1, last_error = 'automatic hook LLM gate failed before durable insert', op_state = 'failed' WHERE id = ?1",
+        params![llm_gate],
+    )
+    .expect("mark llm gate failed");
+    drop(conn);
+
+    let core_stats =
+        mempal::core::queue::queue_stats_readonly(&db_path).expect("shared queue stats");
+    let server = MempalMcpServer::new(db_path, config).expect("create MCP server");
+    let response = server.mempal_status().await.expect("status").0;
+
+    assert_eq!(response.queue_stats.pending, core_stats.pending);
+    assert_eq!(response.queue_stats.claimed, core_stats.claimed);
+    assert_eq!(response.queue_stats.failed, core_stats.failed);
+    assert_eq!(
+        response.queue_stats.failed_retryable,
+        core_stats.failed_retryable
+    );
+    assert_eq!(
+        response.queue_stats.failed_terminal,
+        core_stats.failed_terminal
+    );
+    assert_eq!(response.queue_stats.retrying, core_stats.retrying);
+    assert_eq!(
+        response.queue_stats.failed_buckets.len(),
+        core_stats.failed_buckets.len()
+    );
+    let storage_bucket = response
+        .queue_stats
+        .failed_buckets
+        .iter()
+        .find(|bucket| bucket.reason_code == "storage_merge_reopen")
+        .expect("storage bucket");
+    assert_eq!(storage_bucket.count, 2);
+    assert_eq!(storage_bucket.retry_class, "terminal");
+    let gate_bucket = response
+        .queue_stats
+        .failed_buckets
+        .iter()
+        .find(|bucket| bucket.reason_code == "automatic_hook_llm_gate")
+        .expect("llm gate bucket");
+    assert_eq!(gate_bucket.count, 1);
+    for bucket in &response.queue_stats.failed_buckets {
+        assert!(
+            !bucket
+                .sanitized_message
+                .contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"),
+            "{bucket:?}"
+        );
+    }
+    assert!(
+        response.system_warnings.iter().any(|warning| {
+            warning.source == "queue"
+                && warning
+                    .message
+                    .contains("top_failed_reason=storage_merge_reopen")
+                && warning.message.contains("count=2")
         }),
         "{:?}",
         response.system_warnings

--- a/tests/queue_claim_confirm.rs
+++ b/tests/queue_claim_confirm.rs
@@ -4,8 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mempal::core::db::Database;
 use mempal::core::queue::{
-    ClaimedMessage, LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueConfig, QueueError,
-    QueueFailureDisposition,
+    ClaimedMessage, LAST_ERROR_MAX_BYTES, PendingMessageStore, QueueError, QueueFailureDisposition,
 };
 use mempal::llm::worker::confirm_llm_task;
 use rusqlite::Connection;
@@ -473,48 +472,6 @@ fn test_stale_claim_finalizers_fail_without_touching_reclaimed_claim() {
 }
 
 #[test]
-fn test_retryable_failure_stays_retryable_past_max_retries() {
-    let tmp = TempDir::new().expect("tempdir");
-    let db_path = tmp.path().join("palace.db");
-    Database::open(&db_path).expect("open db");
-    let store = PendingMessageStore::with_config(
-        &db_path,
-        QueueConfig {
-            base_delay_ms: 0,
-            max_delay_ms: 0,
-            max_retries: 3,
-        },
-    )
-    .expect("store");
-
-    let id = store.enqueue("hook_event", r#"{"n":1}"#).expect("enqueue");
-    for worker in ["worker-a", "worker-b", "worker-c", "worker-d"] {
-        let claimed = store
-            .claim_next(worker, 60)
-            .expect("claim")
-            .expect("message");
-        assert_eq!(claimed.id, id);
-        store.mark_failed(&claimed, "timeout").expect("mark failed");
-    }
-
-    let conn = Connection::open(&db_path).expect("open sqlite");
-    let (status, retry_count): (String, i64) = conn
-        .query_row(
-            "SELECT status, retry_count FROM pending_messages WHERE id = ?1",
-            [&id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .expect("query status");
-    assert_eq!(status, "pending");
-    assert_eq!(retry_count, 4);
-    let retry = store
-        .claim_next("worker-z", 60)
-        .expect("claim after retryable failures")
-        .expect("retryable message");
-    assert_eq!(retry.id, id);
-}
-
-#[test]
 fn test_claim_next_breaks_timestamp_ties_by_id() {
     let (_tmp, db_path, store) = new_store();
     let first = store
@@ -559,7 +516,7 @@ fn test_retry_failed_embed_messages_preserves_fifo_after_later_retry() {
 
     let conn = Connection::open(&db_path).expect("open sqlite");
     conn.execute(
-        "UPDATE pending_messages SET status = 'failed', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom', created_at = ?2, next_attempt_at = ?2 WHERE id = ?1",
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'retryable_model', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom', created_at = ?2, next_attempt_at = ?2 WHERE id = ?1",
         rusqlite::params![failed_embed, base],
     )
     .expect("mark failed embed with older queue position");
@@ -600,7 +557,7 @@ fn test_retry_failed_embed_messages_requeues_only_failed_embed_items() {
 
     let conn = Connection::open(&db_path).expect("open sqlite");
     conn.execute(
-        "UPDATE pending_messages SET status = 'failed', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom' WHERE id IN (?1, ?2)",
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'retryable_model', retry_count = 7, retry_backoff_ms = 5000, last_error = 'boom' WHERE id IN (?1, ?2)",
         rusqlite::params![failed_embed, failed_llm],
     )
     .expect("mark failed rows");

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -10,7 +10,9 @@ use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mempal::core::db::{Database, apply_fork_ext_migrations_to};
-use mempal::core::queue::{PendingMessageStore, QueueConfig, QueueFailureDisposition};
+use mempal::core::queue::{
+    PendingMessageStore, QueueConfig, QueueFailureDisposition, QueueFailureFilter,
+};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use rusqlite::{Connection, params};
 use tempfile::TempDir;
@@ -611,7 +613,7 @@ fn test_reindex_failed_requeues_only_failed_embed_queue_items() {
     Connection::open(&db_path)
         .expect("open sqlite")
         .execute(
-            "UPDATE pending_messages SET status = 'failed', retry_count = 4, last_error = 'boom' WHERE id IN (?1, ?2)",
+            "UPDATE pending_messages SET status = 'failed', failure_class = 'retryable_model', retry_count = 4, last_error = 'boom' WHERE id IN (?1, ?2)",
             params![failed_embed, failed_llm],
         )
         .expect("mark failed rows");
@@ -681,6 +683,495 @@ fn test_queue_stats_split_failed_retryable_and_terminal_model_work() {
     assert_eq!(stats.failed_terminal, 1);
     assert_eq!(stats.failed_retryable_embed, 1);
     assert_eq!(stats.failed_retryable_llm, 1);
+}
+
+#[test]
+fn test_queue_stats_classifies_failed_reasons_and_retrying_backoff() {
+    let (_tmp, db_path, store) = new_store(QueueConfig::default());
+    let malformed = store
+        .enqueue("ingest_async", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue malformed");
+    let gate = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue gate");
+    let llm_decode = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue llm decode");
+    let storage_terminal = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage terminal");
+    let storage_retrying = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage retrying");
+    let now = now_secs();
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    for (id, kind, status, failure_class, retry_count, next_attempt_at, last_error) in [
+        (
+            malformed.as_str(),
+            "ingest_async",
+            "failed",
+            Some("terminal"),
+            18_i64,
+            now,
+            "failed to decode queued hook envelope",
+        ),
+        (
+            gate.as_str(),
+            "hook_post_tool",
+            "failed",
+            Some("terminal"),
+            3_i64,
+            now,
+            "automatic hook LLM gate failed before durable insert",
+        ),
+        (
+            llm_decode.as_str(),
+            "hook_post_tool",
+            "failed",
+            Some("terminal"),
+            4_i64,
+            now,
+            "automatic hook LLM gate failed before durable insert: LLM gating request failed: failed to decode LLM response: error decoding response body",
+        ),
+        (
+            storage_terminal.as_str(),
+            "hook_post_tool",
+            "failed",
+            Some("terminal"),
+            46_i64,
+            now,
+            "failed to reopen db for merge drawer_hooks_raw_bash_69633781",
+        ),
+        (
+            storage_retrying.as_str(),
+            "hook_post_tool",
+            "pending",
+            None,
+            2_i64,
+            now + 60,
+            "failed to reopen db for merge drawer_hooks_raw_bash_69633781",
+        ),
+    ] {
+        conn.execute(
+            r#"
+            UPDATE pending_messages
+            SET kind = ?2,
+                status = ?3,
+                failure_class = ?4,
+                retry_count = ?5,
+                next_attempt_at = ?6,
+                last_error = ?7,
+                op_state = CASE WHEN ?3 = 'failed' THEN 'failed' ELSE 'queued' END
+            WHERE id = ?1
+            "#,
+            params![
+                id,
+                kind,
+                status,
+                failure_class,
+                retry_count,
+                next_attempt_at,
+                last_error
+            ],
+        )
+        .expect("update queue fixture");
+    }
+    drop(conn);
+
+    let stats = store.stats().expect("stats");
+    assert_eq!(stats.failed, 4);
+    assert_eq!(stats.failed_retryable, 0);
+    assert_eq!(stats.failed_terminal, 4);
+    assert_eq!(stats.retrying, 1);
+    assert_eq!(stats.next_retry_at_unix_secs, Some((now + 60) as u64));
+
+    let failed_reason_count = |reason: &str| -> u64 {
+        stats
+            .failed_buckets
+            .iter()
+            .find(|bucket| bucket.reason_code == reason)
+            .map_or(0, |bucket| bucket.count)
+    };
+    assert_eq!(failed_reason_count("invalid_hook_envelope"), 1);
+    assert_eq!(failed_reason_count("automatic_hook_llm_gate"), 1);
+    assert_eq!(failed_reason_count("llm_response_decode"), 1);
+    assert_eq!(failed_reason_count("storage_merge_reopen"), 1);
+    let retrying_storage = stats
+        .retrying_buckets
+        .iter()
+        .find(|bucket| bucket.reason_code == "storage_merge_reopen")
+        .expect("retrying storage bucket");
+    assert_eq!(retrying_storage.retry_class, "retrying_backoff");
+    assert_eq!(retrying_storage.count, 1);
+    for bucket in stats
+        .failed_buckets
+        .iter()
+        .chain(stats.retrying_buckets.iter())
+    {
+        assert!(
+            !bucket
+                .sanitized_message
+                .contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"),
+            "{bucket:?}"
+        );
+    }
+}
+
+#[test]
+fn test_queue_failed_preview_retry_and_archive_are_filtered() {
+    let (_tmp, db_path, store) = new_store(QueueConfig::default());
+    let malformed = store
+        .enqueue("ingest_async", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue malformed");
+    let storage = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage");
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 1, last_error = 'failed to decode queued hook envelope', op_state = 'failed' WHERE id = ?1",
+        [malformed.as_str()],
+    )
+    .expect("mark malformed failed");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 2, last_error = 'failed to reopen db for merge drawer_hooks_raw_bash_69633781', op_state = 'failed' WHERE id = ?1",
+        [storage.as_str()],
+    )
+    .expect("mark storage failed");
+    drop(conn);
+
+    assert!(
+        store
+            .retry_failed_messages(QueueFailureFilter::default())
+            .is_err(),
+        "unfiltered retry must be rejected"
+    );
+    assert!(
+        store
+            .archive_failed_messages(QueueFailureFilter::default())
+            .is_err(),
+        "unfiltered archive must be rejected"
+    );
+
+    let malformed_filter = QueueFailureFilter {
+        kind: Some("ingest_async".to_string()),
+        retry_class: None,
+        reason_code: Some("invalid_hook_envelope".to_string()),
+    };
+    let preview = store
+        .preview_failed_action(malformed_filter.clone())
+        .expect("preview malformed archive");
+    assert_eq!(preview.matched, 1);
+    let failed_before = store.stats().expect("stats before archive").failed;
+    assert_eq!(failed_before, 2, "preview must not mutate failed rows");
+
+    let archived = store
+        .archive_failed_messages(malformed_filter)
+        .expect("archive malformed");
+    assert_eq!(archived.changed, 1);
+    let storage_filter = QueueFailureFilter {
+        kind: Some("hook_post_tool".to_string()),
+        retry_class: Some("terminal".to_string()),
+        reason_code: Some("storage_merge_reopen".to_string()),
+    };
+    let retried = store
+        .retry_failed_messages(storage_filter)
+        .expect("retry storage row");
+    assert_eq!(retried.changed, 1);
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    let pending_failed = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'failed'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count failed rows");
+    let pending_ready = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'pending' AND last_error IS NULL",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count pending rows");
+    let archived_failed = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pending_message_completions WHERE op_state = 'failed'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count archived rows");
+    assert_eq!(pending_failed, 0);
+    assert_eq!(pending_ready, 1);
+    assert_eq!(archived_failed, 1);
+    assert_eq!(
+        store.stats().expect("stats after actions").failed_archived,
+        1
+    );
+}
+
+#[test]
+fn test_queue_retry_and_archive_revalidate_filter_at_execute_time() {
+    let (_tmp, db_path, store) = new_store(QueueConfig::default());
+    let retry_target = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue retry target");
+    let archive_target = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue archive target");
+    let storage_filter = QueueFailureFilter {
+        kind: Some("hook_post_tool".to_string()),
+        retry_class: Some("terminal".to_string()),
+        reason_code: Some("storage_merge_reopen".to_string()),
+    };
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    for id in [&retry_target, &archive_target] {
+        conn.execute(
+            "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 2, last_error = 'failed to reopen db for merge drawer_hooks_raw_bash_69633781', op_state = 'failed' WHERE id = ?1",
+            [id.as_str()],
+        )
+        .expect("mark storage failed");
+    }
+    drop(conn);
+
+    let preview = store
+        .preview_failed_action(storage_filter.clone())
+        .expect("preview storage filter");
+    assert_eq!(preview.matched, 2);
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET last_error = 'automatic hook LLM gate failed before durable insert' WHERE id = ?1",
+        [retry_target.as_str()],
+    )
+    .expect("change retry target reason");
+    conn.execute(
+        "UPDATE pending_messages SET failure_class = 'retryable_model' WHERE id = ?1",
+        [archive_target.as_str()],
+    )
+    .expect("change archive target class");
+    drop(conn);
+
+    let retried = store
+        .retry_failed_messages(storage_filter.clone())
+        .expect("retry with stale filter");
+    assert_eq!(retried.matched, 0);
+    assert_eq!(retried.changed, 0);
+    let archived = store
+        .archive_failed_messages(storage_filter)
+        .expect("archive with stale filter");
+    assert_eq!(archived.matched, 0);
+    assert_eq!(archived.changed, 0);
+
+    let still_failed = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'failed'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count failed rows");
+    assert_eq!(still_failed, 2);
+}
+
+#[test]
+fn test_failed_archived_counts_only_queue_archive_provenance() {
+    let (_tmp, db_path, store) = new_store(QueueConfig::default());
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute_batch(
+        r#"
+        INSERT INTO pending_message_completions (
+            message_id,
+            kind,
+            created_at,
+            claimed_at,
+            completed_at,
+            processing_ms,
+            op_state,
+            rejected_reason
+        )
+        VALUES (
+            'ordinary-failed-completion',
+            'ingest_async',
+            1700000000000,
+            1700000001000,
+            1700000002000,
+            1000,
+            'failed',
+            'normal_ingest_failure'
+        );
+        "#,
+    )
+    .expect("insert ordinary failed completion");
+    drop(conn);
+
+    assert_eq!(store.stats().expect("ordinary stats").failed_archived, 0);
+
+    let malformed = store
+        .enqueue("ingest_async", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue malformed");
+    Connection::open(&db_path)
+        .expect("open sqlite")
+        .execute(
+            "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 1, last_error = 'failed to decode queued hook envelope', op_state = 'failed' WHERE id = ?1",
+            [malformed.as_str()],
+        )
+        .expect("mark malformed failed");
+    store
+        .archive_failed_messages(QueueFailureFilter {
+            kind: Some("ingest_async".to_string()),
+            retry_class: None,
+            reason_code: Some("invalid_hook_envelope".to_string()),
+        })
+        .expect("archive malformed");
+    assert_eq!(store.stats().expect("archived stats").failed_archived, 1);
+}
+
+#[test]
+fn test_queue_cli_failed_summary_and_retry_dry_run_are_aggregate_only() {
+    let (home, db_path) = setup_home();
+    let store = PendingMessageStore::new(&db_path).expect("create store");
+    let malformed = store
+        .enqueue("ingest_async", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue malformed");
+    let storage = store
+        .enqueue("hook_post_tool", "RAW_PAYLOAD_SHOULD_NOT_APPEAR")
+        .expect("enqueue storage");
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 1, last_error = 'failed to decode queued hook envelope', op_state = 'failed' WHERE id = ?1",
+        [malformed.as_str()],
+    )
+    .expect("mark malformed failed");
+    conn.execute(
+        "UPDATE pending_messages SET status = 'failed', failure_class = 'terminal', retry_count = 2, last_error = 'failed to reopen db for merge drawer_hooks_raw_bash_69633781', op_state = 'failed' WHERE id = ?1",
+        [storage.as_str()],
+    )
+    .expect("mark storage failed");
+    drop(conn);
+
+    let stats_output = Command::new(mempal_bin())
+        .arg("stats")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal stats");
+    assert!(stats_output.status.success(), "{stats_output:?}");
+    let stats_stdout = String::from_utf8(stats_output.stdout).expect("stats stdout utf8");
+    assert!(stats_stdout.contains("failed: 2"), "{stats_stdout}");
+    assert!(
+        stats_stdout.contains("failed_terminal: 2"),
+        "{stats_stdout}"
+    );
+    assert!(
+        stats_stdout.contains("failed_retryable: 0"),
+        "{stats_stdout}"
+    );
+    assert!(
+        stats_stdout.contains("failed_by_kind_class_reason:"),
+        "{stats_stdout}"
+    );
+    assert!(
+        stats_stdout.contains("invalid_hook_envelope"),
+        "{stats_stdout}"
+    );
+    assert!(
+        stats_stdout.contains("storage_merge_reopen"),
+        "{stats_stdout}"
+    );
+    assert!(
+        !stats_stdout.contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"),
+        "{stats_stdout}"
+    );
+
+    let failed_output = Command::new(mempal_bin())
+        .args(["queue", "failed", "--reason", "storage_merge_reopen"])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal queue failed");
+    assert!(failed_output.status.success(), "{failed_output:?}");
+    let failed_stdout = String::from_utf8(failed_output.stdout).expect("queue failed stdout utf8");
+    assert!(failed_stdout.contains("filter: reason=storage_merge_reopen"));
+    assert!(failed_stdout.contains("matched_failed: 1"));
+    assert!(failed_stdout.contains("storage_merge_reopen"));
+    assert!(!failed_stdout.contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"));
+
+    let retry_dry_run = Command::new(mempal_bin())
+        .args([
+            "queue",
+            "retry-failed",
+            "--kind",
+            "hook_post_tool",
+            "--reason",
+            "storage_merge_reopen",
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal queue retry dry-run");
+    assert!(retry_dry_run.status.success(), "{retry_dry_run:?}");
+    let retry_stdout = String::from_utf8(retry_dry_run.stdout).expect("retry stdout utf8");
+    assert!(retry_stdout.contains("dry_run: true"), "{retry_stdout}");
+    assert!(retry_stdout.contains("matched: 1"), "{retry_stdout}");
+    assert!(
+        !retry_stdout.contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"),
+        "{retry_stdout}"
+    );
+    let archive_dry_run = Command::new(mempal_bin())
+        .args([
+            "queue",
+            "archive-failed",
+            "--kind",
+            "ingest_async",
+            "--reason",
+            "invalid_hook_envelope",
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal queue archive dry-run");
+    assert!(archive_dry_run.status.success(), "{archive_dry_run:?}");
+    let archive_stdout = String::from_utf8(archive_dry_run.stdout).expect("archive stdout utf8");
+    assert!(archive_stdout.contains("dry_run: true"), "{archive_stdout}");
+    assert!(archive_stdout.contains("matched: 1"), "{archive_stdout}");
+    assert!(
+        !archive_stdout.contains("RAW_PAYLOAD_SHOULD_NOT_APPEAR"),
+        "{archive_stdout}"
+    );
+    let failed_after_dry_run = Connection::open(&db_path)
+        .expect("open sqlite")
+        .query_row(
+            "SELECT COUNT(*) FROM pending_messages WHERE status = 'failed'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("count failed after dry-run");
+    assert_eq!(failed_after_dry_run, 2);
+
+    let unfiltered_execute = Command::new(mempal_bin())
+        .args(["queue", "retry-failed", "--execute"])
+        .env("HOME", home.path())
+        .output()
+        .expect("run unfiltered queue retry");
+    assert!(!unfiltered_execute.status.success());
+    let stderr = String::from_utf8(unfiltered_execute.stderr).expect("stderr utf8");
+    assert!(
+        stderr.contains("requires at least one explicit --kind, --class, or --reason filter"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn test_queue_help_documents_failed_recovery_examples() {
+    let output = Command::new(mempal_bin())
+        .args(["queue", "--help"])
+        .output()
+        .expect("run mempal queue help");
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("help stdout utf8");
+    assert!(stdout.contains("invalid_hook_envelope"), "{stdout}");
+    assert!(stdout.contains("automatic_hook_llm_gate"), "{stdout}");
+    assert!(stdout.contains("llm_response_decode"), "{stdout}");
+    assert!(stdout.contains("storage_merge_reopen"), "{stdout}");
+    assert!(stdout.contains("retry-failed"), "{stdout}");
+    assert!(stdout.contains("archive-failed"), "{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #556.

This PR makes failed queue health actionable without exposing raw hook/drawer payloads.

Changes:
- Adds shared failed/retrying queue classification buckets in core: `kind`, retry class, stable reason code, and sanitized message.
- Reuses the same queue summary for `mempal stats`, `mempal status`, and MCP `mempal_status`.
- Classifies common failure families separately, including malformed hook envelope, automatic hook LLM gate, LLM response decode, and storage merge/reopen failures.
- Adds safe queue recovery commands: `mempal queue failed`, `mempal queue retry-failed`, and `mempal queue archive-failed`.
- Keeps retry/archive mutating operations behind explicit filters and `--execute`; dry-run is safe and non-mutating.
- Narrows failed embed retry handling so terminal hook/envelope failures are not treated as embed backlog.

## Verification

- CSA writer salvage completed and committed `1fa9d941dcf3`.
- `git diff --check`
- `git diff --check main...HEAD`
- `cargo +1.96.0 fmt --all -- --check`
- Commit hook passed:
  - `just clippy`
  - `just test`
  - `cargo fmt --all --check`
- Exact-head CSA review PASS/CLEAN:
  - session: `01KVYK0XKSVZ1437MQEZQ0PNJ4`
  - range: `main...HEAD`
  - reviewed head: `1fa9d941dcf`
- `csa review --check-verdict --sa-mode true --range main...HEAD`
- Hook-enabled push/local gates passed:
  - log: `/tmp/mempal-556-push-20260624-221622.log`
  - `PUSH_EXIT 0`
