### PR TITLE
fix(mcp): retry transient ingest write locks

### DIFF
--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -232,6 +232,8 @@ pub struct AsyncPendingMessageStore {
     claim_blocking_delay: Option<Duration>,
     #[cfg(any(test, feature = "db-test-seam"))]
     release_lock_failures: Arc<AtomicUsize>,
+    #[cfg(any(test, feature = "db-test-seam"))]
+    complete_lock_failures: Arc<AtomicUsize>,
 }
 
 impl AsyncPendingMessageStore {
@@ -259,6 +261,8 @@ impl AsyncPendingMessageStore {
             claim_blocking_delay: None,
             #[cfg(any(test, feature = "db-test-seam"))]
             release_lock_failures: Arc::new(AtomicUsize::new(0)),
+            #[cfg(any(test, feature = "db-test-seam"))]
+            complete_lock_failures: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -289,6 +293,13 @@ impl AsyncPendingMessageStore {
     #[cfg(any(test, feature = "db-test-seam"))]
     pub fn with_release_lock_failures_for_test(self, failures: usize) -> Self {
         self.release_lock_failures.store(failures, Ordering::SeqCst);
+        self
+    }
+
+    #[cfg(any(test, feature = "db-test-seam"))]
+    pub fn with_complete_lock_failures_for_test(self, failures: usize) -> Self {
+        self.complete_lock_failures
+            .store(failures, Ordering::SeqCst);
         self
     }
 
@@ -451,6 +462,16 @@ impl AsyncPendingMessageStore {
         failure_detail: Option<String>,
         result_json: Option<String>,
     ) -> Result<()> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .complete_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         self.run(move |store| {
             store.complete_operation(
                 &claim,

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -86,6 +86,15 @@ pub struct PendingOperationRecord {
     pub result_json: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingOperationCompletion {
+    pub op_state: String,
+    pub result_drawer_id: Option<String>,
+    pub rejected_reason: Option<String>,
+    pub failure_detail: Option<String>,
+    pub result_json: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct QueueStats {
     pub pending: u64,
@@ -462,6 +471,26 @@ impl AsyncPendingMessageStore {
         failure_detail: Option<String>,
         result_json: Option<String>,
     ) -> Result<()> {
+        self.complete_operation_with_busy_timeout(
+            claim,
+            PendingOperationCompletion {
+                op_state,
+                result_drawer_id,
+                rejected_reason,
+                failure_detail,
+                result_json,
+            },
+            None,
+        )
+        .await
+    }
+
+    pub async fn complete_operation_with_busy_timeout(
+        &self,
+        claim: ClaimedMessage,
+        completion: PendingOperationCompletion,
+        busy_timeout: Option<Duration>,
+    ) -> Result<()> {
         #[cfg(any(test, feature = "db-test-seam"))]
         if self
             .complete_lock_failures
@@ -473,14 +502,7 @@ impl AsyncPendingMessageStore {
             return Err(sqlite_busy_queue_error());
         }
         self.run(move |store| {
-            store.complete_operation(
-                &claim,
-                &op_state,
-                result_drawer_id.as_deref(),
-                rejected_reason.as_deref(),
-                failure_detail.as_deref(),
-                result_json.as_deref(),
-            )
+            store.complete_operation_with_busy_timeout(&claim, completion, busy_timeout)
         })
         .await
     }
@@ -1017,8 +1039,31 @@ impl PendingMessageStore {
         failure_detail: Option<&str>,
         result_json: Option<&str>,
     ) -> Result<()> {
-        let mut conn = self.open_connection()?;
+        self.complete_operation_with_busy_timeout(
+            claim,
+            PendingOperationCompletion {
+                op_state: op_state.to_owned(),
+                result_drawer_id: result_drawer_id.map(str::to_owned),
+                rejected_reason: rejected_reason.map(str::to_owned),
+                failure_detail: failure_detail.map(str::to_owned),
+                result_json: result_json.map(str::to_owned),
+            },
+            None,
+        )
+    }
+
+    pub fn complete_operation_with_busy_timeout(
+        &self,
+        claim: &ClaimedMessage,
+        completion: PendingOperationCompletion,
+        busy_timeout: Option<Duration>,
+    ) -> Result<()> {
+        let mut conn = self.open_connection_with_busy_timeout(busy_timeout)?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let result_drawer_id = completion.result_drawer_id.as_deref();
+        let rejected_reason = completion.rejected_reason.as_deref();
+        let failure_detail = completion.failure_detail.as_deref();
+        let result_json = completion.result_json.as_deref();
         let updated = tx.execute(
             r#"
             UPDATE pending_messages
@@ -1031,7 +1076,7 @@ impl PendingMessageStore {
             "#,
             params![
                 claim.id,
-                op_state,
+                completion.op_state,
                 result_drawer_id,
                 rejected_reason,
                 failure_detail,
@@ -1042,7 +1087,7 @@ impl PendingMessageStore {
         if updated == 0 {
             return Err(claim_miss_error(&tx, &claim.id)?);
         }
-        confirm_in_tx(&tx, claim, op_state)?;
+        confirm_in_tx(&tx, claim, &completion.op_state)?;
         tx.commit()?;
         Ok(())
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3351,8 +3351,10 @@ enum DaemonIngestEnqueue {
 fn should_defer_local_ingest_to_daemon(
     daemon_ingest_ipc_available: bool,
     daemon_enqueue_may_have_reached: bool,
+    local_fallback_persisted_after_daemon_uncertainty: bool,
 ) -> bool {
-    daemon_ingest_ipc_available || daemon_enqueue_may_have_reached
+    !local_fallback_persisted_after_daemon_uncertainty
+        && (daemon_ingest_ipc_available || daemon_enqueue_may_have_reached)
 }
 
 fn should_start_local_ingest_worker(
@@ -3379,6 +3381,7 @@ struct IngestQueueAdmission {
     operation_id: String,
     processor: IngestQueueProcessor,
     daemon_enqueue_may_have_reached: bool,
+    local_fallback_persisted_after_daemon_uncertainty: bool,
 }
 
 #[doc(hidden)]
@@ -6129,6 +6132,7 @@ impl MempalMcpServer {
                 && should_defer_local_ingest_to_daemon(
                     self.daemon_ingest_ipc_available() || daemon_writer_lease_visible,
                     queue_admission.daemon_enqueue_may_have_reached,
+                    queue_admission.local_fallback_persisted_after_daemon_uncertainty,
                 );
         let use_local_ingest_worker = should_start_local_ingest_worker(
             queue_admission.processor,
@@ -6267,6 +6271,7 @@ impl MempalMcpServer {
                     operation_id,
                     processor: IngestQueueProcessor::Daemon,
                     daemon_enqueue_may_have_reached: true,
+                    local_fallback_persisted_after_daemon_uncertainty: false,
                 });
             }
             DaemonIngestEnqueue::Fallback {
@@ -6284,6 +6289,7 @@ impl MempalMcpServer {
                     operation_id,
                     processor: IngestQueueProcessor::Daemon,
                     daemon_enqueue_may_have_reached,
+                    local_fallback_persisted_after_daemon_uncertainty: false,
                 });
             }
 
@@ -6295,6 +6301,7 @@ impl MempalMcpServer {
                     operation_id,
                     processor: IngestQueueProcessor::Local,
                     daemon_enqueue_may_have_reached,
+                    local_fallback_persisted_after_daemon_uncertainty: true,
                 }),
                 Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
                     if self
@@ -6305,6 +6312,7 @@ impl MempalMcpServer {
                             operation_id,
                             processor: IngestQueueProcessor::Daemon,
                             daemon_enqueue_may_have_reached,
+                            local_fallback_persisted_after_daemon_uncertainty: false,
                         });
                     }
                     Err(error.context(
@@ -6322,6 +6330,7 @@ impl MempalMcpServer {
             operation_id,
             processor: IngestQueueProcessor::Local,
             daemon_enqueue_may_have_reached,
+            local_fallback_persisted_after_daemon_uncertainty: false,
         })
     }
 
@@ -12220,9 +12229,11 @@ mod tests {
 
     #[test]
     fn test_mcp_local_queue_defers_when_daemon_enqueue_may_have_arrived() {
-        assert!(should_defer_local_ingest_to_daemon(false, true));
-        assert!(should_defer_local_ingest_to_daemon(true, false));
-        assert!(!should_defer_local_ingest_to_daemon(false, false));
+        assert!(should_defer_local_ingest_to_daemon(false, true, false));
+        assert!(should_defer_local_ingest_to_daemon(true, false, false));
+        assert!(!should_defer_local_ingest_to_daemon(false, false, false));
+        assert!(!should_defer_local_ingest_to_daemon(false, true, true));
+        assert!(!should_defer_local_ingest_to_daemon(true, false, true));
         assert!(!should_start_local_ingest_worker(
             IngestQueueProcessor::Local,
             true
@@ -12706,7 +12717,7 @@ quality_policy = "llm_required_for_keep"
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_mcp_ingest_falls_back_when_daemon_ack_lacks_queryable_operation() {
+    async fn test_mcp_ingest_completes_local_fallback_when_daemon_ack_lacks_queryable_operation() {
         let (tempdir, db_path, server) = setup_server();
         let (listener, _socket_guard) =
             crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
@@ -12725,22 +12736,32 @@ quality_policy = "llm_required_for_keep"
         });
 
         let response = server
-            .mempal_ingest(Parameters(IngestRequest {
-                content: "daemon ACK without durable operation must use local admission"
-                    .to_string(),
-                wing: "mcp".to_string(),
-                room: Some("receipt".to_string()),
-                wait: Some(true),
-                wait_timeout_secs: Some(0),
-                ..IngestRequest::default()
-            }))
+            .mempal_ingest_with_controls(
+                IngestRequest {
+                    content: "daemon ACK without durable operation must complete local fallback"
+                        .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("receipt".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(10),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            )
             .await
-            .expect("ingest admission should recover with local idempotent enqueue")
+            .expect("ingest admission should complete through local idempotent fallback")
             .0;
 
         let request = daemon.await.expect("daemon IPC task");
-        assert_eq!(response.state, Some(IngestOperationState::Queued));
-        assert!(response.timed_out);
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "local fallback completion must expose cleanup-safe created ids"
+        );
         let operation_id = response.operation_id.as_deref().expect("operation id");
         assert_eq!(
             operation_id,
@@ -12749,14 +12770,14 @@ quality_policy = "llm_required_for_keep"
         let record = PendingMessageStore::new_without_reclaim(&db_path)
             .operation_status(operation_id)
             .expect("query operation")
-            .expect("returned operation id must be queryable");
+            .expect("returned operation id must be completed");
         assert_eq!(record.id, operation_id);
-        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        assert_eq!(record.op_state, IngestOperationState::Completed.as_str());
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_mcp_ingest_uncertain_daemon_lock_returns_queryable_local_receipt() {
+    async fn test_mcp_ingest_uncertain_daemon_read_failure_completes_local_fallback() {
         let (tempdir, db_path, server) = setup_server();
         let (listener, _socket_guard) =
             crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
@@ -12771,28 +12792,37 @@ quality_policy = "llm_required_for_keep"
         });
 
         let response = tokio::time::timeout(
-            Duration::from_secs(3),
-            server.mempal_ingest(Parameters(IngestRequest {
-                content:
-                    "uncertain daemon enqueue with local SQLite lock waits for durable receipt"
-                        .to_string(),
-                wing: "mcp".to_string(),
-                room: Some("receipt".to_string()),
-                wait: Some(true),
-                wait_timeout_secs: Some(0),
-                ..IngestRequest::default()
-            })),
+            Duration::from_secs(8),
+            server.mempal_ingest_with_controls(
+                IngestRequest {
+                    content:
+                        "uncertain daemon enqueue with local SQLite lock completes local fallback"
+                            .to_string(),
+                    wing: "mcp".to_string(),
+                    room: Some("receipt".to_string()),
+                    wait: Some(true),
+                    wait_timeout_secs: Some(5),
+                    ..IngestRequest::default()
+                },
+                IngestControls {
+                    no_gate: true,
+                    bypass_novelty: true,
+                },
+            ),
         )
         .await
-        .expect("uncertain daemon lock path should stay bounded by admission retry")
-        .expect("uncertain daemon lock should wait for a durable local operation row")
+        .expect("uncertain daemon lock path should complete within the wait budget")
+        .expect("uncertain daemon lock should complete a durable local operation row")
         .0;
 
         let request = daemon.await.expect("daemon IPC task");
         lock.join().expect("release SQLite lock");
-        assert_eq!(response.state, Some(IngestOperationState::Queued));
-        assert!(response.timed_out);
-        assert!(response.created_drawer_ids.is_empty());
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(!response.timed_out);
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "local fallback completion must expose cleanup-safe created ids"
+        );
         let operation_id = response.operation_id.as_deref().expect("operation id");
         assert_eq!(
             operation_id,
@@ -12801,9 +12831,9 @@ quality_policy = "llm_required_for_keep"
         let record = PendingMessageStore::new_without_reclaim(&db_path)
             .operation_status(operation_id)
             .expect("query operation")
-            .expect("returned operation id must be queryable after lock clears");
+            .expect("returned operation id must be completed after lock clears");
         assert_eq!(record.id, operation_id);
-        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        assert_eq!(record.op_state, IngestOperationState::Completed.as_str());
     }
 
     #[tokio::test]
@@ -13382,6 +13412,19 @@ quality_policy = "llm_required_for_keep"
             .expect("query queued operation")
             .expect("queued operation");
         assert_eq!(record.kind, INGEST_ASYNC_KIND);
+
+        let completed = tokio::time::timeout(
+            Duration::from_secs(8),
+            server.wait_for_operation_completion(operation_id),
+        )
+        .await
+        .expect("stalled daemon IPC local fallback should finish in the background")
+        .expect("stalled daemon IPC local fallback should reach terminal status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(
+            !completed.created_drawer_ids.is_empty(),
+            "background local fallback must expose cleanup-safe created ids"
+        );
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -31,7 +31,7 @@ use crate::core::{
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
     queue::{
         AsyncPendingMessageStore, CLAIM_LOCK_RETRY_DEADLINE, ClaimedMessage, PendingMessageStore,
-        QueueError,
+        PendingOperationCompletion, QueueError,
     },
     reindex::ReindexProgressStore,
     remote_calls::{
@@ -1041,6 +1041,7 @@ impl MempalMcpServer {
                 queue_wait_ms,
                 outcome,
                 MCP_INGEST_RESULT_RETRY_DEADLINE,
+                false,
             )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
@@ -1148,6 +1149,7 @@ impl MempalMcpServer {
                 queue_wait_ms,
                 outcome,
                 MCP_INGEST_RESULT_RETRY_DEADLINE,
+                false,
             )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
@@ -1179,7 +1181,8 @@ impl MempalMcpServer {
                     &claim,
                     queue_wait_ms,
                     detail,
-                    completion_deadline,
+                    completion_deadline.saturating_sub(MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN),
+                    true,
                 )
                 .await
                 {
@@ -1332,6 +1335,7 @@ impl MempalMcpServer {
                 queue_wait_ms,
                 outcome,
                 completion_deadline,
+                true,
             )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
@@ -1351,6 +1355,7 @@ impl MempalMcpServer {
         queue_wait_ms: u64,
         outcome: std::result::Result<IngestResponse, String>,
         result_retry_deadline: Duration,
+        bound_attempt_busy_timeout: bool,
     ) -> anyhow::Result<()> {
         match outcome {
             Ok(mut response) => {
@@ -1390,7 +1395,7 @@ impl MempalMcpServer {
                 complete_ingest_operation_with_lock_retry_deadline(
                     queue,
                     claim,
-                    IngestOperationCompletion {
+                    PendingOperationCompletion {
                         op_state: state.as_str().to_string(),
                         result_drawer_id: result_drawer_id.map(ToOwned::to_owned),
                         rejected_reason: rejected_reason.clone(),
@@ -1398,6 +1403,7 @@ impl MempalMcpServer {
                         result_json: Some(result_json),
                     },
                     result_retry_deadline,
+                    bound_attempt_busy_timeout,
                 )
                 .await
                 .map_err(|error| {
@@ -1411,6 +1417,7 @@ impl MempalMcpServer {
                     queue_wait_ms,
                     detail,
                     result_retry_deadline,
+                    bound_attempt_busy_timeout,
                 )
                 .await?;
             }
@@ -11208,14 +11215,6 @@ fn queue_wait_ms(created_at_secs: i64, claimed_at_secs: i64) -> u64 {
         .saturating_mul(1_000) as u64
 }
 
-struct IngestOperationCompletion {
-    op_state: String,
-    result_drawer_id: Option<String>,
-    rejected_reason: Option<String>,
-    failure_detail: Option<String>,
-    result_json: Option<String>,
-}
-
 async fn complete_failed_ingest_claim(
     queue: &AsyncPendingMessageStore,
     claim: &ClaimedMessage,
@@ -11228,6 +11227,7 @@ async fn complete_failed_ingest_claim(
         queue_wait_ms,
         detail,
         MCP_INGEST_RESULT_RETRY_DEADLINE,
+        false,
     )
     .await
 }
@@ -11238,6 +11238,7 @@ async fn complete_failed_ingest_claim_with_lock_retry_deadline(
     queue_wait_ms: u64,
     detail: String,
     result_retry_deadline: Duration,
+    bound_attempt_busy_timeout: bool,
 ) -> anyhow::Result<()> {
     let mut finalized =
         finalize_failed_ingest_response(claim.id.clone(), claim.created_at, detail.clone());
@@ -11249,7 +11250,7 @@ async fn complete_failed_ingest_claim_with_lock_retry_deadline(
     complete_ingest_operation_with_lock_retry_deadline(
         queue,
         claim,
-        IngestOperationCompletion {
+        PendingOperationCompletion {
             op_state: IngestOperationState::Failed.as_str().to_string(),
             result_drawer_id: None,
             rejected_reason: None,
@@ -11257,6 +11258,7 @@ async fn complete_failed_ingest_claim_with_lock_retry_deadline(
             result_json: Some(result_json),
         },
         result_retry_deadline,
+        bound_attempt_busy_timeout,
     )
     .await
     .map_err(|error| anyhow::Error::new(error).context("failed to store async ingest failure"))?;
@@ -11266,20 +11268,20 @@ async fn complete_failed_ingest_claim_with_lock_retry_deadline(
 async fn complete_ingest_operation_with_lock_retry_deadline(
     queue: &AsyncPendingMessageStore,
     claim: &ClaimedMessage,
-    completion: IngestOperationCompletion,
+    completion: PendingOperationCompletion,
     retry_deadline: Duration,
+    bound_attempt_busy_timeout: bool,
 ) -> crate::core::queue::Result<()> {
     let started = Instant::now();
     loop {
+        let remaining = retry_deadline.saturating_sub(started.elapsed());
+        let busy_timeout = if bound_attempt_busy_timeout {
+            Some(MCP_INGEST_RESULT_RETRY_DELAY.min(remaining))
+        } else {
+            None
+        };
         match queue
-            .complete_operation(
-                claim.clone(),
-                completion.op_state.clone(),
-                completion.result_drawer_id.clone(),
-                completion.rejected_reason.clone(),
-                completion.failure_detail.clone(),
-                completion.result_json.clone(),
-            )
+            .complete_operation_with_busy_timeout(claim.clone(), completion.clone(), busy_timeout)
             .await
         {
             Ok(()) => return Ok(()),
@@ -14499,6 +14501,75 @@ pattern_boost = 0.2
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_scoped_finite_completion_real_sqlite_lock_respects_budget() {
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, "{}")
+            .expect("enqueue async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-real-complete-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+        let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_secs(2));
+        let response = IngestResponse {
+            operation_id: None,
+            accepted_at: None,
+            state: None,
+            timed_out: false,
+            drawer_id: "drawer-real-complete-lock".to_string(),
+            drawer_ids: vec!["drawer-real-complete-lock".to_string()],
+            created_drawer_ids: vec!["drawer-real-complete-lock".to_string()],
+            chunk_count: 1,
+            dropped: false,
+            gating_decision: None,
+            novelty_action: None,
+            near_drawer_id: None,
+            duplicate_warning: None,
+            lock_wait_ms: None,
+            superseded_drawer_id: None,
+            rejected_reason: None,
+            failure_detail: None,
+            timings: BTreeMap::new(),
+            fact_check_warnings: Vec::new(),
+            system_warnings: Vec::new(),
+        };
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            server.complete_ingest_claim_outcome(
+                &async_queue,
+                &claim,
+                queue_wait_ms(claim.created_at, claim.claimed_at),
+                Ok(response),
+                Duration::from_secs(1),
+                true,
+            ),
+        )
+        .await
+        .expect("finite scoped completion must not wait for SQLite's default busy timeout");
+        let error =
+            result.expect_err("real locked completion receipt should return a bounded error");
+        assert!(
+            anyhow_chain_contains_sqlite_lock(&error),
+            "bounded completion error should preserve the SQLite lock source: {error:#}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "finite scoped completion waited for the default SQLite busy timeout"
+        );
+        lock.join().expect("lock thread");
+        let record = queue
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Running.as_str());
+        assert!(record.completed_at.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_async_ingest_uses_admission_supersedes_target_after_queue_wait() {
         let (_tempdir, db_path, server) = setup_server();
         let seed_id = "async-supersedes-old";
@@ -14682,6 +14753,52 @@ pattern_boost = 0.2
             record.claimed_at.is_none(),
             "malformed payload must release the claim when failure receipt persistence times out"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_scoped_finite_malformed_payload_real_sqlite_lock_respects_budget() {
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, "{not json")
+            .expect("enqueue malformed async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-real-failure-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim malformed op")
+            .expect("claimed malformed op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+        let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_secs(2));
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            server.process_ingest_claim_inline_with_budget(
+                &async_queue,
+                "worker-real-failure-lock",
+                claim,
+                Duration::from_secs(1),
+            ),
+        )
+        .await
+        .expect("finite scoped failure receipt must not wait for SQLite's default busy timeout");
+        let error = result.expect_err("real locked failure receipt should return a bounded error");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to release timed-out scoped ingest claim"),
+            "{error:#}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "finite scoped malformed-payload completion waited for the default SQLite busy timeout"
+        );
+        lock.join().expect("lock thread");
+        let record = queue
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Running.as_str());
+        assert!(record.completed_at.is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3369,8 +3369,9 @@ fn should_use_scoped_ingest_wait_worker(
     use_local_ingest_worker: bool,
 ) -> bool {
     claim_policy != ScopedIngestClaimPolicy::PollOnly
-        && ((use_local_ingest_worker && matches!(worker_mode, IngestWaitWorkerMode::Scoped))
-            || matches!(processor, IngestQueueProcessor::Daemon))
+        && matches!(processor, IngestQueueProcessor::Local)
+        && use_local_ingest_worker
+        && matches!(worker_mode, IngestWaitWorkerMode::Scoped)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -6273,13 +6274,21 @@ impl MempalMcpServer {
             } => may_have_reached_daemon,
         };
         if daemon_enqueue_may_have_reached {
+            let operation_id =
+                PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &idempotency_key);
+            if self
+                .daemon_admitted_operation_is_visible(&operation_id)
+                .await?
+            {
+                return Ok(IngestQueueAdmission {
+                    operation_id,
+                    processor: IngestQueueProcessor::Daemon,
+                    daemon_enqueue_may_have_reached,
+                });
+            }
+
             return match self
-                .async_queue
-                .enqueue_idempotent_with_key_fail_fast(
-                    INGEST_ASYNC_KIND.to_string(),
-                    payload.clone(),
-                    idempotency_key.clone(),
-                )
+                .enqueue_ingest_operation_locally_with_retry(payload, idempotency_key)
                 .await
             {
                 Ok(operation_id) => Ok(IngestQueueAdmission {
@@ -6287,25 +6296,22 @@ impl MempalMcpServer {
                     processor: IngestQueueProcessor::Local,
                     daemon_enqueue_may_have_reached,
                 }),
-                Err(error) if error.is_sqlite_lock() => {
-                    let error = anyhow::Error::new(error).context(
-                        "SQLite queue admission after daemon enqueue may have reached daemon",
-                    );
-                    let Some(admission) = queue_admission_for_uncertain_daemon_enqueue(
-                        &idempotency_key,
-                        daemon_enqueue_may_have_reached,
-                        &error,
-                    ) else {
-                        return Err(error);
-                    };
-                    tracing::warn!(
-                        operation_id = %admission.operation_id,
-                        error = %error,
-                        "local ingest queue admission hit SQLite lock after daemon enqueue may have reached daemon; returning pending operation receipt"
-                    );
-                    Ok(admission)
+                Err(error) if anyhow_chain_contains_sqlite_lock(&error) => {
+                    if self
+                        .daemon_admitted_operation_is_visible(&operation_id)
+                        .await?
+                    {
+                        return Ok(IngestQueueAdmission {
+                            operation_id,
+                            processor: IngestQueueProcessor::Daemon,
+                            daemon_enqueue_may_have_reached,
+                        });
+                    }
+                    Err(error.context(
+                        "SQLite queue admission remained locked and no durable daemon operation row became visible",
+                    ))
                 }
-                Err(error) => Err(error.into()),
+                Err(error) => Err(error),
             };
         }
 
@@ -11078,25 +11084,6 @@ fn mcp_ingest_failure_is_retryable_writer_lease_lost(detail: &str) -> bool {
         .any(|operation| lower.contains(operation))
 }
 
-fn queue_admission_for_uncertain_daemon_enqueue(
-    idempotency_key: &str,
-    daemon_enqueue_may_have_reached: bool,
-    error: &anyhow::Error,
-) -> Option<IngestQueueAdmission> {
-    if !daemon_enqueue_may_have_reached || !anyhow_chain_contains_sqlite_lock(error) {
-        return None;
-    }
-
-    Some(IngestQueueAdmission {
-        operation_id: PendingMessageStore::idempotent_message_id(
-            INGEST_ASYNC_KIND,
-            idempotency_key,
-        ),
-        processor: IngestQueueProcessor::Local,
-        daemon_enqueue_may_have_reached: true,
-    })
-}
-
 fn push_mcp_timeout_warning(
     response_warnings: &mut Vec<String>,
     system_warnings: &mut Vec<SystemWarning>,
@@ -12240,7 +12227,7 @@ mod tests {
             IngestQueueProcessor::Local,
             true
         ));
-        assert!(should_use_scoped_ingest_wait_worker(
+        assert!(!should_use_scoped_ingest_wait_worker(
             IngestQueueProcessor::Daemon,
             IngestWaitWorkerMode::Background,
             ScopedIngestClaimPolicy::InlineWithinDeadline,
@@ -12249,8 +12236,8 @@ mod tests {
     }
 
     #[test]
-    fn test_operation_wait_can_scope_claim_daemon_admitted_operation() {
-        assert!(should_use_scoped_ingest_wait_worker(
+    fn test_operation_wait_does_not_scope_claim_daemon_admitted_operation() {
+        assert!(!should_use_scoped_ingest_wait_worker(
             IngestQueueProcessor::Daemon,
             IngestWaitWorkerMode::Background,
             ScopedIngestClaimPolicy::InlineWithinDeadline,
@@ -12653,7 +12640,7 @@ quality_policy = "llm_required_for_keep"
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_mcp_ingest_wait_completes_daemon_admitted_operation_without_daemon_worker() {
+    async fn test_mcp_ingest_wait_keeps_daemon_admitted_operation_queryable_without_worker() {
         let (tempdir, db_path, server) = setup_server();
         let (listener, _socket_guard) =
             crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
@@ -12682,11 +12669,12 @@ quality_policy = "llm_required_for_keep"
         let response = server
             .mempal_ingest_with_controls(
                 IngestRequest {
-                    content: "daemon-admitted MCP wait caller completes receipt".to_string(),
+                    content: "daemon-admitted MCP wait caller receives queryable receipt"
+                        .to_string(),
                     wing: "mcp".to_string(),
                     room: Some("daemon-wait-receipt".to_string()),
                     wait: Some(true),
-                    wait_timeout_secs: Some(10),
+                    wait_timeout_secs: Some(1),
                     ..IngestRequest::default()
                 },
                 IngestControls {
@@ -12695,7 +12683,7 @@ quality_policy = "llm_required_for_keep"
                 },
             )
             .await
-            .expect("daemon-admitted wait should complete through scoped worker")
+            .expect("daemon-admitted wait should poll without local claim")
             .0;
 
         let (request, operation_id) = daemon.await.expect("daemon IPC task");
@@ -12704,19 +12692,16 @@ quality_policy = "llm_required_for_keep"
             response.operation_id.as_deref(),
             Some(operation_id.as_str())
         );
-        assert_eq!(response.state, Some(IngestOperationState::Completed));
-        assert!(!response.timed_out);
-        assert!(
-            !response.created_drawer_ids.is_empty(),
-            "completed daemon-backed wait must return cleanup-safe created drawer ids"
-        );
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(response.timed_out);
+        assert!(response.created_drawer_ids.is_empty());
 
         let status = server
             .operation_status_json_for_test(&operation_id)
             .await
-            .expect("completed operation status");
-        assert_eq!(status.state, Some(IngestOperationState::Completed));
-        assert_eq!(status.created_drawer_ids, response.created_drawer_ids);
+            .expect("queued operation status remains queryable");
+        assert_eq!(status.state, Some(IngestOperationState::Queued));
+        assert!(status.created_drawer_ids.is_empty());
     }
 
     #[cfg(unix)]
@@ -12771,13 +12756,11 @@ quality_policy = "llm_required_for_keep"
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_mcp_ingest_uncertain_daemon_lock_returns_pending_receipt() {
+    async fn test_mcp_ingest_uncertain_daemon_lock_returns_queryable_local_receipt() {
         let (tempdir, db_path, server) = setup_server();
-        let async_queue = AsyncPendingMessageStore::new_without_reclaim(&db_path)
-            .with_enqueue_lock_failures_for_test(1);
-        let server = server.with_async_queue_for_test(async_queue);
         let (listener, _socket_guard) =
             crate::hook_ipc::bind_listener(tempdir.path()).expect("bind daemon IPC");
+        let lock = hold_sqlite_write_lock(db_path.clone(), Duration::from_millis(250));
         let daemon = tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.expect("accept daemon IPC");
             let request = crate::hook_ipc::read_enqueue_request(&mut stream)
@@ -12788,10 +12771,11 @@ quality_policy = "llm_required_for_keep"
         });
 
         let response = tokio::time::timeout(
-            Duration::from_millis(500),
+            Duration::from_secs(3),
             server.mempal_ingest(Parameters(IngestRequest {
-                content: "uncertain daemon enqueue with local SQLite lock returns pending receipt"
-                    .to_string(),
+                content:
+                    "uncertain daemon enqueue with local SQLite lock waits for durable receipt"
+                        .to_string(),
                 wing: "mcp".to_string(),
                 room: Some("receipt".to_string()),
                 wait: Some(true),
@@ -12800,11 +12784,12 @@ quality_policy = "llm_required_for_keep"
             })),
         )
         .await
-        .expect("uncertain daemon lock path must not spend the normal local retry budget")
-        .expect("uncertain daemon lock should return a pending operation receipt")
+        .expect("uncertain daemon lock path should stay bounded by admission retry")
+        .expect("uncertain daemon lock should wait for a durable local operation row")
         .0;
 
         let request = daemon.await.expect("daemon IPC task");
+        lock.join().expect("release SQLite lock");
         assert_eq!(response.state, Some(IngestOperationState::Queued));
         assert!(response.timed_out);
         assert!(response.created_drawer_ids.is_empty());
@@ -12813,13 +12798,12 @@ quality_policy = "llm_required_for_keep"
             operation_id,
             PendingMessageStore::idempotent_message_id(INGEST_ASYNC_KIND, &request.idempotency_key)
         );
-        assert!(
-            PendingMessageStore::new_without_reclaim(&db_path)
-                .operation_status(operation_id)
-                .expect("query operation")
-                .is_none(),
-            "the pending receipt must tolerate a daemon-owned operation row that is not visible yet"
-        );
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query operation")
+            .expect("returned operation id must be queryable after lock clears");
+        assert_eq!(record.id, operation_id);
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1035,7 +1035,13 @@ impl MempalMcpServer {
 
         Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
-            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .complete_ingest_claim_outcome(
+                queue,
+                &claim,
+                queue_wait_ms,
+                outcome,
+                MCP_INGEST_RESULT_RETRY_DEADLINE,
+            )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
         let released = match writer_lease {
@@ -1136,7 +1142,13 @@ impl MempalMcpServer {
 
         Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
-            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .complete_ingest_claim_outcome(
+                queue,
+                &claim,
+                queue_wait_ms,
+                outcome,
+                MCP_INGEST_RESULT_RETRY_DEADLINE,
+            )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
         let released = match writer_lease {
@@ -1160,7 +1172,26 @@ impl MempalMcpServer {
             Ok(prepared) => prepared,
             Err(error) => {
                 let detail = format!("failed to decode ingest operation {}: {error}", claim.id);
-                complete_failed_ingest_claim(queue, &claim, queue_wait_ms, detail).await?;
+                let completion_deadline =
+                    scoped_process_remaining(started, budget).unwrap_or_default();
+                if let Err(error) = complete_failed_ingest_claim_with_lock_retry_deadline(
+                    queue,
+                    &claim,
+                    queue_wait_ms,
+                    detail,
+                    completion_deadline,
+                )
+                .await
+                {
+                    if anyhow_chain_contains_sqlite_lock(&error) {
+                        let release_deadline =
+                            scoped_process_remaining(started, budget).unwrap_or_default();
+                        Self::release_scoped_claim_after_timeout(queue, claim, release_deadline)
+                            .await?;
+                        return Ok(ScopedIngestProcessResult::TimedOut);
+                    }
+                    return Err(error);
+                }
                 return Ok(ScopedIngestProcessResult::Processed);
             }
         };
@@ -1293,8 +1324,15 @@ impl MempalMcpServer {
         }
 
         Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
+        let completion_deadline = scoped_process_remaining(started, budget).unwrap_or_default();
         let completed = self
-            .complete_ingest_claim_outcome(queue, &claim, queue_wait_ms, outcome)
+            .complete_ingest_claim_outcome(
+                queue,
+                &claim,
+                queue_wait_ms,
+                outcome,
+                completion_deadline,
+            )
             .await;
         Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
         let released = match writer_lease {
@@ -1312,6 +1350,7 @@ impl MempalMcpServer {
         claim: &ClaimedMessage,
         queue_wait_ms: u64,
         outcome: std::result::Result<IngestResponse, String>,
+        result_retry_deadline: Duration,
     ) -> anyhow::Result<()> {
         match outcome {
             Ok(mut response) => {
@@ -1348,20 +1387,32 @@ impl MempalMcpServer {
                     }
                     _ => None,
                 };
-                complete_ingest_operation_with_lock_retry(
+                complete_ingest_operation_with_lock_retry_deadline(
                     queue,
                     claim,
-                    state.as_str().to_string(),
-                    result_drawer_id.map(ToOwned::to_owned),
-                    rejected_reason.clone(),
-                    None,
-                    Some(result_json),
+                    IngestOperationCompletion {
+                        op_state: state.as_str().to_string(),
+                        result_drawer_id: result_drawer_id.map(ToOwned::to_owned),
+                        rejected_reason: rejected_reason.clone(),
+                        failure_detail: None,
+                        result_json: Some(result_json),
+                    },
+                    result_retry_deadline,
                 )
                 .await
-                .map_err(|error| anyhow::anyhow!("failed to store async ingest result: {error}"))?;
+                .map_err(|error| {
+                    anyhow::Error::new(error).context("failed to store async ingest result")
+                })?;
             }
             Err(detail) => {
-                complete_failed_ingest_claim(queue, claim, queue_wait_ms, detail).await?;
+                complete_failed_ingest_claim_with_lock_retry_deadline(
+                    queue,
+                    claim,
+                    queue_wait_ms,
+                    detail,
+                    result_retry_deadline,
+                )
+                .await?;
             }
         }
 
@@ -11157,11 +11208,36 @@ fn queue_wait_ms(created_at_secs: i64, claimed_at_secs: i64) -> u64 {
         .saturating_mul(1_000) as u64
 }
 
+struct IngestOperationCompletion {
+    op_state: String,
+    result_drawer_id: Option<String>,
+    rejected_reason: Option<String>,
+    failure_detail: Option<String>,
+    result_json: Option<String>,
+}
+
 async fn complete_failed_ingest_claim(
     queue: &AsyncPendingMessageStore,
     claim: &ClaimedMessage,
     queue_wait_ms: u64,
     detail: String,
+) -> anyhow::Result<()> {
+    complete_failed_ingest_claim_with_lock_retry_deadline(
+        queue,
+        claim,
+        queue_wait_ms,
+        detail,
+        MCP_INGEST_RESULT_RETRY_DEADLINE,
+    )
+    .await
+}
+
+async fn complete_failed_ingest_claim_with_lock_retry_deadline(
+    queue: &AsyncPendingMessageStore,
+    claim: &ClaimedMessage,
+    queue_wait_ms: u64,
+    detail: String,
+    result_retry_deadline: Duration,
 ) -> anyhow::Result<()> {
     let mut finalized =
         finalize_failed_ingest_response(claim.id.clone(), claim.created_at, detail.clone());
@@ -11170,48 +11246,45 @@ async fn complete_failed_ingest_claim(
         .insert("queue_wait_ms".to_string(), queue_wait_ms);
     let result_json =
         serde_json::to_string(&finalized).context("failed to serialize failed ingest response")?;
-    complete_ingest_operation_with_lock_retry(
+    complete_ingest_operation_with_lock_retry_deadline(
         queue,
         claim,
-        IngestOperationState::Failed.as_str().to_string(),
-        None,
-        None,
-        Some(detail),
-        Some(result_json),
+        IngestOperationCompletion {
+            op_state: IngestOperationState::Failed.as_str().to_string(),
+            result_drawer_id: None,
+            rejected_reason: None,
+            failure_detail: Some(detail),
+            result_json: Some(result_json),
+        },
+        result_retry_deadline,
     )
     .await
-    .map_err(|error| anyhow::anyhow!("failed to store async ingest failure: {error}"))?;
+    .map_err(|error| anyhow::Error::new(error).context("failed to store async ingest failure"))?;
     Ok(())
 }
 
-async fn complete_ingest_operation_with_lock_retry(
+async fn complete_ingest_operation_with_lock_retry_deadline(
     queue: &AsyncPendingMessageStore,
     claim: &ClaimedMessage,
-    op_state: String,
-    result_drawer_id: Option<String>,
-    rejected_reason: Option<String>,
-    failure_detail: Option<String>,
-    result_json: Option<String>,
+    completion: IngestOperationCompletion,
+    retry_deadline: Duration,
 ) -> crate::core::queue::Result<()> {
     let started = Instant::now();
     loop {
         match queue
             .complete_operation(
                 claim.clone(),
-                op_state.clone(),
-                result_drawer_id.clone(),
-                rejected_reason.clone(),
-                failure_detail.clone(),
-                result_json.clone(),
+                completion.op_state.clone(),
+                completion.result_drawer_id.clone(),
+                completion.rejected_reason.clone(),
+                completion.failure_detail.clone(),
+                completion.result_json.clone(),
             )
             .await
         {
             Ok(()) => return Ok(()),
-            Err(error)
-                if error.is_sqlite_lock()
-                    && started.elapsed() < MCP_INGEST_RESULT_RETRY_DEADLINE =>
-            {
-                let remaining = MCP_INGEST_RESULT_RETRY_DEADLINE.saturating_sub(started.elapsed());
+            Err(error) if error.is_sqlite_lock() && started.elapsed() < retry_deadline => {
+                let remaining = retry_deadline.saturating_sub(started.elapsed());
                 tracing::warn!(
                     ?error,
                     operation_id = %claim.id,
@@ -14353,6 +14426,79 @@ pattern_boost = 0.2
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_scoped_finite_completion_lock_respects_budget() {
+        let (_tempdir, db_path, server) = setup_server();
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "finite scoped wait must not use background completion retry".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("runtime".to_string()),
+            project_id: Some("project-finite-complete-lock".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls::default(),
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-finite-complete-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone())
+            .with_complete_lock_failures_for_test(10_000);
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            server.process_ingest_claim_inline_with_budget(
+                &async_queue,
+                "worker-finite-complete-lock",
+                claim,
+                Duration::from_secs(1),
+            ),
+        )
+        .await
+        .expect("finite scoped completion retry must not use the 300s background window");
+        let error = result.expect_err("locked completion receipt should return a bounded error");
+        assert!(
+            error
+                .to_string()
+                .contains("failed to store async ingest result"),
+            "{error:#}"
+        );
+        assert!(
+            anyhow_chain_contains_sqlite_lock(&error),
+            "bounded completion error should preserve the SQLite lock source: {error:#}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "finite scoped completion retry exceeded the caller budget"
+        );
+        let record = queue
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Running.as_str());
+        assert!(record.completed_at.is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_async_ingest_uses_admission_supersedes_target_after_queue_wait() {
         let (_tempdir, db_path, server) = setup_server();
         let seed_id = "async-supersedes-old";
@@ -14492,6 +14638,50 @@ pattern_boost = 0.2
             .expect("operation record exists");
         assert_eq!(record.op_state, IngestOperationState::Failed.as_str());
         assert!(record.completed_at.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_scoped_finite_malformed_payload_completion_lock_releases_claim() {
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, "{not json")
+            .expect("enqueue malformed async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-finite-failure-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim malformed op")
+            .expect("claimed malformed op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone())
+            .with_complete_lock_failures_for_test(10_000);
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            server.process_ingest_claim_inline_with_budget(
+                &async_queue,
+                "worker-finite-failure-lock",
+                claim,
+                Duration::from_secs(1),
+            ),
+        )
+        .await
+        .expect("finite scoped failure receipt retry must not use the 300s background window")
+        .expect("malformed payload should release for retry when failure receipt is locked");
+
+        assert_eq!(result, ScopedIngestProcessResult::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "finite scoped failure receipt retry exceeded the caller budget"
+        );
+        let record = queue
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Queued.as_str());
+        assert!(
+            record.claimed_at.is_none(),
+            "malformed payload must release the claim when failure receipt persistence times out"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -184,8 +184,7 @@ const MCP_INGEST_ADMISSION_DEADLINE: Duration = Duration::from_secs(10);
 const MCP_OPERATION_STATUS_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_INGEST_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(5);
 const MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(30);
-const MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT: Duration =
-    MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE;
+const MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT: Duration = Duration::from_secs(2);
 const MCP_INGEST_QUEUE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 const MCP_SELF_HOLDER_WRITE_LOCK_RETRY_DEADLINE: Duration = Duration::from_secs(30);
 const MCP_SELF_HOLDER_WRITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
@@ -13232,10 +13231,58 @@ quality_policy = "llm_required_for_keep"
             "MCP daemon ingest enqueue must not reuse hook fail-fast IPC timeout"
         );
         assert!(
-            MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT
-                >= MCP_INGEST_SELF_HOLDER_QUEUE_LOCK_RETRY_DEADLINE,
-            "MCP daemon ingest enqueue IPC timeout must cover the observed SQLite holder retry budget"
+            MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT < MCP_INGEST_ADMISSION_DEADLINE,
+            "wait=false MCP ingest must not spend the whole admission budget waiting for daemon IPC"
         );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_ingest_wait_false_falls_back_when_daemon_ipc_stalls() {
+        let (tempdir, db_path, server) = setup_server();
+        let (listener, _socket_guard) =
+            crate::hook_ipc::bind_listener(tempdir.path()).expect("bind fake daemon IPC socket");
+        let fake_daemon = tokio::spawn(async move {
+            if let Ok((_stream, _addr)) = listener.accept().await {
+                tokio::time::sleep(MCP_DAEMON_INGEST_ENQUEUE_IPC_TIMEOUT * 3).await;
+            }
+        });
+
+        let started_at = Instant::now();
+        let response = tokio::time::timeout(
+            MCP_INGEST_ADMISSION_DEADLINE,
+            server.mempal_ingest(Parameters(IngestRequest {
+                content: "normal project case should not wait for stalled daemon IPC".to_string(),
+                wing: "verbatim".to_string(),
+                room: Some("bugfixes".to_string()),
+                source_type: Some("agent_observation".to_string()),
+                memory_kind: Some("case".to_string()),
+                domain: Some("project".to_string()),
+                field: Some("software-engineering".to_string()),
+                source_file: Some(
+                    "/home/obj/project/github/RyderFreeman4Logos/verbatim/crates/verbatim-daemon/src/main.rs"
+                        .to_string(),
+                ),
+                wait: Some(false),
+                ..IngestRequest::default()
+            })),
+        )
+        .await
+        .expect("wait=false ingest must return before the MCP admission deadline")
+        .expect("stalled daemon IPC should fall back to local idempotent admission")
+        .0;
+
+        fake_daemon.abort();
+        assert_eq!(response.state, Some(IngestOperationState::Queued));
+        assert!(
+            started_at.elapsed() < MCP_INGEST_ADMISSION_DEADLINE,
+            "wait=false ingest should not wait until a client can close the transport"
+        );
+        let operation_id = response.operation_id.as_deref().expect("operation id");
+        let record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(operation_id)
+            .expect("query queued operation")
+            .expect("queued operation");
+        assert_eq!(record.kind, INGEST_ASYNC_KIND);
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -191,6 +191,8 @@ const MCP_SELF_HOLDER_WRITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(5
 const MCP_INGEST_CLAIM_RELEASE_RETRY_DEADLINE: Duration = Duration::from_secs(300);
 const MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(50);
 const MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT: Duration = Duration::ZERO;
+const MCP_INGEST_RESULT_RETRY_DEADLINE: Duration = Duration::from_secs(300);
+const MCP_INGEST_RESULT_RETRY_DELAY: Duration = Duration::from_millis(50);
 const MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN: Duration = Duration::from_millis(250);
 // Caller-bounded scoped waits may claim only when this much budget remains. The
 // cleanup margin is reserved for releasing the claim if processing hits the
@@ -1346,19 +1348,17 @@ impl MempalMcpServer {
                     }
                     _ => None,
                 };
-                queue
-                    .complete_operation(
-                        claim.clone(),
-                        state.as_str().to_string(),
-                        result_drawer_id.map(ToOwned::to_owned),
-                        rejected_reason.clone(),
-                        None,
-                        Some(result_json),
-                    )
-                    .await
-                    .map_err(|error| {
-                        anyhow::anyhow!("failed to store async ingest result: {error}")
-                    })?;
+                complete_ingest_operation_with_lock_retry(
+                    queue,
+                    claim,
+                    state.as_str().to_string(),
+                    result_drawer_id.map(ToOwned::to_owned),
+                    rejected_reason.clone(),
+                    None,
+                    Some(result_json),
+                )
+                .await
+                .map_err(|error| anyhow::anyhow!("failed to store async ingest result: {error}"))?;
             }
             Err(detail) => {
                 complete_failed_ingest_claim(queue, claim, queue_wait_ms, detail).await?;
@@ -11170,18 +11170,58 @@ async fn complete_failed_ingest_claim(
         .insert("queue_wait_ms".to_string(), queue_wait_ms);
     let result_json =
         serde_json::to_string(&finalized).context("failed to serialize failed ingest response")?;
-    queue
-        .complete_operation(
-            claim.clone(),
-            IngestOperationState::Failed.as_str().to_string(),
-            None,
-            None,
-            Some(detail),
-            Some(result_json),
-        )
-        .await
-        .map_err(|error| anyhow::anyhow!("failed to store async ingest failure: {error}"))?;
+    complete_ingest_operation_with_lock_retry(
+        queue,
+        claim,
+        IngestOperationState::Failed.as_str().to_string(),
+        None,
+        None,
+        Some(detail),
+        Some(result_json),
+    )
+    .await
+    .map_err(|error| anyhow::anyhow!("failed to store async ingest failure: {error}"))?;
     Ok(())
+}
+
+async fn complete_ingest_operation_with_lock_retry(
+    queue: &AsyncPendingMessageStore,
+    claim: &ClaimedMessage,
+    op_state: String,
+    result_drawer_id: Option<String>,
+    rejected_reason: Option<String>,
+    failure_detail: Option<String>,
+    result_json: Option<String>,
+) -> crate::core::queue::Result<()> {
+    let started = Instant::now();
+    loop {
+        match queue
+            .complete_operation(
+                claim.clone(),
+                op_state.clone(),
+                result_drawer_id.clone(),
+                rejected_reason.clone(),
+                failure_detail.clone(),
+                result_json.clone(),
+            )
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if error.is_sqlite_lock()
+                    && started.elapsed() < MCP_INGEST_RESULT_RETRY_DEADLINE =>
+            {
+                let remaining = MCP_INGEST_RESULT_RETRY_DEADLINE.saturating_sub(started.elapsed());
+                tracing::warn!(
+                    ?error,
+                    operation_id = %claim.id,
+                    "retrying async ingest result persistence after SQLite lock"
+                );
+                tokio::time::sleep(MCP_INGEST_RESULT_RETRY_DELAY.min(remaining)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 fn rfc3339_from_secs(secs: i64) -> String {
@@ -14257,6 +14297,62 @@ pattern_boost = 0.2
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_async_ingest_completion_retries_transient_sqlite_lock() {
+        let (_tempdir, db_path, server) = setup_server();
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "completion receipt survives transient sqlite lock".to_string(),
+            wing: "mcp".to_string(),
+            room: Some("runtime".to_string()),
+            project_id: Some("project-complete-lock".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls::default(),
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-complete-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone())
+            .with_complete_lock_failures_for_test(2);
+
+        server
+            .process_ingest_claim(&async_queue, "worker-complete-lock", claim)
+            .await
+            .expect("transient result persistence locks should be retried");
+
+        let completed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(!completed.drawer_id.is_empty());
+        assert_eq!(completed.drawer_ids, completed.created_drawer_ids);
+        assert!(
+            !completed.created_drawer_ids.is_empty(),
+            "completed receipt must preserve cleanup-safe drawer ids after retry"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn test_async_ingest_uses_admission_supersedes_target_after_queue_wait() {
         let (_tempdir, db_path, server) = setup_server();
         let seed_id = "async-supersedes-old";
@@ -14351,6 +14447,46 @@ pattern_boost = 0.2
         );
 
         let record = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load operation record")
+            .expect("operation record exists");
+        assert_eq!(record.op_state, IngestOperationState::Failed.as_str());
+        assert!(record.completed_at.is_some());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_async_ingest_failure_receipt_retries_transient_sqlite_lock() {
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, "{not json")
+            .expect("enqueue malformed async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-failure-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim malformed op")
+            .expect("claimed malformed op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone())
+            .with_complete_lock_failures_for_test(2);
+
+        server
+            .process_ingest_claim(&async_queue, "worker-failure-lock", claim)
+            .await
+            .expect("transient failure receipt persistence locks should be retried");
+
+        let failed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("failed status");
+        assert_eq!(failed.state, Some(IngestOperationState::Failed));
+        assert!(failed.drawer_id.is_empty());
+        assert!(
+            failed
+                .failure_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("failed to decode ingest operation")),
+            "{failed:?}"
+        );
+        let record = queue
             .operation_status(&operation_id)
             .expect("load operation record")
             .expect("operation record exists");

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -31,7 +31,7 @@ use crate::core::{
     project::{ProjectSearchScope, infer_project_id_from_root_uri, validate_project_id},
     queue::{
         AsyncPendingMessageStore, CLAIM_LOCK_RETRY_DEADLINE, ClaimedMessage, PendingMessageStore,
-        PendingOperationCompletion, QueueError,
+        PendingOperationCompletion, QueueError, QueueFailureDisposition,
     },
     reindex::ReindexProgressStore,
     remote_calls::{
@@ -193,6 +193,7 @@ const MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(50)
 const MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT: Duration = Duration::ZERO;
 const MCP_INGEST_RESULT_RETRY_DEADLINE: Duration = Duration::from_secs(300);
 const MCP_INGEST_RESULT_RETRY_DELAY: Duration = Duration::from_millis(50);
+const MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS: i64 = 1_000;
 const MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN: Duration = Duration::from_millis(250);
 // Caller-bounded scoped waits may claim only when this much budget remains. The
 // cleanup margin is reserved for releasing the claim if processing hits the
@@ -1032,6 +1033,25 @@ impl MempalMcpServer {
             tokio::time::sleep(INGEST_POLL_INTERVAL).await;
             return result;
         }
+        if let Err(detail) = &outcome
+            && mcp_ingest_failure_is_retryable_transient_write_lock(detail)
+        {
+            Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+            let requeued =
+                requeue_ingest_claim_after_transient_write_lock(queue, &claim, detail.clone())
+                    .await;
+            let released = match writer_lease {
+                Some(writer_lease) => writer_lease.release().await,
+                None => Ok(()),
+            };
+            let result = requeued.and(released);
+            match &result {
+                Ok(()) => span.finish_error_class("transient_write_lock_requeued"),
+                Err(error) => span.finish_error(error),
+            }
+            tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+            return result;
+        }
 
         Self::refresh_ingest_claim_heartbeat_once(queue, &claim.id, worker_id).await;
         let completed = self
@@ -1136,6 +1156,19 @@ impl MempalMcpServer {
             Self::release_claim_with_lock_retry(queue, claim)
                 .await
                 .context("failed to release scoped ingest claim after writer lease was lost")?;
+            released?;
+            tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+            return Ok(());
+        }
+        if let Err(detail) = &outcome
+            && mcp_ingest_failure_is_retryable_transient_write_lock(detail)
+        {
+            Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+            requeue_ingest_claim_after_transient_write_lock(queue, &claim, detail.clone()).await?;
+            let released = match writer_lease {
+                Some(writer_lease) => writer_lease.release().await,
+                None => Ok(()),
+            };
             released?;
             tokio::time::sleep(INGEST_POLL_INTERVAL).await;
             return Ok(());
@@ -1323,6 +1356,23 @@ impl MempalMcpServer {
             )
             .await
             .context("failed to release scoped ingest claim after writer lease was lost")?;
+            return Ok(ScopedIngestProcessResult::ReleasedForRetry);
+        }
+        if let Err(detail) = &outcome
+            && mcp_ingest_failure_is_retryable_transient_write_lock(detail)
+        {
+            Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
+            if let Some(writer_lease) = writer_lease {
+                let _ = writer_lease.release().await;
+            }
+            let release_deadline = scoped_process_remaining(started, budget).unwrap_or_default();
+            Self::release_claim_with_lock_retry_deadline(
+                queue,
+                claim,
+                release_deadline.min(CLAIM_LOCK_RETRY_DEADLINE),
+            )
+            .await
+            .context("failed to release scoped ingest claim after transient write lock")?;
             return Ok(ScopedIngestProcessResult::ReleasedForRetry);
         }
 
@@ -6661,6 +6711,26 @@ impl MempalMcpServer {
         let scrubbed_content =
             config.scrub_content_with_compiled(&request.content, compiled_privacy.as_ref());
         let room = request.room.as_deref();
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .sync_db_open_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(database_write_refused_error(
+                &self.db_path,
+                "sync_ingest_open_db",
+                &rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ErrorCode::DatabaseBusy,
+                        extended_code: rusqlite::ffi::SQLITE_BUSY,
+                    },
+                    Some("database is locked".to_string()),
+                ),
+            ));
+        }
         let db = Database::open(&self.db_path).map_err(|error| {
             database_write_refused_error(&self.db_path, "sync_ingest_open_db", &error)
         })?;
@@ -11093,6 +11163,37 @@ fn mcp_ingest_failure_is_retryable_writer_lease_lost(detail: &str) -> bool {
         .any(|operation| lower.contains(operation))
 }
 
+fn mcp_ingest_failure_is_retryable_transient_write_lock(detail: &str) -> bool {
+    let lower = detail.to_ascii_lowercase();
+    let retry_action = lower.contains("retry_after_transient_lock");
+    let database_locked = lower.contains("database_locked")
+        || lower.contains("locked_or_busy")
+        || lower.contains("database is locked")
+        || lower.contains("database is busy");
+    let unconfirmed_write = lower.contains("write admission was not confirmed");
+    retry_action && database_locked && unconfirmed_write
+}
+
+async fn requeue_ingest_claim_after_transient_write_lock(
+    queue: &AsyncPendingMessageStore,
+    claim: &ClaimedMessage,
+    detail: String,
+) -> anyhow::Result<()> {
+    queue
+        .mark_failed_with_disposition(
+            claim.clone(),
+            detail,
+            QueueFailureDisposition::RetryableAfter {
+                delay_ms: MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS,
+            },
+        )
+        .await
+        .map_err(|error| {
+            anyhow::Error::new(error)
+                .context("failed to requeue async ingest after transient write lock")
+        })
+}
+
 fn push_mcp_timeout_warning(
     response_warnings: &mut Vec<String>,
     system_warnings: &mut Vec<SystemWarning>,
@@ -13156,6 +13257,70 @@ quality_policy = "llm_required_for_keep"
     }
 
     #[tokio::test]
+    async fn test_scoped_operation_wait_retries_transient_write_lock_without_failed_receipt() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server.with_sync_db_open_lock_failures_for_test(1);
+        let operation_id = enqueue_prepared_test_ingest_operation(
+            &server,
+            &db_path,
+            "scoped operation wait must retry transient write locks",
+            "transient-write-lock",
+        )
+        .await;
+
+        let wait_result = tokio::time::timeout(
+            Duration::from_secs(15),
+            server.wait_for_operation_status_with_scoped_worker(
+                &operation_id,
+                Duration::from_secs(12),
+                Duration::from_millis(25),
+            ),
+        )
+        .await
+        .expect("scoped operation wait should stay within the caller budget")
+        .expect("scoped operation wait should not fail after a transient write lock");
+        let Some(response) = wait_result else {
+            let record = PendingMessageStore::new_without_reclaim(&db_path)
+                .operation_status(&operation_id)
+                .expect("load timed-out operation")
+                .expect("operation remains queryable");
+            panic!(
+                "scoped operation wait should reach terminal status; state={} claimed_at={:?} completed_at={:?} failure_detail={:?}",
+                record.op_state, record.claimed_at, record.completed_at, record.failure_detail
+            );
+        };
+
+        assert_eq!(response.state, Some(IngestOperationState::Completed));
+        assert!(
+            !response.created_drawer_ids.is_empty(),
+            "retry completion must expose cleanup-safe created drawer IDs"
+        );
+        assert!(response.failure_detail.is_none());
+
+        let completion_count: i64 = rusqlite::Connection::open(&db_path)
+            .expect("open db")
+            .query_row(
+                "SELECT COUNT(*) FROM pending_message_completions WHERE message_id = ?1",
+                [operation_id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("count completions");
+        assert_eq!(
+            completion_count, 1,
+            "transient write lock must produce only the final completed receipt"
+        );
+        let final_record = PendingMessageStore::new_without_reclaim(&db_path)
+            .operation_status(&operation_id)
+            .expect("load final operation")
+            .expect("operation remains queryable");
+        assert_eq!(
+            final_record.op_state,
+            IngestOperationState::Completed.as_str()
+        );
+        assert!(final_record.failure_detail.is_none());
+    }
+
+    #[tokio::test]
     async fn test_mcp_ingest_scoped_finite_wait_processes_local_queue() {
         let (_tempdir, db_path, server) = setup_server();
 
@@ -14452,6 +14617,105 @@ pattern_boost = 0.2
             !completed.created_drawer_ids.is_empty(),
             "completed receipt must preserve cleanup-safe drawer ids after retry"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_async_ingest_transient_write_lock_requeues_instead_of_failing() {
+        let (_tempdir, db_path, server) = setup_server();
+        let server = server.with_sync_db_open_lock_failures_for_test(1);
+        let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
+        let request = IngestRequest {
+            content: "transient write lock should retry async ingest".to_string(),
+            wing: "smoke".to_string(),
+            room: Some("mcp".to_string()),
+            source_type: Some("agent_inference".to_string()),
+            memory_kind: Some("evidence".to_string()),
+            domain: Some("project".to_string()),
+            field: Some("smoke".to_string()),
+            smoke: Some(true),
+            project_id: Some("project-transient-write-lock".to_string()),
+            dry_run: Some(false),
+            ..IngestRequest::default()
+        };
+        let project_id = server
+            .resolve_mcp_project_id(request.project_id.as_deref(), config.as_ref())
+            .await
+            .expect("resolve project");
+        let prepared = server
+            .prepare_async_ingest_operation(
+                &request,
+                IngestControls::default(),
+                config.as_ref(),
+                compiled_privacy.as_ref(),
+                project_id,
+            )
+            .await
+            .expect("prepare async ingest");
+        let payload = serde_json::to_string(&prepared).expect("serialize prepared ingest");
+        let queue = crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path);
+        let operation_id = queue
+            .enqueue(INGEST_ASYNC_KIND, &payload)
+            .expect("enqueue async ingest");
+        let claim = queue
+            .claim_next_by_kind("worker-transient-write-lock", 60, INGEST_ASYNC_KIND)
+            .expect("claim queued op")
+            .expect("claimed queued op");
+        let async_queue = AsyncPendingMessageStore::from_store(queue.clone());
+
+        server
+            .process_ingest_claim(&async_queue, "worker-transient-write-lock", claim)
+            .await
+            .expect("transient write lock should requeue the ingest");
+
+        let queued = queue
+            .operation_status(&operation_id)
+            .expect("load requeued operation")
+            .expect("operation remains durable");
+        assert_eq!(queued.op_state, IngestOperationState::Queued.as_str());
+        assert!(queued.claimed_at.is_none());
+        assert!(queued.completed_at.is_none());
+        assert!(queued.failure_detail.is_none());
+
+        let completion_count: i64 = rusqlite::Connection::open(&db_path)
+            .expect("open db")
+            .query_row(
+                "SELECT COUNT(*) FROM pending_message_completions WHERE message_id = ?1",
+                [operation_id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("count completions");
+        assert_eq!(
+            completion_count, 0,
+            "transient write lock must not create a failed completion receipt"
+        );
+
+        tokio::time::sleep(Duration::from_millis(
+            MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS as u64 + 200,
+        ))
+        .await;
+        let retry_claim = queue
+            .claim_next_by_kind("worker-transient-write-lock-retry", 60, INGEST_ASYNC_KIND)
+            .expect("claim retry op")
+            .expect("retry claim remains available");
+        server
+            .process_ingest_claim(
+                &async_queue,
+                "worker-transient-write-lock-retry",
+                retry_claim,
+            )
+            .await
+            .expect("retry should complete after lock clears");
+
+        let completed = server
+            .operation_status_json_for_test(&operation_id)
+            .await
+            .expect("completed status");
+        assert_eq!(completed.state, Some(IngestOperationState::Completed));
+        assert!(
+            !completed.created_drawer_ids.is_empty(),
+            "retry completion must expose cleanup-safe created drawer IDs"
+        );
+        assert!(completed.failure_detail.is_none());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -328,6 +328,39 @@ async fn mcp_stdio_ingest_stalled_daemon_ipc_keeps_transport_alive() -> Result<(
         Some("queued"),
         "{ingest:#?}"
     );
+    let operation_id = ingest["structuredContent"]["operation_id"]
+        .as_str()
+        .expect("queued ingest operation id")
+        .to_string();
+
+    let mut completed = None;
+    for _ in 0..20 {
+        let status = tokio::time::timeout(
+            Duration::from_secs(5),
+            client.call(
+                "tools/call",
+                serde_json::json!({
+                    "name": "mempal_operation_status",
+                    "arguments": {
+                        "operation_id": operation_id.clone(),
+                    },
+                }),
+            ),
+        )
+        .await??;
+        if status["structuredContent"]["state"].as_str() == Some("completed") {
+            completed = Some(status);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    let completed = completed.expect("stalled daemon IPC local fallback should complete");
+    assert!(
+        completed["structuredContent"]["created_drawer_ids"]
+            .as_array()
+            .is_some_and(|ids| !ids.is_empty()),
+        "{completed:#?}"
+    );
 
     let recovered_status = tokio::time::timeout(
         Duration::from_secs(5),

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -272,6 +272,81 @@ async fn mcp_stdio_ingest_succeeds_with_existing_status_holder() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn mcp_stdio_ingest_stalled_daemon_ipc_keeps_transport_alive() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let mempal_home = tmp.path().join(".mempal");
+    fs::create_dir_all(&mempal_home)?;
+    let db_path = mempal_home.join("palace.db");
+    Database::open(&db_path)?;
+
+    let listener = tokio::net::UnixListener::bind(mempal_home.join("daemon-hook.sock"))?;
+    let fake_daemon = tokio::spawn(async move {
+        if let Ok((_stream, _addr)) = listener.accept().await {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    });
+
+    let mut client = McpStdio::start(&db_path, HashMap::new()).await?;
+    client.initialize().await?;
+    let status = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_status",
+                "arguments": {},
+            }),
+        ),
+    )
+    .await??;
+    assert!(status["structuredContent"].is_object());
+
+    let ingest = tokio::time::timeout(
+        Duration::from_secs(6),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_ingest",
+                "arguments": {
+                    "content": "issue 597 normal case stalled daemon IPC regression payload",
+                    "wing": "verbatim",
+                    "room": "bugfixes",
+                    "source_type": "agent_observation",
+                    "memory_kind": "case",
+                    "domain": "project",
+                    "field": "software-engineering",
+                    "source_file": "/home/obj/project/github/RyderFreeman4Logos/verbatim/crates/verbatim-daemon/src/main.rs",
+                    "wait": false
+                },
+            }),
+        ),
+    )
+    .await??;
+    assert_eq!(
+        ingest["structuredContent"]["state"].as_str(),
+        Some("queued"),
+        "{ingest:#?}"
+    );
+
+    let recovered_status = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.call(
+            "tools/call",
+            serde_json::json!({
+                "name": "mempal_status",
+                "arguments": {},
+            }),
+        ),
+    )
+    .await??;
+    assert!(recovered_status["structuredContent"].is_object());
+
+    fake_daemon.abort();
+    client.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn harness_integration_smoke() -> Result<()> {
     let tmp = TempDir::new()?;

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "b35648d5bb69d9283134e1a091862f88a0fbe057"
+commit = "58686e2ba82d71ece1fb1ee7dc8e0b890491121b"
 source_kind = "git"

--- a/weave.lock
+++ b/weave.lock
@@ -1,5 +1,5 @@
 [[package]]
 name = "cli-sub-agent"
 repo = "https://github.com/RyderFreeman4Logos/cli-sub-agent.git"
-commit = "58686e2ba82d71ece1fb1ee7dc8e0b890491121b"
+commit = "81388f10b47fe8e55a23c2b476df10e7731268ed"
 source_kind = "git"


### PR DESCRIPTION
## Summary

- Keeps MCP ingest responses transport-safe when the daemon/write path is temporarily blocked by SQLite locks or IPC stalls.
- Preserves cleanup-safe operation/drawer recovery metadata so smoke cleanup can recover instead of losing IDs.
- Adds focused coverage for transient write-lock retry behavior and scoped wait behavior.

Closes #597

## Verification

- `just local-gates` — `LOCAL_GATES_EXIT 0 2026-06-28T18:47:59Z`
- `just install` — `JUST_INSTALL_EXIT 0 2026-06-28T18:48:16Z`
- daemon restart verification — MainPID used `/usr/local/bin/mempal`, not deleted
- isolated installed full-smoke — `FULL_SMOKE_EXIT 0`, `overall_ok=true`, cleanup OK
- strict production installed full-smoke — `FULL_SMOKE_EXIT 0 2026-06-28T19:29:17Z`, `overall_ok=true`, daemon stable, cleanup OK
- tier4 CSA-Codex exact-head review — PASS, session `01KW7SZ927T6JZ9ZBWSYCGS6EM`
- `csa review --check-verdict --range main...HEAD` — passed for `237027d5968`
