### PR TITLE
fix: stabilize MCP smoke write receipts

### DIFF
--- a/skills/smoke-test/SKILL.md
+++ b/skills/smoke-test/SKILL.md
@@ -1,66 +1,64 @@
 ---
 name: smoke-test
-description: "Project-local mempal exhaustive smoke test skill. Use after installing, restarting, merging, or changing mempal to verify daemon health, CLI/REST/MCP read surfaces, reversible CLI and MCP memory CRUD, memory growth, and database-holder safety without starting duplicate daemons or leaking drawer content."
+description: "Project-local mempal smoke test. Use after installing, restarting, merging, or changing mempal to verify installed CLI, daemon singleton/current binary, REST/MCP availability, read-only memory surfaces, reversible CLI/MCP CRUD, cleanup, and resource safety without leaking drawer content or starting duplicate daemons."
 ---
 
 # mempal Manual Smoke Test
 
-Use this project-local skill when a main agent must manually verify that the installed `mempal` binary, live daemon, command-line surfaces, REST availability, and MCP tools still work after a merge, install, restart, MCP reconnect, or production-like debugging session.
+Use this project-local skill when validating the installed `mempal` binary and live daemon after a merge, install, restart, MCP reconnect, or production-like debugging session.
 
-Default to the installed CLI plus the MCP tools already exposed to the active client. Do not start extra daemons or long-lived REST/MCP servers unless the test explicitly requires them and the owner process is tracked for cleanup.
+Keep this file as the high-level runbook. Load references only when the current task needs manual detail:
+
+- `references/preflight-and-readonly-cli.md` — preflight, singleton/holder checks, read-only CLI probe matrix, and structure-only capture harness.
+- `references/reversible-crud.md` — reversible CLI and MCP memory CRUD, exact-created-ID cleanup authority, and MCP stdio lifecycle.
+- `references/rest-resource-and-done.md` — REST checks, dangerous/non-default surfaces, memory/I/O guardrails, and done criteria.
+- `scripts/full_smoke.py` — preferred automated full smoke runner; execute it instead of reimplementing the matrix when broad coverage is requested.
 
 ## Safety rules
 
-1. Keep diagnostics aggregate-only. Do not print raw drawer content, prompts, model responses, raw process command lines, environment variables, connection strings, URLs, Authorization headers, bearer tokens, API keys, passwords, `drawer_content`, or prompt-like arguments.
-2. Use the installed binary (`command -v mempal`, `mempal --version`) and the live user daemon. Do not run `cargo run` for smoke unless debugging source changes.
-3. Maintain singleton ownership:
-   - Prefer `systemctl --user restart mempal-daemon.service` for restart.
-   - Verify exactly one `/usr/local/bin/mempal daemon --foreground` after restart.
-   - Do not run `mempal serve` as a long-lived REST server for smoke unless a route test requires it; if started, track and kill it.
-   - Do not spawn unmanaged `mempal serve --mcp` processes from the shell. The checked-in `scripts/full_smoke.py` runner may start short-lived MCP stdio servers because it owns their PID lifecycle, sends shutdown/exit, and kills leftovers.
-4. Before declaring a lock failure, inspect DB holders with `mempal daemon status` and summarize only roles/counts/PIDs/commands.
-5. Full smoke means read-only probes plus reversible memory CRUD through both CLI and MCP when the active client exposes MCP tools. If MCP tools are unavailable, record `mcp_crud=skipped_unavailable` and do not spawn an unmanaged MCP holder just to satisfy the matrix.
-6. If using a synthetic write, use a unique marker, a `smoke/cli` or `smoke/mcp` wing-room, explicit typed metadata, and bounded wait/poll behavior, then clean up only exact drawer ID(s) returned by the create/update operation's `created_drawer_ids`. Never delete IDs discovered from generic search/read results. Report IDs only when cleanup fails; do not print content.
-7. Update smoke must use replacement semantics (`--supersedes` / `supersedes`) against an exact drawer ID created earlier in the same smoke run. If the initial create did not expose a cleanup-safe created ID, skip update/delete and fail closed.
-8. If there is already context that should become durable memory, it is acceptable to ingest a concise real note instead of synthetic content, but only when the note is genuinely useful and non-secret.
+1. Keep diagnostics aggregate-only. Do not print raw drawer content, prompts, model responses, raw process command lines, environment variables, connection strings, URLs, Authorization headers, bearer tokens, API keys, passwords, `drawer_content`, snippets, previews, or prompt-like arguments.
+2. Use the installed binary (`command -v mempal`, `mempal --version`) and the live user daemon. Do not use `cargo run` for smoke unless debugging source changes.
+3. Maintain singleton ownership: prefer the existing `mempal-daemon.service`; verify one current `/usr/local/bin/mempal` daemon; do not start unmanaged long-lived REST/MCP servers. The checked-in `scripts/full_smoke.py` may start short-lived MCP stdio children because it owns shutdown/cleanup.
+4. Before classifying lock failures, inspect DB holders with aggregate-only daemon status and report roles/counts/PIDs only.
+5. For write smoke, clean up only exact IDs returned as `created_drawer_ids` by that same smoke run. Never delete IDs discovered through search/read results.
+6. If there is genuinely useful non-secret context to preserve, one real memory write is allowed instead of purely synthetic content. Keep it concise, typed, and project-scoped.
 
 ## Preferred automated full smoke
 
-Use the checked-in runner first when the goal is broad coverage rather than one-off diagnosis:
+Run from repo root:
 
 ```bash
-python3 skills/smoke-test/scripts/full_smoke.py | tee /tmp/mempal-skill-full-smoke.log
+python3 skills/smoke-test/scripts/full_smoke.py > /tmp/mempal-skill-full-smoke.log
 ```
 
-The runner is intentionally part of this repo-local skill (`skills/smoke-test/scripts/full_smoke.py`) rather than `/tmp` so the exact CLI/MCP protocol, safety rules, and cleanup behavior stay versioned with the skill. It prints one aggregate JSON object and avoids raw memory content.
+The runner prints one aggregate JSON object and avoids raw memory content. It covers installed CLI identity/status, read-only surfaces, reversible CLI CRUD, short-lived MCP read/CRUD, cleanup, and coarse I/O telemetry.
 
-Runner behavior:
-
-- CLI CRUD: JSON stdin `mempal ingest --stdin --json`, `search`, `view`, `context`, `pin`, `unpin`, `ingest --supersedes`, exact-ID `delete`, post-delete search verification.
-- MCP read-only probes: short-lived isolated MCP stdio servers per optional probe to avoid one tool's SQLite read lock poisoning the rest of the matrix.
-- MCP CRUD: `mempal_ingest`, `mempal_operation_status`, `mempal_search`, `mempal_read_drawer`, `mempal_read_drawers`, `mempal_context`, `mempal_brief`, `mempal_ingest` with `supersedes`, `mempal_delete`, post-delete search verification.
-- Timed-out MCP ingest receipts: close the MCP server before following the returned `operation_id` with `mempal operation wait --json`; this avoids MCP self-holder SQLite lock false failures.
-- Cleanup: if a later step fails after create exposed cleanup-safe IDs, delete those exact IDs before exiting.
-- I/O telemetry: sample daemon `/proc/<pid>/io` before/after when the daemon PID stays stable, sample `/proc/<pid>/io` for CLI child commands and short-lived MCP stdio servers, and keep `resource.getrusage(RUSAGE_CHILDREN)` block counters as an aggregate fallback. The runner also appends content-free telemetry to `target/smoke-io-history.jsonl`.
-
-If the runner exits nonzero, parse only the final JSON summary:
+If it exits nonzero or times out, parse only the final JSON summary:
 
 ```bash
 python3 - <<'PY'
 import json, pathlib
-line = [line for line in pathlib.Path('/tmp/mempal-skill-full-smoke.log').read_text(errors='replace').splitlines() if line.strip()][-1]
-data = json.loads(line)
-print({'overall_ok': data.get('overall_ok'), 'failures': data.get('failures'), 'cleanup': data.get('cleanup'), 'created_counts': data.get('created_counts'), 'io': data.get('io')})
-for name in data.get('failures', []):
-    print(name, data.get('groups', {}).get(name))
+p = pathlib.Path('/tmp/mempal-skill-full-smoke.log')
+lines = [line for line in p.read_text(errors='replace').splitlines() if line.strip()]
+data = json.loads(lines[-1]) if lines else {}
+print({
+    'overall_ok': data.get('overall_ok'),
+    'failures': data.get('failures'),
+    'cleanup': data.get('cleanup'),
+    'created_counts': data.get('created_counts'),
+    'group_count': len(data.get('groups', {})),
+})
+for name, info in (data.get('groups') or {}).items():
+    if isinstance(info, dict) and not info.get('ok'):
+        print(name, {k: v for k, v in info.items() if k not in {'content', 'text', 'preview', 'statement', 'narrative'}})
 PY
 ```
 
-Do not paste raw command output from the log into chat; the JSON summary is already redacted/aggregate-only.
+Do not paste raw command stdout/stderr from the smoke log into chat.
 
-## Preflight
+## Minimal preflight
 
-Run from the repository root:
+Use this before any write smoke or full smoke:
 
 ```bash
 git status --short --branch --untracked-files=all
@@ -68,476 +66,40 @@ command -v mempal
 mempal --version
 systemctl --user is-active mempal-daemon.service || true
 systemctl --user show mempal-daemon.service -p MainPID -p ActiveState -p SubState --value || true
-ps -C mempal -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm --sort=-rss || true
-mempal daemon status | awk '/^(status:|pid:|uptime_secs:|memory\.|live_daemons:|extra_holders:|stale_mcp_servers:|orphan_daemons:|search\.active:|rest\.health:|rest\.embedder_cache\.|embedder\.)/ {print}'
+mempal daemon status > /tmp/mempal-daemon-status-smoke.txt
 ```
 
-Record:
-
-- installed version;
-- daemon PID;
-- `exe_deleted`;
-- `live_daemons`;
-- `extra_holders` / `stale_mcp_servers` / `orphan_daemons`;
-- RSS/PSS/private dirty/anonymous memory;
-- queue counts;
-- `search.active`;
-- REST health summary.
-
-Do not record raw command lines, process arguments, environment variables, URLs, connection strings, bearer tokens, prompt-like arguments, or daemon status sections that contain drawer bodies.
-
-## Restart procedure
-
-When restart is allowed or needed:
-
-```bash
-systemctl --user restart mempal-daemon.service
-sleep 3
-main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
-systemctl --user is-active mempal-daemon.service
-ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm
-readlink "/proc/$main_pid/exe"
-printf 'daemon_processes=%s\n' "$(pgrep -fc '^/usr/local/bin/mempal daemon --foreground$' || true)"
-printf 'mcp_server_processes=%s\n' "$(pgrep -fc '^/usr/local/bin/mempal serve --mcp$' || true)"
-```
-
-Pass criteria:
-
-- service is `active`;
-- exactly one daemon process exists;
-- daemon exe resolves to `/usr/local/bin/mempal` and is not deleted;
-- no untracked extra `mempal serve --mcp` processes were created by the smoke;
-- RSS is reasonable immediately after restart (normally hundreds of MB, not multi-GB).
+Summarize only: installed version/path, daemon active state/PID, daemon executable current vs deleted, live daemon count, extra holders/stale MCP/orphans, RSS/PSS/private dirty/anonymous, queue counts, search active, and REST health class. For field-level details, load `references/preflight-and-readonly-cli.md`.
 
 ## Coverage target
 
-Run the broadest safe matrix the current environment supports. A full report should classify each group as `pass`, `fail`, or `skipped_<reason>`.
+Classify each group as `pass`, `fail`, or `skipped_<reason>`:
 
