### PR TITLE
fix(rejudge): defer llm retry checkpoint lease loss

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18689,13 +18689,20 @@ fn historical_rejudge_lost_sqlite_writer_lease_can_defer(
     status: &'static str,
 ) -> Result<bool> {
     let lease = writer_lease.lease();
-    if status != "failed" || lease.name != SQLITE_WRITER_LEASE_NAME || lease.mode != "maintenance" {
+    if !historical_rejudge_checkpoint_status_can_defer_lost_sqlite_writer(status)
+        || lease.name != SQLITE_WRITER_LEASE_NAME
+        || lease.mode != "maintenance"
+    {
         return Ok(false);
     }
     let active = db
         .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
         .context("failed to inspect SQLite writer lease after historical rejudge lease loss")?;
     sqlite_writer_conflict_is_live_daemon(db, &active)
+}
+
+fn historical_rejudge_checkpoint_status_can_defer_lost_sqlite_writer(status: &'static str) -> bool {
+    matches!(status, "failed" | "waiting_llm" | "running")
 }
 
 fn historical_rejudge_checkpoint_lease_check_outcome(
@@ -28581,6 +28588,51 @@ threshold = 0.7
             checkpoint.status, "running",
             "deferred failed checkpoint must restore in-memory status for same-page retry"
         );
+        assert_eq!(checkpoint.last_processed_rowid, Some(2));
+        let persisted = load_historical_rejudge_checkpoint(&db)
+            .expect("load unchanged checkpoint")
+            .expect("checkpoint");
+        assert_eq!(persisted.status, "running");
+        assert_eq!(persisted.last_processed_rowid, Some(2));
+        assert!(
+            db.runtime_writer_lease_is_active(
+                &daemon_lease.name,
+                &daemon_lease.owner,
+                &daemon_lease.session_id
+            )
+            .expect("check daemon writer lease"),
+            "deferred checkpoint must not disturb the live daemon sqlite-writer lease"
+        );
+    }
+
+    #[test]
+    fn historical_rejudge_waiting_llm_checkpoint_lost_sqlite_writer_to_live_daemon_is_deferred() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        ensure_historical_rejudge_checkpoint_storage(&db).expect("ensure checkpoint storage");
+        let writer_lease =
+            acquire_historical_rejudge_writer_lease(&db).expect("historical rejudge writer lease");
+        assert_eq!(writer_lease.lease().name, SQLITE_WRITER_LEASE_NAME);
+        let mut checkpoint =
+            historical_rejudge_checkpoint_for_test(&tmp, "lost-sqlite-writer-waiting-llm-run");
+        save_historical_rejudge_checkpoint(&db, &checkpoint).expect("save initial checkpoint");
+        release_writer_lease_for_test(&db, &writer_lease);
+        let daemon_lease = hold_test_daemon_writer_lease(&db);
+
+        let outcome = persist_historical_rejudge_llm_retry_status_checkpoint(
+            &db,
+            &mut checkpoint,
+            "waiting_llm",
+            Some(&writer_lease),
+        )
+        .expect("lost sqlite-writer under live daemon must defer LLM retry checkpoint persistence");
+
+        assert_eq!(
+            outcome,
+            HistoricalRejudgeCheckpointPersistence::DeferredTransientLock
+        );
+        assert_eq!(checkpoint.status, "waiting_llm");
         assert_eq!(checkpoint.last_processed_rowid, Some(2));
         let persisted = load_historical_rejudge_checkpoint(&db)
             .expect("load unchanged checkpoint")


### PR DESCRIPTION
## Summary

- Defer/retry historical rejudge LLM retry checkpoint persistence when the normal live daemon temporarily owns or regains the `sqlite-writer` lease.
- Preserve cursor safety by retrying the same page/checkpoint state without advancing when the checkpoint cannot be persisted.
- Keep non-daemon / duplicate-maintenance-writer lease-loss cases fatal.

## Validation

- CSA writer session: `01KW1862WEPV65J44AMH2H9ECP`
- Exact-head CSA review: `01KW19HCV5AJKYM66HB3JANVMZ` — no findings for `main...HEAD`
- Durable check-verdict: PASS
- Hook-enabled push/local gates will run before PR creation.

## Production verification plan

After merge/install/restart:

1. Resume the preserved historical rejudge run dir without resetting cursor/work rows.
2. Confirm startup under the live daemon.
3. Confirm LLM retry checkpoint lease-loss no longer exits fatally.
4. Keep aggregate-only reporting; do not print raw memory text, prompts, responses, endpoints, or secrets.

Closes #578
