### PR TITLE
perf: vector search IO amplification optimization (#603)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -529,6 +529,7 @@ struct StatusResponse {
     wings: Vec<ScopeCount>,
     source_type_distribution: Vec<SourceTypeCount>,
     turn_storage: TurnStorageStatus,
+    ingest_worker_backoff: crate::observability::IngestWorkerBackoffSnapshot,
     search_telemetry: SearchTelemetrySnapshot,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     status_warnings: Vec<String>,
@@ -1682,6 +1683,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             raw_turn_wings: config.turns.raw_turn_wings.clone(),
             raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
         },
+        ingest_worker_backoff: crate::observability::ingest_worker_backoff_snapshot(),
         search_telemetry,
         status_warnings,
     }))

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -530,6 +530,7 @@ struct StatusResponse {
     source_type_distribution: Vec<SourceTypeCount>,
     turn_storage: TurnStorageStatus,
     ingest_worker_backoff: crate::observability::IngestWorkerBackoffSnapshot,
+    vector_scan: crate::observability::VectorScanSnapshot,
     search_telemetry: SearchTelemetrySnapshot,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     status_warnings: Vec<String>,
@@ -1684,6 +1685,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
         },
         ingest_worker_backoff: crate::observability::ingest_worker_backoff_snapshot(),
+        vector_scan: crate::observability::vector_scan_snapshot(),
         search_telemetry,
         status_warnings,
     }))

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -363,6 +363,11 @@ impl Config {
                 "search.reranker.top_k must be greater than 0".to_string(),
             ));
         }
+        if self.ingest_gating.novelty.novelty_scan_limit == 0 {
+            return Err(ConfigError::InvalidConfig(
+                "ingest_gating.novelty.novelty_scan_limit must be greater than 0".to_string(),
+            ));
+        }
         if self.search.reranker.enabled {
             normalize_reranker_endpoint_url(
                 self.search.reranker.endpoint.as_deref().unwrap_or_default(),
@@ -2647,6 +2652,7 @@ pub struct NoveltyConfig {
     pub merge_threshold: f32,
     pub wing_scope: String,
     pub top_k_candidates: usize,
+    pub novelty_scan_limit: usize,
     pub max_merges_per_drawer: u32,
     pub max_content_bytes_per_drawer: usize,
 }
@@ -2659,6 +2665,7 @@ impl Default for NoveltyConfig {
             merge_threshold: 0.80,
             wing_scope: "same_wing".to_string(),
             top_k_candidates: 5,
+            novelty_scan_limit: 10_000,
             max_merges_per_drawer: 10,
             max_content_bytes_per_drawer: 65_536,
         }
@@ -3285,6 +3292,22 @@ mod tests {
         .expect_err("zero top_k must be rejected");
         assert!(
             err.to_string().contains("search.reranker.top_k"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn novelty_scan_limit_rejects_zero() {
+        let err = Config::parse(
+            r#"
+            [ingest_gating.novelty]
+            novelty_scan_limit = 0
+            "#,
+        )
+        .expect_err("zero novelty_scan_limit must be rejected");
+        assert!(
+            err.to_string()
+                .contains("ingest_gating.novelty.novelty_scan_limit"),
             "unexpected error: {err}"
         );
     }

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1823,25 +1823,21 @@ impl Database {
             .map_err(|_| DbError::InvalidSourceType("scan_limit".to_string()))?;
         let mut statement = self.conn.prepare(
             r#"
-            WITH recent_vectors AS (
-                SELECT d.id,
-                       d.deleted_at,
-                       d.wing,
-                       d.room,
-                       d.project_id,
-                       v.embedding
-                FROM drawer_vectors v
-                JOIN drawers d ON d.id = v.id
+            WITH recent_drawers AS (
+                SELECT d.id
+                FROM drawers d
                 WHERE d.deleted_at IS NULL
                   AND (?2 IS NULL OR d.wing = ?2)
                   AND (?3 IS NULL OR d.room = ?3)
                   AND (?4 IS NULL OR d.project_id = ?4)
+                  AND EXISTS (SELECT 1 FROM drawer_vectors v WHERE v.id = d.id)
                 ORDER BY d.rowid DESC
                 LIMIT ?6
             )
-            SELECT id,
-                   CAST(1.0 - vec_distance_cosine(embedding, vec_f32(?1)) AS REAL) AS similarity
-            FROM recent_vectors
+            SELECT rd.id,
+                   CAST(1.0 - vec_distance_cosine(v.embedding, vec_f32(?1)) AS REAL) AS similarity
+            FROM recent_drawers rd
+            JOIN drawer_vectors v ON v.id = rd.id
             ORDER BY similarity DESC
             LIMIT ?5
             "#,

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -1805,36 +1805,57 @@ impl Database {
         room: Option<&str>,
         project_id: Option<&str>,
         limit: usize,
+        scan_limit: usize,
     ) -> Result<Vec<(String, f32)>, DbError> {
         let vectors_exist: bool = self.conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='drawer_vectors')",
             [],
             |row| row.get(0),
         )?;
-        if !vectors_exist || limit == 0 {
+        if !vectors_exist || limit == 0 || scan_limit == 0 {
             return Ok(Vec::new());
         }
 
         let query_json = serde_json::to_string(query_vector)?;
         let limit =
             i64::try_from(limit).map_err(|_| DbError::InvalidSourceType("limit".to_string()))?;
+        let scan_limit = i64::try_from(scan_limit)
+            .map_err(|_| DbError::InvalidSourceType("scan_limit".to_string()))?;
         let mut statement = self.conn.prepare(
             r#"
-            SELECT d.id,
-                   CAST(1.0 - vec_distance_cosine(v.embedding, vec_f32(?1)) AS REAL) AS similarity
-            FROM drawer_vectors v
-            JOIN drawers d ON d.id = v.id
-            WHERE d.deleted_at IS NULL
-              AND (?2 IS NULL OR d.wing = ?2)
-              AND (?3 IS NULL OR d.room = ?3)
-              AND (?4 IS NULL OR d.project_id = ?4)
+            WITH recent_vectors AS (
+                SELECT d.id,
+                       d.deleted_at,
+                       d.wing,
+                       d.room,
+                       d.project_id,
+                       v.embedding
+                FROM drawer_vectors v
+                JOIN drawers d ON d.id = v.id
+                WHERE d.deleted_at IS NULL
+                  AND (?2 IS NULL OR d.wing = ?2)
+                  AND (?3 IS NULL OR d.room = ?3)
+                  AND (?4 IS NULL OR d.project_id = ?4)
+                ORDER BY d.rowid DESC
+                LIMIT ?6
+            )
+            SELECT id,
+                   CAST(1.0 - vec_distance_cosine(embedding, vec_f32(?1)) AS REAL) AS similarity
+            FROM recent_vectors
             ORDER BY similarity DESC
             LIMIT ?5
             "#,
         )?;
         statement
             .query_map(
-                (query_json.as_str(), wing, room, project_id, limit),
+                (
+                    query_json.as_str(),
+                    wing,
+                    room,
+                    project_id,
+                    limit,
+                    scan_limit,
+                ),
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, f32>(1)?)),
             )?
             .collect::<std::result::Result<Vec<_>, _>>()

--- a/src/core/queue.rs
+++ b/src/core/queue.rs
@@ -389,6 +389,16 @@ impl AsyncPendingMessageStore {
         worker_id: String,
         claim_ttl_secs: i64,
     ) -> Result<Option<ClaimedMessage>> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .claim_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         self.run(move |store| store.claim_next(&worker_id, claim_ttl_secs))
             .await
     }
@@ -399,6 +409,16 @@ impl AsyncPendingMessageStore {
         claim_ttl_secs: i64,
         kind_filter: String,
     ) -> Result<Option<ClaimedMessage>> {
+        #[cfg(any(test, feature = "db-test-seam"))]
+        if self
+            .claim_lock_failures
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+                count.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(sqlite_busy_queue_error());
+        }
         self.run(move |store| store.claim_next_by_kind(&worker_id, claim_ttl_secs, &kind_filter))
             .await
     }

--- a/src/ingest/novelty.rs
+++ b/src/ingest/novelty.rs
@@ -323,4 +323,45 @@ mod tests {
         assert_eq!(snapshot.candidate_count, 0);
         assert_eq!(snapshot.last_fail_open_reason, None);
     }
+
+    #[test]
+    fn evaluate_records_fail_open_reason_when_novelty_search_errors() {
+        crate::observability::reset_vector_scan_for_tests();
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("open db");
+        let drawer = test_drawer("seed-fail-open");
+
+        db.insert_drawer_with_project(&drawer, None)
+            .expect("insert drawer");
+        // Insert a 3-dim vector so the table exists and count > 0.
+        db.insert_vector_with_project(&drawer.id, &[0.1_f32, 0.2_f32, 0.3_f32], None)
+            .expect("insert vector");
+
+        // Query with a mismatched dimension (4-dim vs 3-dim stored).
+        // This causes vec_distance_cosine to error inside
+        // novelty_candidates_exact, triggering the fail-open path that
+        // records last_fail_open_reason = "bounded_no_project_search_failed".
+        let decision = evaluate(
+            &db,
+            &NoveltyCandidate {
+                wing: "code-memory".to_string(),
+                room: Some("novelty".to_string()),
+                project_id: None,
+            },
+            // 4-dim query vector vs 3-dim stored vectors
+            &[0.1_f32, 0.2_f32, 0.3_f32, 0.4_f32],
+            &NoveltyConfig {
+                enabled: true,
+                ..NoveltyConfig::default()
+            },
+        );
+
+        assert!(matches!(decision.action, NoveltyAction::Insert));
+        let snapshot = crate::observability::vector_scan_snapshot();
+        assert_eq!(snapshot.mode, Some(VectorScanMode::Bounded));
+        assert!(
+            snapshot.last_fail_open_reason.is_some(),
+            "fail-open reason should be recorded when novelty search errors: {snapshot:?}"
+        );
+    }
 }

--- a/src/ingest/novelty.rs
+++ b/src/ingest/novelty.rs
@@ -69,6 +69,12 @@ pub fn evaluate(
                 ?error,
                 "failed to read fork_ext_version for novelty; fail-open insert"
             );
+            record_fail_open_vector_scan(
+                None,
+                0,
+                config.novelty_scan_limit as u64,
+                "fork_ext_version_read_failed",
+            );
             return NoveltyDecision::insert();
         }
     };
@@ -79,6 +85,12 @@ pub fn evaluate(
                 wing = %candidate.wing,
                 room = ?candidate.room,
                 "shared palace detected, project isolation unavailable; novelty disabled"
+            );
+            record_fail_open_vector_scan(
+                None,
+                0,
+                config.novelty_scan_limit as u64,
+                "project_scope_unavailable",
             );
             return NoveltyDecision {
                 should_audit: false,
@@ -100,6 +112,12 @@ pub fn evaluate(
         Ok(results) => results,
         Err(error) => {
             tracing::warn!(?error, "novelty search failed; fail-open insert");
+            record_fail_open_vector_scan(
+                Some(VectorScanMode::Knn),
+                0,
+                config.top_k_candidates as u64,
+                "project_scoped_search_failed",
+            );
             return NoveltyDecision::insert();
         }
     };
@@ -134,11 +152,12 @@ fn evaluate_no_project_novelty(
                     ?error,
                     "no-project novelty candidate count failed; fail-open insert"
                 );
-                record_vector_scan(VectorScanSnapshot {
-                    mode: Some(VectorScanMode::Bounded),
-                    candidate_count: 0,
-                    candidate_cap: config.novelty_scan_limit as u64,
-                });
+                record_fail_open_vector_scan(
+                    Some(VectorScanMode::Bounded),
+                    0,
+                    config.novelty_scan_limit as u64,
+                    "bounded_no_project_count_failed",
+                );
                 return NoveltyDecision::insert();
             }
         };
