### PR TITLE
feat(observability): add io burst telemetry (#583)

### DIFF
--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -522,6 +522,7 @@ struct StatusResponse {
     search_mode: String,
     embedder_circuit: EmbedderCircuitStatus,
     resource_usage: ResourceUsageStatus,
+    io_burst: crate::observability::IoBurstSnapshot,
     write_queue: WriteQueueStats,
     feature_flags: FeatureFlags,
     hermes_compat_version: String,
@@ -1673,6 +1674,7 @@ async fn status_handler(State(state): State<ApiState>) -> Result<Json<StatusResp
             .to_string(),
         embedder_circuit: vector_search_circuit.into(),
         resource_usage,
+        io_burst: crate::observability::io_burst_snapshot(),
         write_queue: state.write_queue().stats(),
         feature_flags: FeatureFlags {
             typed_ingest: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12977,6 +12977,7 @@ fn status_command(db: &Database, config: &Config, full: bool) -> Result<()> {
         println!("triples: {triple_count}");
     }
     println!("db_size_bytes: {db_size_bytes}");
+    print_io_burst_snapshot(&observability::io_burst_snapshot(), "");
     println!("Source Types:");
     if source_type_counts.is_empty() {
         println!("  none");
@@ -15515,6 +15516,7 @@ fn run_daemon_status(db_path: &Path) -> Result<()> {
     {
         print_daemon_rest_embedder_cache(&status);
         print_daemon_rest_resource_usage(&status);
+        print_daemon_rest_io_burst(&status);
         print_daemon_ingest_worker_backoff(&status);
         print_daemon_vector_scan(&status);
         if let Some(telemetry) = status.get("search_telemetry") {
@@ -15607,6 +15609,50 @@ fn print_daemon_process_report(pid: i32, prefix: &str) {
         println!(
             "{prefix}warning: daemon binary has been deleted or replaced; run `mempal daemon restart` after upgrade"
         );
+    }
+}
+
+fn print_io_burst_snapshot(snapshot: &observability::IoBurstSnapshot, prefix: &str) {
+    println!("{prefix}IO Bursts:");
+    println!(
+        "{prefix}  high_read_threshold_bytes: {}",
+        snapshot.high_read_threshold_bytes
+    );
+    println!("{prefix}  sample_count: {}", snapshot.sample_count);
+    println!(
+        "{prefix}  high_read_sample_count: {}",
+        snapshot.high_read_sample_count
+    );
+    println!("{prefix}  total_read_bytes: {}", snapshot.total_read_bytes);
+    println!(
+        "{prefix}  total_logical_read_bytes: {}",
+        snapshot.total_logical_read_bytes
+    );
+    println!(
+        "{prefix}  peak_read_bytes_per_sec: {}",
+        snapshot.peak_read_bytes_per_sec
+    );
+    println!(
+        "{prefix}  avg_read_bytes_per_sec: {}",
+        snapshot.avg_read_bytes_per_sec
+    );
+    if snapshot.paths.is_empty() {
+        println!("{prefix}  paths: none");
+    } else {
+        println!("{prefix}  paths:");
+        for path in &snapshot.paths {
+            println!(
+                "{prefix}    {}: samples={} high_read_samples={} total_read_bytes={} peak_read_bytes={} avg_read_bytes={} peak_read_bytes_per_sec={} avg_read_bytes_per_sec={}",
+                path.path.as_str(),
+                path.sample_count,
+                path.high_read_sample_count,
+                path.total_read_bytes,
+                path.peak_read_bytes,
+                path.avg_read_bytes,
+                path.peak_read_bytes_per_sec,
+                path.avg_read_bytes_per_sec
+            );
+        }
     }
 }
 
@@ -15717,6 +15763,29 @@ fn print_daemon_rest_resource_usage(status: &Value) {
     println!(
         "rest.resource.access_writeback_failed_total: {}",
         json_u64(counters, "access_writeback_failed_total")
+    );
+}
+
+#[cfg(feature = "rest")]
+fn print_daemon_rest_io_burst(status: &Value) {
+    let Some(io_burst) = status.get("io_burst") else {
+        return;
+    };
+    println!(
+        "rest.io_burst.sample_count: {}",
+        json_u64(io_burst, "sample_count")
+    );
+    println!(
+        "rest.io_burst.high_read_sample_count: {}",
+        json_u64(io_burst, "high_read_sample_count")
+    );
+    println!(
+        "rest.io_burst.total_read_bytes: {}",
+        json_u64(io_burst, "total_read_bytes")
+    );
+    println!(
+        "rest.io_burst.peak_read_bytes_per_sec: {}",
+        json_u64(io_burst, "peak_read_bytes_per_sec")
     );
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4962,6 +4962,7 @@ impl MempalMcpServer {
             },
             db_holders,
             resource_usage,
+            io_burst: crate::observability::io_burst_snapshot(),
             scrub_stats: ScrubStatsDto::from(ConfigHandle::scrub_stats()),
             chunker_stats: ChunkerStatsDto::from(
                 crate::ingest::chunk::global_chunker_stats().snapshot(),
@@ -15651,6 +15652,18 @@ prototypes = ["keep"]
         keys
     }
 
+    fn io_burst_path(
+        snapshot: &crate::observability::IoBurstSnapshot,
+        path: crate::observability::IoOperationPath,
+    ) -> crate::observability::IoBurstPathSnapshot {
+        snapshot
+            .paths
+            .iter()
+            .find(|candidate| candidate.path == path)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     #[tokio::test]
     async fn test_mempal_status_compact_default_omits_protocol_but_keeps_health() {
         let (_tempdir, db_path, server) = setup_server();
@@ -15684,6 +15697,17 @@ prototypes = ["keep"]
                 crate::core::queue::QueueFailureDisposition::Terminal,
             )
             .expect("mark terminal failed");
+        let before_io_burst = crate::observability::io_burst_snapshot();
+        let before_search = io_burst_path(
+            &before_io_burst,
+            crate::observability::IoOperationPath::Search,
+        );
+        crate::observability::record_io_burst_sample(
+            crate::observability::IoOperationPath::Search,
+            12_000,
+            24_000,
+            3,
+        );
 
         let status = server.mempal_status().await.expect("status").0;
         let json = serde_json::to_value(&status).expect("serialize compact status");
@@ -15709,6 +15733,31 @@ prototypes = ["keep"]
         assert!(json.get("endpoint_health").is_some());
         assert!(json.get("intelligence_status").is_some());
         assert!(json.get("resource_usage").is_some());
+        assert!(json.get("io_burst").is_some());
+        assert!(
+            status
+                .io_burst
+                .total_read_bytes
+                .saturating_sub(before_io_burst.total_read_bytes)
+                >= 12_000
+        );
+        let search_io_burst = io_burst_path(
+            &status.io_burst,
+            crate::observability::IoOperationPath::Search,
+        );
+        assert!(
+            search_io_burst
+                .sample_count
+                .saturating_sub(before_search.sample_count)
+                >= 1
+        );
+        assert!(
+            search_io_burst
+                .total_read_bytes
+                .saturating_sub(before_search.total_read_bytes)
+                >= 12_000
+        );
+        assert!(search_io_burst.peak_read_bytes_per_sec >= 4_000_000);
         assert!(status.resource_usage.sqlite.async_pool_loaded);
         assert_eq!(
             status.resource_usage.sqlite.per_connection_cache_bytes,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2013,6 +2013,10 @@ pub struct StatusResponse {
     /// counters and configured SQLite cache ceilings; never drawer content,
     /// prompts, tokens, argv, or secret-bearing URLs.
     pub resource_usage: ResourceUsageDto,
+    /// Aggregate per-operation-path read burst counters. Contains only numeric
+    /// deltas/rates and path classes; never drawer content, prompts, raw
+    /// payloads, argv, or secret-bearing URLs.
+    pub io_burst: crate::observability::IoBurstSnapshot,
     pub ingest_worker_backoff: crate::observability::IngestWorkerBackoffSnapshot,
     pub vector_scan: crate::observability::VectorScanSnapshot,
     pub scrub_stats: ScrubStatsDto,

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -7,8 +7,10 @@ pub use operation_telemetry::{
     render_operation_telemetry_summary,
 };
 
+use std::collections::BTreeMap;
 use std::env;
 use std::ffi::OsStr;
+use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
@@ -34,6 +36,7 @@ const FOLLOW_DEBOUNCE_MS: u64 = 250;
 const FOLLOW_SILENCE_TIMEOUT_MS: u64 = 3_000;
 const PREVIEW_CHARS: usize = 120;
 const GATING_STATUS_RECENT_WINDOW_SECS: u64 = 86_400;
+const IO_BURST_HIGH_READ_THRESHOLD_BYTES: u64 = 10 * 1024 * 1024;
 
 static ACCESS_WRITEBACK_SCHEDULED_TOTAL: AtomicU64 = AtomicU64::new(0);
 static ACCESS_WRITEBACK_SKIPPED_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -71,6 +74,317 @@ pub fn reset_resource_counters_for_tests() {
     ACCESS_WRITEBACK_SCHEDULED_TOTAL.store(0, Ordering::Relaxed);
     ACCESS_WRITEBACK_SKIPPED_TOTAL.store(0, Ordering::Relaxed);
     ACCESS_WRITEBACK_FAILED_TOTAL.store(0, Ordering::Relaxed);
+}
+
+#[derive(
+    Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum IoOperationPath {
+    Search,
+    Context,
+    Timeline,
+    Ingest,
+    Status,
+    Maintenance,
+    Queue,
+    Other,
+}
+
+impl IoOperationPath {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Search => "search",
+            Self::Context => "context",
+            Self::Timeline => "timeline",
+            Self::Ingest => "ingest",
+            Self::Status => "status",
+            Self::Maintenance => "maintenance",
+            Self::Queue => "queue",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct IoBurstSnapshot {
+    pub high_read_threshold_bytes: u64,
+    pub sample_count: u64,
+    pub high_read_sample_count: u64,
+    pub total_read_bytes: u64,
+    pub total_logical_read_bytes: u64,
+    pub peak_read_bytes_per_sec: u64,
+    pub avg_read_bytes_per_sec: u64,
+    pub paths: Vec<IoBurstPathSnapshot>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct IoBurstPathSnapshot {
+    pub path: IoOperationPath,
+    pub sample_count: u64,
+    pub high_read_sample_count: u64,
+    pub total_read_bytes: u64,
+    pub total_logical_read_bytes: u64,
+    pub peak_read_bytes: u64,
+    pub avg_read_bytes: u64,
+    pub peak_read_bytes_per_sec: u64,
+    pub avg_read_bytes_per_sec: u64,
+    pub last_read_bytes: u64,
+    pub last_duration_ms: u64,
+}
+
+impl Default for IoBurstPathSnapshot {
+    fn default() -> Self {
+        Self {
+            path: IoOperationPath::Other,
+            sample_count: 0,
+            high_read_sample_count: 0,
+            total_read_bytes: 0,
+            total_logical_read_bytes: 0,
+            peak_read_bytes: 0,
+            avg_read_bytes: 0,
+            peak_read_bytes_per_sec: 0,
+            avg_read_bytes_per_sec: 0,
+            last_read_bytes: 0,
+            last_duration_ms: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct IoBurstAccumulator {
+    sample_count: u64,
+    high_read_sample_count: u64,
+    total_read_bytes: u64,
+    total_logical_read_bytes: u64,
+    total_duration_ms: u64,
+    peak_read_bytes: u64,
+    peak_read_bytes_per_sec: u64,
+    last_read_bytes: u64,
+    last_duration_ms: u64,
+}
+
+impl IoBurstAccumulator {
+    fn record(&mut self, read_bytes: u64, logical_read_bytes: u64, duration_ms: u64) {
+        self.sample_count = self.sample_count.saturating_add(1);
+        self.total_read_bytes = self.total_read_bytes.saturating_add(read_bytes);
+        self.total_logical_read_bytes = self
+            .total_logical_read_bytes
+            .saturating_add(logical_read_bytes);
+        self.total_duration_ms = self.total_duration_ms.saturating_add(duration_ms.max(1));
+        self.peak_read_bytes = self.peak_read_bytes.max(read_bytes);
+        self.peak_read_bytes_per_sec = self
+            .peak_read_bytes_per_sec
+            .max(bytes_per_sec(read_bytes, duration_ms));
+        self.last_read_bytes = read_bytes;
+        self.last_duration_ms = duration_ms;
+        if read_bytes >= IO_BURST_HIGH_READ_THRESHOLD_BYTES {
+            self.high_read_sample_count = self.high_read_sample_count.saturating_add(1);
+        }
+    }
+
+    fn snapshot(&self, path: IoOperationPath) -> IoBurstPathSnapshot {
+        IoBurstPathSnapshot {
+            path,
+            sample_count: self.sample_count,
+            high_read_sample_count: self.high_read_sample_count,
+            total_read_bytes: self.total_read_bytes,
+            total_logical_read_bytes: self.total_logical_read_bytes,
+            peak_read_bytes: self.peak_read_bytes,
+            avg_read_bytes: average_u64(self.total_read_bytes, self.sample_count),
+            peak_read_bytes_per_sec: self.peak_read_bytes_per_sec,
+            avg_read_bytes_per_sec: bytes_per_sec(self.total_read_bytes, self.total_duration_ms),
+            last_read_bytes: self.last_read_bytes,
+            last_duration_ms: self.last_duration_ms,
+        }
+    }
+}
+
+pub struct IoBurstGuard {
+    path: IoOperationPath,
+    started_at: std::time::Instant,
+    start_io: Option<IoBurstIoSnapshot>,
+    finished: bool,
+}
+
+impl IoBurstGuard {
+    pub fn start(path: IoOperationPath) -> Self {
+        Self {
+            path,
+            started_at: std::time::Instant::now(),
+            start_io: read_io_burst_snapshot(),
+            finished: false,
+        }
+    }
+
+    pub fn finish(mut self) {
+        self.finish_inner();
+    }
+
+    fn finish_inner(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let Some(start) = self.start_io else {
+            return;
+        };
+        let Some(end) = read_io_burst_snapshot() else {
+            return;
+        };
+        record_io_burst_sample(
+            self.path,
+            end.read_bytes.saturating_sub(start.read_bytes),
+            end.rchar.saturating_sub(start.rchar),
+            duration_ms(self.started_at.elapsed()),
+        );
+    }
+}
+
+impl Drop for IoBurstGuard {
+    fn drop(&mut self) {
+        self.finish_inner();
+    }
+}
+
+pub fn record_io_burst_sample(
+    path: IoOperationPath,
+    read_bytes: u64,
+    logical_read_bytes: u64,
+    duration_ms: u64,
+) {
+    global_io_burst()
+        .lock()
+        .expect("io burst mutex poisoned")
+        .entry(path)
+        .or_default()
+        .record(read_bytes, logical_read_bytes, duration_ms);
+}
+
+pub fn io_burst_snapshot() -> IoBurstSnapshot {
+    let guard = global_io_burst().lock().expect("io burst mutex poisoned");
+    let total_duration_ms = guard
+        .values()
+        .map(|path| path.total_duration_ms)
+        .sum::<u64>();
+    let paths = guard
+        .iter()
+        .map(|(path, accumulator)| accumulator.snapshot(*path))
+        .collect::<Vec<_>>();
+    let sample_count = paths.iter().map(|path| path.sample_count).sum::<u64>();
+    let high_read_sample_count = paths
+        .iter()
+        .map(|path| path.high_read_sample_count)
+        .sum::<u64>();
+    let total_read_bytes = paths.iter().map(|path| path.total_read_bytes).sum::<u64>();
+    let total_logical_read_bytes = paths
+        .iter()
+        .map(|path| path.total_logical_read_bytes)
+        .sum::<u64>();
+    let peak_read_bytes_per_sec = paths
+        .iter()
+        .map(|path| path.peak_read_bytes_per_sec)
+        .max()
+        .unwrap_or_default();
+    IoBurstSnapshot {
+        high_read_threshold_bytes: IO_BURST_HIGH_READ_THRESHOLD_BYTES,
+        sample_count,
+        high_read_sample_count,
+        total_read_bytes,
+        total_logical_read_bytes,
+        peak_read_bytes_per_sec,
+        avg_read_bytes_per_sec: bytes_per_sec(total_read_bytes, total_duration_ms),
+        paths,
+    }
+}
+
+pub fn classify_io_operation_path(operation: &str, call_site: &str) -> IoOperationPath {
+    let operation = operation.to_ascii_lowercase();
+    let call_site = call_site.to_ascii_lowercase();
+    if call_site.contains("ingest_worker") || call_site.contains("write_worker") {
+        IoOperationPath::Queue
+    } else if operation.contains("search") || operation.contains("/api/search") {
+        IoOperationPath::Search
+    } else if operation.contains("context") {
+        IoOperationPath::Context
+    } else if operation.contains("timeline") {
+        IoOperationPath::Timeline
+    } else if operation.contains("ingest") || operation.contains("/api/ingest") {
+        IoOperationPath::Ingest
+    } else if operation.contains("status") || operation.contains("/api/status") {
+        IoOperationPath::Status
+    } else if operation.contains("maintenance")
+        || call_site.contains("maintenance")
+        || operation.contains("reindex")
+        || operation.contains("consolidate")
+        || operation.contains("sleep")
+    {
+        IoOperationPath::Maintenance
+    } else {
+        IoOperationPath::Other
+    }
+}
+
+pub fn reset_io_burst_for_tests() {
+    global_io_burst()
+        .lock()
+        .expect("io burst mutex poisoned")
+        .clear();
+}
+
+fn global_io_burst() -> &'static Mutex<BTreeMap<IoOperationPath, IoBurstAccumulator>> {
+    static IO_BURST: OnceLock<Mutex<BTreeMap<IoOperationPath, IoBurstAccumulator>>> =
+        OnceLock::new();
+    IO_BURST.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IoBurstIoSnapshot {
+    rchar: u64,
+    read_bytes: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn read_io_burst_snapshot() -> Option<IoBurstIoSnapshot> {
+    let raw = fs::read_to_string("/proc/self/io").ok()?;
+    let mut snapshot = IoBurstIoSnapshot {
+        rchar: 0,
+        read_bytes: 0,
+    };
+    for line in raw.lines() {
+        let (key, value) = line.split_once(':')?;
+        let parsed = value.trim().parse::<u64>().ok()?;
+        match key {
+            "rchar" => snapshot.rchar = parsed,
+            "read_bytes" => snapshot.read_bytes = parsed,
+            _ => {}
+        }
+    }
+    Some(snapshot)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_io_burst_snapshot() -> Option<IoBurstIoSnapshot> {
+    None
+}
+
+fn average_u64(total: u64, count: u64) -> u64 {
+    total.checked_div(count).unwrap_or_default()
+}
+
+fn bytes_per_sec(bytes: u64, duration_ms: u64) -> u64 {
+    if duration_ms == 0 {
+        return 0;
+    }
+    let scaled = u128::from(bytes).saturating_mul(1_000);
+    scaled
+        .checked_div(u128::from(duration_ms.max(1)))
+        .unwrap_or_default()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
@@ -2096,6 +2410,15 @@ mod tests {
 
     const FIXED_NOW: i64 = 1_800_000_000;
 
+    fn io_burst_path(snapshot: &IoBurstSnapshot, path: IoOperationPath) -> IoBurstPathSnapshot {
+        snapshot
+            .paths
+            .iter()
+            .find(|candidate| candidate.path == path)
+            .cloned()
+            .unwrap_or_default()
+    }
+
     #[test]
     fn test_parse_since_10_minutes() {
         let cutoff = parse_since_str("10m", FIXED_NOW).unwrap();
@@ -2166,5 +2489,89 @@ mod tests {
     fn test_parse_since_7_days() {
         let cutoff = parse_since_str("7d", FIXED_NOW).unwrap();
         assert_eq!(cutoff, FIXED_NOW - 7 * 86400);
+    }
+
+    #[test]
+    fn test_io_burst_snapshot_aggregates_path_counters_and_rates() {
+        let before = io_burst_snapshot();
+        let before_search = io_burst_path(&before, IoOperationPath::Search);
+
+        record_io_burst_sample(
+            IoOperationPath::Search,
+            20 * 1024 * 1024,
+            30 * 1024 * 1024,
+            2_000,
+        );
+        record_io_burst_sample(
+            IoOperationPath::Search,
+            4 * 1024 * 1024,
+            6 * 1024 * 1024,
+            1_000,
+        );
+        record_io_burst_sample(IoOperationPath::Status, 1_000, 2_000, 10);
+
+        let snapshot = io_burst_snapshot();
+        assert!(snapshot.sample_count.saturating_sub(before.sample_count) >= 3);
+        assert!(
+            snapshot
+                .high_read_sample_count
+                .saturating_sub(before.high_read_sample_count)
+                >= 1
+        );
+        assert!(
+            snapshot
+                .total_read_bytes
+                .saturating_sub(before.total_read_bytes)
+                >= 24 * 1024 * 1024 + 1_000
+        );
+        assert!(snapshot.peak_read_bytes_per_sec >= 10 * 1024 * 1024);
+
+        let search = io_burst_path(&snapshot, IoOperationPath::Search);
+        assert!(
+            search
+                .sample_count
+                .saturating_sub(before_search.sample_count)
+                >= 2
+        );
+        assert!(
+            search
+                .high_read_sample_count
+                .saturating_sub(before_search.high_read_sample_count)
+                >= 1
+        );
+        assert!(
+            search
+                .total_read_bytes
+                .saturating_sub(before_search.total_read_bytes)
+                >= 24 * 1024 * 1024
+        );
+        assert!(
+            search
+                .total_logical_read_bytes
+                .saturating_sub(before_search.total_logical_read_bytes)
+                >= 36 * 1024 * 1024
+        );
+        assert!(search.peak_read_bytes >= 20 * 1024 * 1024);
+        assert!(search.peak_read_bytes_per_sec >= 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_classify_io_operation_path_uses_content_safe_operation_kind() {
+        assert_eq!(
+            classify_io_operation_path("mempal_search", "mcp.tool"),
+            IoOperationPath::Search
+        );
+        assert_eq!(
+            classify_io_operation_path("GET /api/status", "rest.request"),
+            IoOperationPath::Status
+        );
+        assert_eq!(
+            classify_io_operation_path("ingest ingest_async", "mcp.ingest_worker"),
+            IoOperationPath::Queue
+        );
+        assert_eq!(
+            classify_io_operation_path("maintenance-rejudge", "main"),
+            IoOperationPath::Maintenance
+        );
     }
 }

--- a/src/observability/operation_telemetry.rs
+++ b/src/observability/operation_telemetry.rs
@@ -191,12 +191,24 @@ impl OperationTelemetrySpan {
     pub fn finish_success(mut self) {
         let record = self.finished_record(true, None);
         self.finished = true;
+        crate::observability::record_io_burst_sample(
+            crate::observability::classify_io_operation_path(&record.operation, &record.call_site),
+            record.io.physical_read_bytes,
+            record.io.logical_read_bytes,
+            record.duration_ms,
+        );
         let _ = record_operation_telemetry_path(&self.db_path, record);
     }
 
     pub fn finish_error(mut self, error: impl std::fmt::Display) {
         let record = self.finished_record(false, Some(error.to_string()));
         self.finished = true;
+        crate::observability::record_io_burst_sample(
+            crate::observability::classify_io_operation_path(&record.operation, &record.call_site),
+            record.io.physical_read_bytes,
+            record.io.logical_read_bytes,
+            record.duration_ms,
+        );
         let _ = record_operation_telemetry_path(&self.db_path, record);
     }
 
@@ -211,6 +223,12 @@ impl OperationTelemetrySpan {
             ))
             .with_error_class(error_class);
         self.finished = true;
+        crate::observability::record_io_burst_sample(
+            crate::observability::classify_io_operation_path(&record.operation, &record.call_site),
+            record.io.physical_read_bytes,
+            record.io.logical_read_bytes,
+            record.duration_ms,
+        );
         let _ = record_operation_telemetry_path(&self.db_path, record);
     }
 
@@ -220,6 +238,12 @@ impl OperationTelemetrySpan {
             Err(error) => self.finished_record(false, Some(error.to_string())),
         };
         self.finished = true;
+        crate::observability::record_io_burst_sample(
+            crate::observability::classify_io_operation_path(&record.operation, &record.call_site),
+            record.io.physical_read_bytes,
+            record.io.logical_read_bytes,
+            record.duration_ms,
+        );
         let _ = record_operation_telemetry_path(&self.db_path, record);
     }
 
@@ -249,6 +273,12 @@ impl Drop for OperationTelemetrySpan {
             return;
         }
         let record = self.finished_record(false, Some("unfinished_span".to_string()));
+        crate::observability::record_io_burst_sample(
+            crate::observability::classify_io_operation_path(&record.operation, &record.call_site),
+            record.io.physical_read_bytes,
+            record.io.logical_read_bytes,
+            record.duration_ms,
+        );
         let _ = record_operation_telemetry_path(&self.db_path, record);
         self.finished = true;
     }

--- a/tests/rest_reliability.rs
+++ b/tests/rest_reliability.rs
@@ -18,7 +18,10 @@ use mempal::core::db::{CURRENT_SCHEMA_VERSION, Database};
 use mempal::core::types::{BootstrapEvidenceArgs, Drawer, SourceType};
 use mempal::core::utils::iso_timestamp;
 use mempal::embed::{EmbedError, Embedder, EmbedderFactory, global_embed_status};
-use mempal::observability::{OperationTelemetrySummaryOptions, operation_telemetry_summary};
+use mempal::observability::{
+    IoOperationPath, OperationTelemetrySummaryOptions, operation_telemetry_summary,
+    record_io_burst_sample, reset_io_burst_for_tests,
+};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio::sync::Notify;
@@ -489,10 +492,27 @@ async fn test_status_includes_vector_scan_and_backoff_telemetry() {
     let _guard = TEST_LOCK.lock().await;
     let env = TestEnv::new();
     let state = env.state(Arc::new(StaticEmbedderFactory { dim: 4 }));
+    reset_io_burst_for_tests();
+    record_io_burst_sample(IoOperationPath::Status, 4096, 8192, 2);
 
     let (status, _headers, body) = get_json(state, "/api/status").await;
 
     assert_eq!(status, StatusCode::OK);
+
+    let io_burst = body["io_burst"].as_object().expect("io burst");
+    assert_eq!(
+        io_burst.get("total_read_bytes").and_then(Value::as_u64),
+        Some(4096)
+    );
+    let paths = io_burst["paths"].as_array().expect("io burst paths");
+    assert!(
+        paths.iter().any(|path| {
+            path.get("path").and_then(Value::as_str) == Some("status")
+                && path.get("sample_count").and_then(Value::as_u64) == Some(1)
+                && path.get("peak_read_bytes_per_sec").and_then(Value::as_u64) == Some(2_048_000)
+        }),
+        "status io burst path should be exposed without content: {io_burst:#?}"
+    );
 
     let vector_scan = body["vector_scan"].as_object().expect("vector scan");
     assert_eq!(
@@ -521,6 +541,7 @@ async fn test_status_includes_vector_scan_and_backoff_telemetry() {
         backoff.get("last_error_class").and_then(Value::as_str),
         None
     );
+    reset_io_burst_for_tests();
 }
 
 fn insert_search_drawer(db: &Database) {


### PR DESCRIPTION
## Summary
- Add aggregate IO burst telemetry by operation path
- Expose aggregate counters/rates in status surfaces without raw content
- Add tests for status exposure and delta-based telemetry assertions

## Verification
- CSA implementation session: 01KWA79X38V2AVJB19KNAGSAME
- CSA fix session: 01KWABQ2V6VYK6QHZXSKMV306Q
- CSA review PASS: 01KWAMDG2FRV8J7WXNVC37X3V9
- Hook-enabled push passed branch-protection, local-gates, and review-check

Closes #583