### PR TITLE
fix(deps): update rustls-webpki to 0.103.13 for RUSTSEC-2026 advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Updates `rustls-webpki 0.103.10 → 0.103.13` to resolve three security advisories from `cargo audit`:

- **RUSTSEC-2026-0098** — Name constraints for URI names were incorrectly accepted
- **RUSTSEC-2026-0099** — Name constraints were accepted for certificates asserting a wildcard name
- **RUSTSEC-2026-0104** — Reachable panic in certificate revocation list parsing

## Changes

Lockfile-only update (`Cargo.lock`). No source code changes.

## Verification

```
cargo audit --no-fetch     → 3 target advisories eliminated (6 pre-existing unmaintained/unsound warnings remain)
just fmt-check              → clean
just clippy (-D warnings)   → clean
just test (816+ tests)      → all pass
```

CSA review: **PASS** (session `01KW816SFF9KMMVPZ1ZG6FK60W`, codex tier1, 3m58s)

Closes #600