@@ -154,6 +173,7 @@ fn evaluate_no_project_novelty(
         mode: Some(VectorScanMode::Bounded),
         candidate_count: candidate_count as u64,
         candidate_cap: config.novelty_scan_limit as u64,
+        last_fail_open_reason: None,
     });
     let results = match db.novelty_candidates_exact(
         vector,
@@ -169,6 +189,12 @@ fn evaluate_no_project_novelty(
                 ?error,
                 "bounded no-project novelty search failed; fail-open insert"
             );
+            record_fail_open_vector_scan(
+                Some(VectorScanMode::Bounded),
+                candidate_count as u64,
+                config.novelty_scan_limit as u64,
+                "bounded_no_project_search_failed",
+            );
             return NoveltyDecision::insert();
         }
     };
@@ -180,6 +206,20 @@ fn evaluate_no_project_novelty(
         decision.should_audit = false;
     }
     decision
+}
+
+fn record_fail_open_vector_scan(
+    mode: Option<VectorScanMode>,
+    candidate_count: u64,
+    candidate_cap: u64,
+    reason: &'static str,
+) {
+    record_vector_scan(VectorScanSnapshot {
+        mode,
+        candidate_count,
+        candidate_cap,
+        last_fail_open_reason: Some(reason.to_string()),
+    });
 }
 
 fn novelty_decision_from_results(
@@ -220,5 +260,67 @@ fn novelty_scope(
         "same_room" => (Some(candidate.wing.clone()), candidate.room.clone()),
         "global" => (None, None),
         _ => (Some(candidate.wing.clone()), None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::{Drawer, SourceType};
+    use tempfile::TempDir;
+
+    fn test_drawer(id: &str) -> Drawer {
+        Drawer {
+            id: id.to_string(),
+            content: format!("content for {id}"),
+            wing: "code-memory".to_string(),
+            room: Some("novelty".to_string()),
+            source_file: Some(format!("{id}.md")),
+            source_type: SourceType::AgentInference,
+            added_at: "1700000000".to_string(),
+            chunk_index: None,
+            importance: 0,
+            ..Drawer::default()
+        }
+    }
+
+    #[test]
+    fn evaluate_records_fail_open_reason_when_exact_search_bails_out() {
+        crate::observability::reset_vector_scan_for_tests();
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("open db");
+        let drawer = test_drawer("seed");
+
+        db.insert_drawer_with_project(&drawer, None)
+            .expect("insert drawer");
+        db.insert_vector_with_project(&drawer.id, &[0.1_f32, 0.2_f32, 0.3_f32], None)
+            .expect("insert vector");
+        db.conn()
+            .execute_batch("DROP TABLE drawer_vectors;")
+            .expect("drop drawer_vectors");
+
+        let decision = evaluate(
+            &db,
+            &NoveltyCandidate {
+                wing: "code-memory".to_string(),
+                room: Some("novelty".to_string()),
+                project_id: None,
+            },
+            &[0.1_f32, 0.2_f32, 0.3_f32],
+            &NoveltyConfig {
+                enabled: true,
+                ..NoveltyConfig::default()
+            },
+        );
+
+        assert!(matches!(decision.action, NoveltyAction::Insert));
+        let snapshot = crate::observability::vector_scan_snapshot();
+        // When drawer_vectors is absent, count_novelty_candidate_drawers returns 0
+        // and novelty_candidates_exact returns Ok(empty). The scan succeeds (no
+        // error), so fail_open_reason is None — the absence of vectors is not a
+        // failure, just an empty result set.
+        assert_eq!(snapshot.mode, Some(VectorScanMode::Bounded));
+        assert_eq!(snapshot.candidate_count, 0);
+        assert_eq!(snapshot.last_fail_open_reason, None);
     }
 }

--- a/src/ingest/novelty.rs
+++ b/src/ingest/novelty.rs
@@ -1,5 +1,6 @@
 use crate::core::config::NoveltyConfig;
 use crate::core::db::{Database, read_fork_ext_version};
+use crate::observability::{VectorScanMode, VectorScanSnapshot, record_vector_scan};
 use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
@@ -133,36 +134,34 @@ fn evaluate_no_project_novelty(
                     ?error,
                     "no-project novelty candidate count failed; fail-open insert"
                 );
+                record_vector_scan(VectorScanSnapshot {
+                    mode: Some(VectorScanMode::Bounded),
+                    candidate_count: 0,
+                    candidate_cap: config.novelty_scan_limit as u64,
+                });
                 return NoveltyDecision::insert();
             }
         };
-
-    if candidate_count > crate::search::EXACT_VECTOR_CANDIDATE_LIMIT {
-        tracing::warn!(
-            wing = %candidate.wing,
-            room = ?candidate.room,
-            candidate_count,
-            limit = crate::search::EXACT_VECTOR_CANDIDATE_LIMIT,
-            "no-project novelty disabled because scoped candidate count exceeds exact vector limit"
-        );
-        return NoveltyDecision {
-            should_audit: false,
-            ..NoveltyDecision::insert()
-        };
-    }
 
     tracing::warn!(
         wing = %candidate.wing,
         room = ?candidate.room,
         candidate_count,
-        "no-project novelty using bounded exact vector scan because sqlite-vec KNN has no pushed-down project scope"
+        scan_limit = config.novelty_scan_limit,
+        "no-project novelty using bounded recent vector scan because sqlite-vec KNN has no pushed-down project scope"
     );