-| Group | Surface | Required coverage |
-|---|---|---|
-| Runtime | CLI/systemd/process | installed binary, daemon singleton, current executable, DB holders, RSS/resource summary |
-| Read-only memory | CLI | status, stats, search, context, timeline/tail shape, pinned shape, knowledge/card/repair/pattern/skill surfaces where supported |
-| Reversible CRUD | CLI | create via `mempal ingest`, read via `search` + `view`, update via `ingest --supersedes`, pin/unpin, delete via exact created IDs, post-delete verification |
-| REST | CLI doctor or tracked REST server | route/health shape and degraded warning categories |
-| Read-only MCP | MCP tools | `mempal_status`, `mempal_search`, `mempal_context`, `mempal_pinned_facts`, `mempal_timeline`, `mempal_doctor`, plus optional knowledge/brief/taxonomy/skill tools exposed by the client |
-| Reversible CRUD | MCP tools | create via `mempal_ingest`, read via `mempal_search` + `mempal_read_drawer`, update via `mempal_ingest` with `supersedes`, delete via `mempal_delete`, post-delete search verification |
-| Cleanup | CLI/process | no extra daemon/MCP/REST holders, all exact-created smoke IDs soft-deleted or explicitly reported |
+| Group | Required coverage |
+|---|---|
+| Runtime | installed binary, daemon singleton, current executable, DB holders, RSS/resource summary |
+| Read-only CLI | status/stats/search/context/timeline/tail/pinned/knowledge/card/repair/pattern/skill shapes where supported |
+| Reversible CLI CRUD | create, search/read/context, update via `--supersedes`, pin/unpin, exact-ID delete, post-delete verification |
+| REST | doctor/route availability, degraded warning categories if any |
+| MCP read-only | status/search/context/pinned/timeline/doctor plus optional skill/brief/taxonomy tools exposed by the client |
+| Reversible MCP CRUD | create, read/search/context, update, exact-ID delete, post-delete verification |
+| Cleanup/resource | no extra REST/MCP holders, created IDs cleaned, daemon PID stable or restart classified, I/O/RSS summarized |
 
-Never downgrade a failed CRUD path to pass because another surface worked. Report CLI CRUD and MCP CRUD separately.
+Never downgrade a failed CRUD path to pass because another surface worked. Report CLI and MCP CRUD separately.
 
-## Read-only CLI smoke matrix
+## Manual smoke pointers
 
-Do not paste raw stdout or stderr from `mempal` commands into chat, issues, or logs unless the command is explicitly listed as safe-direct below. For every other command, capture stdout/stderr to temporary files and report only:
+- For read-only CLI probes and shape-only output handling, load `references/preflight-and-readonly-cli.md`.
+- For CLI/MCP write/update/delete details, load `references/reversible-crud.md`.
+- For REST, memory growth, dangerous surfaces, and final checklist, load `references/rest-resource-and-done.md`.
 
-- exit code;
-- latency;
-- stdout/stderr byte counts;
-- JSON/NDJSON parse success/failure;
-- top-level JSON type, field names, line counts, and item counts;
-- health/status/warning strings only after redaction and only when they do not include drawer/card/prompt content.
+## Verification checklist
 
