### PR TITLE
fix(rejudge): retry sqlite protocol lock collisions

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -266,11 +266,15 @@ pub fn rusqlite_error_is_lock(error: &rusqlite::Error) -> bool {
         rusqlite::Error::SqliteFailure(sqlite, _)
             if matches!(
                 sqlite.code,
-                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+                rusqlite::ErrorCode::DatabaseBusy
+                    | rusqlite::ErrorCode::DatabaseLocked
+                    | rusqlite::ErrorCode::FileLockingProtocolFailed
             )
                 || matches!(
                     sqlite.extended_code & 0xff,
-                    rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+                    rusqlite::ffi::SQLITE_BUSY
+                        | rusqlite::ffi::SQLITE_LOCKED
+                        | rusqlite::ffi::SQLITE_PROTOCOL
                 )
     )
 }
@@ -7634,6 +7638,26 @@ fn segment_cjk_query(query: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sqlite_protocol_is_classified_as_transient_lock() {
+        let protocol_error = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        );
+
+        assert!(
+            rusqlite_error_is_lock(&protocol_error),
+            "SQLITE_PROTOCOL is a transient lock-protocol collision and must be retried"
+        );
+        assert!(
+            db_error_is_sqlite_lock(&DbError::from(protocol_error)),
+            "DbError classification must preserve SQLITE_PROTOCOL as a transient lock"
+        );
+    }
 
     fn test_drawer(id: &str, content: &str) -> Drawer {
         Drawer::new_bootstrap_evidence(super::super::types::BootstrapEvidenceArgs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19005,10 +19005,12 @@ fn is_transient_sqlite_lock_code(sqlite_error: &rusqlite::ffi::Error) -> bool {
     let primary_code = sqlite_error.extended_code & 0xff;
     matches!(
         sqlite_error.code,
-        rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+        rusqlite::ErrorCode::DatabaseBusy
+            | rusqlite::ErrorCode::DatabaseLocked
+            | rusqlite::ErrorCode::FileLockingProtocolFailed
     ) || matches!(
         primary_code,
-        rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+        rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED | rusqlite::ffi::SQLITE_PROTOCOL
     )
 }
 
@@ -29352,6 +29354,24 @@ threshold = 0.7
         assert_eq!(decision.score, Some(0.125));
         assert_eq!(decision.tier, 3);
         assert_eq!(decision.judge, "llm");
+    }
+
+    #[test]
+    fn historical_rejudge_treats_sqlite_protocol_as_transient_lock() {
+        let protocol_error = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        );
+        let error = anyhow::Error::new(mempal::core::db::DbError::from(protocol_error))
+            .context("failed to load historical rejudge work item test-drawer");
+
+        assert!(
+            is_transient_sqlite_lock_error(&error),
+            "historical rejudge page errors caused by SQLITE_PROTOCOL must defer/retry instead of failing the run: {error:#}"
+        );
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2825,11 +2825,15 @@ fn rusqlite_error_is_lock(error: &rusqlite::Error) -> bool {
         rusqlite::Error::SqliteFailure(sqlite, _)
             if matches!(
                 sqlite.code,
-                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+                rusqlite::ErrorCode::DatabaseBusy
+                    | rusqlite::ErrorCode::DatabaseLocked
+                    | rusqlite::ErrorCode::FileLockingProtocolFailed
             )
                 || matches!(
                     sqlite.extended_code & 0xff,
-                    rusqlite::ffi::SQLITE_BUSY | rusqlite::ffi::SQLITE_LOCKED
+                    rusqlite::ffi::SQLITE_BUSY
+                        | rusqlite::ffi::SQLITE_LOCKED
+                        | rusqlite::ffi::SQLITE_PROTOCOL
                 )
     )
 }