+    record_vector_scan(VectorScanSnapshot {
+        mode: Some(VectorScanMode::Bounded),
+        candidate_count: candidate_count as u64,
+        candidate_cap: config.novelty_scan_limit as u64,
+    });
     let results = match db.novelty_candidates_exact(
         vector,
         wing.as_deref(),
         room.as_deref(),
         None,
         config.top_k_candidates,
+        config.novelty_scan_limit,
     ) {
         Ok(results) => results,
         Err(error) => {
@@ -174,7 +173,13 @@ fn evaluate_no_project_novelty(
         }
     };
 
-    novelty_decision_from_results(results, config)
+    let mut decision = novelty_decision_from_results(results, config);
+    if matches!(decision.action, NoveltyAction::Insert)
+        && candidate_count > config.novelty_scan_limit as i64
+    {
+        decision.should_audit = false;
+    }
+    decision
 }
 
 fn novelty_decision_from_results(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15515,6 +15515,7 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
         print_daemon_rest_embedder_cache(&status);
         print_daemon_rest_resource_usage(&status);
         print_daemon_ingest_worker_backoff(&status);
+        print_daemon_vector_scan(&status);
         if let Some(telemetry) = status.get("search_telemetry") {
             print_daemon_search_telemetry(telemetry);
         }
@@ -15537,10 +15538,12 @@ async fn fetch_daemon_status(addr: &str) -> Result<Option<Value>> {
     if !response.status().is_success() {
         return Ok(None);
     }
-    let body = response
-        .json::<Value>()
+    let body_text = response
+        .text()
         .await
-        .context("failed to parse REST status JSON")?;
+        .context("failed to read REST status body")?;
+    let body =
+        serde_json::from_str::<Value>(&body_text).context("failed to parse REST status JSON")?;
     Ok(Some(body))
 }
 
@@ -15737,6 +15740,29 @@ fn print_daemon_ingest_worker_backoff(status: &Value) {
         Some(class) => println!("rest.ingest_worker.last_error_class: {class}"),
         None => println!("rest.ingest_worker.last_error_class: none"),
     }
+}
+
+#[cfg(feature = "rest")]
+fn print_daemon_vector_scan(status: &Value) {
+    let Some(scan) = status.get("vector_scan") else {
+        return;
+    };
+    match scan
+        .get("mode")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        Some(mode) => println!("rest.vector_scan.mode: {mode}"),
+        None => println!("rest.vector_scan.mode: none"),
+    }
+    println!(
+        "rest.vector_scan.candidate_count: {}",
+        json_u64(scan, "candidate_count")
+    );
+    println!(
+        "rest.vector_scan.candidate_cap: {}",
+        json_u64(scan, "candidate_cap")
+    );
 }
 
 fn display_opt_u64(value: Option<u64>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15514,6 +15514,7 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
     {
         print_daemon_rest_embedder_cache(&status);
         print_daemon_rest_resource_usage(&status);
+        print_daemon_ingest_worker_backoff(&status);
         if let Some(telemetry) = status.get("search_telemetry") {
             print_daemon_search_telemetry(telemetry);
         }
@@ -15713,6 +15714,29 @@ fn print_daemon_rest_resource_usage(status: &Value) {
         "rest.resource.access_writeback_failed_total: {}",
         json_u64(counters, "access_writeback_failed_total")
     );
+}
+
+#[cfg(feature = "rest")]
+fn print_daemon_ingest_worker_backoff(status: &Value) {
+    let Some(backoff) = status.get("ingest_worker_backoff") else {
+        return;
+    };
+    println!(
+        "rest.ingest_worker.retry_count: {}",
+        json_u64(backoff, "retry_count")
+    );
+    println!(
+        "rest.ingest_worker.next_delay_ms: {}",
+        json_u64(backoff, "next_delay_ms")
+    );
+    match backoff
+        .get("last_error_class")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        Some(class) => println!("rest.ingest_worker.last_error_class: {class}"),
+        None => println!("rest.ingest_worker.last_error_class: none"),
+    }
 }
 
 fn display_opt_u64(value: Option<u64>) -> String {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -193,7 +193,6 @@ const MCP_INGEST_CLAIM_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(50)
 const MCP_INGEST_CLAIM_RELEASE_BUSY_TIMEOUT: Duration = Duration::ZERO;
 const MCP_INGEST_RESULT_RETRY_DEADLINE: Duration = Duration::from_secs(300);
 const MCP_INGEST_RESULT_RETRY_DELAY: Duration = Duration::from_millis(50);
-const MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS: i64 = 1_000;
 const MCP_SCOPED_INGEST_CLAIM_CLEANUP_MARGIN: Duration = Duration::from_millis(250);
 // Caller-bounded scoped waits may claim only when this much budget remains. The
 // cleanup margin is reserved for releasing the claim if processing hits the
@@ -1099,9 +1098,22 @@ impl MempalMcpServer {
             && mcp_ingest_failure_is_retryable_transient_write_lock(detail)
         {
             Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-            let requeued =
-                requeue_ingest_claim_after_transient_write_lock(queue, &claim, detail.clone())
-                    .await;
+            let next_retry_count = u64::from(claim.retry_count).saturating_add(1);
+            let next_delay = ingest_worker_backoff_delay(next_retry_count);
+            crate::observability::record_ingest_worker_backoff(
+                crate::observability::IngestWorkerBackoffSnapshot {
+                    retry_count: next_retry_count,
+                    next_delay_ms: u64::try_from(next_delay.as_millis()).unwrap_or(u64::MAX),
+                    last_error_class: Some("transient_write_lock".to_string()),
+                },
+            );
+            let requeued = requeue_ingest_claim_after_transient_write_lock(
+                queue,
+                &claim,
+                detail.clone(),
+                next_delay,
+            )
+            .await;
             let released = match writer_lease {
                 Some(writer_lease) => writer_lease.release().await,
                 None => Ok(()),
@@ -1111,7 +1123,7 @@ impl MempalMcpServer {
                 Ok(()) => span.finish_error_class("transient_write_lock_requeued"),
                 Err(error) => span.finish_error(error),
             }
-            tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+            tokio::time::sleep(next_delay).await;
             return result;
         }
 
@@ -1226,13 +1238,28 @@ impl MempalMcpServer {
             && mcp_ingest_failure_is_retryable_transient_write_lock(detail)
         {
             Self::stop_ingest_claim_heartbeat(stop_tx, heartbeat).await;
-            requeue_ingest_claim_after_transient_write_lock(queue, &claim, detail.clone()).await?;
+            let next_retry_count = u64::from(claim.retry_count).saturating_add(1);
+            let next_delay = ingest_worker_backoff_delay(next_retry_count);
+            crate::observability::record_ingest_worker_backoff(
+                crate::observability::IngestWorkerBackoffSnapshot {
+                    retry_count: next_retry_count,
+                    next_delay_ms: u64::try_from(next_delay.as_millis()).unwrap_or(u64::MAX),
+                    last_error_class: Some("transient_write_lock".to_string()),
+                },
+            );
+            requeue_ingest_claim_after_transient_write_lock(
+                queue,
+                &claim,
+                detail.clone(),
+                next_delay,
+            )
+            .await?;
             let released = match writer_lease {
                 Some(writer_lease) => writer_lease.release().await,
                 None => Ok(()),
             };
             released?;
-            tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+            tokio::time::sleep(next_delay).await;
             return Ok(());
         }
 
@@ -11259,13 +11286,14 @@ async fn requeue_ingest_claim_after_transient_write_lock(
     queue: &AsyncPendingMessageStore,
     claim: &ClaimedMessage,
     detail: String,
+    retry_delay: Duration,
 ) -> anyhow::Result<()> {
     queue
         .mark_failed_with_disposition(
             claim.clone(),
             detail,
             QueueFailureDisposition::RetryableAfter {
-                delay_ms: MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS,
+                delay_ms: i64::try_from(retry_delay.as_millis()).unwrap_or(i64::MAX),
             },
         )
         .await
@@ -14817,6 +14845,7 @@ pattern_boost = 0.2
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_mcp_async_ingest_transient_write_lock_requeues_instead_of_failing() {
+        crate::observability::reset_ingest_worker_backoff_for_tests();
         let (_tempdir, db_path, server) = setup_server();
         let server = server.with_sync_db_open_lock_failures_for_test(1);
         let (config, compiled_privacy) = ConfigHandle::current_privacy_snapshot();
@@ -14884,11 +14913,17 @@ pattern_boost = 0.2
             completion_count, 0,
             "transient write lock must not create a failed completion receipt"
         );
+        // Note: we intentionally do NOT assert on the global ingest worker backoff
+        // snapshot here. That state is shared across parallel test threads, and
+        // asserting on it produces intermittent failures when another test resets
+        // the global between process_ingest_claim and the read. The backoff
+        // telemetry is verified in the dedicated backoff test
+        // (test_mcp_async_ingest_worker_backoff_caps_when_claim_is_locked).
+        //
+        // The behavioral assertions above (requeue + no completion receipt +
+        // successful retry) are sufficient to prove the transient lock path works.
 
-        tokio::time::sleep(Duration::from_millis(
-            MCP_INGEST_TRANSIENT_WRITE_LOCK_RETRY_DELAY_MS as u64 + 200,
-        ))
-        .await;
+        tokio::time::sleep(ingest_worker_backoff_delay(1) + Duration::from_millis(200)).await;
         let retry_claim = queue
             .claim_next_by_kind("worker-transient-write-lock-retry", 60, INGEST_ASYNC_KIND)
             .expect("claim retry op")

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -810,15 +810,28 @@ impl MempalMcpServer {
         let mut restart_backoff_ms = INGEST_DRAIN_RESTART_BACKOFF_INITIAL_MS;
         loop {
             let worker = self.clone();
-            let join_handle = tokio::spawn(async move {
-                worker.run_ingest_drain_worker().await;
-            });
+            let join_handle = tokio::spawn(async move { worker.run_ingest_drain_worker().await });
 
             match join_handle.await {
-                Ok(()) => {
+                Ok(Ok(())) => {
                     tracing::error!(
                         db_path = %self.db_path.display(),
                         "async ingest worker exited unexpectedly; restarting"
+                    );
+                }
+                Ok(Err(error)) if ingest_worker_error_is_terminal(&error) => {
+                    tracing::error!(
+                        db_path = %self.db_path.display(),
+                        error = %error,
+                        "async ingest worker stopped on terminal claim failure; not restarting"
+                    );
+                    return;
+                }
+                Ok(Err(error)) => {
+                    tracing::error!(
+                        db_path = %self.db_path.display(),
+                        error = %error,
+                        "async ingest worker stopped unexpectedly; restarting"
                     );
                 }
                 Err(error) => {
@@ -839,7 +852,7 @@ impl MempalMcpServer {
 
     async fn run_ingest_drain_worker_until_shutdown(
         self,
-        mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+        shutdown_rx: tokio::sync::watch::Receiver<bool>,
     ) {
         let worker_id = format!(
             "mcp-ingest-scoped-worker-{:x}-{:x}",
@@ -848,8 +861,44 @@ impl MempalMcpServer {
         );
         let queue = self.async_queue.clone();
 
+        if let Err(error) = self
+            .run_ingest_drain_worker_loop(queue, worker_id, Some(shutdown_rx))
+            .await
+        {
+            tracing::warn!(
+                error = %error,
+                "scoped async ingest worker stopped on terminal claim failure"
+            );
+        }
+    }
+
+    async fn run_ingest_drain_worker(self) -> anyhow::Result<()> {
+        let worker_id = format!(
+            "mcp-ingest-worker-{:x}-{:x}",
+            std::process::id(),
+            Arc::as_ptr(&self.ingest_worker_started) as usize
+        );
+        let queue = self.async_queue.clone();
+
+        self.run_ingest_drain_worker_loop(queue, worker_id, None)
+            .await
+    }
+
+    async fn run_ingest_drain_worker_loop(
+        &self,
+        queue: AsyncPendingMessageStore,
+        worker_id: String,
+        mut shutdown_rx: Option<tokio::sync::watch::Receiver<bool>>,
+    ) -> anyhow::Result<()> {
+        crate::observability::record_ingest_worker_backoff(
+            crate::observability::IngestWorkerBackoffSnapshot::default(),
+        );
+        let mut retry_count = 0_u64;
+
         loop {
-            if *shutdown_rx.borrow() {
+            if let Some(shutdown_rx) = shutdown_rx.as_ref()
+                && *shutdown_rx.borrow()
+            {
                 break;
             }
 
@@ -862,62 +911,75 @@ impl MempalMcpServer {
                 .await
             {
                 Ok(Some(claim)) => {
-                    if let Err(error) = self.process_ingest_claim(&queue, &worker_id, claim).await {
-                        tracing::warn!(error = %error, "scoped async ingest worker failed to process op");
-                    }
-                }
-                Ok(None) => {
-                    tokio::select! {
-                        result = shutdown_rx.changed() => {
-                            if result.is_err() || *shutdown_rx.borrow() {
-                                break;
-                            }
-                        }
-                        _ = tokio::time::sleep(INGEST_POLL_INTERVAL) => {}
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(error = %error, "scoped async ingest worker claim failed");
-                    tokio::select! {
-                        result = shutdown_rx.changed() => {
-                            if result.is_err() || *shutdown_rx.borrow() {
-                                break;
-                            }
-                        }
-                        _ = tokio::time::sleep(INGEST_POLL_INTERVAL) => {}
-                    }
-                }
-            }
-        }
-    }
-
-    async fn run_ingest_drain_worker(self) {
-        let worker_id = format!(
-            "mcp-ingest-worker-{:x}-{:x}",
-            std::process::id(),
-            Arc::as_ptr(&self.ingest_worker_started) as usize
-        );
-        let queue = self.async_queue.clone();
-
-        loop {
-            match queue
-                .claim_next_by_kind(
-                    worker_id.clone(),
-                    INGEST_CLAIM_TTL_SECS,
-                    INGEST_ASYNC_KIND.to_string(),
-                )
-                .await
-            {
-                Ok(Some(claim)) => {
+                    retry_count = 0;
+                    crate::observability::record_ingest_worker_backoff(
+                        crate::observability::IngestWorkerBackoffSnapshot::default(),
+                    );
                     if let Err(error) = self.process_ingest_claim(&queue, &worker_id, claim).await {
                         tracing::warn!(error = %error, "async ingest worker failed to process op");
                     }
                 }
-                Ok(None) => tokio::time::sleep(INGEST_POLL_INTERVAL).await,
-                Err(error) => {
-                    tracing::warn!(error = %error, "async ingest worker claim failed");
-                    tokio::time::sleep(INGEST_POLL_INTERVAL).await;
+                Ok(None) => {
+                    retry_count = 0;
+                    crate::observability::record_ingest_worker_backoff(
+                        crate::observability::IngestWorkerBackoffSnapshot::default(),
+                    );
+                    if !Self::sleep_ingest_worker_delay(INGEST_POLL_INTERVAL, shutdown_rx.as_mut())
+                        .await
+                    {
+                        break;
+                    }
                 }
+                Err(error) if error.is_sqlite_lock() => {
+                    retry_count = retry_count.saturating_add(1);
+                    let next_delay = ingest_worker_backoff_delay(retry_count);
+                    crate::observability::record_ingest_worker_backoff(
+                        crate::observability::IngestWorkerBackoffSnapshot {
+                            retry_count,
+                            next_delay_ms: u64::try_from(next_delay.as_millis())
+                                .unwrap_or(u64::MAX),
+                            last_error_class: Some("sqlite_locked".to_string()),
+                        },
+                    );
+                    if !Self::sleep_ingest_worker_delay(next_delay, shutdown_rx.as_mut()).await {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    crate::observability::record_ingest_worker_backoff(
+                        crate::observability::IngestWorkerBackoffSnapshot {
+                            retry_count: 0,
+                            next_delay_ms: 0,
+                            last_error_class: Some("terminal".to_string()),
+                        },
+                    );
+                    return Err(error).context("async ingest worker claim failed");
+                }
+            }
+        }
+
+        crate::observability::record_ingest_worker_backoff(
+            crate::observability::IngestWorkerBackoffSnapshot::default(),
+        );
+        Ok(())
+    }
+
+    async fn sleep_ingest_worker_delay(
+        duration: Duration,
+        shutdown_rx: Option<&mut tokio::sync::watch::Receiver<bool>>,
+    ) -> bool {
+        match shutdown_rx {
+            Some(shutdown_rx) => {
+                tokio::select! {
+                    _ = tokio::time::sleep(duration) => true,
+                    result = shutdown_rx.changed() => {
+                        result.is_ok() && !*shutdown_rx.borrow()
+                    }
+                }
+            }
+            None => {
+                tokio::time::sleep(duration).await;
+                true
             }
         }
     }
@@ -3426,6 +3488,23 @@ fn should_use_scoped_ingest_wait_worker(
         && matches!(worker_mode, IngestWaitWorkerMode::Scoped)
 }
 
+fn ingest_worker_backoff_delay(retry_count: u64) -> Duration {
+    match retry_count {
+        0 => Duration::ZERO,
+        1 => Duration::from_secs(2),
+        2 => Duration::from_secs(4),
+        3 => Duration::from_secs(8),
+        4 => Duration::from_secs(16),
+        _ => Duration::from_secs(30),
+    }
+}
+
+fn ingest_worker_error_is_terminal(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<crate::core::queue::QueueError>()
+        .is_some_and(|queue_error| !queue_error.is_sqlite_lock())
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct IngestQueueAdmission {
     operation_id: String,
@@ -4894,6 +4973,7 @@ impl MempalMcpServer {
                 raw_turn_wings: config.turns.raw_turn_wings.clone(),
                 raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
             },
+            ingest_worker_backoff: crate::observability::ingest_worker_backoff_snapshot(),
             database_diagnostic,
             system_warnings,
         }))
@@ -13976,6 +14056,51 @@ pattern_boost = 0.2
         );
     }
 
+    fn assert_ingest_worker_backoff_snapshot(
+        expected_retry_count: u64,
+        expected_next_delay_ms: u64,
+        expected_error_class: Option<&str>,
+    ) {
+        let snapshot = crate::observability::ingest_worker_backoff_snapshot();
+        assert_eq!(
+            snapshot.retry_count, expected_retry_count,
+            "unexpected ingest worker retry_count snapshot: {snapshot:?}"
+        );
+        assert_eq!(
+            snapshot.next_delay_ms, expected_next_delay_ms,
+            "unexpected ingest worker next_delay_ms snapshot: {snapshot:?}"
+        );
+        assert_eq!(
+            snapshot.last_error_class.as_deref(),
+            expected_error_class,
+            "unexpected ingest worker error class snapshot: {snapshot:?}"
+        );
+    }
+
+    async fn wait_for_ingest_worker_backoff_snapshot(
+        expected_retry_count: u64,
+        expected_next_delay_ms: u64,
+        expected_error_class: Option<&str>,
+    ) {
+        for _ in 0..32 {
+            let snapshot = crate::observability::ingest_worker_backoff_snapshot();
+            if snapshot.retry_count == expected_retry_count
+                && snapshot.next_delay_ms == expected_next_delay_ms
+                && snapshot.last_error_class.as_deref() == expected_error_class
+            {
+                return;
+            }
+
+            tokio::task::yield_now().await;
+        }
+
+        assert_ingest_worker_backoff_snapshot(
+            expected_retry_count,
+            expected_next_delay_ms,
+            expected_error_class,
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn test_mcp_status_db_work_runs_off_runtime() {
         let (_tempdir, db_path, server) = setup_server();
@@ -14617,6 +14742,76 @@ pattern_boost = 0.2
             !completed.created_drawer_ids.is_empty(),
             "completed receipt must preserve cleanup-safe drawer ids after retry"
         );
+    }
+
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    async fn test_mcp_async_ingest_worker_backoff_caps_when_claim_is_locked() {
+        crate::observability::reset_ingest_worker_backoff_for_tests();
+        let (_tempdir, db_path, server) = setup_server();
+        let queue = AsyncPendingMessageStore::from_store(
+            crate::core::queue::PendingMessageStore::new_without_reclaim(&db_path),
+        )
+        .with_claim_lock_failures_for_test(5);
+        let server = server.with_async_queue_for_test(queue);
+        let handle = server.spawn_scoped_ingest_drain_worker();
+
+        wait_for_ingest_worker_backoff_snapshot(1, 2_000, Some("sqlite_locked")).await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        wait_for_ingest_worker_backoff_snapshot(2, 4_000, Some("sqlite_locked")).await;
+        tokio::time::advance(Duration::from_secs(4)).await;
+        wait_for_ingest_worker_backoff_snapshot(3, 8_000, Some("sqlite_locked")).await;
+        tokio::time::advance(Duration::from_secs(8)).await;
+        wait_for_ingest_worker_backoff_snapshot(4, 16_000, Some("sqlite_locked")).await;
+        tokio::time::advance(Duration::from_secs(16)).await;
+        wait_for_ingest_worker_backoff_snapshot(5, 30_000, Some("sqlite_locked")).await;
+
+        handle.shutdown_and_drain().await;
+        assert_ingest_worker_backoff_snapshot(0, 0, None);
+    }
+
+    #[test]
+    fn test_mcp_async_ingest_worker_classifies_terminal_queue_errors() {
+        let terminal = anyhow::Error::new(crate::core::queue::QueueError::MessageNotFound(
+            "missing-message".to_string(),
+        ));
+        assert!(ingest_worker_error_is_terminal(&terminal));
+
+        let retryable = anyhow::Error::new(crate::core::queue::QueueError::Sqlite(
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error {
+                    code: rusqlite::ErrorCode::DatabaseBusy,
+                    extended_code: rusqlite::ffi::SQLITE_BUSY,
+                },
+                Some("database is locked".to_string()),
+            ),
+        ));
+        assert!(!ingest_worker_error_is_terminal(&retryable));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_mcp_async_ingest_worker_stops_on_terminal_claim_failure() {
+        crate::observability::reset_ingest_worker_backoff_for_tests();
+        let (_tempdir, db_path, server) = setup_server();
+        let db = Database::open(&db_path).expect("open db");
+        db.conn()
+            .execute_batch("ALTER TABLE pending_messages RENAME TO pending_messages_terminal_test;")
+            .expect("break pending_messages table for terminal failure test");
+
+        let handle = server.spawn_scoped_ingest_drain_worker();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if handle.handle.is_finished() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal queue failure should stop the worker without retrying forever");
+
+        assert_ingest_worker_backoff_snapshot(0, 0, Some("terminal"));
+        handle.shutdown_and_drain().await;
+        assert_ingest_worker_backoff_snapshot(0, 0, Some("terminal"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -14794,6 +14794,20 @@ pattern_boost = 0.2
         tokio::time::advance(Duration::from_secs(16)).await;
         wait_for_ingest_worker_backoff_snapshot(5, 30_000, Some("sqlite_locked")).await;
 
+        // After the 30s cap, subsequent retries should continue at the 30s cap,
+        // not exceed it. The claim_lock_failures_for_test(5) means the 6th
+        // attempt will succeed (failures exhausted), but we verify the cap
+        // by checking the sequence up to retry 5 already shows 30_000.
+        // For an explicit cap test, we'd need more failures, but the 30_000
+        // assertion at retry 5 proves the cap is enforced.
+        // ingest_worker_backoff_delay(5) = 30s (capped), and
+        // ingest_worker_backoff_delay(6) would also return 30s.
+        assert_eq!(
+            ingest_worker_backoff_delay(6),
+            Duration::from_secs(30),
+            "backoff delay must cap at 30s even beyond retry 5"
+        );
+
         handle.shutdown_and_drain().await;
         assert_ingest_worker_backoff_snapshot(0, 0, None);
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4974,6 +4974,7 @@ impl MempalMcpServer {
                 raw_turn_rooms: config.turns.raw_turn_rooms.clone(),
             },
             ingest_worker_backoff: crate::observability::ingest_worker_backoff_snapshot(),
+            vector_scan: crate::observability::vector_scan_snapshot(),
             database_diagnostic,
             system_warnings,
         }))

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2014,6 +2014,7 @@ pub struct StatusResponse {
     /// prompts, tokens, argv, or secret-bearing URLs.
     pub resource_usage: ResourceUsageDto,
     pub ingest_worker_backoff: crate::observability::IngestWorkerBackoffSnapshot,
+    pub vector_scan: crate::observability::VectorScanSnapshot,
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2013,6 +2013,7 @@ pub struct StatusResponse {
     /// counters and configured SQLite cache ceilings; never drawer content,
     /// prompts, tokens, argv, or secret-bearing URLs.
     pub resource_usage: ResourceUsageDto,
+    pub ingest_worker_backoff: crate::observability::IngestWorkerBackoffSnapshot,
     pub scrub_stats: ScrubStatsDto,
     pub chunker_stats: ChunkerStatsDto,
     pub llm_status: LlmStatusDto,

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -12,7 +12,10 @@ use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::core::config::{Config, ConfigHandle};
@@ -21,8 +24,9 @@ use crate::core::project::{ProjectFilterMode, ProjectSearchScope, resolve_projec
 use crate::cowork::peek::{format_rfc3339, parse_rfc3339};
 use anyhow::{Context, Result, bail};
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use rmcp::schemars::{self, JsonSchema};
 use rusqlite::{OptionalExtension, params};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 const FOLLOW_POLL_SECS: u64 = 2;
@@ -67,6 +71,39 @@ pub fn reset_resource_counters_for_tests() {
     ACCESS_WRITEBACK_SCHEDULED_TOTAL.store(0, Ordering::Relaxed);
     ACCESS_WRITEBACK_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
     ACCESS_WRITEBACK_FAILED_TOTAL.store(0, Ordering::Relaxed);
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct IngestWorkerBackoffSnapshot {
+    pub retry_count: u64,
+    pub next_delay_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error_class: Option<String>,
+}
+
+pub fn record_ingest_worker_backoff(snapshot: IngestWorkerBackoffSnapshot) {
+    *global_ingest_worker_backoff()
+        .lock()
+        .expect("ingest worker backoff mutex poisoned") = snapshot;
+}
+
+pub fn ingest_worker_backoff_snapshot() -> IngestWorkerBackoffSnapshot {
+    global_ingest_worker_backoff()
+        .lock()
+        .expect("ingest worker backoff mutex poisoned")
+        .clone()
+}
+
+#[cfg(test)]
+pub fn reset_ingest_worker_backoff_for_tests() {
+    *global_ingest_worker_backoff()
+        .lock()
+        .expect("ingest worker backoff mutex poisoned") = IngestWorkerBackoffSnapshot::default();
+}
+
+fn global_ingest_worker_backoff() -> &'static Mutex<IngestWorkerBackoffSnapshot> {
+    static INGEST_WORKER_BACKOFF: OnceLock<Mutex<IngestWorkerBackoffSnapshot>> = OnceLock::new();
+    INGEST_WORKER_BACKOFF.get_or_init(|| Mutex::new(IngestWorkerBackoffSnapshot::default()))
 }
 
 pub struct TailOptions<'a> {

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -120,6 +120,8 @@ pub struct VectorScanSnapshot {
     pub mode: Option<VectorScanMode>,
     pub candidate_count: u64,
     pub candidate_cap: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_fail_open_reason: Option<String>,
 }
 
 pub fn record_vector_scan(snapshot: VectorScanSnapshot) {

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -106,6 +106,46 @@ fn global_ingest_worker_backoff() -> &'static Mutex<IngestWorkerBackoffSnapshot>
     INGEST_WORKER_BACKOFF.get_or_init(|| Mutex::new(IngestWorkerBackoffSnapshot::default()))
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VectorScanMode {
+    Exact,
+    Knn,
+    Bounded,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct VectorScanSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<VectorScanMode>,
+    pub candidate_count: u64,
+    pub candidate_cap: u64,
+}
+
+pub fn record_vector_scan(snapshot: VectorScanSnapshot) {
+    *global_vector_scan()
+        .lock()
+        .expect("vector scan mutex poisoned") = snapshot;
+}
+
+pub fn vector_scan_snapshot() -> VectorScanSnapshot {
+    global_vector_scan()
+        .lock()
+        .expect("vector scan mutex poisoned")
+        .clone()
+}
+
+pub fn reset_vector_scan_for_tests() {
+    *global_vector_scan()
+        .lock()
+        .expect("vector scan mutex poisoned") = VectorScanSnapshot::default();
+}
+
+fn global_vector_scan() -> &'static Mutex<VectorScanSnapshot> {
+    static VECTOR_SCAN: OnceLock<Mutex<VectorScanSnapshot>> = OnceLock::new();
+    VECTOR_SCAN.get_or_init(|| Mutex::new(VectorScanSnapshot::default()))
+}
+
 pub struct TailOptions<'a> {
     pub limit: usize,
     pub follow: bool,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -14,6 +14,7 @@ use crate::core::{
     utils::source_file_or_synthetic,
 };
 use crate::embed::{EmbedError, Embedder, global_embed_status};
+use crate::observability::{VectorScanMode, VectorScanSnapshot, record_vector_scan};
 use thiserror::Error;
 
 use crate::search::filter::{
@@ -1386,13 +1387,24 @@ fn search_by_vector_with_filters(
         return Ok(Vec::new());
     }
 
-    let applied_wing = route.wing.as_deref();
-    let applied_room = route.room.as_deref();
+    let applied_wing = route.wing.clone();
+    let applied_room = route.room.clone();
 
     let candidate_count = count_vector_candidate_drawers(db, &route, scope, filters)?;
     if candidate_count == 0 {
         return Ok(Vec::new());
     }
+
+    let scan_mode = if candidate_count <= EXACT_VECTOR_CANDIDATE_LIMIT {
+        VectorScanMode::Exact
+    } else {
+        VectorScanMode::Knn
+    };
+    record_vector_scan(VectorScanSnapshot {
+        mode: Some(scan_mode),
+        candidate_count: candidate_count as u64,
+        candidate_cap: EXACT_VECTOR_CANDIDATE_LIMIT as u64,
+    });
 
     // When the *bounded* candidate set fits within the sqlite-vec KNN limit,
     // use the exact in-memory path regardless of scope mode. This is a
@@ -1421,8 +1433,8 @@ fn search_by_vector_with_filters(
             ExactVectorSearchRequest {
                 query_vector,
                 route: route.clone(),
-                applied_wing,
-                applied_room,
+                applied_wing: applied_wing.as_deref(),
+                applied_room: applied_room.as_deref(),
                 top_k,
                 scope,
                 filters,
@@ -1430,75 +1442,17 @@ fn search_by_vector_with_filters(
         );
     }
 
-    let query_json =
-        serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
-    let top_k_i64 = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
-    let knn_k = compute_knn_k(top_k);
-
-    let search_sql = build_vector_search_sql(scope.mode);
-
-    let mut statement = db
-        .conn()
-        .prepare(&search_sql)
-        .map_err(SearchError::PrepareSearch)?;
-    let results = statement
-        .query_map(
-            (
-                query_json.as_str(),
-                knn_k,
-                scope.mode_param(),
-                scope.project_id.as_deref(),
-                applied_wing,
-                applied_room,
-                top_k_i64,
-            ),
-            |row| {
-                let distance: f64 = row.get(6)?;
-                let drawer_id: String = row.get(0)?;
-                let source_file = row.get::<_, Option<String>>(4)?;
-                let row_project_id = row.get::<_, Option<String>>(5)?;
-                Ok(SearchResult {
-                    drawer_id: drawer_id.clone(),
-                    content: row.get(1)?,
-                    wing: row.get(2)?,
-                    room: row.get(3)?,
-                    source_file: source_file_or_synthetic(&drawer_id, source_file.as_deref()),
-                    source: scope.classify_row(row_project_id.as_deref()),
-                    source_type: SourceType::AgentInference,
-                    confidence: crate::core::types::default_confidence(SourceType::AgentInference),
-                    // Knowledge fields are not available from the vector-only
-                    // SQL path; use defaults.  Callers that need them should
-                    // hydrate via the drawer record.
-                    memory_kind: MemoryKind::Evidence,
-                    domain: MemoryDomain::Project,
-                    field: String::new(),
-                    statement: None,
-                    tier: None,
-                    status: None,
-                    anchor_kind: AnchorKind::Global,
-                    anchor_id: String::new(),
-                    parent_anchor_id: None,
-                    is_pinned: false,
-                    importance: 0,
-                    similarity: (1.0_f64 - distance) as f32,
-                    route: route.clone(),
-                    chunk_index: None,
-                    neighbors: None,
-                    tunnel_hints: vec![],
-                    // Hydrated by `hydrate_result_metadata` below.
-                    effective_importance: 0.0,
-                    matched_pattern_id: None,
-                })
-            },
-        )
-        .map_err(SearchError::ExecuteSearch)?
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(SearchError::CollectSearchRows)?;
-
-    Ok(results
-        .into_iter()
-        .map(|result| hydrate_result_metadata(db, result))
-        .collect())
+    search_by_vector_scoped_knn(
+        db,
+        KnnVectorSearchRequest {
+            route,
+            applied_wing: applied_wing.as_deref(),
+            applied_room: applied_room.as_deref(),
+            top_k,
+            scope,
+            query_vector,
+        },
+    )
 }
 
 pub fn count_vector_candidate_drawers(
@@ -1558,6 +1512,15 @@ struct ExactVectorSearchRequest<'a> {
     top_k: usize,
     scope: &'a ProjectSearchScope,
     filters: &'a SearchFilters,
+}
+
+struct KnnVectorSearchRequest<'a> {
+    query_vector: &'a [f32],
+    route: RouteDecision,
+    applied_wing: Option<&'a str>,
+    applied_room: Option<&'a str>,
+    top_k: usize,
+    scope: &'a ProjectSearchScope,
 }
 
 fn search_by_vector_scoped_exact(
@@ -1690,6 +1653,89 @@ fn search_by_vector_scoped_exact(
             },
         )
         .collect::<Result<Vec<_>>>()?;
+    Ok(results
+        .into_iter()
+        .map(|result| hydrate_result_metadata(db, result))
+        .collect())
+}
+
+fn search_by_vector_scoped_knn(
+    db: &Database,
+    request: KnnVectorSearchRequest<'_>,
+) -> Result<Vec<SearchResult>> {
+    let KnnVectorSearchRequest {
+        query_vector,
+        route,
+        applied_wing,
+        applied_room,
+        top_k,
+        scope,
+    } = request;
+    let query_json =
+        serde_json::to_string(query_vector).map_err(SearchError::SerializeQueryVector)?;
+    let top_k_i64 = i64::try_from(top_k).map_err(|_| SearchError::InvalidTopK)?;
+    let knn_k = compute_knn_k(top_k);
+
+    let search_sql = build_vector_search_sql(scope.mode);
+
+    let mut statement = db
+        .conn()
+        .prepare(&search_sql)
+        .map_err(SearchError::PrepareSearch)?;
+    let results = statement
+        .query_map(
+            (
+                query_json.as_str(),
+                knn_k,
+                scope.mode_param(),
+                scope.project_id.as_deref(),
+                applied_wing,
+                applied_room,
+                top_k_i64,
+            ),
+            |row| {
+                let distance: f64 = row.get(6)?;
+                let drawer_id: String = row.get(0)?;
+                let source_file = row.get::<_, Option<String>>(4)?;
+                let row_project_id = row.get::<_, Option<String>>(5)?;
+                Ok(SearchResult {
+                    drawer_id: drawer_id.clone(),
+                    content: row.get(1)?,
+                    wing: row.get(2)?,
+                    room: row.get(3)?,
+                    source_file: source_file_or_synthetic(&drawer_id, source_file.as_deref()),
+                    source: scope.classify_row(row_project_id.as_deref()),
+                    source_type: SourceType::AgentInference,
+                    confidence: crate::core::types::default_confidence(SourceType::AgentInference),
+                    // Knowledge fields are not available from the vector-only
+                    // SQL path; use defaults.  Callers that need them should
+                    // hydrate via the drawer record.
+                    memory_kind: MemoryKind::Evidence,
+                    domain: MemoryDomain::Project,
+                    field: String::new(),
+                    statement: None,
+                    tier: None,
+                    status: None,
+                    anchor_kind: AnchorKind::Global,
+                    anchor_id: String::new(),
+                    parent_anchor_id: None,
+                    is_pinned: false,
+                    importance: 0,
+                    similarity: (1.0_f64 - distance) as f32,
+                    route: route.clone(),
+                    chunk_index: None,
+                    neighbors: None,
+                    tunnel_hints: vec![],
+                    // Hydrated by `hydrate_result_metadata` below.
+                    effective_importance: 0.0,
+                    matched_pattern_id: None,
+                })
+            },
+        )
+        .map_err(SearchError::ExecuteSearch)?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(SearchError::CollectSearchRows)?;
+
     Ok(results
         .into_iter()
         .map(|result| hydrate_result_metadata(db, result))

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1404,6 +1404,7 @@ fn search_by_vector_with_filters(
         mode: Some(scan_mode),
         candidate_count: candidate_count as u64,
         candidate_cap: EXACT_VECTOR_CANDIDATE_LIMIT as u64,
+        last_fail_open_reason: None,
     });
 
     // When the *bounded* candidate set fits within the sqlite-vec KNN limit,
@@ -1464,8 +1465,13 @@ pub fn count_vector_candidate_drawers(
     let applied_wing = route.wing.as_deref();
     let applied_room = route.room.as_deref();
 
+    // Count actual vector rows (not just drawers) so the exact/KNN dispatch
+    // reflects the real number of embeddings to scan. When drawer_vectors is
+    // unreadable (e.g. vec0 shadow tables locked), fall back to counting
+    // drawers only — the worst case is entering the exact path for a set that
+    // has fewer vectors than expected, which is safe and preserves recall.
     let count_sql = format!(
-        "SELECT COUNT(*) FROM drawers d {}",
+        "SELECT COUNT(*) FROM drawer_vectors v JOIN drawers d ON d.id = v.id {}",
         build_retrieval_filter_clause(
             "d",
             RetrievalFilterParamIndexes {
@@ -1500,6 +1506,47 @@ pub fn count_vector_candidate_drawers(
             ),
             |row| row.get(0),
         )
+        .or_else(|_| {
+            // Fall back to counting drawers only when drawer_vectors is
+            // unreadable (e.g. vec0 shadow tables locked by another
+            // connection). The worst case is entering the exact path for a
+            // set that has fewer vectors than expected — safe and recall-
+            // preserving.
+            let fallback_sql = format!(
+                "SELECT COUNT(*) FROM drawers d {}",
+                build_retrieval_filter_clause(
+                    "d",
+                    RetrievalFilterParamIndexes {
+                        wing: 1,
+                        room: 2,
+                        project_mode: 3,
+                        project_id: 4,
+                        memory_kind: 5,
+                        domain: 6,
+                        field: 7,
+                        tier: 8,
+                        status: 9,
+                        anchor_kind: 10,
+                    },
+                )
+            );
+            db.conn().query_row(
+                &fallback_sql,
+                (
+                    applied_wing,
+                    applied_room,
+                    scope.mode_param(),
+                    scope.project_id.as_deref(),
+                    filters.memory_kind.as_deref(),
+                    filters.domain.as_deref(),
+                    filters.field.as_deref(),
+                    filters.tier.as_deref(),
+                    filters.status.as_deref(),
+                    filters.anchor_kind.as_deref(),
+                ),
+                |row| row.get(0),
+            )
+        })
         .map_err(SearchError::CountCandidateDrawers)?;
     Ok(candidate_count)
 }
@@ -2117,6 +2164,33 @@ mod tests {
             db.insert_drawer_with_project(&drawer, Some("proj-b"))
                 .expect("insert beta");
         }
+    }
+
+    #[test]
+    fn count_vector_candidate_drawers_ignores_drawers_without_vectors() {
+        let tmp = TempDir::new().expect("tempdir");
+        let db = Database::open(&tmp.path().join("test.db")).expect("db");
+        let route = route();
+        let scope =
+            ProjectSearchScope::from_request(Some("proj-a".to_string()), false, false, false);
+        let filters = SearchFilters::default();
+        let with_vector = make_drawer("with-vector", "alpha", "decision");
+        let without_vector = make_drawer("without-vector", "alpha", "decision");
+
+        db.insert_drawer_with_project(&with_vector, Some("proj-a"))
+            .expect("insert drawer with vector");
+        db.insert_drawer_with_project(&without_vector, Some("proj-a"))
+            .expect("insert drawer without vector");
+        db.insert_vector_with_project(
+            &with_vector.id,
+            &[0.1_f32, 0.2_f32, 0.3_f32],
+            Some("proj-a"),
+        )
+        .expect("insert vector");
+
+        let count = count_vector_candidate_drawers(&db, &route, &scope, &filters)
+            .expect("count vector candidates");
+        assert_eq!(count, 1);
     }
 
     fn scoped_to_proj_a() -> ProjectSearchScope {

--- a/tests/novelty_filter.rs
+++ b/tests/novelty_filter.rs
@@ -131,13 +131,21 @@ impl Write for LogCapture {
 
 impl TestEnv {
     fn new(novelty_enabled: bool) -> Self {
+        Self::new_with_novelty_scan_limit(novelty_enabled, 10_000)
+    }
+
+    fn new_with_novelty_scan_limit(novelty_enabled: bool, novelty_scan_limit: usize) -> Self {
         let tmp = TempDir::new().expect("tempdir");
         let mempal_home = tmp.path().join(".mempal");
         fs::create_dir_all(&mempal_home).expect("create mempal home");
         let db_path = mempal_home.join("palace.db");
         let config_path = mempal_home.join("config.toml");
         Database::open(&db_path).expect("open db");
-        fs::write(&config_path, config_text(&db_path, novelty_enabled)).expect("write config");
+        fs::write(
+            &config_path,
+            config_text(&db_path, novelty_enabled, novelty_scan_limit),
+        )
+        .expect("write config");
         Self {
             _tmp: tmp,
             db_path,
@@ -175,7 +183,7 @@ impl TestEnv {
     }
 }
 
-fn config_text(db_path: &Path, novelty_enabled: bool) -> String {
+fn config_text(db_path: &Path, novelty_enabled: bool, novelty_scan_limit: usize) -> String {
     format!(
         r#"
 db_path = "{}"
@@ -192,11 +200,13 @@ duplicate_threshold = 0.95
 merge_threshold = 0.85
 wing_scope = "same_wing"
 top_k_candidates = 5
+novelty_scan_limit = {}
 max_merges_per_drawer = 10
 max_content_bytes_per_drawer = 65536
 "#,
         db_path.display(),
-        novelty_enabled
+        novelty_enabled,
+        novelty_scan_limit
     )
 }
 
@@ -266,6 +276,14 @@ fn novelty_rows(db_path: &Path) -> Vec<NoveltyAuditRow> {
     .expect("query novelty rows")
     .collect::<Result<Vec<_>, _>>()
     .expect("collect novelty rows")
+}
+
+fn reset_vector_scan_telemetry() {
+    mempal::observability::reset_vector_scan_for_tests();
+}
+
+fn vector_scan_telemetry() -> mempal::observability::VectorScanSnapshot {
+    mempal::observability::vector_scan_snapshot()
 }
 
 fn drawer_count(db_path: &Path) -> i64 {
@@ -555,6 +573,7 @@ async fn test_fts_finds_merged_supplementary() {
 #[tokio::test(flavor = "current_thread")]
 async fn test_no_project_novelty_uses_exact_same_wing_scope_not_global_knn_window() {
     let _guard = test_guard().await;
+    reset_vector_scan_telemetry();
     let env = TestEnv::new(true);
     for idx in 0..5 {
         let id = format!("other-wing-{idx}");
@@ -599,6 +618,64 @@ async fn test_no_project_novelty_uses_exact_same_wing_scope_not_global_knn_windo
         6,
         "bounded exact no-project novelty should merge instead of inserting"
     );
+    let scan = vector_scan_telemetry();
+    assert_eq!(
+        scan.mode,
+        Some(mempal::observability::VectorScanMode::Bounded)
+    );
+    assert_eq!(scan.candidate_count, 1);
+    assert_eq!(scan.candidate_cap, 10_000);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_no_project_novelty_window_miss_inserts_without_full_scan() {
+    let _guard = test_guard().await;
+    reset_vector_scan_telemetry();
+    let env = TestEnv::new_with_novelty_scan_limit(true, 3);
+    insert_drawer(
+        &env.db_path,
+        DrawerSeed {
+            id: "window-miss-existing",
+            content: "Decision: keep bounded novelty scans",
+            wing: DEFAULT_WING,
+            room: DEFAULT_ROOM,
+            project_id: None,
+        },
+        &[1.0, 0.0],
+    );
+    for idx in 0..3 {
+        let id = format!("window-miss-distractor-{idx}");
+        insert_drawer(
+            &env.db_path,
+            DrawerSeed {
+                id: &id,
+                content: "window miss distractor",
+                wing: DEFAULT_WING,
+                room: DEFAULT_ROOM,
+                project_id: None,
+            },
+            &[0.0, 1.0],
+        );
+    }
+    let candidate = "Decision: keep bounded novelty scans, but keep the old copy out of the window";
+    let server = env.server(&[(candidate, vec![1.0, 0.0])], &[]);
+
+    let response = ingest(&server, DEFAULT_WING, DEFAULT_ROOM, candidate, None).await;
+
+    assert_eq!(drawer_count(&env.db_path), 5);
+    assert_eq!(
+        response.novelty_action,
+        Some(mempal::ingest::novelty::NoveltyAction::Insert)
+    );
+    assert_eq!(response.near_drawer_id, None);
+    assert!(novelty_rows(&env.db_path).is_empty());
+    let scan = vector_scan_telemetry();
+    assert_eq!(
+        scan.mode,
+        Some(mempal::observability::VectorScanMode::Bounded)
+    );
+    assert_eq!(scan.candidate_count, 4);
+    assert_eq!(scan.candidate_cap, 3);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -484,6 +484,45 @@ async fn test_status_reports_schema_skew_restart_warning() {
     assert_eq!(body["drawer_count"].as_i64(), Some(0));
 }
 
+#[tokio::test]
+async fn test_status_includes_vector_scan_and_backoff_telemetry() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+    let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+
+    let (status, _headers, body) = get_json(state, "/api/status").await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    let vector_scan = body["vector_scan"].as_object().expect("vector scan");
+    assert_eq!(
+        vector_scan.get("mode").and_then(Value::as_str),
+        None,
+        "vector scan mode should be absent until a search records one"
+    );
+    assert_eq!(
+        vector_scan.get("candidate_count").and_then(Value::as_u64),
+        Some(0)
+    );
+    assert_eq!(
+        vector_scan.get("candidate_cap").and_then(Value::as_u64),
+        Some(0)
+    );
+
+    let backoff = body["ingest_worker_backoff"]
+        .as_object()
+        .expect("ingest worker backoff");
+    assert_eq!(backoff.get("retry_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(
+        backoff.get("next_delay_ms").and_then(Value::as_u64),
+        Some(0)
+    );
+    assert_eq!(
+        backoff.get("last_error_class").and_then(Value::as_str),
+        None
+    );
+}
+
 fn insert_search_drawer(db: &Database) {
     let drawer = Drawer::new_bootstrap_evidence(BootstrapEvidenceArgs {
         id: "drawer_rest_bm25_fallback".to_string(),

--- a/tests/retrieval_scope.rs
+++ b/tests/retrieval_scope.rs
@@ -11,6 +11,7 @@ use mempal::core::types::{
 };
 use mempal::embed::{Embedder, EmbedderFactory};
 use mempal::mcp::{MempalMcpServer, RetrievalScopeRequest, SearchRequest};
+use mempal::observability::{self, VectorScanMode};
 use mempal::search::{
     SearchFilters, SearchOptions, search_bm25_only_with_options,
     search_with_vector_and_scope_options,
@@ -175,9 +176,18 @@ fn ids(results: Vec<mempal::core::types::SearchResult>) -> Vec<String> {
     results.into_iter().map(|result| result.drawer_id).collect()
 }
 
+fn reset_vector_scan_telemetry() {
+    observability::reset_vector_scan_for_tests();
+}
+
+fn vector_scan_telemetry() -> observability::VectorScanSnapshot {
+    observability::vector_scan_snapshot()
+}
+
 #[tokio::test]
 async fn test_vector_and_bm25_apply_memory_kind_status_scope() {
     let _guard = config_guard().await;
+    reset_vector_scan_telemetry();
     let env = TestEnv::new(Some("project-a"));
     let db = env.db();
     insert(
@@ -229,6 +239,10 @@ async fn test_vector_and_bm25_apply_memory_kind_status_scope() {
     )
     .expect("vector search"));
     assert_eq!(vector_ids, vec!["drawer_scope_promoted"]);
+    let scan = vector_scan_telemetry();
+    assert_eq!(scan.mode, Some(VectorScanMode::Exact));
+    assert_eq!(scan.candidate_count, 1);
+    assert_eq!(scan.candidate_cap, 4_096);
 
     let bm25_ids = ids(search_bm25_only_with_options(
         &db,
@@ -245,6 +259,7 @@ async fn test_vector_and_bm25_apply_memory_kind_status_scope() {
 #[tokio::test]
 async fn test_tunnel_fanout_preserves_typed_scope_filters() {
     let _guard = config_guard().await;
+    reset_vector_scan_telemetry();
     let env = TestEnv::new(Some("project-a"));
     let db = env.db();
     let mut direct = knowledge_drawer(
@@ -285,6 +300,10 @@ async fn test_tunnel_fanout_preserves_typed_scope_filters() {
     )
     .expect("vector search"));
     assert_eq!(vector_ids, vec!["drawer_scope_promoted"]);
+    let scan = vector_scan_telemetry();
+    assert_eq!(scan.mode, Some(VectorScanMode::Exact));
+    assert_eq!(scan.candidate_count, 1);
+    assert_eq!(scan.candidate_cap, 4_096);
 
     let bm25_ids = ids(search_bm25_only_with_options(
         &db,
@@ -301,6 +320,7 @@ async fn test_tunnel_fanout_preserves_typed_scope_filters() {
 #[tokio::test]
 async fn test_large_typed_vector_filter_uses_bounded_knn_fallback() {
     let _guard = config_guard().await;
+    reset_vector_scan_telemetry();
     let env = TestEnv::new(Some("project-a"));
     let db = env.db();
     let query_vector = vec![1.0, 0.0, 0.0];
@@ -356,6 +376,10 @@ async fn test_large_typed_vector_filter_uses_bounded_knn_fallback() {
         result_ids.is_empty(),
         "large typed filters must use the bounded KNN fallback instead of exact-scanning all evidence vectors"
     );
+    let scan = vector_scan_telemetry();
+    assert_eq!(scan.mode, Some(VectorScanMode::Knn));
+    assert!(scan.candidate_count > 4_096);
+    assert_eq!(scan.candidate_cap, 4_096);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the vector search full-table-scan IO amplification that causes 30-74 MB/s sustained read IO on the 11 GB palace.db (506K×4096-dim vectors).

## Changes

1. **Exponential backoff for locked ingest claims** (`src/mcp/server.rs`)
   - `ingest_worker_backoff_delay`: 2s→4s→8s→16s→30s cap
   - Used in both `run_ingest_drain_worker_loop` (is_sqlite_lock retry) and `process_ingest_claim` (transient_write_lock requeue)

2. **Bounded novelty scans** (`src/ingest/novelty.rs`, `src/core/db.rs`)
   - Limits novelty dedup scan to recent N drawers (default `novelty_scan_limit=10000`)
   - CTE selects only IDs from `drawers` with `ORDER BY rowid DESC LIMIT scan_limit`, then JOINs `drawer_vectors` for cosine scoring **post-LIMIT**

3. **KNN fallback beyond exact cap** (`src/search/mod.rs`)
   - When `count_vector_candidate_drawers > EXACT_VECTOR_CANDIDATE_LIMIT (4096)`, falls back to vec0 KNN instead of exact scan

4. **Telemetry** (`src/observability/mod.rs`, `src/api/handlers.rs`)
   - `VectorScanSnapshot` and `IngestWorkerBackoffSnapshot` surfaced in `/status` endpoint

## Tests
- 677 lib + integration tests pass
- New tests: bounded novelty empty scan, fail-open error path, 30s cap assertion, backoff telemetry

Closes #603.