### PR TITLE
fix(strata): keep hermes facts out of raw turns (#599)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1232,7 +1232,12 @@ async fn process_ingest_request(
     let validated = validate_ingest_request(&request)?;
     let project_id = resolve_project_id(request.project_id.as_deref(), config.as_ref(), None)
         .map_err(internal_error)?;
-    let raw_turn = is_raw_turn(&request.wing, request.room.as_deref(), &config.turns);
+    let raw_turn = is_raw_turn(
+        &request.wing,
+        request.room.as_deref(),
+        validated.typed_memory_kind.as_ref(),
+        &config.turns,
+    );
     if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
         return Ok(IngestResponse {
             drawer_id: String::new(),
@@ -1243,9 +1248,13 @@ async fn process_ingest_request(
             fact_check_warnings: Vec::new(),
         });
     }
-    let drawer_importance =
-        raw_turn_importance(&request.wing, request.room.as_deref(), &config.turns)
-            .unwrap_or_else(|| request.importance.unwrap_or(0));
+    let drawer_importance = raw_turn_importance(
+        &request.wing,
+        request.room.as_deref(),
+        validated.typed_memory_kind.as_ref(),
+        &config.turns,
+    )
+    .unwrap_or_else(|| request.importance.unwrap_or(0));
 
     // Chunk the content using the token-aware chunker (issue #57).
     let chunks =

--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -368,6 +368,14 @@ pub enum DbError {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawTurnClassificationRow {
+    pub wing: String,
+    pub room: Option<String>,
+    pub memory_kind: MemoryKind,
+    pub importance: i32,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FtsMetadataFilters<'a> {
     pub memory_kind: Option<&'a str>,
@@ -2468,6 +2476,29 @@ impl Database {
                     row.get::<_, Option<String>>(1)?,
                     row.get::<_, i64>(2)?,
                 ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    pub fn raw_turn_classification_rows(&self) -> Result<Vec<RawTurnClassificationRow>, DbError> {
+        let mut statement = self.conn.prepare(
+            r#"
+            SELECT wing, room, memory_kind, importance
+            FROM drawers
+            WHERE deleted_at IS NULL
+            "#,
+        )?;
+        let rows = statement
+            .query_map([], |row| {
+                let memory_kind =
+                    memory_kind_from_str(&row.get::<_, String>(2)?).map_err(row_decode_error)?;
+                Ok(RawTurnClassificationRow {
+                    wing: row.get::<_, String>(0)?,
+                    room: row.get::<_, Option<String>>(1)?,
+                    memory_kind,
+                    importance: row.get::<_, i32>(3)?,
+                })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)

--- a/src/core/strata.rs
+++ b/src/core/strata.rs
@@ -1,8 +1,17 @@
 use super::config::{TurnStorageMode, TurnsConfig};
 use super::db::{Database, DbError};
-use super::types::{Drawer, SearchResult};
+use super::types::{Drawer, MemoryKind, SearchResult};
 
-pub fn is_raw_turn(wing: &str, room: Option<&str>, config: &TurnsConfig) -> bool {
+pub fn is_raw_turn(
+    wing: &str,
+    room: Option<&str>,
+    memory_kind: Option<&MemoryKind>,
+    config: &TurnsConfig,
+) -> bool {
+    if room == Some("facts") || memory_kind.is_some_and(|kind| kind == &MemoryKind::ProfileFact) {
+        return false;
+    }
+
     config
         .raw_turn_wings
         .iter()
@@ -21,23 +30,30 @@ pub fn should_store_raw_turns(mode: &TurnStorageMode) -> bool {
     matches!(mode, TurnStorageMode::RawEvidence)
 }
 
-pub fn raw_turn_importance(wing: &str, room: Option<&str>, config: &TurnsConfig) -> Option<i32> {
-    is_raw_turn(wing, room, config).then_some(config.default_importance)
+pub fn raw_turn_importance(
+    wing: &str,
+    room: Option<&str>,
+    memory_kind: Option<&MemoryKind>,
+    config: &TurnsConfig,
+) -> Option<i32> {
+    is_raw_turn(wing, room, memory_kind, config).then_some(config.default_importance)
 }
 
 pub fn is_excluded_raw_turn(
     wing: &str,
     room: Option<&str>,
+    memory_kind: &MemoryKind,
     importance: i32,
     config: &TurnsConfig,
 ) -> bool {
-    importance == 0 && is_raw_turn(wing, room, config)
+    importance == 0 && is_raw_turn(wing, room, Some(memory_kind), config)
 }
 
 pub fn is_excluded_raw_turn_result(result: &SearchResult, config: &TurnsConfig) -> bool {
     is_excluded_raw_turn(
         &result.wing,
         result.room.as_deref(),
+        &result.memory_kind,
         result.importance,
         config,
     )
@@ -47,6 +63,7 @@ pub fn is_excluded_raw_turn_drawer(drawer: &Drawer, config: &TurnsConfig) -> boo
     is_excluded_raw_turn(
         &drawer.wing,
         drawer.room.as_deref(),
+        &drawer.memory_kind,
         drawer.importance,
         config,
     )
@@ -54,11 +71,18 @@ pub fn is_excluded_raw_turn_drawer(drawer: &Drawer, config: &TurnsConfig) -> boo
 
 pub fn count_raw_turn_drawers(db: &Database, config: &TurnsConfig) -> Result<i64, DbError> {
     Ok(db
-        .scope_counts()?
+        .raw_turn_classification_rows()?
         .into_iter()
-        .filter(|(wing, room, _)| is_raw_turn(wing, room.as_deref(), config))
-        .map(|(_, _, count)| count)
-        .sum())
+        .filter(|row| {
+            is_excluded_raw_turn(
+                &row.wing,
+                row.room.as_deref(),
+                &row.memory_kind,
+                row.importance,
+                config,
+            )
+        })
+        .count() as i64)
 }
 
 #[cfg(test)]
@@ -73,10 +97,21 @@ mod tests {
             ..TurnsConfig::default()
         };
 
-        assert!(is_raw_turn("hooks-raw", Some("user-prompt"), &config));
-        assert!(is_raw_turn("hermes-user/alice", Some("facts"), &config));
-        assert!(is_raw_turn("project", Some("turns"), &config));
-        assert!(!is_raw_turn("project", Some("decision"), &config));
+        assert!(is_raw_turn("hooks-raw", Some("user-prompt"), None, &config));
+        assert!(!is_raw_turn(
+            "hermes-user/alice",
+            Some("facts"),
+            None,
+            &config
+        ));
+        assert!(is_raw_turn("project", Some("turns"), None, &config));
+        assert!(!is_raw_turn("project", Some("decision"), None, &config));
+        assert!(!is_raw_turn(
+            "hermes-user/alice",
+            Some("turns"),
+            Some(&MemoryKind::ProfileFact),
+            &config
+        ));
     }
 
     #[test]
@@ -87,6 +122,6 @@ mod tests {
             ..TurnsConfig::default()
         };
 
-        assert!(!is_raw_turn("project", Some("decision"), &config));
+        assert!(!is_raw_turn("project", Some("decision"), None, &config));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2005,9 +2005,12 @@ fn build_drawer_records(
 }
 
 fn apply_turn_strata(record: &mut DrawerRecord, config: &crate::core::config::Config) {
-    if let Some(importance) =
-        raw_turn_importance(&record.wing, Some(record.room.as_str()), &config.turns)
-    {
+    if let Some(importance) = raw_turn_importance(
+        &record.wing,
+        Some(record.room.as_str()),
+        None,
+        &config.turns,
+    ) {
         record.importance = importance;
     }
 }
@@ -2017,7 +2020,7 @@ fn should_keep_drawer_record(record: &DrawerRecord, config: &crate::core::config
 }
 
 fn raw_turn_storage_disabled(wing: &str, room: &str, config: &crate::core::config::Config) -> bool {
-    is_raw_turn(wing, Some(room), &config.turns)
+    is_raw_turn(wing, Some(room), None, &config.turns)
         && !should_store_raw_turns(&config.turns.storage_mode)
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -263,7 +263,7 @@ fn should_drop_hook_capture(event: HookEvent, bytes: &[u8], config: &Config) -> 
 
 fn is_raw_turn_for_hook_event(event: HookEvent, bytes: &[u8], config: &Config) -> bool {
     let (wing, room) = raw_turn_target_for_hook_event(event, bytes);
-    is_raw_turn(wing, Some(room.as_str()), &config.turns)
+    is_raw_turn(wing, Some(room.as_str()), None, &config.turns)
 }
 
 fn raw_turn_target_for_hook_event(event: HookEvent, bytes: &[u8]) -> (&'static str, String) {

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -406,7 +406,12 @@ pub async fn ingest_file_with_options_and_writer_lease<E: Embedder + ?Sized>(
             route_room_from_taxonomy(&scrubbed, wing, &taxonomy)
         }
     };
-    let raw_turn = is_raw_turn(wing, Some(resolved_room.as_str()), &config.turns);
+    let raw_turn = is_raw_turn(
+        wing,
+        Some(resolved_room.as_str()),
+        options.memory_kind.as_ref(),
+        &config.turns,
+    );
     if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
         return Ok(IngestStats {
             files: 1,
@@ -415,8 +420,13 @@ pub async fn ingest_file_with_options_and_writer_lease<E: Embedder + ?Sized>(
             ..IngestStats::default()
         });
     }
-    let drawer_importance =
-        raw_turn_importance(wing, Some(resolved_room.as_str()), &config.turns).unwrap_or(0);
+    let drawer_importance = raw_turn_importance(
+        wing,
+        Some(resolved_room.as_str()),
+        options.memory_kind.as_ref(),
+        &config.turns,
+    )
+    .unwrap_or(0);
     let source_display = path.to_string_lossy();
     let chunker_config = &config.chunker;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5942,8 +5942,9 @@ fn resolve_stdin_ingest(
     let cwd = env::current_dir().ok();
     let project_id = resolve_project_id(project, config, cwd.as_deref())
         .context("failed to resolve stdin ingest project id")?;
-    let raw_turn = is_raw_turn(&wing, room.as_deref(), &config.turns);
-    let drawer_importance = raw_turn_importance(&wing, room.as_deref(), &config.turns).unwrap_or(0);
+    let raw_turn = is_raw_turn(&wing, room.as_deref(), Some(&memory_kind), &config.turns);
+    let drawer_importance =
+        raw_turn_importance(&wing, room.as_deref(), Some(&memory_kind), &config.turns).unwrap_or(0);
 
     Ok(ResolvedStdinIngest {
         content,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6185,7 +6185,8 @@ impl MempalMcpServer {
             .await?;
         let wait = request.wait.unwrap_or(false);
         let wait_timeout_secs = request.wait_timeout_secs.unwrap_or(30);
-        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
+        let memory_kind = parse_memory_kind(request.memory_kind.as_deref())?;
+        let raw_turn = is_raw_turn(&request.wing, room, memory_kind.as_ref(), &config.turns);
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
                 operation_id: None,
@@ -6677,12 +6678,22 @@ impl MempalMcpServer {
             .as_deref()
             .map(|value| config.scrub_content_with_compiled(value, compiled_privacy));
         let room = request.room.as_deref();
-        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
-        let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
-            .unwrap_or_else(|| request.importance.unwrap_or(0));
         let source_type = parse_source_type_param(request.source_type.as_deref())?;
         let confidence = resolve_confidence_param(source_type, request.confidence)?;
         let metadata = validate_ingest_request(request, &source_type)?;
+        let raw_turn = is_raw_turn(
+            &request.wing,
+            room,
+            Some(&metadata.memory_kind),
+            &config.turns,
+        );
+        let drawer_importance = raw_turn_importance(
+            &request.wing,
+            room,
+            Some(&metadata.memory_kind),
+            &config.turns,
+        )
+        .unwrap_or_else(|| request.importance.unwrap_or(0));
         let scrubbed_replace_text = request
             .replace_text
             .as_deref()
@@ -6849,7 +6860,15 @@ impl MempalMcpServer {
         let mut request_system_warnings = system_warnings_with_stale_index(&db);
         let no_gate = controls.no_gate;
         let bypass_novelty = controls.bypass_novelty;
-        let raw_turn = is_raw_turn(&request.wing, room, &config.turns);
+        let source_type = parse_source_type_param(request.source_type.as_deref())?;
+        let confidence = resolve_confidence_param(source_type, request.confidence)?;
+        let metadata = validate_ingest_request(&request, &source_type)?;
+        let raw_turn = is_raw_turn(
+            &request.wing,
+            room,
+            Some(&metadata.memory_kind),
+            &config.turns,
+        );
         if raw_turn && !should_store_raw_turns(&config.turns.storage_mode) {
             return Ok(Json(IngestResponse {
                 operation_id: None,
@@ -6874,11 +6893,13 @@ impl MempalMcpServer {
                 system_warnings: request_system_warnings,
             }));
         }
-        let drawer_importance = raw_turn_importance(&request.wing, room, &config.turns)
-            .unwrap_or_else(|| request.importance.unwrap_or(0));
-        let source_type = parse_source_type_param(request.source_type.as_deref())?;
-        let confidence = resolve_confidence_param(source_type, request.confidence)?;
-        let metadata = validate_ingest_request(&request, &source_type)?;
+        let drawer_importance = raw_turn_importance(
+            &request.wing,
+            room,
+            Some(&metadata.memory_kind),
+            &config.turns,
+        )
+        .unwrap_or_else(|| request.importance.unwrap_or(0));
         let mut timings = BTreeMap::new();
 
         let embedder = self.embedder_factory.build().await.map_err(|error| {

--- a/tests/rest_typed_ingest.rs
+++ b/tests/rest_typed_ingest.rs
@@ -265,6 +265,50 @@ async fn test_typed_ingest_persists_memory_kind() {
 }
 
 #[tokio::test]
+async fn test_hermes_user_facts_are_visible_in_default_rest_timeline() {
+    let _guard = TEST_LOCK.lock().await;
+    let env = TestEnv::new();
+
+    let (status, body) = post_json(
+        env.state(Arc::new(StaticEmbedderFactory { dim: 4 })),
+        "/api/ingest",
+        json!({
+            "content": "Hermes user fact should remain durable.",
+            "wing": "hermes-user/obj/default",
+            "room": "facts",
+            "memory_kind": "profile_fact",
+            "domain": "user",
+            "field": "preferences",
+            "importance": 4,
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED, "body={body}");
+    let drawer_id = body["drawer_id"].as_str().expect("drawer_id").to_string();
+    let drawer = env
+        .db()
+        .get_drawer(&drawer_id)
+        .expect("load drawer")
+        .expect("drawer exists");
+    assert_eq!(drawer.importance, 4);
+
+    let (status, timeline) = get_json(
+        env.state(Arc::new(StaticEmbedderFactory { dim: 4 })),
+        "/api/timeline?limit=10",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "timeline={timeline}");
+    let entries = timeline.as_array().expect("timeline response is an array");
+    let entry = entries
+        .iter()
+        .find(|entry| entry["drawer_id"].as_str() == Some(drawer_id.as_str()))
+        .expect("hermes-user facts drawer should be visible without include_raw_turns=true");
+    assert_eq!(entry["importance"].as_i64(), Some(4));
+}
+
+#[tokio::test]
 async fn test_typed_ingest_status_and_tier() {
     let _guard = TEST_LOCK.lock().await;
     let env = TestEnv::new();


### PR DESCRIPTION
## Summary

Fixes #599: Hermes `mempal_conclude` facts stored with `wing=hermes-user/obj/default` + `room=facts` were classified as raw turns by `is_raw_turn` and filtered from REST timeline/search/`mempal_profile`.

## Root Cause

`src/core/strata.rs::is_raw_turn` used `wing.starts_with(prefix)` which treated ALL `hermes-user/...` wings as raw, including durable facts (`room=facts`, `memory_kind=profile_fact`).

## Changes

- `is_raw_turn` now excludes `room=facts` and `memory_kind=profile_fact` from raw-turn classification
- Importance from REST/Hermes `mempal_conclude` is preserved instead of being overridden by raw-turn default
- Regression test: ingest with `wing='hermes-user/obj/default'`, `room='facts'`, verify REST `/api/timeline` returns it without `include_raw_turns=true`
- Raw conversation-turn suppression preserved for actual raw turn rooms (`turns`, `turns/raw`)

## Review

CSA review: PASS (5m 8s, no blocking findings)

Closes #599.