-Treat these commands as content-bearing by default and never print their raw stdout in chat: `mempal status`, `mempal status --full`, `mempal timeline`, `mempal tail`, `mempal pinned`, `mempal knowledge-card list`, `mempal cards --pending`, `mempal reflect`, `mempal prime`, `mempal wake-up`, `mempal context`, `mempal search`, `mempal recall hermes search`, and any command that returns drawers, cards, recall snippets, evidence, timeline entries, prompts, model responses, or previews.
-
-Simple non-content identity commands may be displayed directly only when their output is known not to include memory content, for example `mempal --version`. For `doctor`, `doctor rest`, `daemon status`, stats, cost, and gating commands, still prefer summarized fields and redacted warning categories over raw output.
-
-Use a capture harness for all content-bearing or uncertain commands:
-
-```bash
-run_mempal_probe() {
-  name="$1"
-  expect_json="$2"
-  shift 2
-  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/mempal-smoke.XXXXXX")"
-  stdout_file="$tmpdir/stdout"
-  stderr_file="$tmpdir/stderr"
-  start_ms="$(date +%s%3N)"
-  "$@" >"$stdout_file" 2>"$stderr_file"
-  status=$?
-  end_ms="$(date +%s%3N)"
-  python3 - "$name" "$expect_json" "$status" "$start_ms" "$end_ms" "$stdout_file" "$stderr_file" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-name, expect_json, status, start_ms, end_ms, stdout_path, stderr_path = sys.argv[1:]
-stdout = Path(stdout_path).read_bytes()
-stderr = Path(stderr_path).read_bytes()
-summary = {
-    "name": name,
-    "exit_code": int(status),
-    "latency_ms": max(0, int(end_ms) - int(start_ms)),
-    "stdout_bytes": len(stdout),
-    "stderr_bytes": len(stderr),
-}
-
-if expect_json == "json":
-    try:
-        parsed = json.loads(stdout.decode("utf-8") or "null")
-    except Exception as exc:
-        lines = [line for line in stdout.decode("utf-8", errors="replace").splitlines() if line.strip()]
-        try:
-            parsed_lines = [json.loads(line) for line in lines]
-        except Exception:
-            summary["json"] = {"ok": False, "error_type": type(exc).__name__}
-        else:
-            field_names = sorted({
-                key
-                for item in parsed_lines
-                if isinstance(item, dict)
-                for key in item.keys()
-            })
-            summary["json"] = {
-                "ok": True,
-                "type": "ndjson",
-                "line_count": len(parsed_lines),
-                "fields": field_names,
-            }
-    else:
-        if isinstance(parsed, dict):
-            summary["json"] = {
-                "ok": True,
-                "type": "object",
-                "fields": sorted(parsed.keys()),
-                "field_count": len(parsed),
-            }
-        elif isinstance(parsed, list):
-            summary["json"] = {"ok": True, "type": "array", "count": len(parsed)}
-        else:
-            summary["json"] = {"ok": True, "type": type(parsed).__name__}
-
-print(json.dumps(summary, sort_keys=True))
-PY
-  rm -rf "$tmpdir"
-  return "$status"
-}
-```
-
-The harness prints structure only. It must not print command stdout/stderr, JSON values, drawer IDs from content-bearing output, search snippets, previews, prompts, or model responses.
-
-| Group | Command | Output handling | Pass criteria |
-|---|---|---|---|
-| Identity | `mempal --version` | safe-direct | exits 0, expected version string |
-| Daemon | `mempal daemon status` | summarize/redact | exits 0, running, singleton/current binary |
-| Doctor | `mempal doctor` | summarize/redact | exits 0; warning categories summarized |
-| REST doctor | `mempal doctor rest --format json` | harness JSON/NDJSON | exits 0, JSON parses, routes reported; degraded is allowed only with warning recorded |
-| Dashboard | `mempal status` | content-bearing harness | exits 0 |
-| Stats | `mempal stats` | summarize/redact | exits 0 |
-| Config | `mempal config intelligence` | summarize/redact | exits 0 |
-| Cost | `mempal cost status` | summarize/redact | exits 0 |
-| Gating | `mempal gating stats` | summarize/redact | exits 0 |
-| Timeline | `mempal timeline --since 1h --format json` | content-bearing harness JSON/NDJSON | exits 0, empty output or valid JSON/NDJSON accepted |
-| Tail | `mempal tail --limit 3` | content-bearing harness | exits 0 |
-| Pinned | `mempal pinned --json` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
-| KG | `mempal kg stats` | summarize/redact | exits 0 |
-| Cards | `mempal knowledge-card list --format json` and `mempal cards --pending --format json` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
-| Reflection | `mempal reflect --json --limit 3` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
-| Prime | `mempal prime --format json --token-budget 512 --no-stats` | content-bearing harness JSON/NDJSON | exits 0, JSON parses |
-| Wake-up | `mempal wake-up --format protocol` | content-bearing harness | exits 0 |
-| Taxonomy | `mempal field-taxonomy --format json` | harness JSON/NDJSON | exits 0, JSON parses |
-| Integrations | `mempal integrations status` | summarize/redact | exits 0 |
-| Checkpoint | `mempal checkpoint status` | summarize/redact | exits 0 |
-| Patterns/skills/repair | `mempal patterns list`, `mempal skills list`, `mempal repair list` | summarize/redact | exits 0 |
-| Cowork | `mempal cowork-status --cwd "$PWD"` | summarize/redact | exits 0 |
-| Maintenance | `mempal maintenance guided-run --format json` | harness JSON/NDJSON | exits 0, JSON parses |
-| Release | `mempal release-readiness --format json` | harness JSON/NDJSON | exits 0, JSON parses |
-| xurl | `mempal xurl stats` | summarize/redact | exits 0 |
-| Benchmark | `mempal bench matrix --mode no-llm --top-k 3 --format json` | harness JSON/NDJSON | exits 0, JSON parses |
-| Recall help | `mempal recall hermes --help` | safe-direct | exits 0 |
-
-For expensive semantic queries, run them only when needed and bound time explicitly:
-
-```bash
-run_mempal_probe search json timeout 180s mempal search '<known safe query>' --top-k 3 --json
-run_mempal_probe context json timeout 120s mempal context '<known safe query>' --format json --max-items 3 --no-distill-suggestions
-```
-
-If these are slow, report latency and memory growth; do not treat slowness as pass unless the task only asked for availability.
-
-## Reversible CLI memory CRUD smoke
-
-Run this by default for full smoke unless the operator explicitly requests read-only mode. The flow must exercise create, read, update, pin/unpin, search, context, and delete through the command line.
-
-1. Generate a unique marker:
-
-   ```bash
-   marker="mempal-smoke-$(date +%s)-$RANDOM"
-   ```
-
-2. Ingest via stdin with a smoke scope, capture the response, and extract only cleanup-safe IDs explicitly returned by ingest:
-
-   ```bash
-   ingest_json="$(mktemp)"
-   operation_json=""
-   smoke_ids="$(mktemp)"
-   if python3 - "$marker" <<'PY' \
-     | mempal ingest --stdin --wing smoke --room cli --source-type agent_inference --memory-kind evidence --domain project --field smoke --no-gate --wait --wait-timeout-secs 90 --json \
-     > "$ingest_json"; then
-import json, sys
-marker = sys.argv[1]
-print(json.dumps({
-    "content": f"{marker} reversible CLI smoke drawer; safe to delete",
-    "wing": "smoke",
-    "room": "cli",
-    "source_type": "agent_inference",
-    "memory_kind": "evidence",
-    "domain": "project",
-    "field": "smoke",
-}))
-PY
-     :
-   fi
-   python3 - "$ingest_json" > "$smoke_ids" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
-ids = []
-drawer_ids = obj.get("created_drawer_ids")
-if isinstance(drawer_ids, list):
-    ids.extend(item for item in drawer_ids if isinstance(item, str) and item)
-for item in dict.fromkeys(ids):
-    print(item)
-PY
-   if [ ! -s "$smoke_ids" ]; then
-     operation_id="$(python3 - "$ingest_json" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
-operation_id = obj.get("operation_id")
-state = obj.get("state")
-if isinstance(operation_id, str) and operation_id and state not in {"completed", "rejected", "failed"}:
-    print(operation_id)
-PY
-)"
-     if [ -n "$operation_id" ]; then
-       operation_json="$(mktemp)"
-       if mempal operation wait "$operation_id" --timeout-secs 300 --json > "$operation_json"; then
-         wait_status=0
-       else
-         wait_status=$?
-       fi
-       if [ "$wait_status" -ne 0 ]; then
-         mempal operation status "$operation_id" --json > "$operation_json" || true
-       fi
-       python3 - "$operation_json" > "$smoke_ids" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
-if obj.get("state") != "completed":
-    raise SystemExit(0)
-ids = []
-drawer_ids = obj.get("created_drawer_ids")
-if isinstance(drawer_ids, list):
-    ids.extend(item for item in drawer_ids if isinstance(item, str) and item)
-for item in dict.fromkeys(ids):
-    print(item)
-PY
-     fi
-   fi
-   if [ ! -s "$smoke_ids" ]; then
-     echo "cleanup requires manual operator action: terminal response did not expose created_drawer_ids; do not delete drawer_id, drawer_ids, or cleanup_drawer_ids" >&2
-     rm -f "$ingest_json" "$operation_json" "$smoke_ids"
-     exit 1
-   fi
-   ```
-
-   Do not print the ingest response, operation response, or smoke IDs unless cleanup fails. `created_drawer_ids` from the terminal ingest JSON, or from terminal `mempal operation wait/status --json`, is the cleanup authority. `cleanup_drawer_ids` is only a human-readable alias when it mirrors the created list. `drawer_id` and `drawer_ids` are informational because they may name pre-existing, deduplicated, dropped, or merge-target drawers. If `created_drawer_ids` is empty after the terminal wait/status step, fail closed.
-
-3. Read and query the created memory without printing content:
-
-   ```bash
-   created_id="$(head -n 1 "$smoke_ids")"
-   view_out="$(mktemp)"
-   search_json="$(mktemp)"
-   context_json="$(mktemp)"
-   pinned_json="$(mktemp)"
-
-   mempal view "$created_id" --all-projects > "$view_out"
-   mempal search "$marker" --top-k 5 --json > "$search_json"
-   mempal context "$marker" --format json --max-items 3 --no-distill-suggestions > "$context_json"
-   mempal pinned --json > "$pinned_json"
-
-   python3 - "$view_out" "$search_json" "$context_json" "$pinned_json" <<'PY'
-import json, sys
-from pathlib import Path
-view_out, search_path, context_path, pinned_path = [Path(p) for p in sys.argv[1:]]
-results = json.loads(search_path.read_text() or "[]")
-context = json.loads(context_path.read_text() or "{}")
-pinned = json.loads(pinned_path.read_text() or "[]")
-summary = {
-    "view_stdout_bytes": view_out.stat().st_size,
-    "search_count": len(results) if isinstance(results, list) else None,
-    "context_fields": sorted(context.keys()) if isinstance(context, dict) else [],
-    "pinned_type": type(pinned).__name__,
-}
-print(json.dumps(summary, sort_keys=True))
-PY
-   rm -f "$view_out" "$search_json" "$context_json" "$pinned_json"
-   ```
-
-   The summary is aggregate-only. Do not print `view`, search result content, context sections, pinned text, snippets, or previews. Search result IDs are not cleanup authority.
-
-4. Update by replacement semantics, then verify the replacement ID:
-
-   ```bash
-   created_id="$(head -n 1 "$smoke_ids")"
-   update_json="$(mktemp)"
-   update_ids="$(mktemp)"
-   if python3 - "$marker" <<'PY' \
-     | mempal ingest --stdin --wing smoke --room cli --source-type agent_inference --memory-kind evidence --domain project --field smoke --no-gate --supersedes "$created_id" --wait --wait-timeout-secs 90 --json \
-     > "$update_json"; then
-import json, sys
-marker = sys.argv[1]
-print(json.dumps({
-    "content": f"{marker} reversible CLI smoke drawer updated; safe to delete",
-    "wing": "smoke",
-    "room": "cli",
-    "source_type": "agent_inference",
-    "memory_kind": "evidence",
-    "domain": "project",
-    "field": "smoke",
-}))
-PY
-     :
-   fi
-   python3 - "$update_json" > "$update_ids" <<'PY'
-import json, sys
-from pathlib import Path
-obj = json.loads(Path(sys.argv[1]).read_text() or "{}")
-for item in dict.fromkeys(x for x in obj.get("created_drawer_ids", []) if isinstance(x, str) and x):
-    print(item)
-PY
-   if [ ! -s "$update_ids" ]; then
-     echo "update smoke did not expose cleanup-safe created_drawer_ids; fail closed" >&2
-     exit 1
-   fi
-   cat "$update_ids" >> "$smoke_ids"
-   updated_id="$(head -n 1 "$update_ids")"
-   updated_view="$(mktemp)"
-   mempal view "$updated_id" --all-projects > "$updated_view"
-   rm -f "$updated_view" "$update_json" "$update_ids"
-   ```
-
-5. Verify marker visibility again, then pin/unpin and delete exact smoke IDs from create/update responses. Suppress command output so `mempal delete` cannot print drawer summaries:
-
-   ```bash
-   verify_json="$(mktemp)"
-   mempal search "$marker" --top-k 5 --json > "$verify_json"
-   python3 - "$verify_json" "$marker" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-results = json.loads(Path(sys.argv[1]).read_text() or "[]")
-marker = sys.argv[2]
-matches = [
-    item for item in results
-    if isinstance(item, dict)
-    and item.get("wing") == "smoke"
-    and item.get("room") == "cli"
-    and marker in str(item.get("content", ""))
-]
-print(f"active_cli_smoke_marker_matches={len(matches)}")
-PY
-   rm -f "$verify_json"
-
-   sort -u "$smoke_ids" -o "$smoke_ids"
-   while IFS= read -r smoke_id; do
-     mempal pin "$smoke_id" >/dev/null || true
-     mempal unpin "$smoke_id" >/dev/null || true
-     if ! mempal delete "$smoke_id" >/dev/null; then
-       echo "cleanup failed for smoke drawer id: $smoke_id" >&2
-       exit 1
-     fi
-   done < "$smoke_ids"
-   rm -f "$ingest_json" "$operation_json" "$smoke_ids"
-   ```
-
-6. Re-run aggregate marker verification and confirm no active `smoke/cli` marker match remains, or record soft-delete behavior if tombstones remain visible only with explicit include-deleted flags.
-
-## Reversible MCP memory CRUD smoke
-
-Run this by default for full smoke. Prefer MCP tools already exposed to the active client. If the active client has no mempal MCP tools, it is acceptable to start a short-lived tracked stdio child with `mempal serve --mcp`, call the tools, then shut it down and verify no extra holder remains.
-
-Required MCP tool coverage when available:
-
-| Step | MCP method/tool | Required assertion |
-|---|---|---|
-| initialize | JSON-RPC `initialize` then `notifications/initialized` | server name present |
-| discover | `tools/list` | includes `mempal_ingest`, `mempal_operation_status`, `mempal_search`, `mempal_read_drawer`, `mempal_delete` |
-| status | `mempal_status` | structured object, db holder fields summarized only |
-| create | `mempal_ingest` with `wing="smoke"`, `room="mcp"`, `smoke=true`, `wait=true`, typed metadata | completed or terminal success; `created_drawer_ids` non-empty |
-| read/search | `mempal_search`, `mempal_read_drawer`, optionally `mempal_read_drawers` | structured responses parse; do not print content |
-| context/read-only | `mempal_context`, `mempal_pinned_facts`, `mempal_timeline`, `mempal_doctor`, optionally `mempal_taxonomy`, `mempal_field_taxonomy`, `mempal_kg`, `mempal_skill`, `mempal_brief` | shape-only success or classified skip/failure |
-| update | `mempal_ingest` with `supersedes=<created_id>`, same smoke scope, `smoke=true`, `wait=true` | replacement `created_drawer_ids` non-empty |
-| delete | `mempal_delete` for every exact create/update ID | `deleted=true` or explicit already-deleted for duplicate cleanup attempt |
-| post-delete | `mempal_search` marker query | no active `smoke/mcp` marker matches, or soft-delete visibility classified |
-| shutdown | `shutdown` then `notifications/exit`; kill only if needed | child exits; no extra MCP/DB holder remains |
-
-MCP stdio uses newline-delimited JSON-RPC messages in this project. A minimal client pattern is:
-
-```python
-send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mempal-smoke","version":"0"}}})
-send({"jsonrpc":"2.0","method":"notifications/initialized"})
-send({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}})
-send({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"mempal_ingest","arguments":{"content":"<marker> reversible MCP smoke drawer; safe to delete","wing":"smoke","room":"mcp","source_type":"agent_inference","memory_kind":"evidence","domain":"project","field":"smoke","smoke":True,"wait":True,"wait_timeout_secs":90}}})
-```
-
-Capture MCP responses to temp files and report only: method/tool name, JSON-RPC error class if any, latency, structuredContent top-level fields, result counts, and cleanup-created ID counts. Never print `content`, snippets, previews, prompts, drawer text, or raw response bodies.
-
-Cleanup authority is the same as CLI: only `created_drawer_ids` from `mempal_ingest` or `mempal_operation_status` may be deleted automatically. Do not delete `drawer_id`, search hits, read results, or marker matches.
-
-Public MCP `mempal_ingest` exposes a constrained smoke path through `smoke=true`. The server accepts it only for small writes under `wing="smoke"` and `room="mcp"`, rejects diary rollup, and internally bypasses gating/novelty so automated smoke can receive cleanup-authoritative `created_drawer_ids`. If a terminal MCP smoke write still has no `created_drawer_ids`, classify it as `inconclusive_no_cleanup_id`, do not attempt update/delete, and do not use search result IDs for cleanup.
-
-## Dangerous or non-default surfaces
-
-Default smoke must skip these unless the task explicitly asks for them and an exact cleanup plan exists:
-
-- `mempal_rollback`: dry-run only; never execute real rollback in smoke.
-- Purge/delete-all style commands: forbidden for smoke.
-- `mempal_peek_partner`: may read live session text; skip.
-- `mempal_cowork_push` and `mempal_cowork_bus send/broadcast/drain/capture`: skip because they mutate or expose cowork traffic.
-- Taxonomy/tunnel/knowledge graph mutations such as taxonomy edit, tunnel add/delete, and `mempal_kg add/invalidate`: skip unless exact synthetic IDs and cleanup are proven.
-- Knowledge/profile promotion workflows (`promote`, `adopt`, `reject`, `retire`, `publish`, card promote/demote): read/list/gate summaries only by default.
-
-For content-bearing read-only tools (`mempal_context`, `mempal_brief`, `mempal_pinned_facts`, `mempal_timeline`, search/read tools), summarize counts/fields/bytes only and redact or omit values named `content`, `text`, `preview`, `statement`, `narrative`, `messages`, `facts.content`, snippets, prompts, and model output.
-
-## REST checks
-
-Prefer `mempal doctor rest --format json` for route availability. If an actual REST route smoke is required:
-
-1. First check whether an endpoint is already running (`doctor rest`).
-2. If not running, start `mempal serve` as a tracked background process and ensure it listens before probing.
-3. Probe only aggregate/status endpoints or synthetic content.
-4. Kill the temporary server and verify no extra `mempal serve` process remains.
-
-Do not confuse daemon service health with REST server availability; they are separate surfaces.
-
-## Memory growth guard
-
-Capture daemon memory before and after smoke:
-
-```bash
-main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
-ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm
-mempal daemon status | awk '/^(memory\.|live_daemons:|extra_holders:|search\.active:|rest\.embedder_cache\.|embedder\.)/ {print}'
-```
-
-If read-only commands push RSS into multi-GB territory, file or update an issue with aggregate evidence. Restarting is only mitigation; the product fix should bound/lazily load/evict caches.
-
-## Done when
-
-- Preflight state recorded without leaking content.
-- Daemon restart, if performed, leaves one current-binary daemon.
-- Read-only matrix exits 0 or failures are classified by command/stderr class.
-- Raw stdout/stderr from content-bearing `mempal` commands was captured, structurally summarized, and not pasted into chat or log summaries.
-- CLI CRUD smoke creates, reads/searches/contexts, updates, pin/unpins, deletes, and verifies cleanup using only exact `created_drawer_ids`.
-- MCP CRUD smoke creates, reads/searches/contexts, updates, deletes, and verifies cleanup through MCP tools using the constrained `smoke=true` write path. If a terminal MCP smoke write lacks cleanup-safe `created_drawer_ids`, classify it as `inconclusive_no_cleanup_id` and keep the MCP CRUD group non-pass. Use `skipped_unavailable` only when no MCP client/tooling is available.
-- REST/MCP checks do not leave extra processes or DB holders.
-- Memory before/after is recorded.
-- Worktree remains clean except intentional skill/code changes.
+- [ ] Preflight recorded without leaking content.
+- [ ] Installed binary and daemon are current; singleton/holder state is classified.
+- [ ] Read-only matrix exits 0 or failures are classified by command/error class.
+- [ ] CLI CRUD creates, reads/searches/contexts, updates, pin/unpins, deletes, and verifies cleanup using only `created_drawer_ids`.
+- [ ] MCP CRUD passes or is explicitly skipped/unavailable; failures are not hidden by CLI success.
+- [ ] REST/MCP checks do not leave extra processes or DB holders.
+- [ ] Memory/I/O before/after is summarized aggregate-only.
+- [ ] Worktree remains clean except intentional skill/code changes.

