### PR TITLE
fix(maintenance): retry rejudge startup opens

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4297,7 +4297,7 @@ fn command_retries_historical_rejudge_startup_open(command: &Commands) -> bool {
         command,
         Commands::Maintenance {
             command: MaintenanceCommands::Rejudge(args),
-        } if args.command.is_none() && args.resume
+        } if args.command.is_none()
     )
 }
 
@@ -22976,6 +22976,107 @@ mod historical_rejudge_tests {
         );
         anyhow::Error::new(mempal::core::db::DbError::from(sqlite_error))
             .context("failed to open database")
+    }
+
+    fn top_level_rejudge_command(configure: impl FnOnce(&mut MaintenanceRejudgeArgs)) -> Commands {
+        let mut args = MaintenanceRejudgeArgs {
+            command: None,
+            help_verbose: false,
+            execute: false,
+            hard_delete: false,
+            backup_dir: None,
+            unsafe_no_backup: false,
+            limit: 1000,
+            all: false,
+            resume: false,
+            unsafe_allow_config_version_drift: false,
+            page_size: DEFAULT_HISTORICAL_REJUDGE_PAGE_SIZE,
+            llm_concurrency: DEFAULT_HISTORICAL_REJUDGE_LLM_CONCURRENCY,
+            progress_file: None,
+            proposal_only: false,
+            confirm_pending_only: false,
+            proposal_llm_endpoint: None,
+            confirm_llm_endpoint: None,
+            wing: None,
+            room: None,
+            project: None,
+            format: "plain".to_string(),
+        };
+        configure(&mut args);
+        Commands::Maintenance {
+            command: MaintenanceCommands::Rejudge(Box::new(args)),
+        }
+    }
+
+    fn assert_historical_rejudge_startup_retry(name: &str, command: Commands) {
+        assert!(
+            command_retries_historical_rejudge_startup_open(&command),
+            "expected startup retry for {name}"
+        );
+    }
+
+    #[test]
+    fn historical_rejudge_startup_retry_covers_top_level_sweep_modes() {
+        assert_historical_rejudge_startup_retry(
+            "limited dry-run",
+            top_level_rejudge_command(|args| {
+                args.limit = 20;
+                args.format = "json".to_string();
+            }),
+        );
+        assert_historical_rejudge_startup_retry(
+            "all dry-run",
+            top_level_rejudge_command(|args| {
+                args.all = true;
+            }),
+        );
+        assert_historical_rejudge_startup_retry(
+            "execute",
+            top_level_rejudge_command(|args| {
+                args.execute = true;
+                args.backup_dir = Some(PathBuf::from("/tmp/mempal-rejudge-backup"));
+            }),
+        );
+        assert_historical_rejudge_startup_retry(
+            "proposal-only",
+            top_level_rejudge_command(|args| {
+                args.all = true;
+                args.proposal_only = true;
+            }),
+        );
+        assert_historical_rejudge_startup_retry(
+            "confirm-pending resume",
+            top_level_rejudge_command(|args| {
+                args.all = true;
+                args.resume = true;
+                args.execute = true;
+                args.confirm_pending_only = true;
+                args.backup_dir = Some(PathBuf::from("/tmp/mempal-rejudge-backup"));
+            }),
+        );
+        assert_historical_rejudge_startup_retry(
+            "resume",
+            top_level_rejudge_command(|args| {
+                args.all = true;
+                args.resume = true;
+                args.execute = true;
+                args.backup_dir = Some(PathBuf::from("/tmp/mempal-rejudge-backup"));
+            }),
+        );
+    }
+
+    #[test]
+    fn historical_rejudge_restore_subcommand_does_not_use_sweep_startup_retry() {
+        let command = top_level_rejudge_command(|args| {
+            args.command = Some(MaintenanceRejudgeCommands::Restore {
+                backup: PathBuf::from("/tmp/mempal-rejudge-backup.json"),
+                execute: false,
+                conflict_policy: RejudgeRestoreConflictPolicy::Skip,
+                format: "plain".to_string(),
+            });
+        });
+
+        assert!(!command_retries_historical_rejudge_startup_open(&command));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "323353527c21f28dd8a5b8c6efc071cb21bdd8dd"
+commit = "2a80993f50ac779da7589fd6f74e3f179785681e"
 source_kind = "git"


### PR DESCRIPTION
Closes #562.

## Summary

This PR fixes `maintenance rejudge` startup under normal active mempal daemon/MCP DB-holder contention.

Changes:
- Routes top-level `maintenance rejudge` sweep modes through the existing bounded SQLite-lock startup-open retry path.
- Keeps `maintenance rejudge restore` excluded from that sweep retry predicate.
- Adds regression coverage for non-resume top-level sweep modes and restore exclusion.
- Includes related generated `weave.lock` drift in the same logical change.

## Verification

CSA-Codex writer:
- Session: `01KVZ4QXTET6GH1Y1T0WTG6HRE`
- Commit initially produced: `243855a`

Lockfile cleanup:
- Session: `01KVZ66E53TKCSPG1QGKV9CEV4`
- Final amended HEAD: `a8995141e58893096fe807654c639e556d97fc81`

Exact-head review:
- Session: `01KVZ6B9DMDP5KV1ENQDHDM9P0`
- Verdict: PASS / CLEAN
- `csa review --check-verdict --sa-mode true --range main...HEAD` passed for `a8995141e58`

Pre-push local gates:
- branch-protection passed
- local-gates passed
- review-check passed
- push log: `/tmp/mempal-562-push-20260625-035254.log`
- `PUSH_EXIT 0`

## Notes

The original live failure was:

```text
mempal maintenance rejudge --limit 20 --format json
error: failed to open database
  caused by: database is locked
```

This happened while an active initialized MCP context holder was alive; after the contention ended, the same dry-run succeeded. The fix addresses that startup-open retry gap rather than requiring operators to stop mempal clients before a reversible maintenance sweep.