@@ -3355,19 +3359,33 @@ fn status_db_failure_kind(error: &(dyn std::error::Error + 'static)) -> &'static
 
 fn status_rusqlite_failure_kind(error: &rusqlite::Error) -> Option<&'static str> {
     match error {
-        rusqlite::Error::SqliteFailure(sqlite, _) => match sqlite.code {
-            rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked => {
+        rusqlite::Error::SqliteFailure(sqlite, _) => {
+            let primary_code = sqlite.extended_code & 0xff;
+            if matches!(
+                sqlite.code,
+                rusqlite::ErrorCode::DatabaseBusy
+                    | rusqlite::ErrorCode::DatabaseLocked
+                    | rusqlite::ErrorCode::FileLockingProtocolFailed
+            ) || matches!(
+                primary_code,
+                rusqlite::ffi::SQLITE_BUSY
+                    | rusqlite::ffi::SQLITE_LOCKED
+                    | rusqlite::ffi::SQLITE_PROTOCOL
+            ) {
                 Some("locked_or_busy")
+            } else {
+                match sqlite.code {
+                    rusqlite::ErrorCode::CannotOpen
+                    | rusqlite::ErrorCode::NotFound
+                    | rusqlite::ErrorCode::PermissionDenied
+                    | rusqlite::ErrorCode::ReadOnly => Some("path_or_permission"),
+                    rusqlite::ErrorCode::DatabaseCorrupt | rusqlite::ErrorCode::NotADatabase => {
+                        Some("corrupt_or_invalid")
+                    }
+                    _ => None,
+                }
             }
-            rusqlite::ErrorCode::CannotOpen
-            | rusqlite::ErrorCode::NotFound
-            | rusqlite::ErrorCode::PermissionDenied
-            | rusqlite::ErrorCode::ReadOnly => Some("path_or_permission"),
-            rusqlite::ErrorCode::DatabaseCorrupt | rusqlite::ErrorCode::NotADatabase => {
-                Some("corrupt_or_invalid")
-            }
-            _ => None,
-        },
+        }
         _ => None,
     }
 }
@@ -12832,6 +12850,36 @@ quality_policy = "llm_required_for_keep"
     }
 
     #[test]
+    fn test_mcp_sqlite_protocol_is_classified_as_transient_lock() {
+        let protocol_error = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        );
+
+        assert!(
+            rusqlite_error_is_lock(&protocol_error),
+            "MCP retry paths must treat SQLITE_PROTOCOL as transient SQLite lock contention"
+        );
+
+        let wrapped_error = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        ))
+        .context("wrapped MCP SQLite lock protocol failure");
+
+        assert!(
+            anyhow_chain_contains_sqlite_lock(&wrapped_error),
+            "wrapped MCP SQLITE_PROTOCOL failures must reach the same retry classifier"
+        );
+    }
+
+    #[test]
     fn test_mcp_context_database_deadline_exceeds_large_db_smoke_latency() {
         assert!(
             MCP_SEARCH_DB_DEADLINE >= Duration::from_secs(60),
@@ -14149,10 +14197,50 @@ pattern_boost = 0.2
             },
             Some("file is not a database".to_string()),
         );
+        let protocol = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        );
 
         assert_eq!(status_db_failure_kind(&busy), "locked_or_busy");
+        assert_eq!(status_db_failure_kind(&protocol), "locked_or_busy");
         assert_eq!(status_db_failure_kind(&permission), "path_or_permission");
         assert_eq!(status_db_failure_kind(&invalid), "corrupt_or_invalid");
+    }
+
+    #[test]
+    fn test_mcp_ingest_database_write_refused_error_classifies_sqlite_protocol() {
+        let protocol = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::FileLockingProtocolFailed,
+                extended_code: rusqlite::ffi::SQLITE_PROTOCOL,
+            },
+            Some("Database lock protocol error".to_string()),
+        );
+
+        let error =
+            database_write_refused_error(Path::new("/tmp/palace.db"), "async_db", &protocol);
+
+        assert!(error.message.contains("locked_or_busy"));
+        let data = error.data.expect("structured error data");
+        assert_eq!(
+            data.get("reason").and_then(Value::as_str),
+            Some("database_locked")
+        );
+        assert_eq!(
+            data.get("action").and_then(Value::as_str),
+            Some("retry_after_transient_lock")
+        );
+        let diagnostic = data
+            .get("database_diagnostic")
+            .expect("database diagnostic payload");
+        assert_eq!(
+            diagnostic.get("failure_kind").and_then(Value::as_str),
+            Some("locked_or_busy")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- classify SQLite SQLITE_PROTOCOL / FileLockingProtocolFailed as transient lock collisions across DB, historical rejudge, MCP retry, and MCP diagnostics paths
- preserve retry/diagnostic behavior for daemon/MCP/maintenance contention instead of fatal/unknown handling
- add focused regressions covering core DB, historical rejudge, MCP retry, and MCP diagnostic paths

## Verification
- git commit/amend hooks: branch-protection, quality-gates, quick-format-check
- just release-gate
- pre-push hooks: branch-protection, local-gates, review-check
- csa review --sa-mode true --tool codex --tier tier4 --range main...HEAD --full-consistency --security-mode on
- csa review --check-verdict --range main...HEAD

Closes #585