### PR TITLE
feat(observability): record operation telemetry

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -29,6 +29,9 @@ use crate::core::{
 use crate::embed::global_embed_status;
 use crate::ingest::gating::evaluate_fact_check_gate;
 use crate::ingest::normalize::CURRENT_NORMALIZE_VERSION;
+use crate::observability::{
+    OperationTelemetryRecord, OperationTelemetrySource, OperationTelemetrySpan,
+};
 use crate::process_diagnostics::inspect_process_memory;
 use crate::search::{
     SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
@@ -39,8 +42,13 @@ use crate::search::{
 };
 use axum::{
     Json, Router,
+    body::Body,
     extract::{Query, State},
-    http::{HeaderMap, HeaderValue, Method, StatusCode, header::CONTENT_TYPE, header::USER_AGENT},
+    http::{
+        HeaderMap, HeaderValue, Method, Request, StatusCode, header::CONTENT_TYPE,
+        header::USER_AGENT,
+    },
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -106,6 +114,7 @@ async fn shutdown_signal() {
 }
 
 pub fn router(state: ApiState) -> Router {
+    let telemetry_state = state.clone();
     Router::new()
         .route("/api/search", get(search_handler))
         .route("/api/ingest", post(ingest_handler))
@@ -113,8 +122,34 @@ pub fn router(state: ApiState) -> Router {
         .route("/api/status", get(status_handler))
         .route("/api/pinned_facts", get(pinned_facts_handler))
         .merge(super::hermes_compat::routes())
+        .route_layer(middleware::from_fn_with_state(
+            telemetry_state,
+            rest_operation_telemetry,
+        ))
         .with_state(state)
         .layer(cors_layer())
+}
+
+async fn rest_operation_telemetry(
+    State(state): State<ApiState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let operation = format!("{} {}", request.method().as_str(), request.uri().path());
+    let span = OperationTelemetrySpan::start(
+        state.db_path.clone(),
+        OperationTelemetryRecord::new(OperationTelemetrySource::Rest, operation, "rest.request"),
+    );
+    let response = next.run(request).await;
+    let status = response.status();
+    if status.is_client_error() {
+        span.finish_error_class("http_4xx");
+    } else if status.is_server_error() {
+        span.finish_error_class("http_5xx");
+    } else {
+        span.finish_success();
+    }
+    response
 }
 
 fn cors_layer() -> CorsLayer {

--- a/src/core/db_fork_ext.rs
+++ b/src/core/db_fork_ext.rs
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS fork_ext_meta (
 );
 "#;
 
-pub const CURRENT_FORK_EXT_VERSION: u32 = 22;
+pub const CURRENT_FORK_EXT_VERSION: u32 = 23;
 
 // Partial indexes on the most expensive GROUP BY + COUNT(*) paths used by `mempal status`.
 // idx_drawers_project_id_active is a partial replacement for the non-partial
@@ -120,6 +120,39 @@ CREATE INDEX IF NOT EXISTS idx_pending_failed_failure_class
 INSERT INTO fork_ext_meta (key, value)
 VALUES ('queue.auto_requeue.last_at_unix_ms', '0')
 ON CONFLICT(key) DO NOTHING;
+"#;
+
+pub const FORK_EXT_V23_SCHEMA_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS operation_telemetry (
+    id                         TEXT PRIMARY KEY,
+    started_at_unix_ms         INTEGER NOT NULL,
+    duration_ms                INTEGER NOT NULL,
+    source                     TEXT NOT NULL CHECK(source IN ('cli', 'mcp', 'rest', 'daemon')),
+    operation                  TEXT NOT NULL,
+    call_site                  TEXT NOT NULL,
+    success                    INTEGER NOT NULL CHECK(success IN (0, 1)),
+    error_class                TEXT,
+    sqlite_error_class         TEXT,
+    rows_scanned               INTEGER NOT NULL DEFAULT 0,
+    rows_returned              INTEGER NOT NULL DEFAULT 0,
+    rows_changed               INTEGER NOT NULL DEFAULT 0,
+    lock_wait_count            INTEGER NOT NULL DEFAULT 0,
+    retry_count                INTEGER NOT NULL DEFAULT 0,
+    result_count               INTEGER NOT NULL DEFAULT 0,
+    physical_read_bytes        INTEGER NOT NULL DEFAULT 0,
+    physical_write_bytes       INTEGER NOT NULL DEFAULT 0,
+    logical_read_bytes         INTEGER NOT NULL DEFAULT 0,
+    logical_write_bytes        INTEGER NOT NULL DEFAULT 0,
+    cancelled_write_bytes      INTEGER NOT NULL DEFAULT 0,
+    metadata_json              TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_operation_telemetry_started
+    ON operation_telemetry(started_at_unix_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_operation_telemetry_source_operation
+    ON operation_telemetry(source, operation, started_at_unix_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_operation_telemetry_call_site
+    ON operation_telemetry(call_site, started_at_unix_ms DESC);
 "#;
 
 pub const FORK_EXT_V15_SCHEMA_SQL: &str = r#"
@@ -452,6 +485,10 @@ fn fork_ext_migrations() -> &'static [Migration] {
             version: 22,
             up: apply_v22,
         },
+        Migration {
+            version: 23,
+            up: apply_v23,
+        },
     ]
 }
 
@@ -698,6 +735,10 @@ fn apply_v22(conn: &Connection) -> rusqlite::Result<()> {
         "#,
     )?;
     conn.execute_batch(FORK_EXT_V22_SCHEMA_SQL)
+}
+
+fn apply_v23(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(FORK_EXT_V23_SCHEMA_SQL)
 }
 
 fn apply_v10(conn: &Connection) -> rusqlite::Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -31,6 +31,9 @@ use crate::ingest::gating::{
 };
 use crate::ingest::novelty::{NoveltyAction, NoveltyCandidate, evaluate as evaluate_novelty};
 use crate::llm::LlmError;
+use crate::observability::{
+    OperationTelemetryRecord, OperationTelemetrySource, OperationTelemetrySpan,
+};
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use serde_json::{Value, json};
@@ -269,6 +272,7 @@ async fn run_loop(context: &DaemonContext) -> Result<()> {
 
     let hook_worker_state = HookWorkerState {
         async_db: context.async_db.clone(),
+        db_path: db_path.clone(),
         store: context.store.clone(),
         worker_id: worker_id.clone(),
         embedder: Arc::clone(&embedder),
@@ -581,6 +585,7 @@ fn spawn_daemon_ingest_drain_worker(
 #[derive(Clone)]
 struct HookWorkerState {
     async_db: AsyncDb,
+    db_path: PathBuf,
     store: AsyncPendingMessageStore,
     worker_id: String,
     embedder: Arc<DaemonEmbedder>,
@@ -743,6 +748,15 @@ async fn process_hook_worker_message(
     claim_ttl_secs: i64,
 ) {
     let message_id = message.id.clone();
+    let span = OperationTelemetrySpan::start(
+        state.db_path.clone(),
+        OperationTelemetryRecord::new(
+            OperationTelemetrySource::Daemon,
+            format!("hook {}", message.kind),
+            "daemon.hook_worker.message",
+        )
+        .with_retry_count(message.retry_count as u64),
+    );
     refresh_hook_message_heartbeat(&state.store, &message_id, &state.worker_id).await;
     let heartbeat_handle = spawn_hook_message_heartbeat(
         state.store.clone(),
@@ -775,23 +789,29 @@ async fn process_hook_worker_message(
                 state
                     .write_observer
                     .record_error(format!("failed to confirm {message_id}: {error}"));
+                span.finish_error(error);
             } else {
                 state.write_observer.record_successful_write();
+                span.finish_success();
             }
         }
         Err(error) => {
-            tracing::error!("daemon message {message_id} failed: {error}");
-            state.write_observer.record_error(error.to_string());
+            let error_text = error.to_string();
+            tracing::error!("daemon message {message_id} failed: {error_text}");
+            state.write_observer.record_error(error_text.clone());
             let disposition = queue_failure_disposition(&error);
             if let Err(mark_error) = state
                 .store
-                .mark_failed_with_disposition(message.clone(), error.to_string(), disposition)
+                .mark_failed_with_disposition(message.clone(), error_text.clone(), disposition)
                 .await
             {
                 tracing::error!(?mark_error, "failed to mark_failed {message_id}");
                 state
                     .write_observer
                     .record_error(format!("failed to mark_failed {message_id}: {mark_error}"));
+                span.finish_error(mark_error);
+            } else {
+                span.finish_error(error_text);
             }
         }
     }
@@ -3598,6 +3618,7 @@ mod tests {
     use crate::endpoint_health::{EndpointHealthSnapshot, ProbeStatus};
     use crate::hook::{CapturedHookEnvelope, HookEvent};
     use crate::llm::LlmError;
+    use crate::observability::{OperationTelemetrySummaryOptions, operation_telemetry_summary};
     use arc_swap::ArcSwap;
     use std::pin::Pin;
     use tokio::sync::Notify;
@@ -4401,6 +4422,7 @@ mod tests {
         let worker = tokio::spawn(run_hook_worker(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: "bounded-continuation-worker".to_string(),
                 embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -4440,6 +4462,34 @@ mod tests {
         let stats = store.stats().expect("queue stats");
         assert_eq!(stats.pending, 0);
         assert_eq!(stats.claimed, 0);
+
+        let hook_row = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let telemetry_db = Database::open(&db_path).expect("open telemetry db");
+                let telemetry = operation_telemetry_summary(
+                    &telemetry_db,
+                    OperationTelemetrySummaryOptions {
+                        since_unix_ms: None,
+                        limit: 10,
+                    },
+                )
+                .expect("summarize daemon hook telemetry");
+                if let Some(row) = telemetry.into_iter().find(|row| {
+                    row.source == "daemon"
+                        && row.operation == "hook hook_post_tool"
+                        && row.call_site == "daemon.hook_worker.message"
+                        && row.operation_count == 2
+                }) {
+                    break row;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("daemon hook operation telemetry should record both completed hooks");
+        assert_eq!(hook_row.operation_count, 2);
+        assert_eq!(hook_row.success_count, 2);
+        assert_eq!(hook_row.error_count, 0);
 
         tokio::time::timeout(Duration::from_secs(5), idle_observer.notified())
             .await
@@ -4558,6 +4608,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: "lease-loss-worker".to_string(),
                 embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -4759,6 +4810,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: worker_id.to_string(),
                 embedder: std::sync::Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -4854,6 +4906,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: "merge-conflict-worker".to_string(),
                 embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -4994,6 +5047,7 @@ mod tests {
         let worker = tokio::spawn(super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store.clone(),
                 worker_id: worker_id.to_string(),
                 embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -5533,6 +5587,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: "soft-prototype-reject-worker".to_string(),
                 embedder: std::sync::Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(
@@ -5776,6 +5831,7 @@ mod tests {
         super::process_hook_worker_message(
             HookWorkerState {
                 async_db,
+                db_path: db_path.clone(),
                 store: async_store,
                 worker_id: "llm-malformed-worker".to_string(),
                 embedder: Arc::new(DaemonEmbedder::from_primary_for_test(Box::new(

--- a/src/foresight_cli.rs
+++ b/src/foresight_cli.rs
@@ -37,6 +37,14 @@ pub enum ForesightCommands {
     },
 }
 
+pub fn command_uses_read_only_database(command: &ForesightCommands) -> bool {
+    matches!(command, ForesightCommands::List(_)) || command_is_dry_run(command)
+}
+
+pub fn command_is_dry_run(command: &ForesightCommands) -> bool {
+    matches!(command, ForesightCommands::Add(args) if args.dry_run)
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct ForesightAddArgs {
     /// Future check or risk statement.

--- a/src/main.rs
+++ b/src/main.rs
@@ -816,6 +816,18 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         raw: bool,
     },
+    /// Summarize operation-scoped latency, I/O, and error telemetry.
+    Telemetry {
+        #[arg(long, default_value_t = false)]
+        json: bool,
+        #[arg(
+            long,
+            help = "Filter to operations after this point. Duration: '10s', '15m', '2h', '3d'. Unix milliseconds are also accepted."
+        )]
+        since: Option<String>,
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
     /// View a drawer by ID.
     View {
         drawer_id: String,
@@ -3596,14 +3608,30 @@ fn run() -> Result<()> {
     if read_only_database {
         validate_read_only_command_args(&cli.command)?;
     }
-    if read_only_database && !db_path.exists() {
+    let empty_read_only_db_dir = if read_only_database
+        && !db_path.exists()
+        && command_reads_missing_database_as_empty(&cli.command)
+    {
+        Some(
+            tempfile::TempDir::new()
+                .context("failed to create empty read-only database scratch dir")?,
+        )
+    } else {
+        None
+    };
+    let empty_read_only_db_path = empty_read_only_db_dir
+        .as_ref()
+        .map(|dir| dir.path().join("palace.db"));
+    if read_only_database && !db_path.exists() && empty_read_only_db_path.is_none() {
         bail!(
             "no palace.db found at {}; run `mempal init` first",
             display_path_for_user(&db_path)
         );
     }
 
-    let db = match if read_only_database {
+    let db = match if let Some(path) = empty_read_only_db_path.as_ref() {
+        Database::open(path).context("failed to open empty read-only database")
+    } else if read_only_database {
         open_read_only_database(&db_path).context("failed to open read-only database")
     } else if command_retries_stdin_ingest_startup_open(&cli.command) {
         open_stdin_ingest_database_with_retry(&db_path)
@@ -3641,7 +3669,18 @@ fn run() -> Result<()> {
         Err(error) => return Err(error),
     };
 
-    match cli.command {
+    let cli_span =
+        command_records_cli_operation_telemetry(&cli.command, read_only_database).then(|| {
+            observability::OperationTelemetrySpan::start(
+                db.path().to_path_buf(),
+                observability::OperationTelemetryRecord::new(
+                    observability::OperationTelemetrySource::Cli,
+                    cli_command_telemetry_label(&cli.command),
+                    "main",
+                ),
+            )
+        });
+    let command_result = match cli.command {
         Commands::Init { dir, dry_run } => init_command(&db, &dir, dry_run),
         Commands::Ingest {
             dir,
@@ -4179,6 +4218,9 @@ fn run() -> Result<()> {
         Commands::Stats { raw } => {
             observability::stats_command(&db, config.as_ref(), observability::StatsOptions { raw })
         }
+        Commands::Telemetry { json, since, limit } => {
+            telemetry_command(&db, json, since.as_deref(), limit)
+        }
         Commands::View {
             drawer_id,
             raw,
@@ -4315,6 +4357,247 @@ fn run() -> Result<()> {
         | Commands::ReleaseReadiness { .. }
         | Commands::Cost { .. }
         | Commands::Doctor { .. } => unreachable!(),
+    };
+    if let Some(cli_span) = cli_span {
+        cli_span.finish_result(&command_result);
+    }
+    command_result
+}
+
+fn telemetry_command(db: &Database, json: bool, since: Option<&str>, limit: usize) -> Result<()> {
+    let since_unix_ms = parse_telemetry_since_unix_ms(since)?;
+    let rows = observability::operation_telemetry_summary(
+        db,
+        observability::OperationTelemetrySummaryOptions {
+            since_unix_ms,
+            limit,
+        },
+    )?;
+    let format = if json {
+        observability::OperationTelemetryFormat::Json
+    } else {
+        observability::OperationTelemetryFormat::Plain
+    };
+    let rendered = observability::render_operation_telemetry_summary(&rows, format)?;
+    println!("{rendered}");
+    Ok(())
+}
+
+fn parse_telemetry_since_unix_ms(raw: Option<&str>) -> Result<Option<i64>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        bail!("--since must not be empty");
+    }
+    if raw.chars().all(|ch| ch.is_ascii_digit()) {
+        return raw
+            .parse::<i64>()
+            .map(Some)
+            .context("invalid --since Unix millisecond timestamp");
+    }
+    if let Some(duration) = parse_telemetry_duration(raw)? {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("system clock is before Unix epoch")?
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        let duration_ms = duration.as_millis().min(i64::MAX as u128) as i64;
+        return Ok(Some(now_ms.saturating_sub(duration_ms)));
+    }
+    bail!("invalid --since value: {raw} (use duration suffix s/m/h/d or Unix milliseconds)")
+}
+
+fn parse_telemetry_duration(raw: &str) -> Result<Option<std::time::Duration>> {
+    let Some(unit) = raw.chars().last() else {
+        return Ok(None);
+    };
+    let multiplier = match unit {
+        's' => 1,
+        'm' => 60,
+        'h' => 3_600,
+        'd' => 86_400,
+        _ => return Ok(None),
+    };
+    let digits = &raw[..raw.len().saturating_sub(unit.len_utf8())];
+    if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+        bail!("invalid duration for --since: {raw}");
+    }
+    let value = digits
+        .parse::<u64>()
+        .context("invalid --since duration digits")?;
+    if value == 0 {
+        bail!("--since duration must be positive");
+    }
+    let seconds = value
+        .checked_mul(multiplier)
+        .context("--since duration overflow")?;
+    Ok(Some(std::time::Duration::from_secs(seconds)))
+}
+
+fn cli_command_telemetry_label(command: &Commands) -> &'static str {
+    match command {
+        Commands::Init { .. } => "init",
+        Commands::Ingest { .. } => "ingest",
+        Commands::Operation { .. } => "operation",
+        Commands::Export { .. } => "export",
+        Commands::Wiki { .. } => "wiki",
+        Commands::IngestConversation { .. } => "ingest-conversation",
+        Commands::Hermes { .. } => "hermes",
+        Commands::Recall { .. } => "recall",
+        Commands::Search { .. } => "search",
+        Commands::Context { .. } => "context",
+        Commands::Config { .. } => "config",
+        Commands::Project { .. } => "project",
+        Commands::Prime(_) => "prime",
+        Commands::Delete { .. } => "delete",
+        Commands::Pin { .. } => "pin",
+        Commands::Unpin { .. } => "unpin",
+        Commands::Pinned { .. } => "pinned",
+        Commands::Rollback { .. } => "rollback",
+        Commands::Cost { .. } => "cost",
+        Commands::Purge { .. } => "purge",
+        Commands::WakeUp { .. } => "wake-up",
+        Commands::Compress { .. } => "compress",
+        Commands::Bench { .. } => "bench",
+        Commands::Reindex { .. } => "reindex",
+        Commands::Consolidate { .. } => "consolidate",
+        Commands::Crystallize { .. } => "crystallize",
+        Commands::Sleep { .. } => "sleep",
+        Commands::Reflect { .. } => "reflect",
+        Commands::Kg { .. } => "kg",
+        Commands::Knowledge { .. } => "knowledge",
+        Commands::KnowledgeCard { .. } => "knowledge-card",
+        Commands::Cards { .. } => "cards",
+        Commands::Phase3 { .. } => "phase3",
+        Commands::Insight { .. } => "insight",
+        Commands::Tunnels { .. } => "tunnels",
+        Commands::Taxonomy { .. } => "taxonomy",
+        Commands::FieldTaxonomy { .. } => "field-taxonomy",
+        Commands::Serve { .. } => "serve",
+        Commands::Status { .. } => "status",
+        Commands::Queue { .. } => "queue",
+        Commands::Gating { .. } => "gating",
+        Commands::Tail { .. } => "tail",
+        Commands::Timeline { .. } => "timeline",
+        Commands::Stats { .. } => "stats",
+        Commands::Telemetry { .. } => "telemetry",
+        Commands::View { .. } => "view",
+        Commands::Audit { .. } => "audit",
+        Commands::RecomputeImportance => "recompute-importance",
+        Commands::FactCheck { .. } => "fact-check",
+        Commands::CoworkDrain { .. } => "cowork-drain",
+        Commands::CoworkStatus { .. } => "cowork-status",
+        Commands::CoworkInstallHooks { .. } => "cowork-install-hooks",
+        Commands::Integrations { .. } => "integrations",
+        Commands::Hook { .. } => "hook",
+        Commands::Hotpatch { .. } => "hotpatch",
+        Commands::Daemon { .. } => "daemon",
+        Commands::Checkpoint { .. } => "checkpoint",
+        Commands::Patterns { .. } => "patterns",
+        Commands::Case { .. } => "case",
+        Commands::Foresight { .. } => "foresight",
+        Commands::Skills { .. } => "skills",
+        Commands::Repair { .. } => "repair",
+        Commands::Xurl { .. } => "xurl",
+        Commands::CoworkRegister { .. } => "cowork-register",
+        Commands::CoworkHeartbeat { .. } => "cowork-heartbeat",
+        Commands::CoworkAgents { .. } => "cowork-agents",
+        Commands::CoworkSend { .. } => "cowork-send",
+        Commands::CoworkAgentDrain { .. } => "cowork-agent-drain",
+        Commands::CoworkDeliveries { .. } => "cowork-deliveries",
+        Commands::CoworkAck { .. } => "cowork-ack",
+        Commands::CoworkEvents { .. } => "cowork-events",
+        Commands::CoworkChannelSet { .. } => "cowork-channel-set",
+        Commands::CoworkChannelSend { .. } => "cowork-channel-send",
+        Commands::CoworkBroadcast { .. } => "cowork-broadcast",
+        Commands::CoworkRunbook { .. } => "cowork-runbook",
+        Commands::CoworkDoctor { .. } => "cowork-doctor",
+        Commands::CoworkTmuxPeek { .. } => "cowork-tmux-peek",
+        Commands::CoworkSessionCreate { .. } => "cowork-session-create",
+        Commands::CoworkSessions { .. } => "cowork-sessions",
+        Commands::CoworkSessionStatus { .. } => "cowork-session-status",
+        Commands::CoworkSessionClose { .. } => "cowork-session-close",
+        Commands::CoworkHandoff { .. } => "cowork-handoff",
+        Commands::CoworkCapture { .. } => "cowork-capture",
+        Commands::MaintenanceRunbook { .. } => "maintenance-runbook",
+        Commands::Maintenance { .. } => "maintenance",
+        Commands::ReleaseReadiness { .. } => "release-readiness",
+        Commands::Doctor { .. } => "doctor",
+        Commands::Brief { .. } => "brief",
+    }
+}
+
+fn command_records_cli_operation_telemetry(command: &Commands, read_only_database: bool) -> bool {
+    !read_only_database && !command_is_dry_run_cli_operation(command)
+}
+
+fn command_is_dry_run_cli_operation(command: &Commands) -> bool {
+    match command {
+        Commands::Init { dry_run: true, .. }
+        | Commands::Ingest { dry_run: true, .. }
+        | Commands::IngestConversation { dry_run: true, .. }
+        | Commands::Rollback { dry_run: true, .. }
+        | Commands::Reindex { dry_run: true, .. }
+        | Commands::Consolidate { dry_run: true, .. }
+        | Commands::Crystallize { dry_run: true, .. }
+        | Commands::Sleep { dry_run: true, .. } => true,
+        Commands::Knowledge {
+            command: KnowledgeCommands::Distill { dry_run: true, .. },
+        }
+        | Commands::KnowledgeCard {
+            command: KnowledgeCardCommands::BackfillApply { execute: false, .. },
+        }
+        | Commands::Queue {
+            command:
+                QueueCommands::RetryFailed(QueueMutationArgs { execute: false, .. })
+                | QueueCommands::ArchiveFailed(QueueMutationArgs { execute: false, .. }),
+        }
+        | Commands::Checkpoint {
+            command: CheckpointCommands::Cleanup { dry_run: true, .. },
+        }
+        | Commands::Skills {
+            command: skills::SkillsCommands::Propose { dry_run: true, .. },
+        }
+        | Commands::Xurl {
+            command:
+                XurlCommands::Reindex { dry_run: true, .. }
+                | XurlCommands::Backfill { dry_run: true, .. },
+        }
+        | Commands::Audit {
+            command: Some(AuditCommands::Cleanup { dry_run: true, .. }),
+            ..
+        }
+        | Commands::Case {
+            command: case_skill::CaseCommands::Open { dry_run: true, .. },
+        } => true,
+        Commands::Foresight { command } => foresight_cli::command_is_dry_run(command),
+        Commands::Phase3 { command } => phase3_command_is_dry_run(command),
+        Commands::Maintenance {
+            command: MaintenanceCommands::Rejudge(args),
+        } => maintenance_rejudge_command_is_dry_run(args),
+        _ => false,
+    }
+}
+
+fn maintenance_rejudge_command_is_dry_run(args: &MaintenanceRejudgeArgs) -> bool {
+    match &args.command {
+        Some(MaintenanceRejudgeCommands::Restore { execute, .. }) => !*execute,
+        None => !args.execute,
+    }
+}
+
+fn phase3_command_is_dry_run(command: &Phase3Commands) -> bool {
+    match command {
+        Phase3Commands::Adoption { command } => matches!(
+            command,
+            Phase3AdoptionCommands::Capture { execute: false, .. }
+                | Phase3AdoptionCommands::Wrap { execute: false, .. }
+        ),
+        Phase3Commands::RollbackControl { execute, .. }
+        | Phase3Commands::ResearchIngestPlan { execute, .. } => !*execute,
+        _ => false,
     }
 }
 
@@ -4464,18 +4747,25 @@ fn open_historical_rejudge_startup_database_with_retry(
 
 fn command_uses_read_only_database(command: &Commands) -> bool {
     match command {
-        Commands::Status { .. }
+        Commands::Rollback { dry_run: true, .. }
+        | Commands::Reindex { dry_run: true, .. }
+        | Commands::Consolidate { dry_run: true, .. }
+        | Commands::Crystallize { dry_run: true, .. }
+        | Commands::Sleep { dry_run: true, .. }
+        | Commands::Status { .. }
         | Commands::Search { .. }
         | Commands::Context { .. }
         | Commands::WakeUp { .. }
         | Commands::Tail { .. }
         | Commands::Timeline { .. }
         | Commands::Stats { .. }
+        | Commands::Telemetry { .. }
         | Commands::View { .. }
         | Commands::Reflect { .. }
         | Commands::Export { .. }
         | Commands::Wiki { .. }
-        | Commands::FactCheck { .. } => true,
+        | Commands::FactCheck { .. }
+        | Commands::Brief { .. } => true,
         Commands::Pinned { reorder, .. } => reorder.is_empty(),
         Commands::Kg { command } => matches!(
             command,
@@ -4487,7 +4777,9 @@ fn command_uses_read_only_database(command: &Commands) -> bool {
         Commands::Knowledge { command } => {
             matches!(
                 command,
-                KnowledgeCommands::Gate { .. } | KnowledgeCommands::Policy { .. }
+                KnowledgeCommands::Distill { dry_run: true, .. }
+                    | KnowledgeCommands::Gate { .. }
+                    | KnowledgeCommands::Policy { .. }
             )
         }
         Commands::KnowledgeCard { command } => matches!(
@@ -4531,8 +4823,11 @@ fn command_uses_read_only_database(command: &Commands) -> bool {
         ),
         Commands::Skills { command } => matches!(
             command,
-            skills::SkillsCommands::List { .. } | skills::SkillsCommands::Show { .. }
+            skills::SkillsCommands::List { .. }
+                | skills::SkillsCommands::Show { .. }
+                | skills::SkillsCommands::Propose { dry_run: true, .. }
         ),
+        Commands::Foresight { command } => foresight_cli::command_uses_read_only_database(command),
         Commands::Repair { .. } => true,
         Commands::Xurl { command } => matches!(
             command,
@@ -4540,11 +4835,55 @@ fn command_uses_read_only_database(command: &Commands) -> bool {
                 | XurlCommands::Timeline { .. }
                 | XurlCommands::Stats { .. }
                 | XurlCommands::Reindex { dry_run: true, .. }
+                | XurlCommands::Backfill { dry_run: true, .. }
         ),
         Commands::Audit { command, .. } => {
             !matches!(command, Some(AuditCommands::Cleanup { dry_run: false, .. }))
         }
+        Commands::Insight { command } => matches!(
+            command,
+            insights::InsightCommands::List { .. } | insights::InsightCommands::Runbook { .. }
+        ),
+        Commands::Phase3 { command } => phase3_command_uses_read_only_database(command),
+        Commands::Maintenance {
+            command: MaintenanceCommands::Rejudge(args),
+        } if maintenance_rejudge_command_is_dry_run(args) => true,
         _ => false,
+    }
+}
+
+fn command_reads_missing_database_as_empty(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Phase3 { command } if phase3_command_uses_read_only_database(command)
+    )
+}
+
+fn phase3_command_uses_read_only_database(command: &Phase3Commands) -> bool {
+    match command {
+        Phase3Commands::Adoption { command } => matches!(
+            command,
+            Phase3AdoptionCommands::Guidance { .. }
+                | Phase3AdoptionCommands::InstrumentationPolicy { .. }
+                | Phase3AdoptionCommands::PrepareRecord { .. }
+                | Phase3AdoptionCommands::Capture { execute: false, .. }
+                | Phase3AdoptionCommands::CheckRecord { .. }
+                | Phase3AdoptionCommands::Review { .. }
+                | Phase3AdoptionCommands::List { .. }
+                | Phase3AdoptionCommands::Stats { .. }
+                | Phase3AdoptionCommands::Wrap { execute: false, .. }
+                | Phase3AdoptionCommands::Analytics { .. }
+        ),
+        Phase3Commands::Evaluator { .. }
+        | Phase3Commands::DefaultProposal { .. }
+        | Phase3Commands::Gate { .. }
+        | Phase3Commands::Readiness { .. }
+        | Phase3Commands::ResearchValidatePlan { .. } => true,
+        Phase3Commands::RollbackControl { execute, .. }
+        | Phase3Commands::ResearchIngestPlan { execute, .. } => !*execute,
+        Phase3Commands::DefaultControl {
+            enable, disable, ..
+        } => !*enable && !*disable,
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -86,6 +86,9 @@ use crate::knowledge_lifecycle::{
     DemoteRequest as CoreDemoteRequest, PromoteRequest as CorePromoteRequest, demote_knowledge,
     promote_knowledge,
 };
+use crate::observability::{
+    OperationTelemetryRecord, OperationTelemetrySource, OperationTelemetrySpan,
+};
 use crate::search::{
     SearchFilters, SearchMode, SearchOptions, VectorSearchCircuit, bm25_fallback_warning_degraded,
     bm25_fallback_warning_embed_error, bm25_fallback_warning_timeout, dispatch_access_update,
@@ -98,7 +101,7 @@ use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
     model::{ServerCapabilities, ServerInfo},
     service::Peer,
-    tool, tool_handler, tool_router,
+    tool, tool_router,
 };
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
@@ -905,17 +908,36 @@ impl MempalMcpServer {
         }
     }
 
+    fn ingest_claim_telemetry_span(
+        &self,
+        call_site: &'static str,
+        claim: &ClaimedMessage,
+    ) -> OperationTelemetrySpan {
+        let source = if self.external_ingest_writer_lease.is_some() {
+            OperationTelemetrySource::Daemon
+        } else {
+            OperationTelemetrySource::Mcp
+        };
+        OperationTelemetrySpan::start(
+            self.db_path.clone(),
+            OperationTelemetryRecord::new(source, format!("ingest {}", claim.kind), call_site)
+                .with_retry_count(claim.retry_count as u64),
+        )
+    }
+
     async fn process_ingest_claim(
         &self,
         queue: &AsyncPendingMessageStore,
         worker_id: &str,
         claim: ClaimedMessage,
     ) -> anyhow::Result<()> {
+        let span = self.ingest_claim_telemetry_span("mcp.ingest_worker", &claim);
         let queue_wait_ms = queue_wait_ms(claim.created_at, claim.claimed_at);
         let prepared: PreparedIngestOperation = match serde_json::from_str(&claim.payload) {
             Ok(prepared) => prepared,
             Err(error) => {
                 let detail = format!("failed to decode ingest operation {}: {error}", claim.id);
+                span.finish_error(&detail);
                 complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
                 return Ok(());
             }
@@ -931,23 +953,32 @@ impl MempalMcpServer {
                 Ok(Some(lease)) => Some(lease),
                 Ok(None) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    Self::release_claim_with_lock_retry(queue, claim)
+                    if let Err(error) = Self::release_claim_with_lock_retry(queue, claim)
                         .await
-                        .context("failed to release ingest claim after writer lease conflict")?;
+                        .context("failed to release ingest claim after writer lease conflict")
+                    {
+                        span.finish_error(&error);
+                        return Err(error);
+                    }
+                    span.finish_error_class("writer_lease_conflict");
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
                 }
                 Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
                     Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-                    Self::release_claim_with_lock_retry(queue, claim)
+                    if let Err(error) = Self::release_claim_with_lock_retry(queue, claim)
                         .await
-                        .context(
-                            "failed to release ingest claim after transient writer lease lock",
-                        )?;
+                        .context("failed to release ingest claim after transient writer lease lock")
+                    {
+                        span.finish_error(&error);
+                        return Err(error);
+                    }
+                    span.finish_error_class("writer_lease_locked");
                     tokio::time::sleep(INGEST_POLL_INTERVAL).await;
                     return Ok(());
                 }
                 Err(error) => {
+                    span.finish_error(&error);
                     return Err(error).context("failed to acquire MCP ingest writer lease");
                 }
             }
@@ -968,6 +999,7 @@ impl MempalMcpServer {
             Ok(Err(error)) => Err(error.to_string()),
             Err(error) => Err(error.to_string()),
         };
+        let telemetry_error = outcome.as_ref().err().cloned();
 
         Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
@@ -978,8 +1010,13 @@ impl MempalMcpServer {
             Some(writer_lease) => writer_lease.release().await,
             None => Ok(()),
         };
-        completed?;
-        released
+        let result = completed.and(released);
+        match (&telemetry_error, &result) {
+            (_, Err(error)) => span.finish_error(error),
+            (Some(error), Ok(())) => span.finish_error(error),
+            (None, Ok(())) => span.finish_success(),
+        }
+        result
     }
 
     async fn process_ingest_claim_inline(
@@ -10177,7 +10214,6 @@ fn current_rfc3339() -> String {
     crate::cowork::peek::format_rfc3339(UNIX_EPOCH + std::time::Duration::from_secs(secs as u64))
 }
 
-#[tool_handler(router = self.tool_router)]
 impl ServerHandler for MempalMcpServer {
     fn get_info(&self) -> ServerInfo {
         let config = ConfigHandle::current();
@@ -10208,6 +10244,44 @@ impl ServerHandler for MempalMcpServer {
         info.capabilities = capabilities;
         info.instructions = Some(instructions);
         info
+    }
+
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> std::result::Result<rmcp::model::CallToolResult, ErrorData> {
+        let operation = request.name.to_string();
+        let span = OperationTelemetrySpan::start(
+            self.db_path.clone(),
+            OperationTelemetryRecord::new(OperationTelemetrySource::Mcp, operation, "mcp.tool"),
+        );
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        let result = self.tool_router.call(tcc).await;
+        match &result {
+            Ok(response) if response.is_error.unwrap_or(false) => {
+                span.finish_error_class("tool_error");
+            }
+            Ok(_) => span.finish_success(),
+            Err(error) => span.finish_error(format!("{error:?}")),
+        }
+        result
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> std::result::Result<rmcp::model::ListToolsResult, ErrorData> {
+        Ok(rmcp::model::ListToolsResult {
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    fn get_tool(&self, name: &str) -> Option<rmcp::model::Tool> {
+        self.tool_router.get(name).cloned()
     }
 
     async fn initialize(

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,3 +1,12 @@
+mod operation_telemetry;
+
+pub use operation_telemetry::{
+    OperationTelemetryFormat, OperationTelemetryIo, OperationTelemetryRecord,
+    OperationTelemetrySource, OperationTelemetrySpan, OperationTelemetrySummaryOptions,
+    OperationTelemetrySummaryRow, operation_telemetry_summary, record_operation_telemetry,
+    render_operation_telemetry_summary,
+};
+
 use std::env;
 use std::ffi::OsStr;
 use std::io::{self, Write};

--- a/src/observability/operation_telemetry.rs
+++ b/src/observability/operation_telemetry.rs
@@ -1,0 +1,911 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use crate::core::db::Database;
+
+static TELEMETRY_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+const OPERATION_TELEMETRY_RETENTION_MS: i64 = 7 * 24 * 60 * 60 * 1_000;
+const OPERATION_TELEMETRY_MAX_ROWS: i64 = 50_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationTelemetrySource {
+    Cli,
+    Mcp,
+    Rest,
+    Daemon,
+}
+
+impl OperationTelemetrySource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+            Self::Rest => "rest",
+            Self::Daemon => "daemon",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OperationTelemetryIo {
+    pub physical_read_bytes: u64,
+    pub physical_write_bytes: u64,
+    pub logical_read_bytes: u64,
+    pub logical_write_bytes: u64,
+    pub cancelled_write_bytes: u64,
+}
+
+impl OperationTelemetryIo {
+    fn delta(start: Option<ProcIoSnapshot>, end: Option<ProcIoSnapshot>) -> Self {
+        match (start, end) {
+            (Some(start), Some(end)) => Self {
+                physical_read_bytes: end.read_bytes.saturating_sub(start.read_bytes),
+                physical_write_bytes: end.write_bytes.saturating_sub(start.write_bytes),
+                logical_read_bytes: end.rchar.saturating_sub(start.rchar),
+                logical_write_bytes: end.wchar.saturating_sub(start.wchar),
+                cancelled_write_bytes: end
+                    .cancelled_write_bytes
+                    .saturating_sub(start.cancelled_write_bytes),
+            },
+            _ => Self::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OperationTelemetryRecord {
+    source: OperationTelemetrySource,
+    operation: String,
+    call_site: String,
+    started_at_unix_ms: i64,
+    duration_ms: u64,
+    success: bool,
+    error_class: Option<String>,
+    sqlite_error_class: Option<String>,
+    rows_scanned: u64,
+    rows_returned: u64,
+    rows_changed: u64,
+    lock_wait_count: u64,
+    retry_count: u64,
+    result_count: u64,
+    io: OperationTelemetryIo,
+}
+
+impl OperationTelemetryRecord {
+    pub fn new(
+        source: OperationTelemetrySource,
+        operation: impl AsRef<str>,
+        call_site: impl AsRef<str>,
+    ) -> Self {
+        Self {
+            source,
+            operation: bounded_label(operation.as_ref()),
+            call_site: bounded_label(call_site.as_ref()),
+            started_at_unix_ms: unix_ms_now(),
+            duration_ms: 0,
+            success: true,
+            error_class: None,
+            sqlite_error_class: None,
+            rows_scanned: 0,
+            rows_returned: 0,
+            rows_changed: 0,
+            lock_wait_count: 0,
+            retry_count: 0,
+            result_count: 0,
+            io: OperationTelemetryIo::default(),
+        }
+    }
+
+    pub fn with_duration_ms(mut self, duration_ms: u64) -> Self {
+        self.duration_ms = duration_ms;
+        self
+    }
+
+    pub fn with_success(mut self, success: bool) -> Self {
+        self.success = success;
+        if success {
+            self.error_class = None;
+            self.sqlite_error_class = None;
+        }
+        self
+    }
+
+    pub fn with_error(mut self, error: impl AsRef<str>) -> Self {
+        let class = classify_error(error.as_ref());
+        self.success = false;
+        self.sqlite_error_class = sqlite_error_class(&class).map(str::to_string);
+        self.error_class = Some(class);
+        self
+    }
+
+    pub fn with_error_class(mut self, error_class: impl AsRef<str>) -> Self {
+        let class = bounded_label(error_class.as_ref());
+        self.success = false;
+        self.sqlite_error_class = sqlite_error_class(&class).map(str::to_string);
+        self.error_class = Some(class);
+        self
+    }
+
+    pub fn with_result_count(mut self, result_count: u64) -> Self {
+        self.result_count = result_count;
+        self
+    }
+
+    pub fn with_rows_returned(mut self, rows_returned: u64) -> Self {
+        self.rows_returned = rows_returned;
+        self
+    }
+
+    pub fn with_rows_changed(mut self, rows_changed: u64) -> Self {
+        self.rows_changed = rows_changed;
+        self
+    }
+
+    pub fn with_rows_scanned(mut self, rows_scanned: u64) -> Self {
+        self.rows_scanned = rows_scanned;
+        self
+    }
+
+    pub fn with_lock_wait_count(mut self, lock_wait_count: u64) -> Self {
+        self.lock_wait_count = lock_wait_count;
+        self
+    }
+
+    pub fn with_retry_count(mut self, retry_count: u64) -> Self {
+        self.retry_count = retry_count;
+        self
+    }
+
+    pub fn with_io(mut self, io: OperationTelemetryIo) -> Self {
+        self.io = io;
+        self
+    }
+}
+
+pub struct OperationTelemetrySpan {
+    db_path: PathBuf,
+    template: OperationTelemetryRecord,
+    started_at: Instant,
+    start_io: Option<ProcIoSnapshot>,
+    finished: bool,
+}
+
+impl OperationTelemetrySpan {
+    pub fn start(db_path: impl Into<PathBuf>, template: OperationTelemetryRecord) -> Self {
+        Self {
+            db_path: db_path.into(),
+            template,
+            started_at: Instant::now(),
+            start_io: read_proc_io_snapshot(),
+            finished: false,
+        }
+    }
+
+    pub fn finish_success(mut self) {
+        let record = self.finished_record(true, None);
+        self.finished = true;
+        let _ = record_operation_telemetry_path(&self.db_path, record);
+    }
+
+    pub fn finish_error(mut self, error: impl std::fmt::Display) {
+        let record = self.finished_record(false, Some(error.to_string()));
+        self.finished = true;
+        let _ = record_operation_telemetry_path(&self.db_path, record);
+    }
+
+    pub fn finish_error_class(mut self, error_class: impl AsRef<str>) {
+        let record = self
+            .template
+            .clone()
+            .with_duration_ms(duration_ms(self.started_at.elapsed()))
+            .with_io(OperationTelemetryIo::delta(
+                self.start_io,
+                read_proc_io_snapshot(),
+            ))
+            .with_error_class(error_class);
+        self.finished = true;
+        let _ = record_operation_telemetry_path(&self.db_path, record);
+    }
+
+    pub fn finish_result<T, E: std::fmt::Display>(mut self, result: &std::result::Result<T, E>) {
+        let record = match result {
+            Ok(_) => self.finished_record(true, None),
+            Err(error) => self.finished_record(false, Some(error.to_string())),
+        };
+        self.finished = true;
+        let _ = record_operation_telemetry_path(&self.db_path, record);
+    }
+
+    fn finished_record(&self, success: bool, error: Option<String>) -> OperationTelemetryRecord {
+        let mut record = self
+            .template
+            .clone()
+            .with_duration_ms(duration_ms(self.started_at.elapsed()))
+            .with_io(OperationTelemetryIo::delta(
+                self.start_io,
+                read_proc_io_snapshot(),
+            ));
+        if success {
+            record = record.with_success(true);
+        } else if let Some(error) = error {
+            record = record.with_error(error);
+        } else {
+            record = record.with_error_class("error");
+        }
+        record
+    }
+}
+
+impl Drop for OperationTelemetrySpan {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let record = self.finished_record(false, Some("unfinished_span".to_string()));
+        let _ = record_operation_telemetry_path(&self.db_path, record);
+        self.finished = true;
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OperationTelemetrySummaryOptions {
+    pub since_unix_ms: Option<i64>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum OperationTelemetryFormat {
+    Plain,
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OperationTelemetrySummaryRow {
+    pub source: String,
+    pub operation: String,
+    pub call_site: String,
+    pub operation_count: u64,
+    pub success_count: u64,
+    pub error_count: u64,
+    pub duration_ms_avg: u64,
+    pub duration_ms_p50: u64,
+    pub duration_ms_p95: u64,
+    pub duration_ms_max: u64,
+    pub physical_read_bytes_total: u64,
+    pub physical_read_bytes_max: u64,
+    pub physical_write_bytes_total: u64,
+    pub physical_write_bytes_max: u64,
+    pub logical_read_bytes_total: u64,
+    pub logical_read_bytes_max: u64,
+    pub logical_write_bytes_total: u64,
+    pub logical_write_bytes_max: u64,
+    pub cancelled_write_bytes_total: u64,
+    pub lock_wait_count_total: u64,
+    pub retry_count_total: u64,
+    pub rows_scanned_total: u64,
+    pub rows_returned_total: u64,
+    pub rows_changed_total: u64,
+    pub result_count_total: u64,
+    pub last_error_class: Option<String>,
+    pub last_sqlite_error_class: Option<String>,
+}
+
+#[derive(Debug)]
+struct AggregateAccumulator {
+    source: String,
+    operation: String,
+    call_site: String,
+    operation_count: u64,
+    success_count: u64,
+    error_count: u64,
+    durations: Vec<u64>,
+    physical_read_bytes_total: u64,
+    physical_read_bytes_max: u64,
+    physical_write_bytes_total: u64,
+    physical_write_bytes_max: u64,
+    logical_read_bytes_total: u64,
+    logical_read_bytes_max: u64,
+    logical_write_bytes_total: u64,
+    logical_write_bytes_max: u64,
+    cancelled_write_bytes_total: u64,
+    lock_wait_count_total: u64,
+    retry_count_total: u64,
+    rows_scanned_total: u64,
+    rows_returned_total: u64,
+    rows_changed_total: u64,
+    result_count_total: u64,
+    last_error_class: Option<String>,
+    last_sqlite_error_class: Option<String>,
+}
+
+impl AggregateAccumulator {
+    fn new(source: String, operation: String, call_site: String) -> Self {
+        Self {
+            source,
+            operation,
+            call_site,
+            operation_count: 0,
+            success_count: 0,
+            error_count: 0,
+            durations: Vec::new(),
+            physical_read_bytes_total: 0,
+            physical_read_bytes_max: 0,
+            physical_write_bytes_total: 0,
+            physical_write_bytes_max: 0,
+            logical_read_bytes_total: 0,
+            logical_read_bytes_max: 0,
+            logical_write_bytes_total: 0,
+            logical_write_bytes_max: 0,
+            cancelled_write_bytes_total: 0,
+            lock_wait_count_total: 0,
+            retry_count_total: 0,
+            rows_scanned_total: 0,
+            rows_returned_total: 0,
+            rows_changed_total: 0,
+            result_count_total: 0,
+            last_error_class: None,
+            last_sqlite_error_class: None,
+        }
+    }
+
+    fn push(&mut self, row: RawTelemetryRow) {
+        self.operation_count = self.operation_count.saturating_add(1);
+        if row.success {
+            self.success_count = self.success_count.saturating_add(1);
+        } else {
+            self.error_count = self.error_count.saturating_add(1);
+            if self.last_error_class.is_none() {
+                self.last_error_class = row.error_class.clone();
+            }
+            if self.last_sqlite_error_class.is_none() {
+                self.last_sqlite_error_class = row.sqlite_error_class.clone();
+            }
+        }
+        self.durations.push(row.duration_ms);
+        self.physical_read_bytes_total = self
+            .physical_read_bytes_total
+            .saturating_add(row.physical_read_bytes);
+        self.physical_read_bytes_max = self.physical_read_bytes_max.max(row.physical_read_bytes);
+        self.physical_write_bytes_total = self
+            .physical_write_bytes_total
+            .saturating_add(row.physical_write_bytes);
+        self.physical_write_bytes_max = self.physical_write_bytes_max.max(row.physical_write_bytes);
+        self.logical_read_bytes_total = self
+            .logical_read_bytes_total
+            .saturating_add(row.logical_read_bytes);
+        self.logical_read_bytes_max = self.logical_read_bytes_max.max(row.logical_read_bytes);
+        self.logical_write_bytes_total = self
+            .logical_write_bytes_total
+            .saturating_add(row.logical_write_bytes);
+        self.logical_write_bytes_max = self.logical_write_bytes_max.max(row.logical_write_bytes);
+        self.cancelled_write_bytes_total = self
+            .cancelled_write_bytes_total
+            .saturating_add(row.cancelled_write_bytes);
+        self.lock_wait_count_total = self
+            .lock_wait_count_total
+            .saturating_add(row.lock_wait_count);
+        self.retry_count_total = self.retry_count_total.saturating_add(row.retry_count);
+        self.rows_scanned_total = self.rows_scanned_total.saturating_add(row.rows_scanned);
+        self.rows_returned_total = self.rows_returned_total.saturating_add(row.rows_returned);
+        self.rows_changed_total = self.rows_changed_total.saturating_add(row.rows_changed);
+        self.result_count_total = self.result_count_total.saturating_add(row.result_count);
+    }
+
+    fn into_summary(mut self) -> OperationTelemetrySummaryRow {
+        self.durations.sort_unstable();
+        let duration_sum = self.durations.iter().copied().sum::<u64>();
+        let duration_avg = duration_sum.checked_div(self.operation_count).unwrap_or(0);
+        let duration_max = self.durations.last().copied().unwrap_or(0);
+        OperationTelemetrySummaryRow {
+            source: self.source,
+            operation: self.operation,
+            call_site: self.call_site,
+            operation_count: self.operation_count,
+            success_count: self.success_count,
+            error_count: self.error_count,
+            duration_ms_avg: duration_avg,
+            duration_ms_p50: percentile(&self.durations, 50),
+            duration_ms_p95: percentile(&self.durations, 95),
+            duration_ms_max: duration_max,
+            physical_read_bytes_total: self.physical_read_bytes_total,
+            physical_read_bytes_max: self.physical_read_bytes_max,
+            physical_write_bytes_total: self.physical_write_bytes_total,
+            physical_write_bytes_max: self.physical_write_bytes_max,
+            logical_read_bytes_total: self.logical_read_bytes_total,
+            logical_read_bytes_max: self.logical_read_bytes_max,
+            logical_write_bytes_total: self.logical_write_bytes_total,
+            logical_write_bytes_max: self.logical_write_bytes_max,
+            cancelled_write_bytes_total: self.cancelled_write_bytes_total,
+            lock_wait_count_total: self.lock_wait_count_total,
+            retry_count_total: self.retry_count_total,
+            rows_scanned_total: self.rows_scanned_total,
+            rows_returned_total: self.rows_returned_total,
+            rows_changed_total: self.rows_changed_total,
+            result_count_total: self.result_count_total,
+            last_error_class: self.last_error_class,
+            last_sqlite_error_class: self.last_sqlite_error_class,
+        }
+    }
+}
+
+struct RawTelemetryRow {
+    source: String,
+    operation: String,
+    call_site: String,
+    duration_ms: u64,
+    success: bool,
+    error_class: Option<String>,
+    sqlite_error_class: Option<String>,
+    rows_scanned: u64,
+    rows_returned: u64,
+    rows_changed: u64,
+    lock_wait_count: u64,
+    retry_count: u64,
+    result_count: u64,
+    physical_read_bytes: u64,
+    physical_write_bytes: u64,
+    logical_read_bytes: u64,
+    logical_write_bytes: u64,
+    cancelled_write_bytes: u64,
+}
+
+pub fn record_operation_telemetry(db: &Database, record: OperationTelemetryRecord) -> Result<()> {
+    insert_operation_telemetry(db.conn(), record)
+}
+
+pub fn operation_telemetry_summary(
+    db: &Database,
+    options: OperationTelemetrySummaryOptions,
+) -> Result<Vec<OperationTelemetrySummaryRow>> {
+    if !operation_telemetry_table_exists(db.conn())? {
+        return Ok(Vec::new());
+    }
+
+    let since = options.since_unix_ms.unwrap_or(0);
+    let row_limit = i64::try_from(options.limit.max(1).saturating_mul(200)).unwrap_or(i64::MAX);
+    let mut stmt = db
+        .conn()
+        .prepare(
+            r#"
+            SELECT
+                source,
+                operation,
+                call_site,
+                duration_ms,
+                success,
+                error_class,
+                sqlite_error_class,
+                rows_scanned,
+                rows_returned,
+                rows_changed,
+                lock_wait_count,
+                retry_count,
+                result_count,
+                physical_read_bytes,
+                physical_write_bytes,
+                logical_read_bytes,
+                logical_write_bytes,
+                cancelled_write_bytes
+            FROM operation_telemetry
+            WHERE started_at_unix_ms >= ?1
+            ORDER BY started_at_unix_ms DESC
+            LIMIT ?2
+            "#,
+        )
+        .context("failed to prepare operation telemetry summary query")?;
+    let rows = stmt
+        .query_map(params![since, row_limit], |row| {
+            Ok(RawTelemetryRow {
+                source: row.get(0)?,
+                operation: row.get(1)?,
+                call_site: row.get(2)?,
+                duration_ms: i64_to_u64(row.get::<_, i64>(3)?),
+                success: row.get::<_, i64>(4)? != 0,
+                error_class: row.get(5)?,
+                sqlite_error_class: row.get(6)?,
+                rows_scanned: i64_to_u64(row.get::<_, i64>(7)?),
+                rows_returned: i64_to_u64(row.get::<_, i64>(8)?),
+                rows_changed: i64_to_u64(row.get::<_, i64>(9)?),
+                lock_wait_count: i64_to_u64(row.get::<_, i64>(10)?),
+                retry_count: i64_to_u64(row.get::<_, i64>(11)?),
+                result_count: i64_to_u64(row.get::<_, i64>(12)?),
+                physical_read_bytes: i64_to_u64(row.get::<_, i64>(13)?),
+                physical_write_bytes: i64_to_u64(row.get::<_, i64>(14)?),
+                logical_read_bytes: i64_to_u64(row.get::<_, i64>(15)?),
+                logical_write_bytes: i64_to_u64(row.get::<_, i64>(16)?),
+                cancelled_write_bytes: i64_to_u64(row.get::<_, i64>(17)?),
+            })
+        })
+        .context("failed to query operation telemetry rows")?;
+
+    let mut groups: BTreeMap<(String, String, String), AggregateAccumulator> = BTreeMap::new();
+    for row in rows {
+        let row = row.context("failed to load operation telemetry row")?;
+        groups
+            .entry((
+                row.source.clone(),
+                row.operation.clone(),
+                row.call_site.clone(),
+            ))
+            .or_insert_with(|| {
+                AggregateAccumulator::new(
+                    row.source.clone(),
+                    row.operation.clone(),
+                    row.call_site.clone(),
+                )
+            })
+            .push(row);
+    }
+
+    let mut summaries = groups
+        .into_values()
+        .map(AggregateAccumulator::into_summary)
+        .collect::<Vec<_>>();
+    summaries.sort_by(|a, b| {
+        b.physical_read_bytes_total
+            .cmp(&a.physical_read_bytes_total)
+            .then_with(|| {
+                b.physical_write_bytes_total
+                    .cmp(&a.physical_write_bytes_total)
+            })
+            .then_with(|| b.duration_ms_max.cmp(&a.duration_ms_max))
+            .then_with(|| b.operation_count.cmp(&a.operation_count))
+    });
+    summaries.truncate(options.limit);
+    Ok(summaries)
+}
+
+fn operation_telemetry_table_exists(conn: &Connection) -> Result<bool> {
+    let exists = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='operation_telemetry')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .context("failed to check operation telemetry table")?;
+    Ok(exists == 1)
+}
+
+pub fn render_operation_telemetry_summary(
+    rows: &[OperationTelemetrySummaryRow],
+    format: OperationTelemetryFormat,
+) -> Result<String> {
+    match format {
+        OperationTelemetryFormat::Json => {
+            serde_json::to_string_pretty(rows).context("failed to serialize operation telemetry")
+        }
+        OperationTelemetryFormat::Plain => Ok(render_plain(rows)),
+    }
+}
+
+fn record_operation_telemetry_path(path: &Path, record: OperationTelemetryRecord) -> Result<()> {
+    let conn = Connection::open(path).context("failed to open telemetry database")?;
+    conn.busy_timeout(Duration::from_millis(10))
+        .context("failed to set telemetry busy timeout")?;
+    insert_operation_telemetry(&conn, record)
+}
+
+fn insert_operation_telemetry(conn: &Connection, record: OperationTelemetryRecord) -> Result<()> {
+    let id = next_telemetry_id(&record);
+    conn.execute(
+        r#"
+        INSERT INTO operation_telemetry (
+            id,
+            started_at_unix_ms,
+            duration_ms,
+            source,
+            operation,
+            call_site,
+            success,
+            error_class,
+            sqlite_error_class,
+            rows_scanned,
+            rows_returned,
+            rows_changed,
+            lock_wait_count,
+            retry_count,
+            result_count,
+            physical_read_bytes,
+            physical_write_bytes,
+            logical_read_bytes,
+            logical_write_bytes,
+            cancelled_write_bytes
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+        "#,
+        params![
+            id,
+            record.started_at_unix_ms,
+            u64_to_i64(record.duration_ms),
+            record.source.as_str(),
+            record.operation,
+            record.call_site,
+            if record.success { 1_i64 } else { 0_i64 },
+            record.error_class,
+            record.sqlite_error_class,
+            u64_to_i64(record.rows_scanned),
+            u64_to_i64(record.rows_returned),
+            u64_to_i64(record.rows_changed),
+            u64_to_i64(record.lock_wait_count),
+            u64_to_i64(record.retry_count),
+            u64_to_i64(record.result_count),
+            u64_to_i64(record.io.physical_read_bytes),
+            u64_to_i64(record.io.physical_write_bytes),
+            u64_to_i64(record.io.logical_read_bytes),
+            u64_to_i64(record.io.logical_write_bytes),
+            u64_to_i64(record.io.cancelled_write_bytes),
+        ],
+    )
+    .context("failed to insert operation telemetry")?;
+    prune_operation_telemetry(conn, record.started_at_unix_ms)
+        .context("failed to prune operation telemetry")?;
+    Ok(())
+}
+
+fn prune_operation_telemetry(conn: &Connection, now_unix_ms: i64) -> Result<()> {
+    let cutoff = now_unix_ms.saturating_sub(OPERATION_TELEMETRY_RETENTION_MS);
+    conn.execute(
+        "DELETE FROM operation_telemetry WHERE started_at_unix_ms < ?1",
+        params![cutoff],
+    )
+    .context("failed to prune old operation telemetry rows")?;
+    conn.execute(
+        r#"
+        DELETE FROM operation_telemetry
+        WHERE rowid IN (
+            SELECT rowid
+            FROM operation_telemetry
+            ORDER BY started_at_unix_ms DESC, rowid DESC
+            LIMIT -1 OFFSET ?1
+        )
+        "#,
+        params![OPERATION_TELEMETRY_MAX_ROWS],
+    )
+    .context("failed to cap operation telemetry rows")?;
+    Ok(())
+}
+
+fn render_plain(rows: &[OperationTelemetrySummaryRow]) -> String {
+    let mut output = String::from("Operation telemetry:\n");
+    if rows.is_empty() {
+        output.push_str("  no recent operation telemetry\n");
+        return output;
+    }
+    output.push_str(
+        "  source operation call_site count ok err avg_ms p95_ms max_ms phys_read phys_write logical_read logical_write retries locks last_error\n",
+    );
+    for row in rows {
+        output.push_str(&format!(
+            "  {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {}\n",
+            row.source,
+            row.operation,
+            row.call_site,
+            row.operation_count,
+            row.success_count,
+            row.error_count,
+            row.duration_ms_avg,
+            row.duration_ms_p95,
+            row.duration_ms_max,
+            row.physical_read_bytes_total,
+            row.physical_write_bytes_total,
+            row.logical_read_bytes_total,
+            row.logical_write_bytes_total,
+            row.retry_count_total,
+            row.lock_wait_count_total,
+            row.last_error_class.as_deref().unwrap_or("none")
+        ));
+    }
+    output
+}
+
+fn next_telemetry_id(record: &OperationTelemetryRecord) -> String {
+    let counter = TELEMETRY_ID_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+    next_telemetry_id_with_process(record, std::process::id(), counter)
+}
+
+fn next_telemetry_id_with_process(
+    record: &OperationTelemetryRecord,
+    process_id: u32,
+    counter: u64,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(record.source.as_str().as_bytes());
+    hasher.update(record.operation.as_bytes());
+    hasher.update(record.call_site.as_bytes());
+    hasher.update(&record.started_at_unix_ms.to_le_bytes());
+    hasher.update(&process_id.to_le_bytes());
+    hasher.update(&counter.to_le_bytes());
+    format!("optelemetry_{}", &hasher.finalize().to_hex()[..24])
+}
+
+fn bounded_label(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if is_bounded_label(trimmed) {
+        return trimmed.to_string();
+    }
+    let digest = blake3::hash(trimmed.as_bytes()).to_hex();
+    format!("untrusted_{}", &digest[..12])
+}
+
+fn is_bounded_label(value: &str) -> bool {
+    if value.is_empty() || value.len() > 80 {
+        return false;
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':' | '/' | ' '))
+    {
+        return false;
+    }
+    let lower = value.to_ascii_lowercase();
+    ![
+        "select ",
+        "insert ",
+        " insert ",
+        "update ",
+        " update ",
+        "delete ",
+        " delete ",
+        "where ",
+        " where ",
+        "authorization",
+        "api_key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "?",
+        "=",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn classify_error(raw: &str) -> String {
+    let lower = raw.to_ascii_lowercase();
+    if lower.contains("database is locked") || lower.contains(" locked") {
+        "locked".to_string()
+    } else if lower.contains("busy") {
+        "busy".to_string()
+    } else if lower.contains("protocol") {
+        "protocol".to_string()
+    } else if lower.contains("timeout") || lower.contains("timed out") {
+        "timeout".to_string()
+    } else if lower.contains("cancel") {
+        "cancelled".to_string()
+    } else {
+        "error".to_string()
+    }
+}
+
+fn sqlite_error_class(class: &str) -> Option<&'static str> {
+    match class {
+        "busy" => Some("busy"),
+        "locked" => Some("locked"),
+        "protocol" => Some("protocol"),
+        _ => None,
+    }
+}
+
+fn percentile(sorted: &[u64], percentile: usize) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = sorted.len().saturating_mul(percentile).saturating_add(99) / 100;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProcIoSnapshot {
+    rchar: u64,
+    wchar: u64,
+    read_bytes: u64,
+    write_bytes: u64,
+    cancelled_write_bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_io_snapshot() -> Option<ProcIoSnapshot> {
+    let raw = fs::read_to_string("/proc/self/io").ok()?;
+    let mut snapshot = ProcIoSnapshot {
+        rchar: 0,
+        wchar: 0,
+        read_bytes: 0,
+        write_bytes: 0,
+        cancelled_write_bytes: 0,
+    };
+    for line in raw.lines() {
+        let (key, value) = line.split_once(':')?;
+        let parsed = value.trim().parse::<u64>().ok()?;
+        match key {
+            "rchar" => snapshot.rchar = parsed,
+            "wchar" => snapshot.wchar = parsed,
+            "read_bytes" => snapshot.read_bytes = parsed,
+            "write_bytes" => snapshot.write_bytes = parsed,
+            "cancelled_write_bytes" => snapshot.cancelled_write_bytes = parsed,
+            _ => {}
+        }
+    }
+    Some(snapshot)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_proc_io_snapshot() -> Option<ProcIoSnapshot> {
+    None
+}
+
+fn unix_ms_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(i64::MAX as u128) as i64
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    duration.as_millis().min(u64::MAX as u128) as u64
+}
+
+fn u64_to_i64(value: u64) -> i64 {
+    value.min(i64::MAX as u64) as i64
+}
+
+fn i64_to_u64(value: i64) -> u64 {
+    u64::try_from(value).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::db::Database;
+
+    #[test]
+    fn telemetry_id_includes_process_identity() {
+        let mut record =
+            OperationTelemetryRecord::new(OperationTelemetrySource::Cli, "ingest", "main");
+        record.started_at_unix_ms = 42;
+
+        let first = next_telemetry_id_with_process(&record, 100, 1);
+        let second = next_telemetry_id_with_process(&record, 101, 1);
+
+        assert_ne!(
+            first, second,
+            "same-millisecond same-counter events from separate processes must not collide"
+        );
+    }
+
+    #[test]
+    fn dropped_span_records_unfinished_error_not_success() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let db_path = tmp.path().join("palace.db");
+        let db = Database::open(&db_path).expect("open db");
+
+        drop(OperationTelemetrySpan::start(
+            db_path,
+            OperationTelemetryRecord::new(OperationTelemetrySource::Mcp, "mempal_ingest", "test"),
+        ));
+
+        let rows = operation_telemetry_summary(
+            &db,
+            OperationTelemetrySummaryOptions {
+                since_unix_ms: None,
+                limit: 10,
+            },
+        )
+        .expect("summarize telemetry");
+        let row = rows
+            .iter()
+            .find(|row| row.source == "mcp" && row.operation == "mempal_ingest")
+            .expect("span telemetry row");
+
+        assert_eq!(row.success_count, 0);
+        assert_eq!(row.error_count, 1);
+        assert_eq!(row.last_error_class.as_deref(), Some("error"));
+    }
+}

--- a/tests/operation_telemetry.rs
+++ b/tests/operation_telemetry.rs
@@ -1,0 +1,387 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use mempal::core::db::{Database, set_fork_ext_version};
+use mempal::observability::{
+    OperationTelemetryFormat, OperationTelemetryIo, OperationTelemetryRecord,
+    OperationTelemetrySource, OperationTelemetrySummaryOptions, operation_telemetry_summary,
+    record_operation_telemetry, render_operation_telemetry_summary,
+};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn mempal_bin() -> String {
+    env!("CARGO_BIN_EXE_mempal").to_string()
+}
+
+fn setup_home() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home).expect("create mempal home");
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path).expect("open db");
+    fs::write(
+        mempal_home.join("config.toml"),
+        format!(
+            r#"
+db_path = "{}"
+[embed]
+backend = "stub"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write config");
+    (tmp, db_path)
+}
+
+fn setup_home_without_operation_telemetry_table() -> (TempDir, PathBuf) {
+    let (home, db_path) = setup_home();
+    let conn = Connection::open(&db_path).expect("open sqlite connection");
+    conn.execute_batch(
+        r#"
+        DROP INDEX IF EXISTS idx_operation_telemetry_started;
+        DROP INDEX IF EXISTS idx_operation_telemetry_source_operation;
+        DROP INDEX IF EXISTS idx_operation_telemetry_call_site;
+        DROP TABLE IF EXISTS operation_telemetry;
+        "#,
+    )
+    .expect("drop operation telemetry schema");
+    set_fork_ext_version(&conn, 22).expect("simulate fork-ext v22 database");
+    assert!(!table_exists_read_only(&db_path, "operation_telemetry"));
+    (home, db_path)
+}
+
+fn table_exists_read_only(db_path: &Path, table: &str) -> bool {
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open sqlite read-only connection");
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?1)",
+        [table],
+        |row| row.get::<_, i64>(0),
+    )
+    .expect("query sqlite_master")
+        == 1
+}
+
+fn count_table_rows(db_path: &Path, table: &str) -> i64 {
+    let db = Database::open(db_path).expect("open db");
+    db.conn()
+        .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })
+        .expect("count table rows")
+}
+
+fn assert_cli_command_does_not_record_operation_telemetry(args: &[&str]) {
+    let (home, db_path) = setup_home();
+    assert_eq!(count_table_rows(&db_path, "operation_telemetry"), 0);
+
+    let output = Command::new(mempal_bin())
+        .args(args)
+        .env("HOME", home.path())
+        .output()
+        .unwrap_or_else(|error| panic!("run mempal {args:?}: {error}"));
+
+    assert!(
+        output.status.success(),
+        "mempal {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        count_table_rows(&db_path, "operation_telemetry"),
+        0,
+        "mempal {args:?} must not record CLI operation telemetry"
+    );
+}
+
+#[test]
+fn test_operation_telemetry_summary_returns_empty_without_table() {
+    let (_home, db_path) = setup_home_without_operation_telemetry_table();
+    let db = Database::open_read_only(&db_path).expect("open read-only db");
+
+    let rows = operation_telemetry_summary(
+        &db,
+        OperationTelemetrySummaryOptions {
+            since_unix_ms: None,
+            limit: 20,
+        },
+    )
+    .expect("summarize missing telemetry table");
+
+    assert!(
+        rows.is_empty(),
+        "missing table should render as no telemetry"
+    );
+    assert!(
+        !table_exists_read_only(&db_path, "operation_telemetry"),
+        "read-only summary must not create operation_telemetry"
+    );
+}
+
+#[test]
+fn test_operation_telemetry_records_all_public_operation_sources_and_io_classes() {
+    let (_home, db_path) = setup_home();
+    let db = Database::open(&db_path).expect("open db");
+
+    for (source, operation, call_site, physical_reads, logical_reads) in [
+        (
+            OperationTelemetrySource::Cli,
+            "status",
+            "cli.status",
+            10,
+            100,
+        ),
+        (
+            OperationTelemetrySource::Mcp,
+            "mempal_search",
+            "mcp.mempal_search",
+            20,
+            200,
+        ),
+        (
+            OperationTelemetrySource::Rest,
+            "GET /api/status",
+            "rest.api_status",
+            30,
+            300,
+        ),
+        (
+            OperationTelemetrySource::Daemon,
+            "ingest_worker",
+            "daemon.ingest_worker.claim",
+            40,
+            400,
+        ),
+    ] {
+        let record = OperationTelemetryRecord::new(source, operation, call_site)
+            .with_duration_ms(25)
+            .with_success(true)
+            .with_result_count(3)
+            .with_io(OperationTelemetryIo {
+                physical_read_bytes: physical_reads,
+                physical_write_bytes: 7,
+                logical_read_bytes: logical_reads,
+                logical_write_bytes: 11,
+                cancelled_write_bytes: 0,
+            });
+        record_operation_telemetry(&db, record).expect("record telemetry");
+    }
+
+    assert_eq!(count_table_rows(&db_path, "operation_telemetry"), 4);
+
+    let summaries = operation_telemetry_summary(
+        &db,
+        OperationTelemetrySummaryOptions {
+            since_unix_ms: None,
+            limit: 20,
+        },
+    )
+    .expect("summarize telemetry");
+
+    for expected_source in ["cli", "mcp", "rest", "daemon"] {
+        assert!(
+            summaries.iter().any(|row| row.source == expected_source),
+            "missing {expected_source} summary: {summaries:?}"
+        );
+    }
+
+    let cli = summaries
+        .iter()
+        .find(|row| row.source == "cli" && row.operation == "status")
+        .expect("cli status summary");
+    assert_eq!(cli.operation_count, 1);
+    assert_eq!(cli.success_count, 1);
+    assert_eq!(cli.result_count_total, 3);
+    assert_eq!(cli.physical_read_bytes_total, 10);
+    assert_eq!(cli.logical_read_bytes_total, 100);
+    assert_eq!(cli.physical_write_bytes_total, 7);
+    assert_eq!(cli.logical_write_bytes_total, 11);
+}
+
+#[test]
+fn test_operation_telemetry_sanitizes_unbounded_labels_and_error_text() {
+    let (_home, db_path) = setup_home();
+    let db = Database::open(&db_path).expect("open db");
+    let secret = "SECRET_TOKEN_SHOULD_NOT_APPEAR";
+    let raw_sql = format!("SELECT * FROM drawers WHERE content = '{secret}'");
+    let raw_endpoint = format!("/api/ingest?authorization={secret}");
+    let record =
+        OperationTelemetryRecord::new(OperationTelemetrySource::Rest, raw_sql, raw_endpoint)
+            .with_duration_ms(9)
+            .with_success(false)
+            .with_error("database is locked while handling SECRET_TOKEN_SHOULD_NOT_APPEAR");
+
+    record_operation_telemetry(&db, record).expect("record telemetry");
+    let summaries = operation_telemetry_summary(
+        &db,
+        OperationTelemetrySummaryOptions {
+            since_unix_ms: None,
+            limit: 10,
+        },
+    )
+    .expect("summarize telemetry");
+    let rendered = render_operation_telemetry_summary(&summaries, OperationTelemetryFormat::Json)
+        .expect("render telemetry JSON");
+
+    assert!(!rendered.contains(secret), "rendered secret: {rendered}");
+    assert!(
+        !rendered.contains("SELECT *"),
+        "rendered raw SQL: {rendered}"
+    );
+    assert!(
+        !rendered.contains("authorization="),
+        "rendered raw endpoint: {rendered}"
+    );
+    assert!(
+        rendered.contains("untrusted_"),
+        "expected hashed untrusted label: {rendered}"
+    );
+    assert!(
+        rendered.contains("locked") || rendered.contains("busy"),
+        "expected classified sqlite error, not raw error text: {rendered}"
+    );
+}
+
+#[test]
+fn test_telemetry_cli_json_reports_empty_summary_without_table() {
+    let (home, db_path) = setup_home_without_operation_telemetry_table();
+
+    let output = Command::new(mempal_bin())
+        .args(["telemetry", "--json"])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal telemetry");
+
+    assert!(
+        output.status.success(),
+        "telemetry failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let value: Value = serde_json::from_str(&stdout).expect("telemetry JSON");
+    assert_eq!(
+        value.as_array().map(Vec::is_empty),
+        Some(true),
+        "missing table should return an empty telemetry array: {stdout}"
+    );
+    assert!(
+        !table_exists_read_only(&db_path, "operation_telemetry"),
+        "read-only telemetry command must not run the v23 migration"
+    );
+}
+
+#[test]
+fn test_telemetry_cli_json_reports_recent_sanitized_operation_summary() {
+    let (home, db_path) = setup_home();
+    let db = Database::open(&db_path).expect("open db");
+    record_operation_telemetry(
+        &db,
+        OperationTelemetryRecord::new(
+            OperationTelemetrySource::Mcp,
+            "mempal_search",
+            "mcp.mempal_search",
+        )
+        .with_duration_ms(42)
+        .with_success(true)
+        .with_io(OperationTelemetryIo {
+            physical_read_bytes: 1_024,
+            physical_write_bytes: 0,
+            logical_read_bytes: 4_096,
+            logical_write_bytes: 512,
+            cancelled_write_bytes: 0,
+        }),
+    )
+    .expect("record telemetry");
+
+    let output = Command::new(mempal_bin())
+        .args(["telemetry", "--json", "--since", "1d"])
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal telemetry");
+
+    assert!(
+        output.status.success(),
+        "telemetry failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let value: Value = serde_json::from_str(&stdout).expect("telemetry JSON");
+    let rows = value.as_array().expect("telemetry rows");
+    assert!(
+        rows.iter().any(|row| {
+            row.get("source").and_then(Value::as_str) == Some("mcp")
+                && row.get("operation").and_then(Value::as_str) == Some("mempal_search")
+                && row.get("physical_read_bytes_total").and_then(Value::as_u64) == Some(1_024)
+                && row.get("logical_read_bytes_total").and_then(Value::as_u64) == Some(4_096)
+        }),
+        "missing MCP telemetry row: {stdout}"
+    );
+    assert!(
+        !stdout.contains("SECRET"),
+        "unexpected secret echo: {stdout}"
+    );
+    assert_eq!(
+        count_table_rows(&db_path, "operation_telemetry"),
+        1,
+        "telemetry summary command must not record another telemetry row"
+    );
+}
+
+#[test]
+fn test_read_only_cli_status_does_not_record_operation_telemetry() {
+    let (home, db_path) = setup_home();
+    assert_eq!(count_table_rows(&db_path, "operation_telemetry"), 0);
+
+    let output = Command::new(mempal_bin())
+        .arg("status")
+        .env("HOME", home.path())
+        .output()
+        .expect("run mempal status");
+
+    assert!(
+        output.status.success(),
+        "status failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        count_table_rows(&db_path, "operation_telemetry"),
+        0,
+        "read-only status command must not mutate telemetry tables"
+    );
+}
+
+#[test]
+fn test_read_only_cli_commands_do_not_record_operation_telemetry() {
+    for args in [
+        &["brief", "telemetry regression", "--format", "json"][..],
+        &["foresight", "list", "--format", "json"][..],
+    ] {
+        assert_cli_command_does_not_record_operation_telemetry(args);
+    }
+}
+
+#[test]
+fn test_dry_run_cli_commands_do_not_record_operation_telemetry() {
+    for args in [
+        &[
+            "skills",
+            "propose",
+            "--from-cases",
+            "--min-support",
+            "1",
+            "--dry-run",
+            "--json",
+        ][..],
+        &["crystallize", "--dry-run", "--json"][..],
+        &["sleep", "--dry-run"][..],
+    ] {
+        assert_cli_command_does_not_record_operation_telemetry(args);
+    }
+}

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -18,6 +18,7 @@ use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::core::utils::iso_timestamp;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
+use mempal::observability::{OperationTelemetrySummaryOptions, operation_telemetry_summary};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio::sync::Notify;
@@ -312,6 +313,39 @@ async fn post_json(state: ApiState, uri: &str, body: Value) -> (StatusCode, Valu
         .expect("read body");
     let body = serde_json::from_slice(&bytes).expect("parse json");
     (status, body)
+}
+
+#[tokio::test]
+async fn test_rest_request_records_operation_telemetry_without_query_or_body() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+
+    let (status, _headers, _body) = get_json(
+        state,
+        "/api/status?secret=REST_TELEMETRY_SECRET_DO_NOT_STORE",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let db = env.db();
+    let rows = operation_telemetry_summary(
+        &db,
+        OperationTelemetrySummaryOptions {
+            since_unix_ms: None,
+            limit: 20,
+        },
+    )
+    .expect("summarize operation telemetry");
+    let rest_row = rows
+        .iter()
+        .find(|row| row.source == "rest" && row.operation == "GET /api/status")
+        .expect("REST status request telemetry row");
+    assert_eq!(rest_row.call_site, "rest.request");
+    assert_eq!(rest_row.operation_count, 1);
+    assert_eq!(rest_row.success_count, 1);
+    assert_eq!(rest_row.error_count, 0);
+    assert!(!rest_row.operation.contains("secret="));
 }
 
 #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "5f24c980fec510580462174ad5bf47fab54edc54"
+commit = "00fcde0a451f571c17e12c9181f5900c67690c25"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Add SQLite-backed operation telemetry for CLI, REST, MCP, and daemon paths.
- Expose `mempal telemetry --json` summaries with privacy-safe bounded labels, latency, I/O counters, and error buckets.
- Preserve read-only/dry-run contracts, including empty summaries for pre-v23 databases and missing-DB Phase3 read-only paths.

Closes #587

## Local validation
- Hook-enabled commit: `GIT_COMMIT_EXIT 0` on `c3576b2bc9bd15ffb717b675446b053e434919ad`.
- Clean-tree `just local-gates`: `LOCAL_GATES_EXIT 0`.
- Hook-enabled push: `PUSH_EXIT 0`; pre-push ran `local-gates` and review-check.
- Exact-head CSA/Codex review: `01KW3KVXT5GCRN0S964KSJZCSZ`, `main...HEAD`, PASS/CLEAN.
- Durable review check: `csa review --check-verdict --range main...HEAD` passed for `c3576b2bc9b`.
