### PR TITLE
fix(maintenance): allow rejudge under live daemon lease

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -5435,31 +5435,19 @@ impl Database {
     }
 
     pub fn runtime_writer_lease_has_live_daemon(&self, name: &str) -> Result<bool, DbError> {
-        let now_secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs() as i64)
-            .unwrap_or(0);
         let mut stmt = self.conn.prepare(
-            "SELECT pid, boot_id, expires_at \
+            "SELECT pid, boot_id \
              FROM runtime_writer_leases \
              WHERE name = ?1 AND mode = 'daemon'",
         )?;
         let rows = stmt.query_map([name], |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, String>(2)?,
-            ))
+            Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?))
         })?;
         for row in rows {
-            let (pid_i64, boot_id, expires_at) = row?;
-            let remaining_secs = crate::cowork::peek::parse_rfc3339(&expires_at)
-                .map(|expires| expires - now_secs)
-                .unwrap_or(0);
-            if remaining_secs > 0
-                && u32::try_from(pid_i64).ok().is_some_and(|pid| {
-                    runtime_writer_process_is_live_holder(pid, boot_id.as_deref())
-                })
+            let (pid_i64, boot_id) = row?;
+            if u32::try_from(pid_i64)
+                .ok()
+                .is_some_and(|pid| runtime_writer_process_is_live_holder(pid, boot_id.as_deref()))
             {
                 return Ok(true);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23363,6 +23363,27 @@ mod historical_rejudge_tests {
         .expect("daemon writer lease")
     }
 
+    fn expire_writer_lease_for_test(db: &Database, lease: &RuntimeWriterLease) {
+        let expired_at = mempal::cowork::peek::format_rfc3339(
+            std::time::SystemTime::now() - std::time::Duration::from_secs(300),
+        );
+        let heartbeat_at = mempal::cowork::peek::format_rfc3339(std::time::SystemTime::now());
+        db.conn()
+            .execute(
+                "UPDATE runtime_writer_leases \
+                 SET expires_at = ?1, heartbeat_at = ?2 \
+                 WHERE name = ?3 AND owner = ?4 AND session_id = ?5",
+                rusqlite::params![
+                    expired_at,
+                    heartbeat_at,
+                    lease.name,
+                    lease.owner,
+                    lease.session_id
+                ],
+            )
+            .expect("expire writer lease for test");
+    }
+
     fn database_locked_open_error() -> anyhow::Error {
         let sqlite_error = rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error {
@@ -25224,6 +25245,7 @@ threshold = 0.7
         let backups = backup_dir(&tmp);
         let progress_path = tmp.path().join("rejudge-progress.jsonl");
         let daemon_lease = hold_test_daemon_writer_lease(&db);
+        expire_writer_lease_for_test(&db, &daemon_lease);
 
         maintenance_rejudge_command(
             &db,
@@ -25269,6 +25291,7 @@ threshold = 0.7
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db = Database::open(&tmp.path().join("palace.db")).expect("open db");
         let daemon_lease = hold_test_daemon_writer_lease(&db);
+        expire_writer_lease_for_test(&db, &daemon_lease);
         let _first = acquire_historical_rejudge_writer_lease(&db).expect("first rejudge lease");
 
         let error = match acquire_historical_rejudge_writer_lease(&db) {

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "9cc97023ebf324d0bd34d900c3f47b8e84087bda"
+commit = "51326263ec440c0d2bb343bc1c40468587a38b83"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Allow maintenance rejudge startup to coexist with the normal live daemon's `sqlite-writer` lease instead of failing before progress.
- Preserve duplicate maintenance-runner protection and fatal handling for genuinely conflicting maintenance writer leases.
- Add regression coverage for live-daemon coexistence and duplicate rejudge rejection.

## Verification

- CSA writer completed commit `222e6554e4155eaf3b4503898c1e0ad6fc59a5b3`.
- Exact-head CSA review PASS/CLEAN: `01KW0V6Y72AEQB9589BABAZKMN`.
- `csa review --check-verdict --sa-mode true --range main...HEAD` passed locally before push.
- Pre-push hook local gates/review-check will run during `git push`.

## Live validation plan

After merge:

1. Sync main and run `just install`.
2. Restart any deleted-inode daemon onto the merged `/usr/local/bin/mempal`.
3. Resume the preserved historical rejudge run dir without resetting cursor/work tables.
4. Verify startup progresses under the live daemon and then return to short startup + IO monitoring.

Fixes #574
