### PR TITLE
fix(rejudge): recover lost maintenance writer lease

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -5384,6 +5384,70 @@ impl Database {
         })
     }
 
+    /// Restore a previously-owned runtime writer lease only when the recorded
+    /// holder is still alive and no holder currently owns the same lease name.
+    ///
+    /// This is a crash-recovery primitive for long maintenance commands whose
+    /// heartbeat lost the row to a transient cleanup race. It deliberately does
+    /// not steal from any visible holder, including expired-but-live holders.
+    pub fn runtime_writer_lease_restore_if_unheld(
+        &self,
+        lease: &RuntimeWriterLease,
+        ttl_secs: u64,
+    ) -> Result<bool, DbError> {
+        let mut restored = false;
+        self.with_immediate_tx(|| {
+            self.runtime_writer_lease_cleanup_expired_tx(true)?;
+            if !runtime_writer_process_is_live_holder(lease.pid, lease.boot_id.as_deref()) {
+                return Ok(());
+            }
+            let same_lease_exists = self.conn.query_row(
+                "SELECT EXISTS(
+                     SELECT 1 FROM runtime_writer_leases
+                     WHERE name = ?1 AND owner = ?2 AND session_id = ?3
+                 )",
+                params![&lease.name, &lease.owner, &lease.session_id],
+                |row| row.get::<_, i64>(0),
+            )?;
+            if same_lease_exists != 0 {
+                restored = true;
+                return Ok(());
+            }
+            let holder_count = self.conn.query_row(
+                "SELECT COUNT(*) FROM runtime_writer_leases WHERE name = ?1",
+                params![&lease.name],
+                |row| row.get::<_, i64>(0),
+            )?;
+            if holder_count != 0 {
+                return Ok(());
+            }
+            let now_time = SystemTime::now();
+            let now = crate::cowork::peek::format_rfc3339(now_time);
+            let expires_at = crate::cowork::peek::format_rfc3339(
+                now_time + Duration::from_secs(ttl_secs),
+            );
+            let rows = self.conn.execute(
+                "INSERT OR IGNORE INTO runtime_writer_leases \
+                 (name, owner, pid, boot_id, session_id, acquired_at, expires_at, heartbeat_at, mode, metadata_json) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?6, ?8, ?9)",
+                params![
+                    &lease.name,
+                    &lease.owner,
+                    lease.pid as i64,
+                    &lease.boot_id,
+                    &lease.session_id,
+                    &now,
+                    &expires_at,
+                    &lease.mode,
+                    &lease.metadata_json,
+                ],
+            )?;
+            restored = rows > 0;
+            Ok(())
+        })?;
+        Ok(restored)
+    }
+
     pub fn runtime_writer_lease_status(
         &self,
         name: Option<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::fs::{self, OpenOptions};
 use std::future::Future;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, mpsc};
