### PR TITLE
fix(status): tolerate corrupt daemon pidfile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12238,7 +12238,10 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
             ),
         });
     }
-    let (daemon_pid, daemon_running) = detect_daemon_status(db.path())?;
+    let (daemon_pid, daemon_running, daemon_pidfile_warning) = detect_daemon_status(db.path())?;
+    if let Some(warning) = daemon_pidfile_warning {
+        runtime_warnings.push(warning);
+    }
     let last_heartbeat = db
         .conn()
         .query_row(
@@ -12916,35 +12919,117 @@ fn read_daemon_pid(db_path: &Path) -> Result<Option<i32>> {
     Ok(Some(pid))
 }
 
+struct DaemonPidfileProbe {
+    pid: Option<i32>,
+    warning: Option<mempal::core::config::RuntimeWarning>,
+}
+
+fn daemon_pidfile_status_warning(
+    pid_path: &Path,
+    reason: &str,
+) -> mempal::core::config::RuntimeWarning {
+    mempal::core::config::RuntimeWarning {
+        level: "warn",
+        source: "daemon",
+        message: format!(
+            "daemon pidfile {} is {reason}; ignoring pidfile for status. Daemon liveness is based on process scan and DB holder diagnostics.",
+            pid_path.display()
+        ),
+    }
+}
+
+fn read_daemon_pid_for_status(db_path: &Path) -> DaemonPidfileProbe {
+    let Some(mempal_home) = db_path.parent() else {
+        return DaemonPidfileProbe {
+            pid: None,
+            warning: None,
+        };
+    };
+    let pid_path = mempal_home.join("daemon.pid");
+    let content = match std::fs::read_to_string(&pid_path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return DaemonPidfileProbe {
+                pid: None,
+                warning: None,
+            };
+        }
+        Err(error) => {
+            return DaemonPidfileProbe {
+                pid: None,
+                warning: Some(daemon_pidfile_status_warning(
+                    &pid_path,
+                    &format!("unreadable ({})", error.kind()),
+                )),
+            };
+        }
+    };
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return DaemonPidfileProbe {
+            pid: None,
+            warning: Some(daemon_pidfile_status_warning(&pid_path, "empty")),
+        };
+    }
+    match trimmed.parse::<i32>() {
+        Ok(pid) => DaemonPidfileProbe {
+            pid: Some(pid),
+            warning: None,
+        },
+        Err(_) => DaemonPidfileProbe {
+            pid: None,
+            warning: Some(daemon_pidfile_status_warning(
+                &pid_path,
+                "not a valid integer",
+            )),
+        },
+    }
+}
+
 #[cfg(unix)]