--- a/skills/smoke-test/references/preflight-and-readonly-cli.md
+++ b/skills/smoke-test/references/preflight-and-readonly-cli.md
@@ -1,0 +1,102 @@
+# Preflight and Read-only CLI Smoke
+
+Use this reference when the smoke needs manual preflight or read-only CLI probes beyond the automated `scripts/full_smoke.py` runner.
+
+## Preflight
+
+Run from repo root. Capture content-bearing output to temp files; report only shapes/counts/status classes.
+
+```bash
+git status --short --branch --untracked-files=all
+command -v mempal
+mempal --version
+systemctl --user is-active mempal-daemon.service || true
+systemctl --user show mempal-daemon.service -p MainPID -p ActiveState -p SubState --value || true
+mempal daemon status > /tmp/mempal-daemon-status-smoke.txt
+```
+
+Summarize only:
+
+- installed path/version;
+- daemon service state/PID;
+- daemon executable current vs `/usr/local/bin/mempal (deleted)`;
+- live daemon count;
+- extra holders / stale MCP servers / orphan daemons;
+- RSS/PSS/private dirty/anonymous memory;
+- queue counts and search active flag;
+- REST health class.
+
+Do not report raw command lines, environment variables, URLs, connection strings, bearer tokens, prompt-like arguments, or drawer/card bodies.
+
+## Structure-only capture harness
+
+Use for content-bearing or uncertain commands:
+
+```bash
+run_mempal_probe() {
+  name="$1"; expect_json="$2"; shift 2
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/mempal-smoke.XXXXXX")"
+  stdout_file="$tmpdir/stdout"; stderr_file="$tmpdir/stderr"
+  start_ms="$(date +%s%3N)"
+  "$@" >"$stdout_file" 2>"$stderr_file"; status=$?
+  end_ms="$(date +%s%3N)"
+  python3 - "$name" "$expect_json" "$status" "$start_ms" "$end_ms" "$stdout_file" "$stderr_file" <<'PY'
+import json, sys
+from pathlib import Path
+name, expect_json, status, start_ms, end_ms, stdout_path, stderr_path = sys.argv[1:]
+stdout = Path(stdout_path).read_bytes(); stderr = Path(stderr_path).read_bytes()
+summary = {
+    'name': name,
+    'exit_code': int(status),
+    'latency_ms': max(0, int(end_ms) - int(start_ms)),
+    'stdout_bytes': len(stdout),
+    'stderr_bytes': len(stderr),
+}
+if expect_json == 'json':
+    text = stdout.decode('utf-8', errors='replace')
+    try:
+        parsed = json.loads(text or 'null')
+        if isinstance(parsed, dict):
+            summary['json'] = {'ok': True, 'type': 'object', 'fields': sorted(parsed.keys()), 'field_count': len(parsed)}
+        elif isinstance(parsed, list):
+            summary['json'] = {'ok': True, 'type': 'array', 'count': len(parsed)}
+        else:
+            summary['json'] = {'ok': True, 'type': type(parsed).__name__}
+    except Exception as exc:
+        lines=[line for line in text.splitlines() if line.strip()]
+        try:
+            parsed_lines=[json.loads(line) for line in lines]
+            fields=sorted({k for item in parsed_lines if isinstance(item, dict) for k in item})
+            summary['json']={'ok': True, 'type': 'ndjson', 'line_count': len(parsed_lines), 'fields': fields}
+        except Exception:
+            summary['json']={'ok': False, 'error_type': type(exc).__name__}
+print(json.dumps(summary, sort_keys=True))
+PY
+  rm -rf "$tmpdir"
+  return "$status"
+}
+```
+
+The harness must not print command stdout/stderr, JSON values, drawer IDs, search snippets, previews, prompts, or model responses.
+
+## Read-only CLI matrix
+
+Treat these commands as content-bearing by default: `status`, `status --full`, `timeline`, `tail`, `pinned`, `knowledge-card list`, `cards --pending`, `reflect`, `prime`, `wake-up`, `context`, `search`, `recall`, and any command returning drawers/snippets/evidence/prompts/previews.
+
+Suggested probes:
+
+| Group | Command | Handling | Pass criteria |
+|---|---|---|---|
+| Identity | `mempal --version` | safe direct | exit 0 |
+| Daemon | `mempal daemon status` | captured summary | exit 0, singleton/current binary classified |
+| Doctor | `mempal doctor` | captured summary | exit 0 or warnings classified |
+| REST doctor | `mempal doctor rest --format json` | JSON harness | JSON parses; degraded allowed only if recorded |
+| Dashboard | `mempal status` | harness | exit 0 |
+| Stats | `mempal stats` | captured summary | exit 0 |
+| Config/cost/gating | `mempal config intelligence`, `mempal cost status`, `mempal gating stats` | captured summary | exit 0 |
+| Timeline/tail/pinned | `mempal timeline --since 1h --format json`, `mempal tail --limit 3`, `mempal pinned --json` | harness | exit 0, JSON parses where requested |
+| KG/cards/reflect | `mempal kg stats`, `mempal knowledge-card list --format json`, `mempal cards --pending --format json`, `mempal reflect --json --limit 3` | harness | exit 0/JSON parses |
+| Context/search | `mempal search <safe-query> --top-k 3 --json`, `mempal context <safe-query> --format json --max-items 3 --no-distill-suggestions` | harness; timeout 120-180s | shape-only success |
+| Maintenance/release/xurl | `mempal maintenance guided-run --format json`, `mempal release-readiness --format json`, `mempal xurl stats` | harness/summary | exit 0 |
+
+If semantic queries are slow, report latency and memory growth. Do not treat slowness as pass unless the task only asked for availability.

--- a/skills/smoke-test/references/rest-resource-and-done.md
+++ b/skills/smoke-test/references/rest-resource-and-done.md
@@ -1,0 +1,55 @@
+# REST, Resource Safety, and Done Criteria
+
+Use this reference for non-default smoke surfaces, resource guards, and final reporting.
+
+## REST checks
+
+Prefer `mempal doctor rest --format json` for route availability. It is cheaper and avoids unmanaged server lifetimes.
+
+If an actual REST route smoke is required:
+
+1. Check whether an endpoint is already running with `doctor rest`.
+2. If no route is available and the test truly requires REST, start `mempal serve` as a tracked background process.
+3. Probe only aggregate/status endpoints or synthetic content.
+4. Kill the temporary server and verify no extra `mempal serve` process remains.
+
+Do not confuse daemon service health with REST server availability; they are separate surfaces.
+
+## Dangerous or non-default surfaces
+
+Skip these unless the task explicitly asks and an exact cleanup plan exists:
+
+- rollback/rollback-like mutation except dry-run;
+- purge/delete-all style commands;
+- partner/session peek tools that may expose live text;
+- cowork push/bus send/broadcast/drain/capture;
+- taxonomy/tunnel/KG mutations without exact synthetic IDs and cleanup;
+- knowledge/profile promotion workflows (`promote`, `adopt`, `reject`, `retire`, `publish`, card promote/demote).
+
+For content-bearing read-only tools (`context`, `brief`, `pinned`, `timeline`, search/read tools), summarize counts/fields/bytes only and omit/redact values named `content`, `text`, `preview`, `statement`, `narrative`, `messages`, snippets, prompts, and model output.
+
+## Memory and I/O guard
+
+Capture daemon memory before/after broad smoke:
+
+```bash
+main_pid=$(systemctl --user show mempal-daemon.service -p MainPID --value)
+ps -p "$main_pid" -o pid,ppid,stat,etime,%cpu,%mem,rss,vsz,comm
+mempal daemon status > /tmp/mempal-daemon-status-smoke.txt
+```
+
+Report only aggregate RSS/PSS/anonymous/private dirty, queue/holder counts, and route/health classes. If read-only commands push RSS into multi-GB territory or tiny smoke writes cause large SSD reads, capture PID-stable `/proc/<pid>/io` deltas and file/fix a resource-governance issue; restarting is mitigation, not the product fix.
+
+## Final report checklist
+
+A smoke report is complete when:
+
+- preflight state is recorded without leaking content;
+- installed binary and daemon executable are current, singleton, and holder state is classified;
+- read-only matrix exits 0 or failures are classified by command/error class;
+- CLI CRUD creates, reads/searches/contexts, updates, pin/unpins, deletes, and verifies cleanup using exact `created_drawer_ids` only;
+- MCP CRUD passes or is explicitly skipped/unavailable; MCP failures are not hidden by CLI success;
+- REST/MCP checks leave no extra processes or DB holders;
+- all exact-created smoke IDs are cleaned, while intentional real-memory writes are preserved;
+- memory and I/O before/after are summarized aggregate-only;
+- worktree is clean except intentional skill/code changes.

--- a/skills/smoke-test/references/reversible-crud.md
+++ b/skills/smoke-test/references/reversible-crud.md
@@ -1,0 +1,52 @@
+# Reversible CLI and MCP CRUD Smoke
+
+Use this reference when the smoke must exercise writes. Prefer `scripts/full_smoke.py` for broad coverage; use these manual steps for targeted diagnosis.
+
+## Cleanup authority
+
+Only delete IDs returned by the same smoke run as `created_drawer_ids` (or a documented alias that exactly mirrors that field). Never delete `drawer_id`, `drawer_ids`, search hits, read results, or marker matches unless they are also in the runtime-created cleanup-safe list.
+
+If a create/update does not expose cleanup-safe IDs, fail closed: skip update/delete, classify the API gap, and avoid guessing.
+
+## Reversible CLI CRUD outline
+
+1. Generate a unique marker.
+2. Ingest via stdin with a smoke scope and JSON output:
+   - `wing=smoke`, `room=cli`
+   - `source_type=agent_inference`, `memory_kind=evidence`, `domain=project`, `field=smoke`
+   - `--no-gate --wait --wait-timeout-secs 90 --json`
+3. Extract only `created_drawer_ids`; if absent but an `operation_id` is returned, close any MCP stdio holder first, then follow with `mempal operation wait <id> --timeout-secs 300 --json` or `operation status`.
+4. Read/query without printing content:
+   - `mempal view <created_id> --all-projects` to temp file; summarize byte count only.
+   - `mempal search <marker> --top-k 5 --json`; summarize count/shape only.
+   - `mempal context <marker> --format json --max-items 3 --no-distill-suggestions`; summarize field names only.
+   - `mempal pinned --json`; summarize type/count only.
+5. Update by replacement semantics with `mempal ingest ... --supersedes <created_id> ... --json`; require new `created_drawer_ids`.
+6. Pin/unpin exact smoke IDs, then `mempal delete <id>` for each created/update ID. Suppress raw delete output.
+7. Re-run marker search and require no active `smoke/cli` matches, or classify tombstone visibility if only include-deleted surfaces show them.
+
+## Reversible MCP CRUD outline
+
+Use MCP tools already exposed to the active client when available. If not, `scripts/full_smoke.py` may start short-lived `mempal serve --mcp` stdio children because it owns shutdown and kills leftovers. Do not manually leave unmanaged MCP servers running.
+
+Required MCP coverage when available:
+
+| Step | Tool/method | Assertion |
+|---|---|---|
+| initialize/discover | JSON-RPC initialize + `tools/list` | server name present; expected tools listed |
+| status | `mempal_status` | structured object; holder fields summarized only |
+| create | `mempal_ingest` with `wing=smoke`, `room=mcp`, `smoke=true`, `wait=true` | terminal success and non-empty `created_drawer_ids` |
+| read/search | `mempal_search`, `mempal_read_drawer`, optionally `mempal_read_drawers` | structured parse; no content printed |
+| context/read-only | `mempal_context`, `mempal_pinned_facts`, `mempal_timeline`, `mempal_doctor`, optional taxonomy/brief/skill tools | shape-only success or classified skip/failure |
+| update | `mempal_ingest` with `supersedes=<created_id>` and same smoke scope | replacement `created_drawer_ids` non-empty |
+| delete | `mempal_delete` for exact create/update IDs | `deleted=true` or explicit already-deleted duplicate cleanup |
+| post-delete | `mempal_search` marker query | no active `smoke/mcp` marker matches |
+| shutdown | `shutdown` + exit notification | child exits; no extra MCP/DB holder remains |
+
+Capture MCP responses to temp files and report only method/tool, JSON-RPC error class, latency, structuredContent top-level fields, result counts, and cleanup-created ID counts. Never print raw response bodies, content, snippets, previews, prompts, drawer text, or model output.
+
+## Real memory write option
+
+When the operator asks for a genuine write smoke, store a concise non-secret note that will be useful later. Keep it project-scoped and typed. Example metadata: `wing=project`, `room=mempal`, `source_type=agent_inference`, `memory_kind=knowledge`, `domain=project`, `field=ops`.
+
+After writing, wait for completion, verify by exact safe query with shape/count only, and do **not** delete it because it is intentional durable memory.