+use std::sync::{Arc, Mutex, mpsc};
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -4601,8 +4601,49 @@ struct MaintenanceWriterLeaseGuard {
     db_path: PathBuf,
     lease: RuntimeWriterLease,
     active: Arc<std::sync::atomic::AtomicBool>,
+    heartbeat: Mutex<MaintenanceWriterLeaseHeartbeat>,
+}
+
+struct MaintenanceWriterLeaseHeartbeat {
     stop: Option<mpsc::Sender<()>>,
-    heartbeat: Option<std::thread::JoinHandle<()>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl MaintenanceWriterLeaseHeartbeat {
+    fn start_new(
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+        active: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        let mut heartbeat = Self {
+            stop: None,
+            handle: None,
+        };
+        heartbeat.start(db_path, lease, active);
+        heartbeat
+    }
+
+    fn start(
+        &mut self,
+        db_path: PathBuf,
+        lease: RuntimeWriterLease,
+        active: Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let (stop_tx, stop_rx) = mpsc::channel();
+        self.stop = Some(stop_tx);
+        self.handle = Some(spawn_maintenance_writer_lease_heartbeat(
+            db_path, lease, active, stop_rx,
+        ));
+    }
+
+    fn stop_and_join(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4651,6 +4692,21 @@ impl MaintenanceWriterLeaseGuard {
         )
     }
 
+    fn restore_active_after_lease_row_recovered(&self) -> Result<()> {
+        let mut heartbeat = self
+            .heartbeat
+            .lock()
+            .map_err(|_| anyhow::anyhow!("writer lease heartbeat state lock poisoned"))?;
+        heartbeat.stop_and_join();
+        self.active.store(true, std::sync::atomic::Ordering::SeqCst);
+        heartbeat.start(
+            self.db_path.clone(),
+            self.lease.clone(),
+            Arc::clone(&self.active),
+        );
+        Ok(())
+    }
+
     fn lease_is_active_once(&self, operation: &'static str) -> Result<bool> {
         let db = Database::open_with_busy_timeout(
             &self.db_path,
@@ -4688,11 +4744,8 @@ fn ensure_maintenance_writer_lease_active(
 
 impl Drop for MaintenanceWriterLeaseGuard {
     fn drop(&mut self) {
-        if let Some(stop) = self.stop.take() {
-            let _ = stop.send(());
-        }
-        if let Some(handle) = self.heartbeat.take() {
-            let _ = handle.join();
+        if let Ok(mut heartbeat) = self.heartbeat.lock() {
+            heartbeat.stop_and_join();
         }
         if let Ok(db) = Database::open(&self.db_path) {
             let _ = db.runtime_writer_lease_release(
@@ -4866,20 +4919,17 @@ fn try_acquire_named_runtime_writer_lease(
     let Some(lease) = lease else {
         return Ok(None);
     };
-    let (stop_tx, stop_rx) = mpsc::channel();
     let active = Arc::new(std::sync::atomic::AtomicBool::new(true));
-    let heartbeat = spawn_maintenance_writer_lease_heartbeat(
+    let heartbeat = MaintenanceWriterLeaseHeartbeat::start_new(
         db.path().to_path_buf(),
         lease.clone(),
         Arc::clone(&active),
-        stop_rx,
     );
     Ok(Some(MaintenanceWriterLeaseGuard {
         db_path: db.path().to_path_buf(),
         lease,
         active,
-        stop: Some(stop_tx),
-        heartbeat: Some(heartbeat),
+        heartbeat: Mutex::new(heartbeat),
     }))
 }
 
@@ -18792,7 +18842,7 @@ fn historical_rejudge_checkpoint_lease_check(
             Ok(HistoricalRejudgeCheckpointLeaseCheck::Active)
         }
         Ok(MaintenanceWriterLeaseCheck::Lost) => {
-            match historical_rejudge_lost_sqlite_writer_lease_can_defer(db, writer_lease, status) {
+            match historical_rejudge_lost_writer_lease_can_defer(db, writer_lease, status) {
                 Ok(true) => Ok(HistoricalRejudgeCheckpointLeaseCheck::DeferredTransientLock),
                 Ok(false) => writer_lease.bail_lost(operation),
                 Err(error) if is_transient_sqlite_lock_error(&error) => {
@@ -18805,22 +18855,31 @@ fn historical_rejudge_checkpoint_lease_check(
     }
 }
 
-fn historical_rejudge_lost_sqlite_writer_lease_can_defer(
+fn historical_rejudge_lost_writer_lease_can_defer(
     db: &Database,
     writer_lease: &MaintenanceWriterLeaseGuard,
     status: &'static str,
 ) -> Result<bool> {
     let lease = writer_lease.lease();
-    if !historical_rejudge_checkpoint_status_can_defer_lost_sqlite_writer(status)
-        || lease.name != SQLITE_WRITER_LEASE_NAME
-        || lease.mode != "maintenance"
-    {
+    if !historical_rejudge_checkpoint_status_can_defer_lost_sqlite_writer(status) {
         return Ok(false);
     }
-    let active = db
-        .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
-        .context("failed to inspect SQLite writer lease after historical rejudge lease loss")?;
-    sqlite_writer_conflict_is_live_daemon(db, &active)
+    if lease.name == SQLITE_WRITER_LEASE_NAME && lease.mode == "maintenance" {
+        let active = db
+            .runtime_writer_lease_status(Some(SQLITE_WRITER_LEASE_NAME))
+            .context("failed to inspect SQLite writer lease after historical rejudge lease loss")?;
+        return sqlite_writer_conflict_is_live_daemon(db, &active);
+    }
+    if lease.name == HISTORICAL_REJUDGE_WRITER_LEASE_NAME && lease.mode == "maintenance-rejudge" {
+        let restored = db
+            .runtime_writer_lease_restore_if_unheld(lease, MAINTENANCE_WRITER_LEASE_TTL_SECS)
+            .context("failed to restore historical rejudge writer lease after transient loss")?;
+        if restored {
+            writer_lease.restore_active_after_lease_row_recovered()?;
+        }
+        return Ok(restored);
+    }
+    Ok(false)
 }
 
 fn historical_rejudge_checkpoint_status_can_defer_lost_sqlite_writer(status: &'static str) -> bool {
@@ -29030,7 +29089,55 @@ threshold = 0.7
     }
 
     #[test]
-    fn historical_rejudge_failed_checkpoint_lost_writer_lease_still_fails() {
+    fn historical_rejudge_failed_checkpoint_lost_rejudge_writer_reacquires_when_unheld() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+        ensure_historical_rejudge_checkpoint_storage(&db).expect("ensure checkpoint storage");
+        let _daemon_lease = hold_test_daemon_writer_lease(&db);
+        let writer_lease =
+            acquire_historical_rejudge_writer_lease(&db).expect("historical rejudge writer lease");
+        assert_eq!(
+            writer_lease.lease().name,
+            HISTORICAL_REJUDGE_WRITER_LEASE_NAME
+        );
+        let mut checkpoint = historical_rejudge_checkpoint_for_test(
+            &tmp,
+            "lost-rejudge-writer-reacquire-failed-checkpoint-run",
+        );
+        save_historical_rejudge_checkpoint(&db, &checkpoint).expect("save initial checkpoint");
+        release_writer_lease_for_test(&db, &writer_lease);
+
+        let outcome = persist_historical_rejudge_failed_status_checkpoint(
+            &db,
+            &mut checkpoint,
+            Some(&writer_lease),
+        )
+        .expect("lost unheld rejudge writer lease must be recovered and deferred");
+
+        assert_eq!(
+            outcome,
+            HistoricalRejudgeCheckpointPersistence::DeferredTransientLock
+        );
+        assert_eq!(
+            writer_lease
+                .active_status("verify recovered rejudge writer lease")
+                .expect("check recovered writer lease"),
+            MaintenanceWriterLeaseCheck::Active
+        );
+        assert_eq!(
+            checkpoint.status, "running",
+            "deferred failed checkpoint must restore in-memory status for same-page retry"
+        );
+        let persisted = load_historical_rejudge_checkpoint(&db)
+            .expect("load unchanged checkpoint")
+            .expect("checkpoint");
+        assert_eq!(persisted.status, "running");
+        assert_eq!(persisted.last_processed_rowid, Some(2));
+    }
+
+    #[test]
+    fn historical_rejudge_failed_checkpoint_lost_writer_lease_with_competing_holder_still_fails() {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
@@ -29042,13 +29149,23 @@ threshold = 0.7
             historical_rejudge_checkpoint_for_test(&tmp, "lost-lease-failed-checkpoint-run");
         save_historical_rejudge_checkpoint(&db, &checkpoint).expect("save initial checkpoint");
         release_writer_lease_for_test(&db, &writer_lease);
+        let _competing_lease = db
+            .runtime_writer_lease_acquire(
+                HISTORICAL_REJUDGE_WRITER_LEASE_NAME,
+                "competing-rejudge-writer",
+                "maintenance-rejudge",
+                MAINTENANCE_WRITER_LEASE_TTL_SECS,
+                None,
+            )
+            .expect("acquire competing rejudge writer lease")
+            .expect("competing rejudge writer lease");
 
         let error = persist_historical_rejudge_failed_status_checkpoint(
             &db,
             &mut checkpoint,
             Some(&writer_lease),
         )
-        .expect_err("lost writer lease must remain fatal");
+        .expect_err("lost writer lease with competing holder must remain fatal");
 
         assert_writer_lease_lost_before(&error, "persist failed historical rejudge checkpoint");
         let persisted = load_historical_rejudge_checkpoint(&db)
@@ -29059,7 +29176,8 @@ threshold = 0.7
     }
 
     #[test]
-    fn historical_rejudge_waiting_llm_checkpoint_lost_writer_lease_still_fails() {
+    fn historical_rejudge_waiting_llm_checkpoint_lost_writer_lease_with_competing_holder_still_fails()
+     {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let db_path = tmp.path().join("palace.db");
         let db = Database::open(&db_path).expect("open db");
@@ -29094,6 +29212,16 @@ threshold = 0.7
         };
         save_historical_rejudge_checkpoint(&db, &checkpoint).expect("save initial checkpoint");
         release_writer_lease_for_test(&db, &writer_lease);
+        let _competing_lease = db
+            .runtime_writer_lease_acquire(
+                HISTORICAL_REJUDGE_WRITER_LEASE_NAME,
+                "competing-rejudge-writer",
+                "maintenance-rejudge",
+                MAINTENANCE_WRITER_LEASE_TTL_SECS,
+                None,
+            )
+            .expect("acquire competing rejudge writer lease")
+            .expect("competing rejudge writer lease");
 
         let error = persist_historical_rejudge_llm_retry_status_checkpoint(
             &db,
@@ -29101,7 +29229,7 @@ threshold = 0.7
             "waiting_llm",
             Some(&writer_lease),
         )
-        .expect_err("lost writer lease must remain fatal");
+        .expect_err("lost writer lease with competing holder must remain fatal");
 
         assert_writer_lease_lost_before(&error, "persist historical rejudge LLM retry checkpoint");
         let persisted = load_historical_rejudge_checkpoint(&db)

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -25,6 +25,19 @@ use tower::ServiceExt;
 
 static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+fn json_string_values_contain(value: &Value, needle: &str) -> bool {
+    match value {
+        Value::String(text) => text.contains(needle),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_string_values_contain(value, needle)),
+        Value::Object(fields) => fields
+            .values()
+            .any(|value| json_string_values_contain(value, needle)),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
 struct TestEnv {
     _tmp: TempDir,
     db_path: PathBuf,
@@ -667,7 +680,7 @@ model = "rerank"
     assert!(endpoints[0]["last_error"].is_null(), "{rendered}");
     assert!(rendered.contains(mempal::core::remote_calls::BLOCKED_REMOTE_ENDPOINT_LABEL));
     assert!(!rendered.contains("api.openai.com"), "{rendered}");
-    assert!(!rendered.contains("9443"), "{rendered}");
+    assert!(!json_string_values_contain(&body, "9443"), "{rendered}");
     assert!(!rendered.contains("private-embed-path"), "{rendered}");
     assert!(!rendered.contains("api_key"), "{rendered}");
     assert!(
@@ -676,10 +689,10 @@ model = "rerank"
     );
     assert!(!rendered.contains("MEMPAL_SECRET_TOKEN_ENV"), "{rendered}");
     assert!(!rendered.contains("llm.example.com"), "{rendered}");
-    assert!(!rendered.contains("9444"), "{rendered}");
+    assert!(!json_string_values_contain(&body, "9444"), "{rendered}");
     assert!(!rendered.contains("private-chat-path"), "{rendered}");
     assert!(!rendered.contains("rerank.example.com"), "{rendered}");
-    assert!(!rendered.contains("9445"), "{rendered}");
+    assert!(!json_string_values_contain(&body, "9445"), "{rendered}");
     assert!(!rendered.contains("private-rerank-path"), "{rendered}");
 }
 


### PR DESCRIPTION
## Summary
- Recover a lost `maintenance-rejudge-writer` lease for historical rejudge failed-checkpoint persistence only when the same runtime writer is currently unheld.
- Keep competing active writer holders fatal, preserving single-runner exclusivity.
- Restart the writer lease heartbeat after safe restore so the recovered lease does not immediately go stale again.
- Harden the REST redaction test so numeric runtime fields do not create false positives for endpoint-port leakage.

Closes #582

## Local gates / review
- `just quality-gates` passed before commit.
- Hook-enabled amend pre-commit gates passed after the REST test false-positive fix.
- Fresh exact-head CSA/Codex review passed:
  - session: `01KW25J54SM056XW1R4KSP4QHM`
  - head: `f8dfac808238beffaacefec3951762252ff58249`
  - range: `main...HEAD`
  - verdict: PASS/CLEAN
- `csa review --check-verdict --sa-mode true --range main...HEAD --cd "$PWD"` passed for the same head.
- Hook-enabled push passed:
  - local-gates: pass
  - review-check: pass
  - release-gate: pass
  - log: `/tmp/mempal-582-push-20260626-144325.log`

## Notes
- Earlier CSA review attempts failed before verdict due host memory/soft-limit admission; evidence was filed in RyderFreeman4Logos/cli-sub-agent#2473 and retried successfully with `--memory-max-mb 9104 --build-jobs 1`.
- This PR intentionally uses direct local-gate merge flow for mempal; no pr-bot/cloud bot.
