### PR TITLE
fix(hermes): redact mempal conclude REST failures

### DIFF
--- a/contrib/hermes-agent-plugin/mempal/__init__.py
+++ b/contrib/hermes-agent-plugin/mempal/__init__.py
@@ -142,6 +142,68 @@ def _encode_query_params(params: Dict[str, Any]) -> str:
     )
 
 
+def _route_class(path: str) -> str:
+    if path in {"/api/ingest", "/api/delete"}:
+        return "write"
+    if path in {"/api/search", "/api/timeline", "/api/pinned_facts"}:
+        return "read"
+    return "other"
+
+
+def _http_status_text(status: int) -> str:
+    from http import HTTPStatus
+
+    try:
+        return HTTPStatus(status).phrase
+    except ValueError:
+        return "HTTP error"
+
+
+def _is_retryable_http_status(status: int) -> bool:
+    return status in {408, 429} or 500 <= status <= 599
+
+
+def _rest_recovery_hint(status: Optional[int], path: str) -> str:
+    if status is None:
+        return "Confirm the local mempal REST daemon is running and reachable, then retry."
+    if _is_retryable_http_status(status):
+        return f"Retry the request; if it persists, inspect mempal daemon logs for {path}."
+    if 400 <= status <= 499:
+        return "Check the tool request fields; mempal rejected the write before storage."
+    return f"Inspect mempal daemon logs for {path}."
+
+
+def _rest_error_payload(message: str, path: str, exc: Exception) -> Dict[str, Any]:
+    import urllib.error
+
+    status: Optional[int] = None
+    details: Dict[str, Any] = {
+        "route": path,
+        "route_class": _route_class(path),
+    }
+    if isinstance(exc, urllib.error.HTTPError):
+        status = int(exc.code)
+        details.update({
+            "kind": "rest_http_error",
+            "http_status": status,
+            "status_text": _http_status_text(status),
+            "retryable": _is_retryable_http_status(status),
+        })
+    elif isinstance(exc, urllib.error.URLError):
+        details.update({
+            "kind": "rest_transport_error",
+            "error_class": exc.__class__.__name__,
+            "retryable": True,
+        })
+    else:
+        details.update({
+            "kind": "plugin_exception",
+            "error_class": exc.__class__.__name__,
+        })
+    details["recovery_hint"] = _rest_recovery_hint(status, path)
+    return {"error": message, "error_details": _strip_none(details)}
+
+
 def _bounded_int(value: Any, default: int, minimum: int, maximum: int) -> int:
     try:
         parsed = int(value)
@@ -900,7 +962,11 @@ class MempalMemoryProvider:
                 return json.dumps(resp)
             except Exception as exc:
                 self._record_failure()
-                return json.dumps({"error": f"Failed to store: {exc}"})
+                return json.dumps(_rest_error_payload(
+                    "Failed to store memory via mempal REST API.",
+                    "/api/ingest",
+                    exc,
+                ))
         return json.dumps({"error": f"Unknown tool: {tool_name}"})
 
     def on_session_end(self, messages):

--- a/contrib/hermes-agent-plugin/test_mempal_provider.py
+++ b/contrib/hermes-agent-plugin/test_mempal_provider.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import time
 import unittest
+import urllib.error
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -69,6 +70,16 @@ class RecordingProvider(MempalMemoryProvider):
 
     def _drain_writes(self) -> None:
         self._write_queue.join()
+
+
+class FailingPostProvider(RecordingProvider):
+    def __init__(self, exc: Exception) -> None:
+        super().__init__()
+        self.exc = exc
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Any:
+        self.posts.append((path, dict(body)))
+        raise self.exc
 
 
 class MempalProviderScopeTests(unittest.TestCase):
@@ -352,6 +363,35 @@ class SearchResultTests(unittest.TestCase):
 
         result = json.loads(provider.handle_tool_call("mempal_conclude", {"conclusion": "test fact"}))
         self.assertIn("drawer_id", result)
+
+    def test_conclude_http_500_returns_redacted_actionable_error(self) -> None:
+        provider = FailingPostProvider(urllib.error.HTTPError(
+            "http://127.0.0.1:3080/api/ingest?debug=true",
+            500,
+            "Internal Server Error",
+            {},
+            None,
+        ))
+        provider.initialize("session-a", user_id="alice", profile="work")
+
+        result = json.loads(provider.handle_tool_call(
+            "mempal_conclude",
+            {"conclusion": "synthetic harmless durable fact"},
+        ))
+
+        self.assertEqual(result["error"], "Failed to store memory via mempal REST API.")
+        details = result["error_details"]
+        self.assertEqual(details["kind"], "rest_http_error")
+        self.assertEqual(details["http_status"], 500)
+        self.assertEqual(details["route"], "/api/ingest")
+        self.assertEqual(details["route_class"], "write")
+        self.assertTrue(details["retryable"])
+        self.assertIn("recovery_hint", details)
+        serialized = json.dumps(result)
+        self.assertNotIn("synthetic harmless durable fact", serialized)
+        self.assertNotIn("127.0.0.1", serialized)
+        self.assertNotIn("debug=true", serialized)
+        self.assertNotIn("HTTP Error 500", serialized)
 
     def test_profile_returns_drawer_id(self) -> None:
         provider = RecordingProvider()

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "2a80993f50ac779da7589fd6f74e3f179785681e"
+commit = "cb1f4333f77a48efe621db9d16c4da2da56ce1c3"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Redacts `mempal_conclude` REST write failures surfaced through the Hermes MemoryProvider plugin so generic HTTP 500s become structured, actionable, non-sensitive errors.
- Preserves successful `mempal_conclude` behavior, including `drawer_id` return handling.
- Adds regression coverage for REST write failure redaction and profile-fact success behavior.

## Verification

- Direct CSA Codex writer completed and committed the fix.
- Hook-enabled amend for `weave.lock` completed successfully.
- Exact-head CSA review PASS: `01KW048M454HM7NSWJHPJTG9Q3`.
- Durable review check passed for `main...HEAD` at `8133d27fa601`.

Closes #570