--- a/skills/smoke-test/scripts/full_smoke.py
+++ b/skills/smoke-test/scripts/full_smoke.py
@@ -299,6 +299,7 @@ def run_cli(name: str, args: list[str], *, input_text: str | None = None, expect
         latency_ms=result['latency_ms'],
         stdout_bytes=len(result['stdout']),
         stderr_bytes=len(result['stderr']),
+        stderr_class=classify_stderr(result['stderr']) if result['stderr'] else None,
         timeout=result.get('timed_out') or None,
         killed=result.get('killed') or None,
         json=shape or None,
@@ -306,19 +307,70 @@ def run_cli(name: str, args: list[str], *, input_text: str | None = None, expect
     return result['returncode'], result['stdout'], result['stderr'], parsed, shape
 
 
+def classify_stderr(data: bytes) -> str:
+    text = data.decode('utf-8', errors='replace').lower()
+    if 'classification=extra_holder' in text or 'extra process holding' in text:
+        return 'database_lock_extra_holder'
+    if 'database is locked' in text or 'sqlite' in text and 'locked' in text:
+        return 'database_locked'
+    if 'operation' in text and 'not found' in text:
+        return 'operation_not_found'
+    if 'timed out' in text or 'timeout' in text:
+        return 'timeout'
+    if 'degraded' in text and 'write' in text:
+        return 'write_degraded'
+    if 'error:' in text:
+        return 'error'
+    return 'stderr_present'
+
+
+def receipt_dicts_from(value: Any) -> list[dict[str, Any]]:
+    """Return operation-style receipt dicts without parsing raw text payloads."""
+    receipts: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        receipts.append(value)
+        for key in ('structuredContent', 'result', 'payload', 'response'):
+            nested = value.get(key)
+            if isinstance(nested, (dict, list)):
+                receipts.extend(receipt_dicts_from(nested))
+        return receipts
+    if isinstance(value, list):
+        for item in value:
+            receipts.extend(receipt_dicts_from(item))
+    return receipts
+
+
 def created_ids_from(value: Any) -> list[str]:
-    if not isinstance(value, dict):
-        return []
     ids: list[str] = []
-    for key in ('created_drawer_ids', 'cleanup_drawer_ids'):
-        values = value.get(key)
-        if isinstance(values, list):
-            ids.extend(x for x in values if isinstance(x, str) and x)
+    for receipt in receipt_dicts_from(value):
+        for key in ('created_drawer_ids', 'cleanup_drawer_ids'):
+            values = receipt.get(key)
+            if isinstance(values, list):
+                ids.extend(x for x in values if isinstance(x, str) and x)
     return list(dict.fromkeys(ids))
 
 
 def terminal_state(value: Any) -> bool:
-    return isinstance(value, dict) and value.get('state') in {'completed', 'rejected', 'failed'}
+    return operation_state_from(value) in {'completed', 'rejected', 'failed'}
+
+
+def operation_id_from(value: Any) -> str | None:
+    for receipt in receipt_dicts_from(value):
+        operation_id = receipt.get('operation_id')
+        if isinstance(operation_id, str) and operation_id:
+            return operation_id
+    return None
+
+
+def operation_state_from(value: Any) -> str | None:
+    last_state: str | None = None
+    for receipt in receipt_dicts_from(value):
+        state = receipt.get('state')
+        if isinstance(state, str) and state:
+            if state in {'completed', 'rejected', 'failed'}:
+                return state
+            last_state = state
+    return last_state
 
 
 def count_marker_matches(value: Any, room: str) -> int:
@@ -387,9 +439,34 @@ def delete_exact_ids_cli(drawer_ids: list[str], label: str, room: str | None = N
 
 def wait_operation(operation_id: str, name: str) -> Any | None:
     rc, out, _err, parsed, _shape = run_cli(name, ['mempal', 'operation', 'wait', operation_id, '--timeout-secs', '300', '--json'], expect_json=True, timeout=330)
+    if created_ids_from(parsed):
+        return parsed
     if rc != 0 or not terminal_state(parsed):
         rc, out, _err, parsed, _shape = run_cli(name + '_status', ['mempal', 'operation', 'status', operation_id, '--json'], expect_json=True, timeout=30)
     return parsed
+
+
+def recover_created_ids(value: Any, wait_label: str) -> tuple[list[str], dict[str, Any]]:
+    ids = created_ids_from(value)
+    operation_id = operation_id_from(value)
+    info: dict[str, Any] = {
+        'operation_id_present': bool(operation_id),
+        'operation_state': operation_state_from(value),
+        'recovered_via': None,
+        'recovered_state': None,
+    }
+    if ids or operation_id is None:
+        return ids, info
+
+    waited = wait_operation(operation_id, wait_label)
+    ids = created_ids_from(waited)
+    info['recovered_via'] = wait_label
+    info['recovered_state'] = operation_state_from(waited)
+    return ids, info
+
+
+def recovery_fields(info: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in info.items() if value not in (None, False)}
 
 
 def cli_crud() -> list[str]:
@@ -402,14 +479,11 @@ def cli_crud() -> list[str]:
         expect_json=True,
         timeout=130,
     )
-    ids = created_ids_from(parsed)
-    if not ids and isinstance(parsed, dict) and parsed.get('operation_id'):
-        parsed2 = wait_operation(parsed['operation_id'], 'cli_create_wait')
-        ids = created_ids_from(parsed2)
-        if ids:
-            note('cli_create', True, recovered_via='cli_create_wait', created_id_count=len(ids))
+    ids, create_recovery = recover_created_ids(parsed, 'cli_create_wait')
+    if ids and create_recovery.get('recovered_via'):
+        note('cli_create', True, created_id_count=len(ids), **recovery_fields(create_recovery))
     if not ids:
-        note('cli_crud', False, reason='create_missing_created_drawer_ids')
+        note('cli_crud', False, reason='create_missing_created_drawer_ids', **recovery_fields(create_recovery))
         return cleanup_ids
     cleanup_ids.extend(ids)
     created_id = ids[0]
@@ -433,15 +507,12 @@ def cli_crud() -> list[str]:
         expect_json=True,
         timeout=130,
     )
-    upd_ids = created_ids_from(upd_parsed)
-    if not upd_ids and isinstance(upd_parsed, dict) and upd_parsed.get('operation_id'):
-        upd_parsed2 = wait_operation(upd_parsed['operation_id'], 'cli_update_wait')
-        upd_ids = created_ids_from(upd_parsed2)
-        if upd_ids:
-            note('cli_update', True, recovered_via='cli_update_wait', created_id_count=len(upd_ids))
+    upd_ids, update_recovery = recover_created_ids(upd_parsed, 'cli_update_wait')
+    if upd_ids and update_recovery.get('recovered_via'):
+        note('cli_update', True, created_id_count=len(upd_ids), **recovery_fields(update_recovery))
     if not upd_ids:
         delete_exact_ids_cli(cleanup_ids, 'cli_cleanup_after_update_failure', room='cli')
-        note('cli_crud', False, reason='update_missing_created_drawer_ids', cleanup_id_count=len(cleanup_ids))
+        note('cli_crud', False, reason='update_missing_created_drawer_ids', cleanup_id_count=len(cleanup_ids), **recovery_fields(update_recovery))
         return cleanup_ids
     cleanup_ids.extend(upd_ids)
     SUMMARY['created_counts']['cli'] = len(cleanup_ids)
@@ -678,21 +749,27 @@ def mcp_crud() -> list[str]:
         create_args = {'content': f'{MARKER} reversible MCP smoke drawer; nonce {NONCE}; lexical tokens azurequill basaltfern cobaltlyric; safe to delete', 'wing': 'smoke', 'room': 'mcp', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke', 'smoke': True, 'wait': True, 'wait_timeout_secs': 90}
         create, info = client.tool('mempal_ingest', create_args, timeout=130)
         ids = created_ids_from(create)
-        if not ids and isinstance(create, dict) and create.get('operation_id'):
+        create_recovery: dict[str, Any] = {
+            'operation_id_present': bool(operation_id_from(create)),
+            'operation_state': operation_state_from(create),
+        }
+        if not ids and operation_id_from(create):
             # A non-terminal MCP ingest receipt means the daemon may still be
             # processing the write. Close this stdio server before following the
             # operation via CLI so the smoke runner never observes a result while
             # its own MCP process is still an extra SQLite holder.
             client.close()
             client = None
-            waited = wait_operation(create['operation_id'], 'mcp_create_cli_wait')
+            waited = wait_operation(operation_id_from(create) or '', 'mcp_create_cli_wait')
             ids = created_ids_from(waited)
-        note('mcp_create', bool(info.get('ok')) and bool(ids), created_id_count=len(ids), **without_ok(info))
+            create_recovery.update({'recovered_via': 'mcp_create_cli_wait', 'recovered_state': operation_state_from(waited)})
+        note('mcp_create', bool(info.get('ok')) and bool(ids), created_id_count=len(ids), **recovery_fields(create_recovery), **without_ok(info))
         if not ids:
             note(
                 'mcp_inconclusive_no_cleanup_id',
                 False,
                 reason='create_missing_created_drawer_ids',
+                **recovery_fields(create_recovery),
                 product_issue='https://github.com/RyderFreeman4Logos/mempal/issues/545',
             )
             return cleanup_ids
@@ -727,18 +804,24 @@ def mcp_crud() -> list[str]:
         update_args = {'content': f'{MARKER} reversible MCP smoke drawer updated; nonce {NONCE[::-1]}; lexical tokens deltaorchid embervault frostcairn; safe to delete', 'wing': 'smoke', 'room': 'mcp', 'source_type': 'agent_inference', 'memory_kind': 'evidence', 'domain': 'project', 'field': 'smoke', 'smoke': True, 'supersedes': created_id, 'wait': True, 'wait_timeout_secs': 90}
         update, uinfo = client.tool('mempal_ingest', update_args, timeout=130)
         upd_ids = created_ids_from(update)
-        if not upd_ids and isinstance(update, dict) and update.get('operation_id'):
+        update_recovery: dict[str, Any] = {
+            'operation_id_present': bool(operation_id_from(update)),
+            'operation_state': operation_state_from(update),
+        }
+        if not upd_ids and operation_id_from(update):
             client.close()
             client = None
-            waited = wait_operation(update['operation_id'], 'mcp_update_cli_wait')
+            waited = wait_operation(operation_id_from(update) or '', 'mcp_update_cli_wait')
             upd_ids = created_ids_from(waited)
-        note('mcp_update', bool(uinfo.get('ok')) and bool(upd_ids), created_id_count=len(upd_ids), **without_ok(uinfo))
+            update_recovery.update({'recovered_via': 'mcp_update_cli_wait', 'recovered_state': operation_state_from(waited)})
+        note('mcp_update', bool(uinfo.get('ok')) and bool(upd_ids), created_id_count=len(upd_ids), **recovery_fields(update_recovery), **without_ok(uinfo))
         if not upd_ids:
             delete_exact_ids_cli(cleanup_ids, 'mcp_cleanup_after_update_failure', room='mcp')
             note(
                 'mcp_inconclusive_no_cleanup_id',
                 False,
                 reason='update_missing_created_drawer_ids',
+                **recovery_fields(update_recovery),
                 product_issue='https://github.com/RyderFreeman4Logos/mempal/issues/545',
             )
             return cleanup_ids

--- a/skills/smoke-test/tests/test_full_smoke_receipts.py
+++ b/skills/smoke-test/tests/test_full_smoke_receipts.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression tests for full_smoke operation receipt handling."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+import unittest
+
+
+def load_full_smoke() -> ModuleType:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "full_smoke.py"
+    spec = importlib.util.spec_from_file_location("full_smoke", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReceiptExtractionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.smoke = load_full_smoke()
+
+    def test_created_ids_from_accepts_only_cleanup_safe_fields(self) -> None:
+        payload = {
+            "drawer_ids": ["unsafe-affected-id"],
+            "result": {
+                "structuredContent": {
+                    "created_drawer_ids": ["created-a"],
+                    "cleanup_drawer_ids": ["created-a", "created-b"],
+                }
+            },
+        }
+
+        self.assertEqual(
+            self.smoke.created_ids_from(payload),
+            ["created-a", "created-b"],
+        )
+
+    def test_created_ids_from_handles_ndjson_style_receipt_lists(self) -> None:
+        receipts = [
+            {"state": "queued", "operation_id": "op-1"},
+            {"state": "completed", "cleanup_drawer_ids": ["created-final"]},
+        ]
+
+        self.assertEqual(
+            self.smoke.created_ids_from(receipts),
+            ["created-final"],
+        )
+        self.assertEqual(self.smoke.operation_id_from(receipts), "op-1")
+        self.assertTrue(self.smoke.terminal_state(receipts))
+
+    def test_recover_created_ids_waits_on_operation_receipt(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def fake_wait(operation_id: str, name: str) -> dict[str, Any]:
+            calls.append((operation_id, name))
+            return {
+                "operation_id": operation_id,
+                "state": "completed",
+                "created_drawer_ids": ["created-after-wait"],
+            }
+
+        original_wait = self.smoke.wait_operation
+        self.smoke.wait_operation = fake_wait
+        try:
+            ids, info = self.smoke.recover_created_ids(
+                {"operation_id": "op-timeout", "state": "queued", "timed_out": True},
+                "unit_wait",
+            )
+        finally:
+            self.smoke.wait_operation = original_wait
+
+        self.assertEqual(ids, ["created-after-wait"])
+        self.assertEqual(calls, [("op-timeout", "unit_wait")])
+        self.assertEqual(info["recovered_via"], "unit_wait")
+        self.assertEqual(info["recovered_state"], "completed")
+
+    def test_recover_created_ids_reports_precise_non_pass_without_operation(self) -> None:
+        ids, info = self.smoke.recover_created_ids(
+            {"state": "queued", "timed_out": True},
+            "unused_wait",
+        )
+
+        self.assertEqual(ids, [])
+        self.assertEqual(info["operation_state"], "queued")
+        self.assertFalse(info["operation_id_present"])
+
+    def test_classify_stderr_reports_database_extra_holder_without_raw_text(self) -> None:
+        stderr = (
+            b"error: failed to open database\n"
+            b"holder summary: pid=427 role=mempal_mcp_server classification=extra_holder\n"
+        )
+
+        self.assertEqual(
+            self.smoke.classify_stderr(stderr),
+            "database_lock_extra_holder",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10563,16 +10563,22 @@ fn context_error(error: crate::context::ContextError) -> ErrorData {
 
 fn mcp_context_read_error_is_degradable(error: &ErrorData) -> bool {
     let message = error.message.to_ascii_lowercase();
-    let lock_or_busy = message.contains("database is locked")
+    let transient_contention = message.contains("database is locked")
         || message.contains("database locked")
         || message.contains("database is busy")
         || message.contains("database busy")
         || message.contains("sqlite_busy")
         || message.contains("sqlite_locked")
-        || message.contains("locked_or_busy");
+        || message.contains("sqlite_protocol")
+        || message.contains("database protocol")
+        || message.contains("locked_or_busy")
+        || message.contains("classification=extra_holder")
+        || message.contains("extra process holding")
+        || message.contains("extra_holder")
+        || message.contains("stale_mcp_server")
+        || message.contains("orphan_daemon");
     let query_timeout = message.contains("query-only database read exceeded");
-    let open_failure = message.contains("failed to open database");
-    lock_or_busy || query_timeout || open_failure
+    transient_contention || query_timeout
 }
 
 fn empty_context_pack_from_request(request: crate::context::ContextRequest) -> ContextPack {
@@ -15474,6 +15480,52 @@ pattern_boost = 0.2
                 .iter()
                 .any(|item| item.kind == "no_evidence")
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_surfaces_non_transient_query_open_error() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_async_db_open_error_for_test("permission denied");
+
+        let error = match server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "max_items": 3
+            }))
+            .await
+        {
+            Ok(_) => panic!("context should not hide non-transient database open failures"),
+            Err(error) => error,
+        };
+
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to open database"));
+        assert!(error_text.contains("permission denied"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_brief_surfaces_non_transient_query_open_error() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_async_db_open_error_for_test("permission denied");
+
+        let error = match server
+            .mempal_brief(Parameters(BriefMcpRequest {
+                query: "debug".to_string(),
+                field: Some("smoke".to_string()),
+                domain: Some("project".to_string()),
+                cwd: None,
+                max_items: Some(3),
+                dao_tian_limit: None,
+            }))
+            .await
+        {
+            Ok(_) => panic!("brief should not hide non-transient database open failures"),
+            Err(error) => error,
+        };
+
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to open database"));
+        assert!(error_text.contains("permission denied"));
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2125,9 +2125,7 @@ impl MempalMcpServer {
         poll_interval: Duration,
         claim_policy: ScopedIngestClaimPolicy,
     ) -> std::result::Result<Option<IngestResponse>, ErrorData> {
-        if claim_policy == ScopedIngestClaimPolicy::PollOnly
-            || !should_claim_scoped_ingest_worker(self.daemon_ingest_ipc_available())
-        {
+        if claim_policy == ScopedIngestClaimPolicy::PollOnly {
             return self
                 .wait_for_operation_status(operation_id, timeout, poll_interval)
                 .await;
@@ -2174,9 +2172,7 @@ impl MempalMcpServer {
                 tokio::time::sleep(poll_interval.min(remaining)).await;
                 continue;
             }
-            if self.daemon_ingest_ipc_available()
-                || self.daemon_writer_lease_visible_for_ingest_wait().await
-            {
+            if self.daemon_writer_lease_visible_for_ingest_wait().await {
                 tokio::time::sleep(poll_interval.min(remaining)).await;
                 continue;
             }
@@ -3236,8 +3232,15 @@ fn should_start_local_ingest_worker(
     matches!(processor, IngestQueueProcessor::Local) && !defer_to_daemon_ingest_worker
 }
 
-fn should_claim_scoped_ingest_worker(defer_to_daemon_ingest_worker: bool) -> bool {
-    !defer_to_daemon_ingest_worker
+fn should_use_scoped_ingest_wait_worker(
+    processor: IngestQueueProcessor,
+    worker_mode: IngestWaitWorkerMode,
+    claim_policy: ScopedIngestClaimPolicy,
+    use_local_ingest_worker: bool,
+) -> bool {
+    claim_policy != ScopedIngestClaimPolicy::PollOnly
+        && ((use_local_ingest_worker && matches!(worker_mode, IngestWaitWorkerMode::Scoped))
+            || matches!(processor, IngestQueueProcessor::Daemon))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -6059,10 +6062,12 @@ impl MempalMcpServer {
                     queue_admission.daemon_enqueue_may_have_reached,
                 )
                 .await
-            } else if use_local_ingest_worker
-                && matches!(worker_mode, IngestWaitWorkerMode::Scoped)
-                && claim_policy != ScopedIngestClaimPolicy::PollOnly
-            {
+            } else if should_use_scoped_ingest_wait_worker(
+                queue_admission.processor,
+                worker_mode,
+                claim_policy,
+                use_local_ingest_worker,
+            ) {
                 self.wait_for_operation_status_with_scoped_worker_mode(
                     operation_id,
                     wait_remaining,
@@ -12086,13 +12091,40 @@ mod tests {
             IngestQueueProcessor::Local,
             true
         ));
-        assert!(!should_claim_scoped_ingest_worker(true));
+        assert!(should_use_scoped_ingest_wait_worker(
+            IngestQueueProcessor::Daemon,
+            IngestWaitWorkerMode::Background,
+            ScopedIngestClaimPolicy::InlineWithinDeadline,
+            false,
+        ));
     }
 
     #[test]
-    fn test_operation_wait_uses_daemon_worker_when_daemon_ipc_is_live() {
-        assert!(should_claim_scoped_ingest_worker(false));
-        assert!(!should_claim_scoped_ingest_worker(true));
+    fn test_operation_wait_can_scope_claim_daemon_admitted_operation() {
+        assert!(should_use_scoped_ingest_wait_worker(
+            IngestQueueProcessor::Daemon,
+            IngestWaitWorkerMode::Background,
+            ScopedIngestClaimPolicy::InlineWithinDeadline,
+            false,
+        ));
+        assert!(should_use_scoped_ingest_wait_worker(
+            IngestQueueProcessor::Local,
+            IngestWaitWorkerMode::Scoped,
+            ScopedIngestClaimPolicy::InlineWithinDeadline,
+            true,
+        ));
+        assert!(!should_use_scoped_ingest_wait_worker(
+            IngestQueueProcessor::Local,
+            IngestWaitWorkerMode::Background,
+            ScopedIngestClaimPolicy::InlineWithinDeadline,
+            true,
+        ));
+        assert!(!should_use_scoped_ingest_wait_worker(
+            IngestQueueProcessor::Daemon,
+            IngestWaitWorkerMode::Background,
+            ScopedIngestClaimPolicy::PollOnly,
+            false,
+        ));
     }
 
     #[test]
@@ -12446,6 +12478,74 @@ quality_policy = "llm_required_for_keep"
             .expect("daemon-accepted operation must be status-queryable");
         assert_eq!(local_record.id, operation_id);
         assert_eq!(local_record.op_state, IngestOperationState::Queued.as_str());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_completes_daemon_admitted_operation_without_daemon_worker() {
+        let (tempdir, db_path, server) = setup_server();
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let daemon_db_path = db_path.clone();
+        let daemon = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
+            let request = crate::hook_ipc::read_enqueue_request(&mut stream)
+                .await
+                .expect("read daemon IPC request");
+            let operation_id = PendingMessageStore::new_without_reclaim(&daemon_db_path)
+                .enqueue_idempotent_with_key(
+                    &request.kind,
+                    &request.payload,
+                    &request.idempotency_key,
+                )
+                .expect("persist daemon-admitted operation");
+            crate::hook_ipc::write_enqueue_response(
+                &mut stream,
+                &crate::hook_ipc::HookIpcEnqueueResponse::Accepted,
+            )
+            .await
+            .expect("write daemon IPC response");
+            (request, operation_id)
+        });
+
+        let response = server
+            .mempal_ingest_with_controls(
+                IngestRequest {
+                    content: "daemon-admitted MCP wait caller completes receipt".to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("daemon-wait-receipt".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(10),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
+            .await
+            .expect("daemon-admitted wait should complete through scoped worker")
+            .0;
+
+        let (request, operation_id) = daemon.await.expect("daemon IPC task");
+        assert_eq!(request.kind, INGEST_ASYNC_KIND);
+        assert_eq!(
+            response.operation_id.as_deref(),
+            Some(operation_id.as_str())
+        );
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "completed daemon-backed wait must return cleanup-safe created drawer ids"
+        );
+
+        let status = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed operation status");
+        assert_eq!(status.state, Some(IngestOperationState::Completed));
+        assert_eq!(status.created_drawer_ids, response.created_drawer_ids);
     }
 
     #[cfg(unix)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
-use crate::context::assemble_context_with_vector;
+use crate::context::{ContextPack, assemble_context_with_vector};
 use crate::core::{
     AsyncDb,
     anchor::{self, DerivedAnchor},
@@ -1663,6 +1663,13 @@ impl MempalMcpServer {
         F: FnOnce(&Database) -> std::result::Result<R, ErrorData> + Send + 'static,
         R: Send + 'static,
     {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if let Some(error) = self.async_db_open_error.as_deref() {
+            return Err(ErrorData::internal_error(
+                format!("{stage} failed to open database: {error}"),
+                None,
+            ));
+        }
         let db_path = self.db_path.clone();
         let read = tokio::task::spawn_blocking(move || {
             let db = Database::open_query_only(&db_path).map_err(|error| {
@@ -5411,12 +5418,26 @@ impl MempalMcpServer {
             context_cfg_override: None,
             include_distill_suggestions: request.include_distill_suggestions.unwrap_or(true),
         };
+        let context_request_for_fallback = context_request.clone();
         let pack = self
             .run_query_only_read_bounded("mempal_context", self.search_db_deadline, move |db| {
                 assemble_context_with_vector(db, context_request, &query_vector)
                     .map_err(context_error)
             })
-            .await?;
+            .await
+            .or_else(|error| {
+                if mcp_context_read_error_is_degradable(&error) {
+                    tracing::warn!(
+                        error = %error,
+                        "mempal_context returning empty context after bounded read contention"
+                    );
+                    Ok(empty_context_pack_from_request(
+                        context_request_for_fallback,
+                    ))
+                } else {
+                    Err(error)
+                }
+            })?;
 
         Ok(Json(ContextResponse::from(pack)))
     }
@@ -6891,7 +6912,12 @@ impl MempalMcpServer {
 
         let embedding_started = Instant::now();
         let chunk_refs: Vec<&str> = chunks.iter().map(|c| c.as_str()).collect();
-        let vectors = if first_vector.is_some() && chunks.len() == 1 {
+        let vectors = if request.smoke.unwrap_or(false) && no_gate && bypass_novelty {
+            let dim = current_vector_dim(&db)
+                .map_err(db_error)?
+                .unwrap_or_else(|| embedder.dimensions());
+            deterministic_smoke_vectors(&chunks, dim)
+        } else if first_vector.is_some() && chunks.len() == 1 {
             vec![first_vector.take().expect("checked Some")]
         } else if let Some(fv) = first_vector.take() {
             if chunks.len() > 1 {
@@ -8240,13 +8266,27 @@ impl MempalMcpServer {
             context_cfg_override: None,
             include_distill_suggestions: false,
         };
+        let context_request_for_fallback = context_request.clone();
         let context = self
             .run_query_only_read_bounded("mempal_brief", self.search_db_deadline, move |db| {
                 assemble_context_with_vector(db, context_request, &query_vector).map_err(|error| {
                     ErrorData::internal_error(format!("brief failed: {error}"), None)
                 })
             })
-            .await?;
+            .await
+            .or_else(|error| {
+                if mcp_context_read_error_is_degradable(&error) {
+                    tracing::warn!(
+                        error = %error,
+                        "mempal_brief returning empty brief after bounded read contention"
+                    );
+                    Ok(empty_context_pack_from_request(
+                        context_request_for_fallback,
+                    ))
+                } else {
+                    Err(error)
+                }
+            })?;
         let brief = brief_from_context(context);
         Ok(Json(BriefMcpResponse::from(brief)))
     }
@@ -10521,6 +10561,35 @@ fn context_error(error: crate::context::ContextError) -> ErrorData {
     }
 }
 
+fn mcp_context_read_error_is_degradable(error: &ErrorData) -> bool {
+    let message = error.message.to_ascii_lowercase();
+    let lock_or_busy = message.contains("database is locked")
+        || message.contains("database locked")
+        || message.contains("database is busy")
+        || message.contains("database busy")
+        || message.contains("sqlite_busy")
+        || message.contains("sqlite_locked")
+        || message.contains("locked_or_busy");
+    let query_timeout = message.contains("query-only database read exceeded");
+    let open_failure = message.contains("failed to open database");
+    lock_or_busy || query_timeout || open_failure
+}
+
+fn empty_context_pack_from_request(request: crate::context::ContextRequest) -> ContextPack {
+    ContextPack {
+        query: request.query,
+        domain: request.domain,
+        field: request.field,
+        anchors: Vec::new(),
+        sections: Vec::new(),
+        recurring_themes: Vec::new(),
+        tiered: None,
+        repair_warnings: Vec::new(),
+        active_skills: Vec::new(),
+        distill_suggestions: Vec::new(),
+    }
+}
+
 fn parse_context_trigger(s: &str) -> crate::search::tiered::ContextTrigger {
     match s {
         "on_demand" => crate::search::tiered::ContextTrigger::OnDemand,
@@ -10571,6 +10640,38 @@ fn current_vector_dim(
         .optional()?
         .map(|value| value as usize);
     Ok(dimension)
+}
+
+fn deterministic_smoke_vectors(chunks: &[String], dim: usize) -> Vec<Vec<f32>> {
+    chunks
+        .iter()
+        .map(|chunk| deterministic_smoke_vector(chunk, dim))
+        .collect()
+}
+
+fn deterministic_smoke_vector(content: &str, dim: usize) -> Vec<f32> {
+    if dim == 0 {
+        return Vec::new();
+    }
+    let hash = blake3::hash(content.as_bytes());
+    let hash_bytes = hash.as_bytes();
+    let mut vector = Vec::with_capacity(dim);
+    for index in 0..dim {
+        let byte = hash_bytes[index % hash_bytes.len()];
+        let value = (f32::from(byte) / 255.0) * 2.0 - 1.0;
+        vector.push(if value.abs() < f32::EPSILON {
+            0.003_921_569
+        } else {
+            value
+        });
+    }
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for value in &mut vector {
+            *value /= norm;
+        }
+    }
+    vector
 }
 
 fn degraded_write_error() -> ErrorData {
@@ -15327,6 +15428,55 @@ pattern_boost = 0.2
     }
 
     #[tokio::test]
+    async fn test_mcp_context_returns_empty_pack_when_query_read_is_locked() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_async_db_open_error_for_test("database is locked");
+
+        let response = server
+            .context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "max_items": 3
+            }))
+            .await
+            .expect("context should degrade instead of returning JSON-RPC internal error");
+
+        assert_eq!(response.query, "debug");
+        assert_eq!(response.domain, "project");
+        assert!(response.sections.is_empty());
+        assert!(response.anchors.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_brief_returns_empty_brief_when_query_read_is_locked() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server.with_async_db_open_error_for_test("database is locked");
+
+        let response = server
+            .mempal_brief(Parameters(BriefMcpRequest {
+                query: "debug".to_string(),
+                field: Some("smoke".to_string()),
+                domain: Some("project".to_string()),
+                cwd: None,
+                max_items: Some(3),
+                dao_tian_limit: None,
+            }))
+            .await
+            .expect("brief should degrade instead of returning JSON-RPC internal error")
+            .0;
+
+        assert_eq!(response.query, "debug");
+        assert_eq!(response.field, "smoke");
+        assert_eq!(response.summary.key_fact_count, 0);
+        assert_eq!(response.summary.evidence_count, 0);
+        assert!(
+            response
+                .uncertainty
+                .iter()
+                .any(|item| item.kind == "no_evidence")
+        );
+    }
+
+    #[tokio::test]
     async fn test_mcp_context_has_no_db_side_effects() {
         let (_tempdir, db_path, server) = setup_server();
         insert_knowledge_drawer(
@@ -18782,7 +18932,7 @@ enabled = false
     }
 
     #[tokio::test]
-    async fn test_mcp_ingest_smoke_mode_sets_internal_controls() {
+    async fn test_mcp_ingest_smoke_mode_uses_deterministic_local_vector() {
         let _tempdir = tempfile::tempdir().expect("tempdir");
         let db_path = _tempdir.path().join("palace.db");
         Database::open(&db_path).expect("open db");
@@ -18823,50 +18973,30 @@ enabled = false
                 domain: Some("project".to_string()),
                 field: Some("smoke".to_string()),
                 smoke: Some(true),
-                wait: Some(false),
+                wait: Some(true),
+                wait_timeout_secs: Some(5),
                 ..IngestRequest::default()
             }))
             .await
-            .expect("smoke ingest should queue")
+            .expect("smoke ingest should complete")
             .0;
 
-        assert_eq!(response.state, Some(IngestOperationState::Queued));
-        let operation_id = response.operation_id.as_deref().expect("operation id");
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while call_count.load(Ordering::SeqCst) == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("worker should reach embed");
-        let db = Database::open(&db_path).expect("open db");
-        let payload: String = db
-            .conn()
-            .query_row(
-                "SELECT payload FROM pending_messages WHERE id = ?1",
-                [operation_id],
-                |row| row.get(0),
-            )
-            .expect("read queued ingest payload");
-        let decoded: PreparedIngestOperation =
-            serde_json::from_str(&payload).expect("decode queued ingest payload");
-
-        assert_eq!(decoded.request.smoke, Some(true));
-        assert!(decoded.controls.no_gate);
-        assert!(decoded.controls.bypass_novelty);
-
-        gate.notify_one();
-
-        let completed = server
-            .wait_for_operation_completion(operation_id)
-            .await
-            .expect("cleanup ingest completion");
-        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "smoke wait response must expose cleanup authority"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "smoke writes must not block on the configured embedder"
+        );
+        gate.notify_waiters();
     }
 
     #[tokio::test]
-    async fn test_mcp_smoke_ingest_wait_and_status_return_created_ids() {
-        let (_tempdir, _db_path, server) = setup_server();
+    async fn test_mcp_smoke_ingest_wait_update_and_status_return_created_ids() {
+        let (_tempdir, db_path, server) = setup_server();
 
         let response = server
             .mempal_ingest(Parameters(IngestRequest {
@@ -18904,6 +19034,56 @@ enabled = false
         assert_eq!(status.drawer_ids, status.created_drawer_ids);
         assert!(!status.dropped);
         assert!(status.rejected_reason.is_none());
+
+        let old_id = response.created_drawer_ids[0].clone();
+        let update = server
+            .mempal_ingest(Parameters(IngestRequest {
+                content: "cleanup-authoritative MCP smoke write two".to_string(),
+                wing: "smoke".to_string(),
+                room: Some("mcp".to_string()),
+                source_type: Some("agent_inference".to_string()),
+                memory_kind: Some("evidence".to_string()),
+                domain: Some("project".to_string()),
+                field: Some("smoke".to_string()),
+                supersedes: Some(old_id.clone()),
+                smoke: Some(true),
+                wait: Some(true),
+                wait_timeout_secs: Some(5),
+                ..IngestRequest::default()
+            }))
+            .await
+            .expect("smoke update should complete")
+            .0;
+
+        assert_eq!(update.state, Some(IngestOperationState::Completed));
+        assert_eq!(
+            update.superseded_drawer_id.as_deref(),
+            Some(old_id.as_str())
+        );
+        assert_eq!(
+            update.created_drawer_ids.len(),
+            1,
+            "smoke update wait response must expose cleanup-safe new drawer id"
+        );
+        assert_eq!(update.drawer_ids, update.created_drawer_ids);
+        assert_ne!(update.created_drawer_ids[0], old_id);
+
+        let operation_id = update.operation_id.as_deref().expect("update operation id");
+        let update_status = server
+            .operation_status_json_for_test(operation_id)
+            .await
+            .expect("update operation status should load");
+        assert_eq!(update_status.state, Some(IngestOperationState::Completed));
+        assert_eq!(update_status.created_drawer_ids, update.created_drawer_ids);
+        assert_eq!(update_status.drawer_ids, update.created_drawer_ids);
+
+        let db = Database::open(&db_path).expect("open db");
+        assert!(db.get_drawer(&old_id).expect("old lookup").is_none());
+        assert!(
+            db.get_drawer(&update.created_drawer_ids[0])
+                .expect("new lookup")
+                .is_some()
+        );
     }
 
     // =========================================================================

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::adoption_analytics::build_runtime_adoption_analytics;
 use crate::brief::brief_from_context;
-use crate::context::{ContextPack, assemble_context_with_vector};
+use crate::context::assemble_context_with_vector;
 use crate::core::{
     AsyncDb,
     anchor::{self, DerivedAnchor},
@@ -271,6 +271,8 @@ pub struct MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     ingest_warning_snapshot_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
+    query_only_read_delay: Option<Duration>,
+    #[cfg(any(test, feature = "db-test-seam"))]
     async_db_open_error: Option<String>,
     #[cfg(any(test, feature = "db-test-seam"))]
     daemon_writer_lease_check_error: Option<String>,
@@ -519,6 +521,8 @@ impl MempalMcpServer {
             #[cfg(any(test, feature = "db-test-seam"))]
             ingest_warning_snapshot_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
+            query_only_read_delay: None,
+            #[cfg(any(test, feature = "db-test-seam"))]
             async_db_open_error: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             daemon_writer_lease_check_error: None,
@@ -580,6 +584,12 @@ impl MempalMcpServer {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_ingest_warning_snapshot_delay_for_test(mut self, delay: Duration) -> Self {
         self.ingest_warning_snapshot_delay = Some(delay);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_query_only_read_delay_for_test(mut self, delay: Duration) -> Self {
+        self.query_only_read_delay = Some(delay);
         self
     }
 
@@ -1670,8 +1680,14 @@ impl MempalMcpServer {
                 None,
             ));
         }
+        #[cfg(any(test, feature = "db-test-seam"))]
+        let query_only_read_delay = self.query_only_read_delay;
         let db_path = self.db_path.clone();
         let read = tokio::task::spawn_blocking(move || {
+            #[cfg(any(test, feature = "db-test-seam"))]
+            if let Some(delay) = query_only_read_delay {
+                std::thread::sleep(delay);
+            }
             let db = Database::open_query_only(&db_path).map_err(|error| {
                 ErrorData::internal_error(format!("{stage} failed to open database: {error}"), None)
             })?;
@@ -5421,26 +5437,12 @@ impl MempalMcpServer {
             context_cfg_override: None,
             include_distill_suggestions: request.include_distill_suggestions.unwrap_or(true),
         };
-        let context_request_for_fallback = context_request.clone();
         let pack = self
             .run_query_only_read_bounded("mempal_context", self.search_db_deadline, move |db| {
                 assemble_context_with_vector(db, context_request, &query_vector)
                     .map_err(context_error)
             })
-            .await
-            .or_else(|error| {
-                if mcp_context_read_error_is_degradable(&error) {
-                    tracing::warn!(
-                        error = %error,
-                        "mempal_context returning empty context after bounded read contention"
-                    );
-                    Ok(empty_context_pack_from_request(
-                        context_request_for_fallback,
-                    ))
-                } else {
-                    Err(error)
-                }
-            })?;
+            .await?;
 
         Ok(Json(ContextResponse::from(pack)))
     }
@@ -8271,27 +8273,13 @@ impl MempalMcpServer {
             context_cfg_override: None,
             include_distill_suggestions: false,
         };
-        let context_request_for_fallback = context_request.clone();
         let context = self
             .run_query_only_read_bounded("mempal_brief", self.search_db_deadline, move |db| {
                 assemble_context_with_vector(db, context_request, &query_vector).map_err(|error| {
                     ErrorData::internal_error(format!("brief failed: {error}"), None)
                 })
             })
-            .await
-            .or_else(|error| {
-                if mcp_context_read_error_is_degradable(&error) {
-                    tracing::warn!(
-                        error = %error,
-                        "mempal_brief returning empty brief after bounded read contention"
-                    );
-                    Ok(empty_context_pack_from_request(
-                        context_request_for_fallback,
-                    ))
-                } else {
-                    Err(error)
-                }
-            })?;
+            .await?;
         let brief = brief_from_context(context);
         Ok(Json(BriefMcpResponse::from(brief)))
     }
@@ -10563,41 +10551,6 @@ fn context_error(error: crate::context::ContextError) -> ErrorData {
         | crate::context::ContextError::Tiered(_) => {
             ErrorData::internal_error(format!("context assembly failed: {error}"), None)
         }
-    }
-}
-
-fn mcp_context_read_error_is_degradable(error: &ErrorData) -> bool {
-    let message = error.message.to_ascii_lowercase();
-    let transient_contention = message.contains("database is locked")
-        || message.contains("database locked")
-        || message.contains("database is busy")
-        || message.contains("database busy")
-        || message.contains("sqlite_busy")
-        || message.contains("sqlite_locked")
-        || message.contains("sqlite_protocol")
-        || message.contains("database protocol")
-        || message.contains("locked_or_busy")
-        || message.contains("classification=extra_holder")
-        || message.contains("extra process holding")
-        || message.contains("extra_holder")
-        || message.contains("stale_mcp_server")
-        || message.contains("orphan_daemon");
-    let query_timeout = message.contains("query-only database read exceeded");
-    transient_contention || query_timeout
-}
-
-fn empty_context_pack_from_request(request: crate::context::ContextRequest) -> ContextPack {
-    ContextPack {
-        query: request.query,
-        domain: request.domain,
-        field: request.field,
-        anchors: Vec::new(),
-        sections: Vec::new(),
-        recurring_themes: Vec::new(),
-        tiered: None,
-        repair_warnings: Vec::new(),
-        active_skills: Vec::new(),
-        distill_suggestions: Vec::new(),
     }
 }
 
@@ -15534,30 +15487,29 @@ pattern_boost = 0.2
     }
 
     #[tokio::test]
-    async fn test_mcp_context_returns_empty_pack_when_query_read_is_locked() {
+    async fn test_mcp_context_surfaces_transient_query_lock_error() {
         let (_tempdir, _db_path, server) = setup_server();
         let server = server.with_async_db_open_error_for_test("database is locked");
 
-        let response = server
+        let error = server
             .context_json_for_test(serde_json::json!({
                 "query": "debug",
                 "max_items": 3
             }))
             .await
-            .expect("context should degrade instead of returning JSON-RPC internal error");
+            .expect_err("context must not hide transient database lock failures");
 
-        assert_eq!(response.query, "debug");
-        assert_eq!(response.domain, "project");
-        assert!(response.sections.is_empty());
-        assert!(response.anchors.is_empty());
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to open database"));
+        assert!(error_text.contains("database is locked"));
     }
 
     #[tokio::test]
-    async fn test_mcp_brief_returns_empty_brief_when_query_read_is_locked() {
+    async fn test_mcp_brief_surfaces_transient_query_lock_error() {
         let (_tempdir, _db_path, server) = setup_server();
         let server = server.with_async_db_open_error_for_test("database is locked");
 
-        let response = server
+        let error = match server
             .mempal_brief(Parameters(BriefMcpRequest {
                 query: "debug".to_string(),
                 field: Some("smoke".to_string()),
@@ -15567,19 +15519,80 @@ pattern_boost = 0.2
                 dao_tian_limit: None,
             }))
             .await
-            .expect("brief should degrade instead of returning JSON-RPC internal error")
-            .0;
+        {
+            Ok(_) => panic!("brief must not hide transient database lock failures"),
+            Err(error) => error,
+        };
 
-        assert_eq!(response.query, "debug");
-        assert_eq!(response.field, "smoke");
-        assert_eq!(response.summary.key_fact_count, 0);
-        assert_eq!(response.summary.evidence_count, 0);
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to open database"));
+        assert!(error_text.contains("database is locked"));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_context_surfaces_query_read_timeout_error() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server
+            .with_query_only_read_delay_for_test(Duration::from_millis(150))
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.context_json_for_test(serde_json::json!({
+                "query": "debug",
+                "max_items": 3
+            })),
+        )
+        .await
+        .expect("context should return before client timeout");
+        let error = match result {
+            Ok(_) => panic!("context must not convert read timeout to empty success"),
+            Err(error) => error,
+        };
+
         assert!(
-            response
-                .uncertainty
-                .iter()
-                .any(|item| item.kind == "no_evidence")
+            error
+                .to_string()
+                .contains("mempal_context query-only database read exceeded"),
+            "unexpected error: {error}"
         );
+
+        tokio::time::sleep(Duration::from_millis(180)).await;
+    }
+
+    #[tokio::test]
+    async fn test_mcp_brief_surfaces_query_read_timeout_error() {
+        let (_tempdir, _db_path, server) = setup_server();
+        let server = server
+            .with_query_only_read_delay_for_test(Duration::from_millis(150))
+            .with_mcp_deadline_for_test(Duration::from_millis(20));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            server.mempal_brief(Parameters(BriefMcpRequest {
+                query: "debug".to_string(),
+                field: Some("smoke".to_string()),
+                domain: Some("project".to_string()),
+                cwd: None,
+                max_items: Some(3),
+                dao_tian_limit: None,
+            })),
+        )
+        .await
+        .expect("brief should return before client timeout");
+        let error = match result {
+            Ok(_) => panic!("brief must not convert read timeout to empty success"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("mempal_brief query-only database read exceeded"),
+            "unexpected error: {error}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(180)).await;
     }
 
     #[tokio::test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "00fcde0a451f571c17e12c9181f5900c67690c25"
+commit = "73a58155e539ccd0dcc8bd2585476f96957391c7"
 source_kind = "git"


### PR DESCRIPTION
## Summary
- Preserve cleanup-safe MCP created IDs for daemon-admitted/waited ingest receipts.
- Surface transient context/brief DB read lock/timeouts as unavailable errors instead of successful empty evidence.
- Keep deterministic operation receipts queryable across daemon/local admission races.

Closes #594

## Verification
- Exact-head CSA tier-4 review: `01KW64P7DQQZZ8G7KM3AK29ZDP`
- Reviewed SHA: `7bc0c36c8788adef3741da66982f608632f653a8`
- `csa review --check-verdict --sa-mode true --range main...HEAD`: PASS/CLEAN
- `just local-gates`: PASS (`LOCAL_GATES_EXIT 0`, rerun after focused tiered_retrieval diagnostics)
- Hook-enabled push pre-push gates: PASS (`PUSH_EXIT 0`)
- Installed `/usr/local/bin/mempal`, restarted user daemon, verified singleton/current binary before smoke
- Full smoke: `FULL_SMOKE_EXIT 0`, `overall_ok: true`, `failures: []`, `group_count: 49`, cleanup failures `0`, marker hash `a517a583dac8c871`