-fn detect_daemon_status(db_path: &Path) -> Result<(Option<i32>, bool)> {
-    let pidfile_pid = read_daemon_pid(db_path)?;
+fn detect_daemon_status(
+    db_path: &Path,
+) -> Result<(
+    Option<i32>,
+    bool,
+    Option<mempal::core::config::RuntimeWarning>,
+)> {
+    let pidfile = read_daemon_pid_for_status(db_path);
+    let pidfile_pid = pidfile.pid;
     if let Some(pid) = pidfile_pid
         && process_is_running(pid).context("failed to probe daemon pid liveness")?
     {
-        return Ok((Some(pid), true));
+        return Ok((Some(pid), true, pidfile.warning));
     }
 
-    let (candidates, live_pidfile_pid) = collect_daemon_candidates(db_path)?;
+    let (candidates, live_pidfile_pid) =
+        collect_daemon_candidates_with_pidfile(db_path, pidfile_pid)?;
     let plan = mempal::daemon_singleton::plan_daemon_reap(&candidates, live_pidfile_pid);
     if let Some(pid) = plan.keeper
         && process_is_running(pid).context("failed to probe daemon singleton liveness")?
     {
-        return Ok((Some(pid), true));
+        return Ok((Some(pid), true, pidfile.warning));
     }
 
-    Ok((pidfile_pid, false))
+    Ok((pidfile_pid, false, pidfile.warning))
 }
 
 #[cfg(not(unix))]
-fn detect_daemon_status(db_path: &Path) -> Result<(Option<i32>, bool)> {
-    let daemon_pid = read_daemon_pid(db_path)?;
+fn detect_daemon_status(
+    db_path: &Path,
+) -> Result<(
+    Option<i32>,
+    bool,
+    Option<mempal::core::config::RuntimeWarning>,
+)> {
+    let pidfile = read_daemon_pid_for_status(db_path);
+    let daemon_pid = pidfile.pid;
     let daemon_running = daemon_pid
         .map(process_is_running)
         .transpose()
         .context("failed to probe daemon pid liveness")?
         .unwrap_or(false);
-    Ok((daemon_pid, daemon_running))
+    Ok((daemon_pid, daemon_running, pidfile.warning))
 }
 
 #[cfg(unix)]
@@ -14324,19 +14409,46 @@ impl DaemonProcessOps for RealDaemonProcessOps {
 
 #[cfg(unix)]
 fn collect_daemon_candidates(db_path: &Path) -> Result<(Vec<i32>, Option<i32>)> {
-    collect_daemon_candidates_with_scan(db_path, mempal::daemon_singleton::enumerate_daemon_pids)
+    let pidfile_pid = read_daemon_pid(db_path)?;
+    collect_daemon_candidates_with_scan_and_pidfile(
+        db_path,
+        mempal::daemon_singleton::enumerate_daemon_pids,
+        pidfile_pid,
+    )
 }
 
 #[cfg(unix)]
+fn collect_daemon_candidates_with_pidfile(
+    db_path: &Path,
+    pidfile_pid: Option<i32>,
+) -> Result<(Vec<i32>, Option<i32>)> {
+    collect_daemon_candidates_with_scan_and_pidfile(
+        db_path,
+        mempal::daemon_singleton::enumerate_daemon_pids,
+        pidfile_pid,
+    )
+}
+
+#[cfg(all(unix, test))]
 fn collect_daemon_candidates_with_scan(
     db_path: &Path,
     enumerate_daemon_pids: impl Fn(&str, &Path) -> Vec<i32>,
+) -> Result<(Vec<i32>, Option<i32>)> {
+    let pidfile_pid = read_daemon_pid(db_path)?;
+    collect_daemon_candidates_with_scan_and_pidfile(db_path, enumerate_daemon_pids, pidfile_pid)
+}
+
+#[cfg(unix)]
+fn collect_daemon_candidates_with_scan_and_pidfile(
+    db_path: &Path,
+    enumerate_daemon_pids: impl Fn(&str, &Path) -> Vec<i32>,
+    pidfile_pid: Option<i32>,
 ) -> Result<(Vec<i32>, Option<i32>)> {
     let binary =
         mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
     let mut candidates = enumerate_daemon_pids(&binary, db_path);
 
-    let pidfile_pid = match read_daemon_pid(db_path)? {
+    let live_pidfile_pid = match pidfile_pid {
         Some(pid) if process_is_running(pid)? => {
             if !candidates.contains(&pid) {
                 candidates.push(pid);
@@ -14349,7 +14461,7 @@ fn collect_daemon_candidates_with_scan(
     candidates.sort_unstable();
     candidates.dedup();
 
-    Ok((candidates, pidfile_pid))
+    Ok((candidates, live_pidfile_pid))
 }
 
 #[cfg(unix)]
@@ -14710,8 +14822,12 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
         mempal::daemon_singleton::current_binary_name().unwrap_or_else(|| "mempal".to_string());
     let mempal_home = daemon_home_from_db_path(db_path);
     let siblings = mempal::daemon_singleton::enumerate_daemon_pids(&binary, db_path);
+    let pidfile = read_daemon_pid_for_status(db_path);
+    if let Some(warning) = pidfile.warning.as_ref() {
+        println!("warning: {}", warning.message);
+    }
 
-    match read_daemon_pid(db_path)? {
+    match pidfile.pid {
         None => {
             if siblings.is_empty() {
                 println!("status: stopped");

--- a/tests/queue_stats.rs
+++ b/tests/queue_stats.rs
@@ -55,6 +55,69 @@ db_path = "{}"
     (tmp, db_path)
 }
 
+fn run_status_in_home(home: &TempDir) -> String {
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal status");
+
+    assert!(
+        output.status.success(),
+        "status failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("status stdout utf8")
+}
+
+fn run_status_with_daemon_pidfile(content: &str) -> String {
+    let (home, db_path) = setup_home();
+    let pid_path = db_path.parent().expect("mempal home").join("daemon.pid");
+    fs::write(pid_path, content).expect("write daemon pidfile");
+
+    run_status_in_home(&home)
+}
+
+#[test]
+fn test_status_command_reports_missing_daemon_pidfile_as_stopped() {
+    let (home, _db_path) = setup_home();
+    let stdout = run_status_in_home(&home);
+
+    assert!(stdout.contains("Daemon:"), "{stdout}");
+    assert!(stdout.contains("running: false"), "{stdout}");
+    assert!(stdout.contains("pid: none"), "{stdout}");
+    assert!(!stdout.contains("daemon pidfile"), "{stdout}");
+}
+
+#[test]
+fn test_status_command_warns_on_empty_daemon_pidfile() {
+    let stdout = run_status_with_daemon_pidfile("");
+
+    assert!(stdout.contains("Daemon:"), "{stdout}");
+    assert!(stdout.contains("running: false"), "{stdout}");
+    assert!(stdout.contains("pid: none"), "{stdout}");
+    assert!(stdout.contains("Warnings:"), "{stdout}");
+    assert!(stdout.contains("daemon pidfile"), "{stdout}");
+    assert!(stdout.contains("empty"), "{stdout}");
+}
+
+#[test]
+fn test_status_command_warns_on_corrupt_daemon_pidfile() {
+    let stdout = run_status_with_daemon_pidfile("not-a-pid\n");
+
+    assert!(stdout.contains("Daemon:"), "{stdout}");
+    assert!(stdout.contains("running: false"), "{stdout}");
+    assert!(stdout.contains("pid: none"), "{stdout}");
+    assert!(stdout.contains("Warnings:"), "{stdout}");
+    assert!(stdout.contains("daemon pidfile"), "{stdout}");
+    assert!(stdout.contains("not a valid integer"), "{stdout}");
+    assert!(
+        !stdout.contains("not-a-pid"),
+        "status must not echo corrupt pidfile payload: {stdout}"
+    );
+}
+
 fn insert_status_drawer(db_path: &Path, id: &str, source_type: SourceType) {
     let db = Database::open(db_path).expect("open db for status drawer");
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {


### PR DESCRIPTION
## Summary

Closes #555.

This PR makes status diagnostics robust to stale/corrupt daemon pidfiles.

Changes:
- Adds a status-only daemon pidfile probe that turns missing, empty, unreadable, and unparsable pidfiles into non-fatal runtime warnings.
- Keeps existing strict pidfile parsing for daemon lifecycle paths that own cleanup/restart policy.
- Lets `mempal status` continue process scanning and DB-holder diagnostics even when the pidfile cannot prove daemon state.
- Makes `mempal daemon status` non-fatal for corrupt pidfiles too.
- Adds regression tests for missing, empty, and corrupt pidfiles, including avoiding echoing corrupt payload content.

## Verification

- CSA writer committed `eb518142a5528f4ea493b89a3fe1d495b824e547`.
- `cargo +1.96.0-x86_64-unknown-linux-gnu fmt`
- `just test-f daemon_pidfile`
- `just test-f test_daemon_start_repairs_orphan_pidfile_before_reporting_running`
- `mise x rust@stable -- cargo test --features integration --test hook_passive_capture test_daemon_status_reports_state_and_queue -- --exact`
- `just fmt-check`
- `git diff --check main...HEAD`
- `just clippy`
- Commit hook passed: branch protection, `just clippy`, `just test`, fmt check.
- Exact-head CSA review PASS/CLEAN:
  - session: `01KVYP6RNEDNS02QVP6V5QM64A`
  - range: `main...HEAD`
  - reviewed head: `eb518142a55`
- `csa review --check-verdict --sa-mode true --range main...HEAD`
- Hook-enabled push/local gates passed:
  - log: `/tmp/mempal-555-push-20260624-231047.log`
  - `PUSH_EXIT 0`
